### PR TITLE
Encode once optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,6 @@ dependencies = [
  "parking_lot",
  "serial_test",
  "slab",
- "smallvec",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/felix-broker/Cargo.toml
+++ b/crates/felix-broker/Cargo.toml
@@ -11,10 +11,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 metrics = "0.24"
 felix-storage = { path = "../felix-storage", version = "0.1.0" }
+felix-wire = { path = "../felix-wire", version = "0.1.0" }
 arc-swap = "1.8"
 ahash = "0.8"
 hashbrown = { version = "0.16", features = ["equivalent"] }
-smallvec = "1.13"
 slab = "0.4"
 parking_lot = "0.12"
 
@@ -25,4 +25,3 @@ perf_debug = []
 
 [dev-dependencies]
 serial_test = "3"
-felix-wire = { path = "../felix-wire", version = "0.1.0" }

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -8,9 +8,8 @@ use felix_storage::StorageApi;
 use hashbrown::HashMap;
 use parking_lot::Mutex;
 use slab::Slab;
-use smallvec::SmallVec;
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Instant;
 use tokio::sync::{RwLock, mpsc};
@@ -78,6 +77,8 @@ pub enum BrokerError {
         namespace: String,
         stream: String,
     },
+    #[error("stream handle {0} is no longer active")]
+    StreamHandleInactive(u64),
     #[error("tenant not found: {0}")]
     TenantNotFound(String),
     #[error("namespace not found: tenant={tenant_id} namespace={namespace}")]
@@ -118,6 +119,8 @@ struct LogEntry {
 
 #[derive(Debug)]
 struct StreamState {
+    handle_id: u64,
+    active: AtomicBool,
     // Snapshot used by publish hot path: lock-free read, no per-publish allocation.
     subscribers_snapshot: ArcSwap<Vec<SubscriberEntry>>,
     // Inner registry mutated only on subscribe/unsubscribe paths.
@@ -145,21 +148,51 @@ struct SubscriberEntry {
 
 #[derive(Debug, Clone)]
 pub struct DeliveryEnvelope {
-    payload: Bytes,
+    inner: Arc<DeliveryBatch>,
+}
+
+#[derive(Debug)]
+struct DeliveryBatch {
+    payloads: Arc<[Bytes]>,
     enqueued_at: Instant,
+    encoded_frame: Mutex<Option<Bytes>>,
 }
 
 impl DeliveryEnvelope {
-    pub fn payload(&self) -> &Bytes {
-        &self.payload
+    fn new(payloads: &[Bytes]) -> Self {
+        Self {
+            inner: Arc::new(DeliveryBatch {
+                payloads: Arc::from(payloads),
+                enqueued_at: Instant::now(),
+                encoded_frame: Mutex::new(None),
+            }),
+        }
     }
 
-    pub fn into_payload(self) -> Bytes {
-        self.payload
+    pub fn payloads(&self) -> &[Bytes] {
+        &self.inner.payloads
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.payloads.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.payloads.is_empty()
+    }
+
+    pub fn shared_event_frame(&self) -> felix_wire::Result<Bytes> {
+        let mut cached = self.inner.encoded_frame.lock();
+        if let Some(frame) = cached.as_ref() {
+            return Ok(frame.clone());
+        }
+        let frame = felix_wire::binary::encode_shared_event_batch_bytes(&self.inner.payloads)?;
+        *cached = Some(frame.clone());
+        Ok(frame)
     }
 
     pub fn enqueued_at(&self) -> Instant {
-        self.enqueued_at
+        self.inner.enqueued_at
     }
 }
 
@@ -172,8 +205,14 @@ struct LogState {
 }
 
 impl StreamState {
-    fn new(subscriber_queue_capacity: usize, subscriber_queue_policy: SubQueuePolicy) -> Self {
+    fn new(
+        handle_id: u64,
+        subscriber_queue_capacity: usize,
+        subscriber_queue_policy: SubQueuePolicy,
+    ) -> Self {
         Self {
+            handle_id,
+            active: AtomicBool::new(true),
             subscribers_snapshot: ArcSwap::from_pointee(Vec::new()),
             subscribers: Mutex::new(SubscriberRegistry::default()),
             log_state: Mutex::new(LogState {
@@ -184,6 +223,10 @@ impl StreamState {
             subscriber_queue_policy,
             queued_items: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    fn deactivate(&self) {
+        self.active.store(false, Ordering::Release);
     }
 
     fn register_subscriber(&self) -> (u64, SubscriptionReceiver) {
@@ -314,11 +357,11 @@ impl StreamState {
         state.next_seq
     }
 
-    fn increment_queue_depth(&self) {
-        let _ = self.queued_items.fetch_add(1, Ordering::Relaxed) + 1;
-        let global = GLOBAL_SUB_QUEUE_DEPTH.fetch_add(1, Ordering::Relaxed) + 1;
+    fn increment_queue_depth(&self, count: usize) {
+        let _ = self.queued_items.fetch_add(count, Ordering::Relaxed) + count;
+        let global = GLOBAL_SUB_QUEUE_DEPTH.fetch_add(count, Ordering::Relaxed) + count;
         metrics::gauge!("felix_sub_queue_len").set(global as f64);
-        metrics::counter!("felix_sub_queue_enqueued_total").increment(1);
+        metrics::counter!("felix_sub_queue_enqueued_total").increment(count as u64);
     }
 }
 
@@ -342,18 +385,28 @@ impl Drop for SubscriptionGuard {
 pub struct Subscription {
     receiver: SubscriptionReceiver,
     guard: SubscriptionGuard,
+    pending: VecDeque<Bytes>,
 }
 
 impl Subscription {
     pub async fn recv(&mut self) -> Option<Bytes> {
-        self.receiver
-            .recv()
-            .await
-            .map(DeliveryEnvelope::into_payload)
+        if let Some(payload) = self.pending.pop_front() {
+            return Some(payload);
+        }
+        let envelope = self.receiver.recv().await?;
+        self.pending.extend(envelope.payloads().iter().cloned());
+        self.pending.pop_front()
     }
 
     pub fn try_recv(&mut self) -> std::result::Result<Bytes, mpsc::error::TryRecvError> {
-        self.receiver.try_recv().map(DeliveryEnvelope::into_payload)
+        if let Some(payload) = self.pending.pop_front() {
+            return Ok(payload);
+        }
+        let envelope = self.receiver.try_recv()?;
+        self.pending.extend(envelope.payloads().iter().cloned());
+        self.pending
+            .pop_front()
+            .ok_or(mpsc::error::TryRecvError::Empty)
     }
 
     pub fn into_parts(self) -> (SubscriptionReceiver, SubscriptionGuard) {
@@ -377,14 +430,14 @@ impl SubscriptionReceiver {
 
     pub async fn recv(&mut self) -> Option<DeliveryEnvelope> {
         let value = self.receiver.recv().await?;
-        self.decrement_depth(1);
+        self.decrement_depth(value.len());
         Some(value)
     }
 
     pub fn try_recv(&mut self) -> std::result::Result<DeliveryEnvelope, mpsc::error::TryRecvError> {
         match self.receiver.try_recv() {
             Ok(value) => {
-                self.decrement_depth(1);
+                self.decrement_depth(value.len());
                 Ok(value)
             }
             Err(err) => Err(err),
@@ -412,7 +465,10 @@ impl SubscriptionReceiver {
 
 impl Drop for SubscriptionReceiver {
     fn drop(&mut self) {
-        let remaining = self.receiver.len();
+        let mut remaining = 0usize;
+        while let Ok(envelope) = self.receiver.try_recv() {
+            remaining = remaining.saturating_add(envelope.len());
+        }
         if remaining > 0 {
             self.decrement_depth(remaining);
         }
@@ -473,6 +529,7 @@ pub struct Broker {
     log_capacity: usize,
     // Subscriber queue backpressure policy.
     subscriber_queue_policy: SubQueuePolicy,
+    next_stream_handle: AtomicU64,
 }
 
 unsafe impl Send for Broker {}
@@ -481,6 +538,21 @@ unsafe impl Send for Broker {}
 pub struct StreamMetadata {
     pub durable: bool,
     pub shards: u32,
+}
+
+#[derive(Clone, Debug)]
+pub struct StreamHandle {
+    state: Arc<StreamState>,
+}
+
+impl StreamHandle {
+    pub fn id(&self) -> u64 {
+        self.state.handle_id
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.state.active.load(Ordering::Acquire)
+    }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -636,6 +708,7 @@ impl Broker {
             topic_capacity: DEFAULT_TOPIC_CAPACITY,
             log_capacity: DEFAULT_LOG_CAPACITY,
             subscriber_queue_policy: DEFAULT_SUB_QUEUE_POLICY,
+            next_stream_handle: AtomicU64::new(1),
         }
     }
 
@@ -680,23 +753,34 @@ impl Broker {
         stream: &str,
         payloads: &[Bytes],
     ) -> Result<usize> {
-        self.assert_stream_exists(tenant_id, namespace, stream)
+        let sample = t_should_sample();
+        let lookup_start = t_now_if(sample);
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
             .await?;
+        if let Some(start) = lookup_start {
+            let lookup_ns = start.elapsed().as_nanos() as u64;
+            timings::record_lookup_ns(lookup_ns);
+            t_histogram!("broker_publish_lookup_ns").record(lookup_ns as f64);
+        }
+        self.publish_batch_to_handle(&handle, payloads).await
+    }
+
+    pub async fn publish_batch_to_handle(
+        &self,
+        handle: &StreamHandle,
+        payloads: &[Bytes],
+    ) -> Result<usize> {
+        if !handle.state.active.load(Ordering::Acquire) {
+            return Err(BrokerError::StreamHandleInactive(handle.id()));
+        }
 
         // Fan-out to current subscribers.
         // We intentionally avoid a global broadcast channel here:
         // each subscriber has a bounded queue and publish uses try_send so a slow consumer
         // drops locally instead of stalling all publishers.
         let sample = t_should_sample();
-        let lookup_start = t_now_if(sample);
-        let stream_state = self.get_stream_state(tenant_id, namespace, stream).await?;
-
-        if let Some(start) = lookup_start {
-            let lookup_ns = start.elapsed().as_nanos() as u64;
-            timings::record_lookup_ns(lookup_ns);
-            t_histogram!("broker_publish_lookup_ns").record(lookup_ns as f64);
-        }
-
+        let stream_state = &handle.state;
         let append_start = t_now_if(sample);
         // Append to the in-memory log first so cursors can replay.
         stream_state.append_batch(payloads, self.log_capacity);
@@ -722,132 +806,46 @@ impl Broker {
         let fanout_start = t_now_if(sample);
         let mut closed_subscribers = Vec::new();
         let mut sent = 0usize;
-        let mut payload_times: SmallVec<[Instant; 8]> = SmallVec::with_capacity(payloads.len());
-        payload_times.extend(payloads.iter().map(|_| Instant::now()));
+        if payloads.is_empty() {
+            return Ok(0);
+        }
+        let envelope = DeliveryEnvelope::new(payloads);
+        let item_count = envelope.len();
         let enqueue_start = t_now_if(sample);
-        'subscribers: for subscriber in senders.iter() {
-            for (payload_idx, payload) in payloads.iter().enumerate() {
-                let enqueued_at = payload_times[payload_idx];
-                match stream_state.subscriber_queue_policy {
-                    SubQueuePolicy::Block => {
-                        metrics::counter!("felix_sub_shared_payload_clones_total").increment(1);
-                        let envelope = DeliveryEnvelope {
-                            payload: payload.clone(),
-                            enqueued_at,
-                        };
-                        if subscriber.sender.send(envelope).await.is_ok() {
-                            stream_state.increment_queue_depth();
-                            sent += 1;
-                        } else {
-                            closed_subscribers.push(subscriber.id as u64);
-                            break;
-                        }
+        for subscriber in senders.iter() {
+            match stream_state.subscriber_queue_policy {
+                SubQueuePolicy::Block => {
+                    metrics::counter!("felix_sub_shared_batch_handles_total").increment(1);
+                    if subscriber.sender.send(envelope.clone()).await.is_ok() {
+                        stream_state.increment_queue_depth(item_count);
+                        sent += item_count;
+                    } else {
+                        closed_subscribers.push(subscriber.id as u64);
                     }
-                    SubQueuePolicy::DropNew => {
-                        if payload_idx == 0 && payloads.len() > 1 {
-                            match subscriber.sender.try_reserve_many(payloads.len()) {
-                                Ok(mut permits) => {
-                                    for (payload_idx, payload) in payloads.iter().enumerate() {
-                                        let Some(permit) = permits.next() else {
-                                            break;
-                                        };
-                                        let enqueued_at = payload_times[payload_idx];
-                                        metrics::counter!("felix_sub_shared_payload_clones_total")
-                                            .increment(1);
-                                        let envelope = DeliveryEnvelope {
-                                            payload: payload.clone(),
-                                            enqueued_at,
-                                        };
-                                        permit.send(envelope);
-                                        stream_state.increment_queue_depth();
-                                        sent += 1;
-                                    }
-                                    continue 'subscribers;
-                                }
-                                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                    closed_subscribers.push(subscriber.id as u64);
-                                    continue 'subscribers;
-                                }
-                                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                    // Fall back to per-payload reservation to preserve drop-new semantics.
-                                }
-                            }
+                }
+                SubQueuePolicy::DropNew | SubQueuePolicy::DropOld => {
+                    match subscriber.sender.try_reserve() {
+                        Ok(permit) => {
+                            metrics::counter!("felix_sub_shared_batch_handles_total").increment(1);
+                            permit.send(envelope.clone());
+                            stream_state.increment_queue_depth(item_count);
+                            sent += item_count;
                         }
-                        match subscriber.sender.try_reserve() {
-                            Ok(permit) => {
-                                metrics::counter!("felix_sub_shared_payload_clones_total")
-                                    .increment(1);
-                                let envelope = DeliveryEnvelope {
-                                    payload: payload.clone(),
-                                    enqueued_at,
-                                };
-                                permit.send(envelope);
-                                stream_state.increment_queue_depth();
-                                sent += 1;
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                metrics::counter!("felix_subscribe_dropped_total").increment(1);
-                                metrics::counter!("felix_sub_queue_dropped_total").increment(1);
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                closed_subscribers.push(subscriber.id as u64);
-                                break;
-                            }
-                        }
-                    }
-                    SubQueuePolicy::DropOld => {
-                        // tokio::mpsc does not expose drop-head; emulate with drop-new semantics.
-                        if payload_idx == 0 && payloads.len() > 1 {
-                            match subscriber.sender.try_reserve_many(payloads.len()) {
-                                Ok(mut permits) => {
-                                    for (payload_idx, payload) in payloads.iter().enumerate() {
-                                        let Some(permit) = permits.next() else {
-                                            break;
-                                        };
-                                        let enqueued_at = payload_times[payload_idx];
-                                        metrics::counter!("felix_sub_shared_payload_clones_total")
-                                            .increment(1);
-                                        let envelope = DeliveryEnvelope {
-                                            payload: payload.clone(),
-                                            enqueued_at,
-                                        };
-                                        permit.send(envelope);
-                                        stream_state.increment_queue_depth();
-                                        sent += 1;
-                                    }
-                                    continue 'subscribers;
-                                }
-                                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                    closed_subscribers.push(subscriber.id as u64);
-                                    continue 'subscribers;
-                                }
-                                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                    // Fall back to per-payload reservation to preserve drop-old emulation.
-                                }
-                            }
-                        }
-                        match subscriber.sender.try_reserve() {
-                            Ok(permit) => {
-                                metrics::counter!("felix_sub_shared_payload_clones_total")
-                                    .increment(1);
-                                let envelope = DeliveryEnvelope {
-                                    payload: payload.clone(),
-                                    enqueued_at,
-                                };
-                                permit.send(envelope);
-                                stream_state.increment_queue_depth();
-                                sent += 1;
-                            }
-                            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                metrics::counter!("felix_subscribe_dropped_total").increment(1);
-                                metrics::counter!("felix_sub_queue_dropped_total").increment(1);
+                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                            metrics::counter!("felix_subscribe_dropped_total")
+                                .increment(item_count as u64);
+                            metrics::counter!("felix_sub_queue_dropped_total")
+                                .increment(item_count as u64);
+                            if matches!(
+                                stream_state.subscriber_queue_policy,
+                                SubQueuePolicy::DropOld
+                            ) {
                                 metrics::counter!("felix_sub_queue_drop_old_emulated_total")
-                                    .increment(1);
+                                    .increment(item_count as u64);
                             }
-                            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                closed_subscribers.push(subscriber.id as u64);
-                                break;
-                            }
+                        }
+                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                            closed_subscribers.push(subscriber.id as u64);
                         }
                     }
                 }
@@ -907,11 +905,10 @@ impl Broker {
         namespace: &str,
         stream: &str,
     ) -> Result<Subscription> {
-        // Fast-path guard: reject unknown scopes before opening a receiver.
-        self.assert_stream_exists(tenant_id, namespace, stream)
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
             .await?;
-
-        let stream_state = self.get_stream_state(tenant_id, namespace, stream).await?;
+        let stream_state = handle.state;
         let (subscriber_id, receiver) = stream_state.register_subscriber();
         Ok(Subscription {
             receiver,
@@ -919,6 +916,7 @@ impl Broker {
                 stream_state: Arc::downgrade(&stream_state),
                 subscriber_id,
             },
+            pending: VecDeque::new(),
         })
     }
 
@@ -929,13 +927,12 @@ impl Broker {
         namespace: &str,
         stream: &str,
     ) -> Result<Cursor> {
-        // Fast-path guard: reject unknown scopes before touching the stream map.
-        self.assert_stream_exists(tenant_id, namespace, stream)
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
             .await?;
-        let stream_state = self.get_stream_state(tenant_id, namespace, stream).await?;
 
         Ok(Cursor {
-            next_seq: stream_state.tail_seq(),
+            next_seq: handle.state.tail_seq(),
         })
     }
 
@@ -948,11 +945,10 @@ impl Broker {
         stream: &str,
         cursor: Cursor,
     ) -> Result<(Vec<Bytes>, Subscription)> {
-        // Fast-path guard: reject unknown scopes before touching the stream map.
-        self.assert_stream_exists(tenant_id, namespace, stream)
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
             .await?;
-
-        let stream_state = self.get_stream_state(tenant_id, namespace, stream).await?;
+        let stream_state = handle.state;
 
         let (oldest, backlog) = stream_state.snapshot_from(cursor.next_seq);
         // TODO: Should we really return an error? Would this not just be all entries?
@@ -972,6 +968,7 @@ impl Broker {
                     stream_state: Arc::downgrade(&stream_state),
                     subscriber_id,
                 },
+                pending: VecDeque::new(),
             },
         ))
     }
@@ -1006,8 +1003,10 @@ impl Broker {
         let key = StreamKey::new(tenant_id, namespace, stream);
         self.streams.write().await.insert(key.clone(), metadata);
         let mut guard = self.topics.write().await;
+        let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
         guard.entry(key).or_insert_with(|| {
             Arc::new(StreamState::new(
+                handle_id,
                 self.topic_capacity,
                 self.subscriber_queue_policy,
             ))
@@ -1071,7 +1070,11 @@ impl Broker {
         let key = StreamKey::new(tenant_id, namespace, stream);
         let removed = self.streams.write().await.remove(&key).is_some();
         if removed {
-            self.topics.write().await.remove(&key);
+            let mut topics = self.topics.write().await;
+            if let Some(state) = topics.get(&key) {
+                state.deactivate();
+            }
+            topics.remove(&key);
         }
         Ok(removed)
     }
@@ -1198,22 +1201,17 @@ impl Broker {
             })
     }
 
-    /// It is up to the caller to check for the error or not.
-    async fn assert_stream_exists(
+    pub async fn resolve_stream_handle(
         &self,
         tenant_id: &str,
         namespace: &str,
         stream: &str,
-    ) -> Result<()> {
-        if !self.stream_exists(tenant_id, namespace, stream).await {
-            return Err(BrokerError::StreamNotFound {
-                tenant_id: tenant_id.to_string(),
-                namespace: namespace.to_string(),
-                stream: stream.to_string(),
-            });
+    ) -> Result<StreamHandle> {
+        let state = self.get_stream_state(tenant_id, namespace, stream).await?;
+        if !state.active.load(Ordering::Acquire) {
+            return Err(BrokerError::StreamHandleInactive(state.handle_id));
         }
-
-        Ok(())
+        Ok(StreamHandle { state })
     }
 
     /// It is up to the caller to check for the error or not.
@@ -1316,7 +1314,7 @@ mod tests {
 
     #[test]
     fn append_batch_keeps_monotonic_sequences_and_trims_once() {
-        let stream = StreamState::new(8, SubQueuePolicy::DropNew);
+        let stream = StreamState::new(1, 8, SubQueuePolicy::DropNew);
         let first = vec![
             Bytes::from_static(b"a"),
             Bytes::from_static(b"b"),
@@ -1518,6 +1516,43 @@ mod tests {
             sub_b.recv().await.expect("recv"),
             Bytes::from_static(b"fanout")
         );
+    }
+
+    #[tokio::test]
+    async fn publish_batch_shares_one_encoded_frame_across_subscribers() {
+        let broker = Broker::new(EphemeralCache::new().into());
+        broker.register_tenant("t1").await.expect("tenant");
+        broker
+            .register_namespace("t1", "default")
+            .await
+            .expect("namespace");
+        broker
+            .register_stream("t1", "default", "orders", StreamMetadata::default())
+            .await
+            .expect("register");
+        let (mut rx_a, _guard_a) = broker
+            .subscribe("t1", "default", "orders")
+            .await
+            .expect("subscribe a")
+            .into_parts();
+        let (mut rx_b, _guard_b) = broker
+            .subscribe("t1", "default", "orders")
+            .await
+            .expect("subscribe b")
+            .into_parts();
+        let payloads = [Bytes::from_static(b"one"), Bytes::from_static(b"two")];
+        broker
+            .publish_batch("t1", "default", "orders", &payloads)
+            .await
+            .expect("publish");
+
+        let envelope_a = rx_a.recv().await.expect("recv a");
+        let envelope_b = rx_b.recv().await.expect("recv b");
+        let frame_a = envelope_a.shared_event_frame().expect("encode a");
+        let frame_b = envelope_b.shared_event_frame().expect("encode b");
+
+        assert_eq!(frame_a, frame_b);
+        assert_eq!(frame_a.as_ptr(), frame_b.as_ptr());
     }
 
     #[tokio::test]
@@ -1734,6 +1769,65 @@ mod tests {
             .await
             .expect_err("stream");
         assert!(matches!(err, BrokerError::StreamNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn resolved_stream_handle_publishes_without_name_lookup() {
+        let broker = Broker::new(EphemeralCache::new().into());
+        broker.register_tenant("t1").await.expect("tenant");
+        broker
+            .register_namespace("t1", "default")
+            .await
+            .expect("namespace");
+        broker
+            .register_stream("t1", "default", "orders", StreamMetadata::default())
+            .await
+            .expect("stream");
+        let mut sub = broker
+            .subscribe("t1", "default", "orders")
+            .await
+            .expect("subscribe");
+        let handle = broker
+            .resolve_stream_handle("t1", "default", "orders")
+            .await
+            .expect("handle");
+
+        broker
+            .publish_batch_to_handle(&handle, &[Bytes::from_static(b"handled")])
+            .await
+            .expect("publish");
+        assert_eq!(
+            sub.recv().await.expect("delivery"),
+            Bytes::from_static(b"handled")
+        );
+    }
+
+    #[tokio::test]
+    async fn removed_stream_invalidates_resolved_handle() {
+        let broker = Broker::new(EphemeralCache::new().into());
+        broker.register_tenant("t1").await.expect("tenant");
+        broker
+            .register_namespace("t1", "default")
+            .await
+            .expect("namespace");
+        broker
+            .register_stream("t1", "default", "orders", StreamMetadata::default())
+            .await
+            .expect("stream");
+        let handle = broker
+            .resolve_stream_handle("t1", "default", "orders")
+            .await
+            .expect("handle");
+        broker
+            .remove_stream("t1", "default", "orders")
+            .await
+            .expect("remove");
+
+        let err = broker
+            .publish_batch_to_handle(&handle, &[Bytes::from_static(b"stale")])
+            .await
+            .expect_err("stale handle");
+        assert!(matches!(err, BrokerError::StreamHandleInactive(id) if id == handle.id()));
     }
 
     #[tokio::test]

--- a/crates/felix-client/src/client/publisher.rs
+++ b/crates/felix-client/src/client/publisher.rs
@@ -248,7 +248,28 @@ impl Publisher {
         Ok(&workers[index])
     }
 
+    /// Publish one payload. Unacked publishes use the binary data-plane encoding by default;
+    /// acked publishes retain the JSON control encoding until binary acknowledgements are
+    /// negotiated by the protocol.
     pub async fn publish(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        payload: Vec<u8>,
+        ack: AckMode,
+    ) -> Result<()> {
+        if ack == AckMode::None {
+            return self
+                .publish_batch_binary(tenant_id, namespace, stream, &[payload])
+                .await;
+        }
+        self.publish_json(tenant_id, namespace, stream, payload, ack)
+            .await
+    }
+
+    /// Publish one payload using the JSON compatibility encoding.
+    pub async fn publish_json(
         &self,
         tenant_id: &str,
         namespace: &str,
@@ -306,7 +327,26 @@ impl Publisher {
         response_rx.await.context("publish response dropped")?
     }
 
+    /// Publish a batch. Unacked batches use binary encoding by default.
     pub async fn publish_batch(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        payloads: Vec<Vec<u8>>,
+        ack: AckMode,
+    ) -> Result<()> {
+        if ack == AckMode::None {
+            return self
+                .publish_batch_binary(tenant_id, namespace, stream, &payloads)
+                .await;
+        }
+        self.publish_batch_json(tenant_id, namespace, stream, payloads, ack)
+            .await
+    }
+
+    /// Publish a batch using the JSON compatibility encoding.
+    pub async fn publish_batch_json(
         &self,
         tenant_id: &str,
         namespace: &str,
@@ -958,6 +998,84 @@ mod tests {
             .await
             .expect("publish ack");
         publisher.finish().await.expect("finish");
+    }
+
+    #[tokio::test]
+    async fn unacked_publish_defaults_to_binary_and_json_is_explicit() {
+        let (tx, mut rx) = mpsc::channel::<PublishRequest>(2);
+        let publisher = Publisher {
+            inner: Arc::new(PublisherInner::new(
+                Arc::new(vec![PublishWorker {
+                    tx,
+                    handle: tokio::sync::Mutex::new(None),
+                    request_counter: AtomicU64::new(1),
+                }]),
+                PublishSharding::RoundRobin,
+            )),
+        };
+
+        let binary_publish = tokio::spawn({
+            let publisher = publisher.clone();
+            async move {
+                publisher
+                    .publish("t", "ns", "s", b"binary".to_vec(), AckMode::None)
+                    .await
+            }
+        });
+        let request = rx.recv().await.expect("binary request");
+        match request {
+            PublishRequest::BinaryBytes {
+                bytes,
+                item_count,
+                response,
+                ..
+            } => {
+                let frame = felix_wire::Frame::decode(bytes).expect("binary frame");
+                let batch = felix_wire::binary::decode_publish_batch(&frame).expect("binary batch");
+                assert_eq!(item_count, 1);
+                assert_eq!(batch.payloads.len(), 1);
+                // In telemetry builds, `runtime_config()` is a process-global OnceLock:
+                // parallel #[serial] env tests can leave FELIX_BENCH_EMBED_TS enabled at
+                // first initialization, which appends an 8-byte bench timestamp to the
+                // payload. Accept either shape — this test asserts the *encoding path*,
+                // not the embed feature.
+                let payload = &batch.payloads[0];
+                assert!(payload.starts_with(b"binary"));
+                assert!(
+                    payload.len() == b"binary".len() || payload.len() == b"binary".len() + 8,
+                    "unexpected payload shape: {payload:?}"
+                );
+                let _ = response.send(Ok(()));
+            }
+            _ => panic!("unacked publish should use binary encoding"),
+        }
+        binary_publish
+            .await
+            .expect("binary task")
+            .expect("binary publish");
+
+        let json_publish = tokio::spawn({
+            let publisher = publisher.clone();
+            async move {
+                publisher
+                    .publish_json("t", "ns", "s", b"json".to_vec(), AckMode::None)
+                    .await
+            }
+        });
+        let request = rx.recv().await.expect("json request");
+        match request {
+            PublishRequest::Message {
+                message, response, ..
+            } => {
+                assert!(matches!(message, Message::Publish { .. }));
+                let _ = response.send(Ok(()));
+            }
+            _ => panic!("explicit JSON publish should use message encoding"),
+        }
+        json_publish
+            .await
+            .expect("json task")
+            .expect("json publish");
     }
 
     #[tokio::test]

--- a/crates/felix-client/src/client/subscription.rs
+++ b/crates/felix-client/src/client/subscription.rs
@@ -187,24 +187,144 @@ async fn run_subscription_dispatch_task(
         #[cfg(feature = "telemetry")]
         let decode_start = crate::t_now_if(sample);
 
-        let payloads = if queued_frame.frame.header.flags & felix_wire::FLAG_BINARY_EVENT_BATCH != 0
-        {
-            match felix_wire::binary::decode_event_batch(&queued_frame.frame)
-                .context("decode binary event batch")
-            {
-                Ok(batch) => {
-                    if batch.subscription_id != subscription_id {
-                        tracing::debug!(
-                            expected = subscription_id,
-                            got = batch.subscription_id,
-                            "subscription id mismatch in dispatch"
-                        );
+        let payloads =
+            if queued_frame.frame.header.flags & felix_wire::FLAG_BINARY_EVENT_BATCH_SHARED != 0 {
+                match felix_wire::binary::decode_shared_event_batch(&queued_frame.frame)
+                    .context("decode shared binary event batch")
+                {
+                    Ok(batch) => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters
+                                .sub_items_in_ok
+                                .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
+                        }
+                        batch.payloads
+                    }
+                    Err(err) => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.frames_in_err.fetch_add(1, Ordering::Relaxed);
+                        }
+                        log_decode_error("shared_binary_event_batch", &err, &queued_frame.frame);
+                        let _ = enqueue_event(
+                            &event_tx,
+                            QueuedEvent::Error(err.context("decode shared binary event batch")),
+                            queue_policy,
+                            queue_capacity,
+                        )
+                        .await;
+                        return;
+                    }
+                }
+            } else if queued_frame.frame.header.flags & felix_wire::FLAG_BINARY_EVENT_BATCH != 0 {
+                match felix_wire::binary::decode_event_batch(&queued_frame.frame)
+                    .context("decode binary event batch")
+                {
+                    Ok(batch) => {
+                        if batch.subscription_id != subscription_id {
+                            tracing::debug!(
+                                expected = subscription_id,
+                                got = batch.subscription_id,
+                                "subscription id mismatch in dispatch"
+                            );
+                            let _ = enqueue_event(
+                                &event_tx,
+                                QueuedEvent::Error(anyhow::anyhow!(
+                                    "subscription id mismatch: expected {} got {}",
+                                    subscription_id,
+                                    batch.subscription_id
+                                )),
+                                queue_policy,
+                                queue_capacity,
+                            )
+                            .await;
+                            return;
+                        }
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters
+                                .sub_items_in_ok
+                                .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
+                        }
+                        batch.payloads
+                    }
+                    Err(err) => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.frames_in_err.fetch_add(1, Ordering::Relaxed);
+                        }
+                        log_decode_error("binary_event_batch", &err, &queued_frame.frame);
+                        let _ = enqueue_event(
+                            &event_tx,
+                            QueuedEvent::Error(err.context("decode binary event batch")),
+                            queue_policy,
+                            queue_capacity,
+                        )
+                        .await;
+                        return;
+                    }
+                }
+            } else {
+                let message =
+                    match Message::decode(queued_frame.frame.clone()).context("decode message") {
+                        Ok(message) => message,
+                        Err(err) => {
+                            #[cfg(feature = "telemetry")]
+                            {
+                                let counters = frame_counters();
+                                counters.frames_in_err.fetch_add(1, Ordering::Relaxed);
+                            }
+                            log_decode_error("event_message", &err, &queued_frame.frame);
+                            let _ = enqueue_event(
+                                &event_tx,
+                                QueuedEvent::Error(err.context("decode message")),
+                                queue_policy,
+                                queue_capacity,
+                            )
+                            .await;
+                            return;
+                        }
+                    };
+                #[cfg(feature = "telemetry")]
+                {
+                    let counters = frame_counters();
+                    counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
+                }
+                match message {
+                    Message::Event { payload, .. } => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters.sub_items_in_ok.fetch_add(1, Ordering::Relaxed);
+                        }
+                        vec![Bytes::from(payload)]
+                    }
+                    Message::EventBatch { payloads, .. } => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
+                            counters
+                                .sub_items_in_ok
+                                .fetch_add(payloads.len() as u64, Ordering::Relaxed);
+                        }
+                        payloads.into_iter().map(Bytes::from).collect()
+                    }
+                    _ => {
                         let _ = enqueue_event(
                             &event_tx,
                             QueuedEvent::Error(anyhow::anyhow!(
-                                "subscription id mismatch: expected {} got {}",
-                                subscription_id,
-                                batch.subscription_id
+                                "unexpected message on subscription stream"
                             )),
                             queue_policy,
                             queue_capacity,
@@ -212,95 +332,8 @@ async fn run_subscription_dispatch_task(
                         .await;
                         return;
                     }
-                    #[cfg(feature = "telemetry")]
-                    {
-                        let counters = frame_counters();
-                        counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
-                        counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
-                        counters
-                            .sub_items_in_ok
-                            .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
-                    }
-                    batch.payloads
                 }
-                Err(err) => {
-                    #[cfg(feature = "telemetry")]
-                    {
-                        let counters = frame_counters();
-                        counters.frames_in_err.fetch_add(1, Ordering::Relaxed);
-                    }
-                    log_decode_error("binary_event_batch", &err, &queued_frame.frame);
-                    let _ = enqueue_event(
-                        &event_tx,
-                        QueuedEvent::Error(err.context("decode binary event batch")),
-                        queue_policy,
-                        queue_capacity,
-                    )
-                    .await;
-                    return;
-                }
-            }
-        } else {
-            let message =
-                match Message::decode(queued_frame.frame.clone()).context("decode message") {
-                    Ok(message) => message,
-                    Err(err) => {
-                        #[cfg(feature = "telemetry")]
-                        {
-                            let counters = frame_counters();
-                            counters.frames_in_err.fetch_add(1, Ordering::Relaxed);
-                        }
-                        log_decode_error("event_message", &err, &queued_frame.frame);
-                        let _ = enqueue_event(
-                            &event_tx,
-                            QueuedEvent::Error(err.context("decode message")),
-                            queue_policy,
-                            queue_capacity,
-                        )
-                        .await;
-                        return;
-                    }
-                };
-            #[cfg(feature = "telemetry")]
-            {
-                let counters = frame_counters();
-                counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
-            }
-            match message {
-                Message::Event { payload, .. } => {
-                    #[cfg(feature = "telemetry")]
-                    {
-                        let counters = frame_counters();
-                        counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
-                        counters.sub_items_in_ok.fetch_add(1, Ordering::Relaxed);
-                    }
-                    vec![Bytes::from(payload)]
-                }
-                Message::EventBatch { payloads, .. } => {
-                    #[cfg(feature = "telemetry")]
-                    {
-                        let counters = frame_counters();
-                        counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
-                        counters
-                            .sub_items_in_ok
-                            .fetch_add(payloads.len() as u64, Ordering::Relaxed);
-                    }
-                    payloads.into_iter().map(Bytes::from).collect()
-                }
-                _ => {
-                    let _ = enqueue_event(
-                        &event_tx,
-                        QueuedEvent::Error(anyhow::anyhow!(
-                            "unexpected message on subscription stream"
-                        )),
-                        queue_policy,
-                        queue_capacity,
-                    )
-                    .await;
-                    return;
-                }
-            }
-        };
+            };
 
         #[cfg(feature = "telemetry")]
         if let Some(start) = decode_start {

--- a/crates/felix-client/src/lib.rs
+++ b/crates/felix-client/src/lib.rs
@@ -62,6 +62,7 @@ D) Protocol invariants we rely on
    - Any acked publish (AckMode != None) must have a request_id.
    - Acks must match request_id (server is allowed to pipeline / reorder).
    - For subscriptions, the first frame on the uni stream must be EventStreamHello.
+   - Subsequent shared event batches are bound by that stream and carry no subscription_id.
 */
 #[macro_use]
 mod macros;

--- a/crates/felix-conformance/src/main.rs
+++ b/crates/felix-conformance/src/main.rs
@@ -21,7 +21,9 @@ use felix_broker::{Broker, CacheMetadata};
 use felix_client::{Client, ClientConfig};
 use felix_storage::EphemeralCache;
 use felix_transport::{QuicClient, QuicServer, TransportConfig};
-use felix_wire::{AckMode, FLAG_BINARY_EVENT_BATCH, Frame, FrameHeader, Message};
+use felix_wire::{
+    AckMode, FLAG_BINARY_EVENT_BATCH, FLAG_BINARY_EVENT_BATCH_SHARED, Frame, FrameHeader, Message,
+};
 use jsonwebtoken::Algorithm;
 use quinn::{ClientConfig as QuinnClientConfig, ReadExactError, RecvStream};
 use rcgen::generate_simple_self_signed;
@@ -449,6 +451,17 @@ fn handle_event_frame(
     pending: &mut VecDeque<Vec<u8>>,
     allow_hello: bool,
 ) -> Result<()> {
+    if frame.header.flags & FLAG_BINARY_EVENT_BATCH_SHARED != 0 {
+        if allow_hello {
+            return Err(anyhow!("missing event stream hello for subscription"));
+        }
+        let batch = felix_wire::binary::decode_shared_event_batch(&frame)
+            .context("decode shared binary event batch")?;
+        for payload in batch.payloads {
+            pending.push_back(payload.to_vec());
+        }
+        return Ok(());
+    }
     if frame.header.flags & FLAG_BINARY_EVENT_BATCH != 0 {
         if allow_hello {
             return Err(anyhow!("missing event stream hello for subscription"));

--- a/crates/felix-wire/src/lib.rs
+++ b/crates/felix-wire/src/lib.rs
@@ -16,6 +16,7 @@ pub const VERSION: u16 = 1;
 // Flags describe how to interpret the frame payload.
 pub const FLAG_BINARY_PUBLISH_BATCH: u16 = 0x0001;
 pub const FLAG_BINARY_EVENT_BATCH: u16 = 0x0002;
+pub const FLAG_BINARY_EVENT_BATCH_SHARED: u16 = 0x0004;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -878,6 +879,11 @@ pub mod binary {
         pub payloads: Vec<Bytes>,
     }
 
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct SharedEventBatch {
+        pub payloads: Vec<Bytes>,
+    }
+
     #[derive(Debug, Clone)]
     pub struct EncodedEventBatchParts {
         frame_len: usize,
@@ -950,6 +956,29 @@ pub mod binary {
         })
     }
 
+    pub fn encode_shared_event_batch_bytes(payloads: &[Bytes]) -> Result<Bytes> {
+        let mut payload_len = 4usize;
+        for payload in payloads {
+            let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+            payload_len = payload_len
+                .checked_add(4 + len as usize)
+                .ok_or(Error::FrameTooLarge)?;
+        }
+        if payload_len > u32::MAX as usize {
+            return Err(Error::FrameTooLarge);
+        }
+
+        let mut buf = BytesMut::with_capacity(FrameHeader::LEN + payload_len);
+        FrameHeader::new(FLAG_BINARY_EVENT_BATCH_SHARED, payload_len as u32).encode(&mut buf);
+        buf.extend_from_slice(&(payloads.len() as u32).to_be_bytes());
+        for payload in payloads {
+            let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+            buf.extend_from_slice(&len.to_be_bytes());
+            buf.extend_from_slice(payload);
+        }
+        Ok(buf.freeze())
+    }
+
     // Decode binary event batch frame into its structured form.
     pub fn decode_event_batch(frame: &Frame) -> Result<EventBatch> {
         let mut buf = frame.payload.clone();
@@ -974,6 +1003,26 @@ pub mod binary {
             subscription_id,
             payloads,
         })
+    }
+
+    pub fn decode_shared_event_batch(frame: &Frame) -> Result<SharedEventBatch> {
+        let mut buf = frame.payload.clone();
+        if buf.remaining() < 4 {
+            return Err(Error::Incomplete);
+        }
+        let count = buf.get_u32() as usize;
+        let mut payloads = Vec::with_capacity(count);
+        for _ in 0..count {
+            if buf.remaining() < 4 {
+                return Err(Error::Incomplete);
+            }
+            let len = buf.get_u32() as usize;
+            if buf.remaining() < len {
+                return Err(Error::Incomplete);
+            }
+            payloads.push(buf.copy_to_bytes(len));
+        }
+        Ok(SharedEventBatch { payloads })
     }
 }
 
@@ -1042,6 +1091,16 @@ mod tests {
         assert_eq!(frame.header.flags, FLAG_BINARY_EVENT_BATCH);
         let decoded = binary::decode_event_batch(&frame).expect("decode batch");
         assert_eq!(decoded.subscription_id, 7);
+        assert_eq!(decoded.payloads, payloads);
+    }
+
+    #[test]
+    fn shared_binary_event_batch_round_trip() {
+        let payloads = vec![Bytes::from_static(b"one"), Bytes::from_static(b"two")];
+        let encoded = binary::encode_shared_event_batch_bytes(&payloads).expect("encode");
+        let frame = Frame::decode(encoded).expect("decode");
+        assert_eq!(frame.header.flags, FLAG_BINARY_EVENT_BATCH_SHARED);
+        let decoded = binary::decode_shared_event_batch(&frame).expect("decode batch");
         assert_eq!(decoded.payloads, payloads);
     }
 

--- a/demos/broker/latency_demo.rs
+++ b/demos/broker/latency_demo.rs
@@ -1337,7 +1337,7 @@ async fn publish_batch(
         .collect::<Vec<_>>();
     if batch_size == 1 {
         publisher
-            .publish(
+            .publish_json(
                 "t1",
                 "default",
                 stream.as_str(),
@@ -1351,7 +1351,7 @@ async fn publish_batch(
             .await?;
     } else {
         publisher
-            .publish_batch(
+            .publish_batch_json(
                 "t1",
                 "default",
                 stream.as_str(),

--- a/docs-site/docs/features/benchmarks.md
+++ b/docs-site/docs/features/benchmarks.md
@@ -69,6 +69,16 @@ Sub-millisecond p999 at fanout 1; low-single-digit-ms p999 at fanout 10.
 Every row completes with `delivery drops 0`: these are sustainable rates under
 end-to-end backpressure, not burst rates measured while shedding load.
 
+### Encode-once fanout CPU efficiency
+
+An A/B run of 200 K deliveries at 1 KiB × fanout 10 showed broker/client
+user-space CPU falling from 1.43–1.61 s to 0.58–0.67 s after shared event-frame
+fanout: roughly **60% less user CPU per delivered message**. Delivered
+throughput remained within variance at 410–431 K msg/s because macOS loopback
+was dominated by UDP kernel time; the same change improved 4 KiB × fanout 10
+p99 latency from 365 ms to 221 ms. Linux GSO/GRO results should be measured
+separately before extrapolating throughput gains.
+
 ## The transport levers that matter
 
 These findings came out of profiling the QUIC path and are wired into

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -151,7 +151,7 @@ sequenceDiagram
     B-->>C: cache_value (request_id, value|null)
 ```
 
-## Binary PublishBatch (experimental)
+## Binary PublishBatch
 When `flags & 0x0001 != 0`, the frame payload is a binary publish batch:
 
 ```
@@ -167,8 +167,23 @@ repeated count times:
   u8[payload_len] payload
 ```
 
-This is a throughput optimization for the data plane and is not used by control
-plane APIs.
+This is the default encoding for unacknowledged client publishes. Acked publishes
+currently use the JSON control encoding. Clients can explicitly select JSON for
+compatibility.
+
+## Shared Binary EventBatch
+When `flags & 0x0004 != 0`, the event-stream frame payload is:
+
+```
+u32 count
+repeated count times:
+  u32 payload_len
+  u8[payload_len] payload
+```
+
+The subscription is identified by the preceding `EventStreamHello`, so event
+batches carry no per-subscriber identifier and the broker can share one encoded
+frame across subscribers. The legacy `0x0002` format remains decodable.
 
 ## Future Compatibility
 - Non-zero `flags` are reserved for compression/encryption negotiation.

--- a/services/broker/src/quic.rs
+++ b/services/broker/src/quic.rs
@@ -5,7 +5,8 @@ QUIC transport protocol overview:
 - Bidirectional streams are the control plane: clients send Publish/PublishBatch, Subscribe,
   and Cache requests, and the broker returns acks/responses on the same stream.
 - Subscribe on the control stream causes the broker to open a uni stream for event delivery;
-  that uni stream starts with EventStreamHello and then carries Event/EventBatch frames.
+  that uni stream starts with EventStreamHello and then carries subscriber-independent
+  Event/EventBatch frames.
 - Client-initiated uni streams are publish-only (no acks); they accept Publish/PublishBatch
   and are treated as fire-and-forget ingress.
 - Frames use felix-wire; high-throughput paths may carry binary batch frames to avoid JSON

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -28,7 +28,9 @@ use crate::config::BrokerConfig;
 use crate::timings;
 
 use super::GLOBAL_INGRESS_DEPTH;
-use super::handlers::publish::{PublishAdmission, PublishContext, PublishJob, decrement_depth};
+use super::handlers::publish::{
+    PublishAdmission, PublishContext, PublishJob, PublishTarget, decrement_depth,
+};
 
 use super::streams::{handle_stream, handle_uni_stream};
 
@@ -116,11 +118,25 @@ fn build_publish_context(broker: Arc<Broker>, config: &BrokerConfig) -> PublishC
                 );
                 #[cfg(feature = "perf_debug")]
                 let worker_start = std::time::Instant::now();
-                let result = broker_for_worker
-                    .publish_batch(&job.tenant_id, &job.namespace, &job.stream, &job.payloads)
-                    .await
-                    .map(|_| ())
-                    .map_err(Into::into);
+                let result = match &job.target {
+                    PublishTarget::Resolved(handle) => {
+                        broker_for_worker
+                            .publish_batch_to_handle(handle, &job.payloads)
+                            .await
+                    }
+                    #[cfg(test)]
+                    PublishTarget::Named {
+                        tenant_id,
+                        namespace,
+                        stream,
+                    } => {
+                        broker_for_worker
+                            .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                            .await
+                    }
+                }
+                .map(|_| ())
+                .map_err(Into::into);
                 #[cfg(feature = "perf_debug")]
                 {
                     let ns = worker_start.elapsed().as_nanos() as u64;
@@ -269,9 +285,11 @@ mod tests {
         let (response_tx, response_rx) = oneshot::channel();
         publish_ctx.workers[0]
             .send(PublishJob {
-                tenant_id: "t1".to_string(),
-                namespace: "default".to_string(),
-                stream: "demo".to_string(),
+                target: PublishTarget::Named {
+                    tenant_id: "t1".to_string(),
+                    namespace: "default".to_string(),
+                    stream: "demo".to_string(),
+                },
                 payloads: vec![Bytes::from_static(b"ok")],
                 response: Some(response_tx),
                 admission_permit: None,
@@ -293,9 +311,11 @@ mod tests {
         let (response_tx, response_rx) = oneshot::channel();
         publish_ctx.workers[0]
             .send(PublishJob {
-                tenant_id: "t1".to_string(),
-                namespace: "default".to_string(),
-                stream: "missing".to_string(),
+                target: PublishTarget::Named {
+                    tenant_id: "t1".to_string(),
+                    namespace: "default".to_string(),
+                    stream: "missing".to_string(),
+                },
                 payloads: vec![Bytes::from_static(b"payload")],
                 response: Some(response_tx),
                 admission_permit: None,

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -26,10 +26,12 @@
 use anyhow::{Context, Result, anyhow};
 use bytes::Bytes;
 use felix_authz::{Action, Namespace, StreamName, TenantId, stream_resource};
-use felix_broker::Broker;
+use felix_broker::{Broker, StreamHandle};
 use felix_wire::{Frame, Message};
 use std::collections::HashMap;
+#[cfg(test)]
 use std::collections::hash_map::DefaultHasher;
+#[cfg(test)]
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -46,24 +48,34 @@ use crate::transport::quic::{
     GLOBAL_INGRESS_DEPTH, STREAM_CACHE_TTL,
 };
 
+pub(crate) type StreamHandleCache = HashMap<String, (Option<StreamHandle>, Instant)>;
+
 /// Work item consumed by publish workers.
 ///
 /// A publish job is the unit the broker’s ingress pipeline processes:
-/// - It identifies the target stream (`tenant_id`, `namespace`, `stream`).
+/// - It identifies the target stream with a resolved handle.
 /// - It carries one or more payloads (single publish or batch).
 /// - `response` is **only** used when the publish was received on the control stream and the
 ///   client requested an ack in commit-ack mode (`ack_on_commit = true`).
 ///
 /// For uni-stream publishes and enqueue-ack mode, `response` is `None`.
 pub(crate) struct PublishJob {
-    pub(crate) tenant_id: String,
-    pub(crate) namespace: String,
-    pub(crate) stream: String,
+    pub(crate) target: PublishTarget,
     pub(crate) payloads: Vec<Bytes>,
     pub(crate) response: Option<oneshot::Sender<Result<()>>>,
     /// Held from `enqueue_publish` admission until this job finishes processing (or is dropped
     /// without ever being enqueued). See [`PublishAdmission`].
     pub(crate) admission_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+}
+
+pub(crate) enum PublishTarget {
+    Resolved(StreamHandle),
+    #[cfg(test)]
+    Named {
+        tenant_id: String,
+        namespace: String,
+        stream: String,
+    },
 }
 
 /// Bounds total bytes queued-or-processing across all publish workers, independent of the
@@ -266,6 +278,7 @@ impl AckTimeoutState {
 ///
 /// This *must* be stable across processes for predictable performance; it does not need to be
 /// cryptographically secure.
+#[cfg(test)]
 pub(crate) fn publish_worker_index(
     tenant_id: &str,
     namespace: &str,
@@ -298,12 +311,15 @@ pub(crate) async fn enqueue_publish(
     mut job: PublishJob,
     policy: EnqueuePolicy,
 ) -> Result<bool> {
-    let worker_index = publish_worker_index(
-        &job.tenant_id,
-        &job.namespace,
-        &job.stream,
-        publish_ctx.worker_count,
-    );
+    let worker_index = match &job.target {
+        PublishTarget::Resolved(handle) => handle.id() as usize % publish_ctx.worker_count.max(1),
+        #[cfg(test)]
+        PublishTarget::Named {
+            tenant_id,
+            namespace,
+            stream,
+        } => publish_worker_index(tenant_id, namespace, stream, publish_ctx.worker_count),
+    };
     let worker = publish_ctx
         .workers
         .get(worker_index)
@@ -512,9 +528,11 @@ mod tests {
 
     fn make_job() -> PublishJob {
         PublishJob {
-            tenant_id: "tenant".to_string(),
-            namespace: "ns".to_string(),
-            stream: "stream".to_string(),
+            target: PublishTarget::Named {
+                tenant_id: "tenant".to_string(),
+                namespace: "ns".to_string(),
+                stream: "stream".to_string(),
+            },
             payloads: vec![Bytes::from_static(b"payload")],
             response: None,
             admission_permit: None,
@@ -2096,14 +2114,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stream_exists_cached_uses_cached_entry_until_cleared() {
+    async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         let broker = Broker::new(EphemeralCache::new().into());
         let mut cache = HashMap::new();
         let mut key = String::new();
 
-        let exists =
-            stream_exists_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
-        assert!(!exists, "no tenant/namespace yet");
+        let handle =
+            resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+        assert!(handle.is_none(), "no tenant/namespace yet");
 
         broker.register_tenant("t1").await.expect("tenant");
         broker
@@ -2121,16 +2139,16 @@ mod tests {
             .expect("stream");
 
         let cached =
-            stream_exists_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+            resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
         assert!(
-            !cached,
+            cached.is_none(),
             "cached miss should be returned until cache expires or clears"
         );
 
         cache.clear();
         let refreshed =
-            stream_exists_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
-        assert!(refreshed, "cache refresh should see stream");
+            resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+        assert!(refreshed.is_some(), "cache refresh should see stream");
     }
 
     #[tokio::test]
@@ -2973,7 +2991,7 @@ pub(crate) async fn handle_ack_enqueue_result(
 
 pub(crate) async fn handle_binary_publish_batch_control(
     broker: &Broker,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     publish_ctx: &PublishContext,
     frame: &Frame,
@@ -3023,7 +3041,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
         timings::record_decode_ns(decode_ns);
         t_histogram!("felix_broker_decode_ns").record(decode_ns as f64);
     }
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3032,10 +3050,10 @@ pub(crate) async fn handle_binary_publish_batch_control(
         &batch.stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(());
-    }
+    };
     let span = tracing::info_span!(
         "publish_batch_binary",
         tenant_id = %batch.tenant_id,
@@ -3053,9 +3071,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id: batch.tenant_id,
-            namespace: batch.namespace,
-            stream: batch.stream,
+            target: PublishTarget::Resolved(stream_handle),
             payloads,
             response: None,
             admission_permit: None,
@@ -3088,7 +3104,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
 pub(crate) async fn handle_publish_message(
     broker: &Broker,
     publish_ctx: &PublishContext,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     throttled: bool,
     ack_on_commit: bool,
@@ -3209,7 +3225,7 @@ pub(crate) async fn handle_publish_message(
     } else {
         (None, None)
     };
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3218,7 +3234,7 @@ pub(crate) async fn handle_publish_message(
         &stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         if ack_mode != felix_wire::AckMode::None {
             let request_id = request_id.expect("request id checked");
@@ -3243,13 +3259,11 @@ pub(crate) async fn handle_publish_message(
             .await?;
         }
         return Ok(());
-    }
+    };
     let enqueue_result = enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id: tenant_id.clone(),
-            namespace: namespace.clone(),
-            stream: stream.clone(),
+            target: PublishTarget::Resolved(stream_handle),
             payloads: vec![Bytes::from(payload)],
             response: response_tx,
             admission_permit: None,
@@ -3444,7 +3458,7 @@ pub(crate) async fn handle_publish_message(
 pub(crate) async fn handle_publish_batch_message(
     broker: &Broker,
     publish_ctx: &PublishContext,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     throttled: bool,
     ack_on_commit: bool,
@@ -3563,7 +3577,7 @@ pub(crate) async fn handle_publish_batch_message(
         .await?;
         return Ok(());
     }
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3572,7 +3586,7 @@ pub(crate) async fn handle_publish_batch_message(
         &stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         if ack_mode != felix_wire::AckMode::None {
             let request_id = request_id.expect("request id checked");
@@ -3597,7 +3611,7 @@ pub(crate) async fn handle_publish_batch_message(
             .await?;
         }
         return Ok(());
-    }
+    };
     let payload_bytes = payloads
         .iter()
         .map(|payload| payload.len())
@@ -3613,9 +3627,7 @@ pub(crate) async fn handle_publish_batch_message(
     let enqueue_result = enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id: tenant_id.clone(),
-            namespace: namespace.clone(),
-            stream: stream.clone(),
+            target: PublishTarget::Resolved(stream_handle),
             payloads,
             response: response_tx,
             admission_permit: None,
@@ -3796,7 +3808,7 @@ pub(crate) async fn handle_publish_batch_message(
 
 pub(crate) async fn handle_binary_publish_batch_uni(
     broker: &Broker,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     publish_ctx: &PublishContext,
     frame: &Frame,
@@ -3842,7 +3854,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
             .pub_items_in_ok
             .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
     }
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3851,10 +3863,10 @@ pub(crate) async fn handle_binary_publish_batch_uni(
         &batch.stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
-    }
+    };
     let payloads = batch
         .payloads
         .into_iter()
@@ -3863,9 +3875,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
     match enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id: batch.tenant_id,
-            namespace: batch.namespace,
-            stream: batch.stream,
+            target: PublishTarget::Resolved(stream_handle),
             payloads,
             response: None,
             admission_permit: None,
@@ -3891,7 +3901,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_publish_message_uni(
     broker: &Broker,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     publish_ctx: &PublishContext,
     tenant_id: String,
@@ -3906,7 +3916,7 @@ pub(crate) async fn handle_publish_message_uni(
         counters.pub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
         counters.pub_items_in_ok.fetch_add(1, Ordering::Relaxed);
     }
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3915,17 +3925,15 @@ pub(crate) async fn handle_publish_message_uni(
         &stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
-    }
+    };
 
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id,
-            namespace,
-            stream,
+            target: PublishTarget::Resolved(stream_handle),
             payloads: vec![Bytes::from(payload)],
             response: None,
             admission_permit: None,
@@ -3952,7 +3960,7 @@ pub(crate) async fn handle_publish_message_uni(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_publish_batch_message_uni(
     broker: &Broker,
-    stream_cache: &mut HashMap<String, (bool, Instant)>,
+    stream_cache: &mut StreamHandleCache,
     stream_cache_key: &mut String,
     publish_ctx: &PublishContext,
     tenant_id: String,
@@ -3969,7 +3977,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
             .pub_items_in_ok
             .fetch_add(payloads.len() as u64, Ordering::Relaxed);
     }
-    if !stream_exists_cached(
+    let Some(stream_handle) = resolve_stream_cached(
         broker,
         stream_cache,
         stream_cache_key,
@@ -3978,18 +3986,16 @@ pub(crate) async fn handle_publish_batch_message_uni(
         &stream,
     )
     .await
-    {
+    else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
-    }
+    };
     let payloads = payloads.into_iter().map(Bytes::from).collect::<Vec<_>>();
 
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            tenant_id,
-            namespace,
-            stream,
+            target: PublishTarget::Resolved(stream_handle),
             payloads,
             response: None,
             admission_permit: None,
@@ -4013,14 +4019,14 @@ pub(crate) async fn handle_publish_batch_message_uni(
     Ok(true)
 }
 
-pub(crate) async fn stream_exists_cached(
+pub(crate) async fn resolve_stream_cached(
     broker: &Broker,
-    cache: &mut HashMap<String, (bool, Instant)>,
+    cache: &mut StreamHandleCache,
     key_scratch: &mut String,
     tenant_id: &str,
     namespace: &str,
     stream: &str,
-) -> bool {
+) -> Option<StreamHandle> {
     // Short-lived cache to avoid repeated stream lookups on hot paths.
     key_scratch.clear();
     let needed = tenant_id.len() + namespace.len() + stream.len() + 2;
@@ -4032,15 +4038,19 @@ pub(crate) async fn stream_exists_cached(
     key_scratch.push_str(namespace);
     key_scratch.push('\0');
     key_scratch.push_str(stream);
-    if let Some((exists, expires)) = cache.get(key_scratch.as_str())
+    if let Some((handle, expires)) = cache.get(key_scratch.as_str())
         && *expires > Instant::now()
+        && handle.as_ref().is_none_or(StreamHandle::is_active)
     {
-        return *exists;
+        return handle.clone();
     }
-    let exists = broker.stream_exists(tenant_id, namespace, stream).await;
+    let handle = broker
+        .resolve_stream_handle(tenant_id, namespace, stream)
+        .await
+        .ok();
     cache.insert(
         key_scratch.clone(),
-        (exists, Instant::now() + STREAM_CACHE_TTL),
+        (handle.clone(), Instant::now() + STREAM_CACHE_TTL),
     );
-    exists
+    handle
 }

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -10,12 +10,12 @@
 //! - Sending `Message::Subscribed` back on the control stream as the acknowledgement.
 //! - Opening a uni stream and sending a `Message::EventStreamHello` so the client can bind
 //!   `subscription_id -> stream`.
-//! - Handing the broker-provided subscriber queue directly to the writer task.
+//! - Handing the broker-provided shared batch queue directly to the writer task.
 //! - Running lane-sharded event writers that preserve per-subscriber ordering.
 //!
 //! ## Buffering and drops
 //! The broker core owns bounded per-subscriber queues and uses `try_send` for fanout:
-//! - If a subscriber queue is full, that event is **dropped** and
+//! - If a subscriber queue is full, that delivery batch is **dropped** and
 //!   `felix_subscribe_dropped_total` is incremented in the broker.
 //! - This keeps backpressure localized to the subscriber rather than stalling publish.
 //!
@@ -29,7 +29,9 @@
 //!   falls back to subscriber-id hashing.
 //!
 //! ## Encoding / batching
-//! Events are framed as binary `EventBatch` using `felix-wire` binary framing.
+//! Multi-event publishes are encoded once as subscriber-independent binary `EventBatch` frames.
+//! `EventStreamHello` provides the subscription binding, so the same frame bytes can be shared
+//! across every subscriber.
 //!
 //! In batch mode, we coalesce by whichever triggers first:
 //! - max events (`max_events`)
@@ -47,7 +49,7 @@
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use dashmap::DashMap;
-use felix_broker::{Broker, SubscriptionReceiver};
+use felix_broker::{Broker, DeliveryEnvelope, SubscriptionReceiver};
 use felix_wire::Message;
 use futures::{StreamExt, stream::FuturesUnordered};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -342,13 +344,11 @@ where
     Ok(())
 }
 
+#[cfg(test)]
 async fn write_parts(
     send: &mut quinn::SendStream,
     parts: felix_wire::binary::EncodedEventBatchParts,
 ) -> Result<()> {
-    // Perf note (measured with `latency-demo` + telemetry, 4096B payload, fanout=10):
-    // publish-side fanout/enqueue is small, while subscriber write-await dominates the
-    // broker hot path. Use a single `write_all_chunks` call per flush to cut await points.
     let mut segments = parts.into_segments();
     send.write_all_chunks(segments.as_mut_slice())
         .await
@@ -356,6 +356,7 @@ async fn write_parts(
     Ok(())
 }
 
+#[cfg(test)]
 async fn write_parts_many(
     send: &mut quinn::SendStream,
     frames: Vec<felix_wire::binary::EncodedEventBatchParts>,
@@ -369,6 +370,21 @@ async fn write_parts_many(
     send.write_all_chunks(segments.as_mut_slice())
         .await
         .context("write subscription coalesced frame chunks")?;
+    Ok(total)
+}
+
+async fn write_frame(send: &mut quinn::SendStream, frame: Bytes) -> Result<()> {
+    send.write_all(frame.as_ref())
+        .await
+        .context("write subscription frame")?;
+    Ok(())
+}
+
+async fn write_frames_many(send: &mut quinn::SendStream, mut frames: Vec<Bytes>) -> Result<usize> {
+    let total = frames.iter().map(Bytes::len).sum();
+    send.write_all_chunks(frames.as_mut_slice())
+        .await
+        .context("write subscription coalesced frames")?;
     Ok(total)
 }
 
@@ -392,7 +408,7 @@ enum ConnectionCommand {
     },
     Delivery {
         subscriber_id: u64,
-        frame_parts: felix_wire::binary::EncodedEventBatchParts,
+        frame: Bytes,
         item_count: usize,
         first_enqueued_at: Instant,
         enqueue_at: Instant,
@@ -413,7 +429,7 @@ enum LaneCommand {
     },
     Delivery {
         subscriber_id: u64,
-        frame_parts: felix_wire::binary::EncodedEventBatchParts,
+        frame: Bytes,
         item_count: usize,
         first_enqueued_at: Instant,
         enqueue_at: Instant,
@@ -448,7 +464,7 @@ struct LaneRuntimeConfig {
 #[derive(Debug)]
 struct LaneDelivery {
     subscriber_id: u64,
-    frame_parts: felix_wire::binary::EncodedEventBatchParts,
+    frame: Bytes,
     item_count: usize,
     first_enqueued_at: Instant,
     enqueue_at: Instant,
@@ -774,7 +790,7 @@ async fn run_writer_lane(
                 }
                 LaneCommand::Delivery {
                     subscriber_id,
-                    frame_parts,
+                    frame,
                     item_count,
                     first_enqueued_at,
                     enqueue_at,
@@ -791,7 +807,7 @@ async fn run_writer_lane(
                             connection_id,
                             ConnectionCommand::Delivery {
                                 subscriber_id,
-                                frame_parts,
+                                frame,
                                 item_count,
                                 first_enqueued_at,
                                 enqueue_at,
@@ -854,7 +870,7 @@ async fn run_connection_writer(
                 }
                 ConnectionCommand::Delivery {
                     subscriber_id,
-                    frame_parts,
+                    frame,
                     item_count,
                     first_enqueued_at,
                     enqueue_at,
@@ -864,7 +880,7 @@ async fn run_connection_writer(
                         .or_default()
                         .push_back(LaneDelivery {
                             subscriber_id,
-                            frame_parts,
+                            frame,
                             item_count,
                             first_enqueued_at,
                             enqueue_at,
@@ -900,19 +916,18 @@ async fn run_connection_writer(
                 };
 
                 let first_subscriber_id = first.subscriber_id;
-                let mut frames = vec![first.frame_parts];
+                let mut frames = vec![first.frame];
                 let mut item_count = first.item_count;
-                let mut coalesced_bytes = frames[0].frame_len();
+                let mut coalesced_bytes = frames[0].len();
                 while let Some(next) = queue.front() {
-                    let next_len = next.frame_parts.frame_len();
+                    let next_len = next.frame.len();
                     if coalesced_bytes.saturating_add(next_len) > max_bytes_per_write {
                         break;
                     }
                     if let Some(next_frame) = queue.pop_front() {
                         item_count = item_count.saturating_add(next_frame.item_count);
-                        coalesced_bytes =
-                            coalesced_bytes.saturating_add(next_frame.frame_parts.frame_len());
-                        frames.push(next_frame.frame_parts);
+                        coalesced_bytes = coalesced_bytes.saturating_add(next_frame.frame.len());
+                        frames.push(next_frame.frame);
                     }
                 }
 
@@ -940,14 +955,14 @@ async fn run_connection_writer(
                 in_flight.insert(subscriber_id);
                 writes.push(async move {
                     let write_result = if frames.len() == 1 {
-                        write_parts(
+                        write_frame(
                             &mut subscriber.event_send,
                             frames.pop().expect("single frame"),
                         )
                         .await
                         .map(|_| coalesced_bytes)
                     } else {
-                        write_parts_many(&mut subscriber.event_send, frames).await
+                        write_frames_many(&mut subscriber.event_send, frames).await
                     };
                     let write_ns = write_start.map(|start| start.elapsed().as_nanos() as u64);
                     (
@@ -1128,19 +1143,87 @@ async fn run_lane_feeder(
         config.flush_max_delay,
         config.max_bytes_per_write,
     );
-    let mut pending: Option<(Bytes, Instant)> = None;
+    let mut pending: Option<DeliveryEnvelope> = None;
 
     loop {
-        let (first, first_enqueued_at) = match pending.take() {
-            Some((payload, enqueued_at)) => (payload, enqueued_at),
+        let envelope = match pending.take() {
+            Some(envelope) => envelope,
             None => match event_rx.recv().await {
-                Some(envelope) => {
-                    let enqueued_at = envelope.enqueued_at();
-                    (envelope.into_payload(), enqueued_at)
-                }
+                Some(envelope) => envelope,
                 None => break,
             },
         };
+        let first_enqueued_at = envelope.enqueued_at();
+
+        if envelope.len() > 1 || config.single_event_mode {
+            let payloads = envelope.payloads();
+            let payload_bytes: usize = payloads.iter().map(Bytes::len).sum();
+            if payloads.len() <= max_events && payload_bytes <= max_bytes {
+                let prefix_start = t_now_if(t_should_sample());
+                let frame = match envelope.shared_event_frame() {
+                    Ok(frame) => frame,
+                    Err(err) => {
+                        tracing::warn!(
+                            error = %err,
+                            subscriber_id = config.subscription_id,
+                            "encode shared lane delivery failed"
+                        );
+                        continue;
+                    }
+                };
+                if let Some(start) = prefix_start {
+                    let prefix_ns = start.elapsed().as_nanos() as u64;
+                    timings::record_sub_prefix_ns(prefix_ns);
+                    t_histogram!("felix_broker_sub_prefix_build_ns").record(prefix_ns as f64);
+                }
+                enqueue_lane_frame(
+                    &manager,
+                    lane_idx,
+                    config.subscription_id,
+                    frame,
+                    payloads.len(),
+                    first_enqueued_at,
+                )
+                .await;
+                continue;
+            }
+
+            let mut start = 0usize;
+            while start < payloads.len() {
+                let mut end = start;
+                let mut bytes = 0usize;
+                while end < payloads.len()
+                    && end - start < max_events
+                    && (end == start || bytes.saturating_add(payloads[end].len()) <= max_bytes)
+                {
+                    bytes = bytes.saturating_add(payloads[end].len());
+                    end += 1;
+                }
+                let batch = &payloads[start..end];
+                match felix_wire::binary::encode_shared_event_batch_bytes(batch) {
+                    Ok(frame) => {
+                        enqueue_lane_frame(
+                            &manager,
+                            lane_idx,
+                            config.subscription_id,
+                            frame,
+                            batch.len(),
+                            first_enqueued_at,
+                        )
+                        .await;
+                    }
+                    Err(err) => tracing::warn!(
+                        error = %err,
+                        subscriber_id = config.subscription_id,
+                        "encode split lane delivery failed"
+                    ),
+                }
+                start = end;
+            }
+            continue;
+        }
+
+        let first = envelope.payloads()[0].clone();
 
         let mut batch = Vec::with_capacity(max_events);
         let mut batch_bytes = first.len();
@@ -1151,18 +1234,20 @@ async fn run_lane_feeder(
                 None
             } else {
                 match tokio::time::timeout(config.flush_delay, event_rx.recv()).await {
-                    Ok(Some(envelope)) => {
-                        let enqueued_at = envelope.enqueued_at();
-                        Some((envelope.into_payload(), enqueued_at))
-                    }
+                    Ok(Some(envelope)) => Some(envelope),
                     Ok(None) | Err(_) => None,
                 }
             };
-            let Some((payload, enqueued_at)) = next else {
+            let Some(envelope) = next else {
                 break;
             };
+            if envelope.len() != 1 {
+                pending = Some(envelope);
+                break;
+            }
+            let payload = envelope.payloads()[0].clone();
             if batch_bytes.saturating_add(payload.len()) > max_bytes {
-                pending = Some((payload, enqueued_at));
+                pending = Some(envelope);
                 break;
             }
             batch_bytes += payload.len();
@@ -1172,34 +1257,33 @@ async fn run_lane_feeder(
         let sample = t_should_sample();
         let enqueue_start = t_now_if(sample);
         let prefix_start = t_now_if(sample);
-        let parts =
-            match felix_wire::binary::encode_event_batch_parts(config.subscription_id, &batch) {
-                Ok(parts) => parts,
-                Err(err) => {
-                    tracing::warn!(
-                        error = %err,
-                        subscriber_id = config.subscription_id,
-                        "encode lane delivery failed"
-                    );
-                    continue;
-                }
-            };
+        let frame = match felix_wire::binary::encode_shared_event_batch_bytes(&batch) {
+            Ok(frame) => frame,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    subscriber_id = config.subscription_id,
+                    "encode lane delivery failed"
+                );
+                continue;
+            }
+        };
         if let Some(start) = prefix_start {
             let prefix_ns = start.elapsed().as_nanos() as u64;
             timings::record_sub_prefix_ns(prefix_ns);
             t_histogram!("felix_broker_sub_prefix_build_ns").record(prefix_ns as f64);
         }
 
-        let cmd = LaneCommand::Delivery {
-            subscriber_id: config.subscription_id,
-            frame_parts: parts,
-            item_count: batch.len(),
+        enqueue_lane_frame(
+            &manager,
+            lane_idx,
+            config.subscription_id,
+            frame,
+            batch.len(),
             first_enqueued_at,
-            enqueue_at: Instant::now(),
-        };
-        if manager.enqueue(lane_idx, cmd).await.is_err() {
-            metrics::counter!("felix_subscriber_lane_dropped_total").increment(1);
-        } else if let Some(start) = enqueue_start {
+        )
+        .await;
+        if let Some(start) = enqueue_start {
             let enqueue_ns = start.elapsed().as_nanos() as u64;
             t_histogram!("broker_sub_lane_enqueue_ns", "lane" => lane_idx.to_string())
                 .record(enqueue_ns as f64);
@@ -1214,6 +1298,26 @@ async fn run_lane_feeder(
         )
         .await;
     manager.unregister_subscriber(config.subscription_id, connection_id);
+}
+
+async fn enqueue_lane_frame(
+    manager: &WriterLaneManager,
+    lane_idx: usize,
+    subscriber_id: u64,
+    frame: Bytes,
+    item_count: usize,
+    first_enqueued_at: Instant,
+) {
+    let cmd = LaneCommand::Delivery {
+        subscriber_id,
+        frame,
+        item_count,
+        first_enqueued_at,
+        enqueue_at: Instant::now(),
+    };
+    if manager.enqueue(lane_idx, cmd).await.is_err() {
+        metrics::counter!("felix_subscriber_lane_dropped_total").increment(1);
+    }
 }
 
 /// Drain subscriber events from an `mpsc` queue and write them onto a uni QUIC stream.
@@ -1635,6 +1739,13 @@ mod tests {
         Bytes::from(payload.to_vec())
     }
 
+    fn decode_delivery_payloads(frame: &felix_wire::Frame) -> Result<Vec<Bytes>> {
+        if frame.header.flags & felix_wire::FLAG_BINARY_EVENT_BATCH_SHARED != 0 {
+            return Ok(felix_wire::binary::decode_shared_event_batch(frame)?.payloads);
+        }
+        Ok(felix_wire::binary::decode_event_batch(frame)?.payloads)
+    }
+
     async fn spawn_event_writer(
         rx: mpsc::Receiver<Bytes>,
         config: EventWriterConfig,
@@ -1947,10 +2058,9 @@ mod tests {
         )
         .await?
         .expect("event frame");
-        let batch = felix_wire::binary::decode_event_batch(&frame).context("decode batch")?;
-        assert_eq!(batch.subscription_id, 7);
-        assert_eq!(batch.payloads.len(), 1);
-        assert_eq!(batch.payloads[0].as_ref(), b"hello");
+        let payloads = decode_delivery_payloads(&frame).context("decode batch")?;
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(payloads[0].as_ref(), b"hello");
 
         let _ = felix_broker::timings::take_samples();
         let handled = server_task.await.context("server join")??;
@@ -2110,11 +2220,10 @@ mod tests {
         )
         .await?
         .expect("frame1");
-        let batch1 = felix_wire::binary::decode_event_batch(&frame1).expect("batch1");
-        assert_eq!(batch1.subscription_id, 21);
-        assert_eq!(batch1.payloads.len(), 2);
-        assert_eq!(batch1.payloads[0].as_ref(), b"aa");
-        assert_eq!(batch1.payloads[1].as_ref(), b"bbbb");
+        let payloads1 = decode_delivery_payloads(&frame1).expect("batch1");
+        assert_eq!(payloads1.len(), 2);
+        assert_eq!(payloads1[0].as_ref(), b"aa");
+        assert_eq!(payloads1[1].as_ref(), b"bbbb");
 
         let frame2 = crate::transport::quic::codec::read_frame_limited_into(
             &mut event_recv,
@@ -2123,10 +2232,9 @@ mod tests {
         )
         .await?
         .expect("frame2");
-        let batch2 = felix_wire::binary::decode_event_batch(&frame2).expect("batch2");
-        assert_eq!(batch2.subscription_id, 21);
-        assert_eq!(batch2.payloads.len(), 1);
-        assert_eq!(batch2.payloads[0].as_ref(), b"ccccc");
+        let payloads2 = decode_delivery_payloads(&frame2).expect("batch2");
+        assert_eq!(payloads2.len(), 1);
+        assert_eq!(payloads2[0].as_ref(), b"ccccc");
 
         let _ = felix_broker::timings::take_samples();
         server_task.await.context("server join")??;
@@ -2264,8 +2372,8 @@ mod tests {
             )
             .await?
             .expect("event frame 1");
-            let batch = felix_wire::binary::decode_event_batch(&frame).context("decode batch 1")?;
-            recv_1.push(batch.payloads[0].to_vec());
+            let payloads = decode_delivery_payloads(&frame).context("decode batch 1")?;
+            recv_1.push(payloads[0].to_vec());
 
             let frame = crate::transport::quic::codec::read_frame_limited_into(
                 &mut event_recv_2,
@@ -2274,8 +2382,8 @@ mod tests {
             )
             .await?
             .expect("event frame 2");
-            let batch = felix_wire::binary::decode_event_batch(&frame).context("decode batch 2")?;
-            recv_2.push(batch.payloads[0].to_vec());
+            let payloads = decode_delivery_payloads(&frame).context("decode batch 2")?;
+            recv_2.push(payloads[0].to_vec());
         }
 
         assert_eq!(recv_1, expected);
@@ -2425,8 +2533,8 @@ mod tests {
         )
         .await?
         .expect("event frame");
-        let batch = felix_wire::binary::decode_event_batch(&frame).context("decode batch")?;
-        assert_eq!(batch.payloads[0].as_ref(), b"ok");
+        let payloads = decode_delivery_payloads(&frame).context("decode batch")?;
+        assert_eq!(payloads[0].as_ref(), b"ok");
 
         let _ = felix_broker::timings::take_samples();
         server_task.await.context("server join")??;
@@ -2791,13 +2899,13 @@ mod tests {
         .await
         .context("register")?;
 
-        let frame_a = felix_wire::binary::encode_event_batch_parts(1, &[Bytes::from_static(b"a")])?;
+        let frame_a = felix_wire::binary::encode_event_batch_bytes(1, &[Bytes::from_static(b"a")])?;
         let frame_b =
-            felix_wire::binary::encode_event_batch_parts(1, &[Bytes::from_static(b"bb")])?;
+            felix_wire::binary::encode_event_batch_bytes(1, &[Bytes::from_static(b"bb")])?;
         let now = Instant::now();
         tx.send(ConnectionCommand::Delivery {
             subscriber_id: 1,
-            frame_parts: frame_a,
+            frame: frame_a,
             item_count: 1,
             first_enqueued_at: now,
             enqueue_at: now,
@@ -2806,7 +2914,7 @@ mod tests {
         .context("delivery a")?;
         tx.send(ConnectionCommand::Delivery {
             subscriber_id: 1,
-            frame_parts: frame_b,
+            frame: frame_b,
             item_count: 1,
             first_enqueued_at: now,
             enqueue_at: now,
@@ -2887,11 +2995,11 @@ mod tests {
         .await
         .context("register")?;
 
-        let frame = felix_wire::binary::encode_event_batch_parts(1, &[Bytes::from_static(b"a")])?;
+        let frame = felix_wire::binary::encode_event_batch_bytes(1, &[Bytes::from_static(b"a")])?;
         let now = Instant::now();
         tx.send(ConnectionCommand::Delivery {
             subscriber_id: 1,
-            frame_parts: frame,
+            frame,
             item_count: 1,
             first_enqueued_at: now,
             enqueue_at: now,
@@ -2949,10 +3057,10 @@ mod tests {
         .context("register")?;
 
         let now = Instant::now();
-        let frame = felix_wire::binary::encode_event_batch_parts(1, &[Bytes::from_static(b"a")])?;
+        let frame = felix_wire::binary::encode_event_batch_bytes(1, &[Bytes::from_static(b"a")])?;
         tx.send(ConnectionCommand::Delivery {
             subscriber_id: 1,
-            frame_parts: frame,
+            frame,
             item_count: 1,
             first_enqueued_at: now,
             enqueue_at: now,
@@ -2978,10 +3086,10 @@ mod tests {
             .await
             .context("unregister")?;
 
-        let late = felix_wire::binary::encode_event_batch_parts(1, &[Bytes::from_static(b"late")])?;
+        let late = felix_wire::binary::encode_event_batch_bytes(1, &[Bytes::from_static(b"late")])?;
         tx.send(ConnectionCommand::Delivery {
             subscriber_id: 1,
-            frame_parts: late,
+            frame: late,
             item_count: 1,
             first_enqueued_at: now,
             enqueue_at: now,

--- a/services/broker/src/transport/quic/streams/control.rs
+++ b/services/broker/src/transport/quic/streams/control.rs
@@ -38,12 +38,11 @@ use felix_authz::{
 };
 use felix_broker::Broker;
 use felix_wire::Message;
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 #[cfg(feature = "telemetry")]
 use std::sync::atomic::Ordering;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::sync::{Mutex, Semaphore, mpsc, watch};
 
 use crate::auth::{AuthContext, BrokerAuth};
@@ -51,9 +50,9 @@ use crate::config::BrokerConfig;
 use crate::timings;
 use crate::transport::quic::errors::{AckEnqueueError, record_ack_enqueue_failure};
 use crate::transport::quic::handlers::publish::{
-    AckTimeoutState, AckWaiterMessage, Outgoing, PublishContext, handle_ack_enqueue_result,
-    handle_binary_publish_batch_control, handle_publish_batch_message, handle_publish_message,
-    send_outgoing_best_effort, send_outgoing_critical,
+    AckTimeoutState, AckWaiterMessage, Outgoing, PublishContext, StreamHandleCache,
+    handle_ack_enqueue_result, handle_binary_publish_batch_control, handle_publish_batch_message,
+    handle_publish_message, send_outgoing_best_effort, send_outgoing_critical,
 };
 use crate::transport::quic::handlers::subscribe::handle_subscribe_message;
 use crate::transport::quic::telemetry::{t_histogram, t_now_if, t_should_sample};
@@ -82,7 +81,7 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
     config: BrokerConfig,
     auth: Arc<BrokerAuth>,
     publish_ctx: PublishContext,
-    mut stream_cache: HashMap<String, (bool, Instant)>,
+    mut stream_cache: StreamHandleCache,
     mut stream_cache_key: String,
     out_ack_tx: mpsc::Sender<Outgoing>,
     out_ack_depth: Arc<AtomicUsize>,

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -56,6 +56,7 @@ use crate::config::BrokerConfig;
 use crate::timings;
 use crate::transport::quic::handlers::publish::{
     AckTimeoutState, AckWaiterMessage, Outgoing, PublishAdmission, PublishContext, PublishJob,
+    PublishTarget,
 };
 use crate::transport::quic::telemetry;
 use crate::transport::quic::{ACK_HI_WATER, ACK_LO_WATER};
@@ -519,16 +520,22 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
     let (tx, mut rx) = mpsc::channel::<PublishJob>(8);
     tokio::spawn(async move {
         while let Some(job) = rx.recv().await {
-            let result = broker
-                .publish_batch(
-                    job.tenant_id.as_str(),
-                    job.namespace.as_str(),
-                    job.stream.as_str(),
-                    &job.payloads,
-                )
-                .await
-                .map(|_| ())
-                .map_err(anyhow::Error::from);
+            let result = match &job.target {
+                PublishTarget::Resolved(handle) => {
+                    broker.publish_batch_to_handle(handle, &job.payloads).await
+                }
+                PublishTarget::Named {
+                    tenant_id,
+                    namespace,
+                    stream,
+                } => {
+                    broker
+                        .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                        .await
+                }
+            }
+            .map(|_| ())
+            .map_err(anyhow::Error::from);
             if let Some(response) = job.response {
                 let _ = response.send(result);
             }

--- a/services/broker/src/transport/quic/streams/uni.rs
+++ b/services/broker/src/transport/quic/streams/uni.rs
@@ -16,7 +16,6 @@ use bytes::BytesMut;
 use felix_authz::{Action, Namespace, StreamName, TenantId, stream_resource};
 use felix_broker::Broker;
 use felix_wire::Message;
-use std::collections::HashMap;
 use std::sync::Arc;
 #[cfg(feature = "telemetry")]
 use std::sync::atomic::Ordering;
@@ -24,8 +23,8 @@ use std::sync::atomic::Ordering;
 use crate::auth::{AuthContext, BrokerAuth};
 use crate::config::BrokerConfig;
 use crate::transport::quic::handlers::publish::{
-    PublishContext, handle_binary_publish_batch_uni, handle_publish_batch_message_uni,
-    handle_publish_message_uni,
+    PublishContext, StreamHandleCache, handle_binary_publish_batch_uni,
+    handle_publish_batch_message_uni, handle_publish_message_uni,
 };
 use crate::transport::quic::telemetry::t_counter;
 
@@ -35,7 +34,7 @@ pub(super) struct UniLoopArgs {
     pub config: BrokerConfig,
     pub auth: Arc<BrokerAuth>,
     pub publish_ctx: PublishContext,
-    pub stream_cache: HashMap<String, (bool, std::time::Instant)>,
+    pub stream_cache: StreamHandleCache,
     pub stream_cache_key: String,
 }
 

--- a/services/broker/tests/latency_text.rs
+++ b/services/broker/tests/latency_text.rs
@@ -135,7 +135,7 @@ async fn text_publish_batch_large_payload_no_drop() -> Result<()> {
         let count = remaining.min(batch_size);
         let payloads = (0..count).map(|_| payload.clone()).collect::<Vec<_>>();
         publisher
-            .publish_batch(
+            .publish_batch_json(
                 "t1",
                 "default",
                 "latency",


### PR DESCRIPTION
• Publish ingress now resolves names to dense  StreamHandle s; worker jobs carry only the handle and publish directly to  StreamState , with stale-handle invalidation. • Unacknowledged  publish / publish_batch  now default to binary. • Added explicit  publish_json / publish_batch_json  compatibility APIs. • Acked publishes remain JSON until binary ack framing is added. • Updated benchmarks and protocol documentation.