### PR TITLE
Add Linux release binary pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  linux-x86_64:
+    name: Linux x86_64 binaries
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.92.0"
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+
+      - name: Build release binaries
+        run: |
+          cargo build --release --locked \
+            -p broker --bin felix-broker \
+            -p controlplane --bin felix-controlplane
+
+      - name: Package release archive
+        run: |
+          set -euxo pipefail
+
+          archive_root="felix-${RELEASE_TAG}-linux-x86_64"
+          mkdir -p "dist/${archive_root}"
+
+          cp target/release/felix-broker "dist/${archive_root}/"
+          cp target/release/felix-controlplane "dist/${archive_root}/"
+          cp README.md LICENSE "dist/${archive_root}/"
+
+          tar -C dist -czf "dist/${archive_root}.tar.gz" "${archive_root}"
+          rm -rf "dist/${archive_root}"
+
+          (
+            cd dist
+            sha256sum "${archive_root}.tar.gz" > SHA256SUMS
+          )
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: felix-${{ env.RELEASE_TAG }}-linux-x86_64
+          path: |
+            dist/*.tar.gz
+            dist/SHA256SUMS
+          if-no-files-found: error
+
+      - name: Publish GitHub prerelease
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: Felix ${{ env.RELEASE_TAG }}
+          prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/SHA256SUMS


### PR DESCRIPTION
Build and package the broker and control plane for Linux x86_64 on release tags or manual dispatch, attach checksums, and publish the GitHub prerelease assets.