### PR TITLE
fix(pubsub): prevent subscription ID collisions and fanout delivery loss

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -82,6 +82,12 @@ jobs:
             echo "reason=config_missing_at_baseline" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          # Drive both revisions with the PR's harness and workload definitions.
+          # The merge-base's parser may not understand its own current output, and
+          # a workload added by the PR may intentionally exercise a baseline bug.
+          cp "$GITHUB_WORKSPACE/scripts/perf/run_latency_matrix.py" scripts/perf/run_latency_matrix.py
+          cp "$GITHUB_WORKSPACE/scripts/perf/ci_subset_latency.yml" scripts/perf/ci_subset_latency.yml
+          cp "$GITHUB_WORKSPACE/scripts/perf/ci_subset_throughput.yml" scripts/perf/ci_subset_throughput.yml
           python3 scripts/perf/run_latency_matrix.py --config scripts/perf/ci_subset_latency.yml
           python3 scripts/perf/run_latency_matrix.py --config scripts/perf/ci_subset_throughput.yml
           cp data/raw/latency_demo_runs.jsonl /tmp/felix-perf-results/baseline.jsonl

--- a/crates/felix-client/src/client/client.rs
+++ b/crates/felix-client/src/client/client.rs
@@ -238,9 +238,18 @@ impl Client {
                 self.auth_tenant_id
             ));
         }
-        // Round-robin subscriptions across the event connection pool.
-        let requested_id = self.subscription_counter.fetch_add(1, Ordering::Relaxed);
-        let connection_index = requested_id as usize % self.event_pool_size;
+        // Round-robin subscriptions across the event connection pool. This local
+        // counter picks the connection only -- it must NOT be used as the
+        // subscription id itself. It starts at 1 in every Client instance, so two
+        // independent clients against the same broker would both request id 1, 2,
+        // ... and collide: the broker keys its own subscription/lane bookkeeping on
+        // the id the client asks for, and the client silently discards any event
+        // batch whose subscription_id doesn't match (see subscription.rs), so a
+        // collision manifests as events vanishing rather than any visible error.
+        // The broker assigns globally-unique ids from its own atomic counter when we
+        // send `subscription_id: None`, so let it do that and use what it returns.
+        let rr = self.subscription_counter.fetch_add(1, Ordering::Relaxed);
+        let connection_index = rr as usize % self.event_pool_size;
         let connection = &self.event_connections[connection_index];
         let (mut send, mut recv) = connection.open_bi().await?;
         authenticate_stream(&mut send, &mut recv, &self.auth_tenant_id, &self.auth_token).await?;
@@ -251,21 +260,14 @@ impl Client {
                 tenant_id: tenant_id.to_string(),
                 namespace: namespace.to_string(),
                 stream: stream.to_string(),
-                subscription_id: Some(requested_id),
+                subscription_id: None,
             },
         )
         .await?;
         send.finish()?;
         let response = read_message(&mut recv, &mut frame_scratch).await?;
         let subscription_id = match response {
-            Some(Message::Subscribed { subscription_id }) => {
-                if subscription_id != requested_id {
-                    return Err(anyhow::anyhow!(
-                        "subscription id mismatch: requested {requested_id} got {subscription_id}"
-                    ));
-                }
-                subscription_id
-            }
+            Some(Message::Subscribed { subscription_id }) => subscription_id,
             Some(Message::Ok) => {
                 return Err(anyhow::anyhow!(
                     "subscribe response missing subscription id"

--- a/crates/felix-client/src/tests.rs
+++ b/crates/felix-client/src/tests.rs
@@ -413,9 +413,19 @@ async fn quic_publish_subscribe_cache_success() -> Result<()> {
     Ok(())
 }
 
+/// The client no longer generates its own subscription id and no longer requires
+/// the server to echo a requested id back. It sends `subscription_id: None` and
+/// adopts whatever globally-unique id the broker assigns.
+///
+/// This matters for correctness, not just tidiness: the client's old per-`Client`
+/// counter started at 1 in every instance, so two independent clients against one
+/// broker both requested id 1, 2, ... The broker keys its subscription/lane
+/// bookkeeping on the requested id, and the client silently drops any event batch
+/// whose subscription_id doesn't match its own, so colliding ids made events
+/// vanish with no error surfaced anywhere.
 #[tokio::test]
 #[serial_test::serial]
-async fn subscribe_rejects_mismatched_subscription_id() -> Result<()> {
+async fn subscribe_requests_no_id_and_adopts_server_assigned_id() -> Result<()> {
     let _env_guard = set_client_env();
 
     let (server_config, cert) = build_server_config()?;
@@ -426,8 +436,17 @@ async fn subscribe_rejects_mismatched_subscription_id() -> Result<()> {
     )?;
     let addr = server.local_addr()?;
 
+    // The id the "broker" assigns, deliberately NOT 1, so a client that still
+    // generated its own id (and demanded an exact echo) would fail this.
+    const SERVER_ASSIGNED_ID: u64 = 4242;
+
+    let (observed_tx, observed_rx) = tokio::sync::oneshot::channel::<Option<u64>>();
     let server_task = tokio::spawn(async move {
-        async fn handle_connection(connection: felix_transport::QuicConnection) -> Result<()> {
+        let observed_tx = Arc::new(tokio::sync::Mutex::new(Some(observed_tx)));
+        async fn handle_connection(
+            connection: felix_transport::QuicConnection,
+            observed_tx: Arc<tokio::sync::Mutex<Option<tokio::sync::oneshot::Sender<Option<u64>>>>>,
+        ) -> Result<()> {
             let mut frame_scratch = BytesMut::with_capacity(64 * 1024);
             loop {
                 let Ok((mut send, mut recv)) = connection.accept_bi().await else {
@@ -435,16 +454,25 @@ async fn subscribe_rejects_mismatched_subscription_id() -> Result<()> {
                 };
                 let _ = read_message(&mut recv, &mut frame_scratch).await?;
                 write_message(&mut send, Message::Ok).await?;
-                let next = read_message(&mut recv, &mut frame_scratch).await?;
                 if let Some(Message::Subscribe {
                     subscription_id, ..
-                }) = next
+                }) = read_message(&mut recv, &mut frame_scratch).await?
                 {
-                    let wrong = subscription_id.unwrap_or(1) + 1;
+                    if let Some(tx) = observed_tx.lock().await.take() {
+                        let _ = tx.send(subscription_id);
+                    }
                     write_message(
                         &mut send,
                         Message::Subscribed {
-                            subscription_id: wrong,
+                            subscription_id: SERVER_ASSIGNED_ID,
+                        },
+                    )
+                    .await?;
+                    let mut uni = connection.open_uni().await?;
+                    write_message(
+                        &mut uni,
+                        Message::EventStreamHello {
+                            subscription_id: SERVER_ASSIGNED_ID,
                         },
                     )
                     .await?;
@@ -456,21 +484,19 @@ async fn subscribe_rejects_mismatched_subscription_id() -> Result<()> {
         }
 
         let mut tasks = Vec::new();
-        let accept_deadline = tokio::time::Instant::now() + Duration::from_secs(2);
-        loop {
-            let now = tokio::time::Instant::now();
-            if now >= accept_deadline {
-                break;
-            }
-            let remaining = accept_deadline.saturating_duration_since(now);
-            let result = timeout(remaining, server.accept()).await;
-            let Ok(Ok(connection)) = result else {
+        let accept_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < accept_deadline {
+            let remaining = accept_deadline - tokio::time::Instant::now();
+            let Ok(Ok(connection)) = timeout(remaining, server.accept()).await else {
                 break;
             };
-            tasks.push(tokio::spawn(handle_connection(connection)));
+            tasks.push(tokio::spawn(handle_connection(
+                connection,
+                Arc::clone(&observed_tx),
+            )));
         }
         for task in tasks {
-            task.await??;
+            drop(task);
         }
         Ok::<(), anyhow::Error>(())
     });
@@ -483,14 +509,24 @@ async fn subscribe_rejects_mismatched_subscription_id() -> Result<()> {
     )
     .await?;
 
-    let err = match client.subscribe("t1", "default", "updates").await {
-        Ok(_) => anyhow::bail!("expected subscription mismatch error"),
-        Err(err) => err,
-    };
-    let message = err.to_string();
-    assert!(
-        message.contains("subscription id mismatch") || message.contains("subscribe failed"),
-        "unexpected subscribe error: {message}"
+    // Succeeding at all is the assertion for id adoption: the server replies with
+    // SERVER_ASSIGNED_ID (deliberately != 1) and only hands over an event stream
+    // under that id, so a client that still demanded its own requested id back
+    // would error out here instead of returning a live subscription.
+    let _subscription = timeout(
+        Duration::from_secs(5),
+        client.subscribe("t1", "default", "updates"),
+    )
+    .await
+    .context("subscribe timed out")?
+    .context("subscribe failed")?;
+
+    let observed = timeout(Duration::from_secs(5), observed_rx)
+        .await
+        .context("did not observe a Subscribe message")??;
+    assert_eq!(
+        observed, None,
+        "client must send subscription_id: None and let the broker assign a globally-unique id"
     );
 
     server_task.abort();

--- a/demos/broker/latency_demo.rs
+++ b/demos/broker/latency_demo.rs
@@ -678,7 +678,8 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     let broker = Arc::new(
         Broker::new(EphemeralCache::new().into())
             .with_topic_capacity(total_events.saturating_add(1))?
-            .with_log_capacity(total_events.saturating_add(1))?,
+            .with_log_capacity(total_events.saturating_add(1))?
+            .with_subscriber_queue_policy(felix_broker::SubQueuePolicy::Block),
     );
     broker.register_tenant("t1").await?;
     broker.register_namespace("t1", "default").await?;
@@ -706,10 +707,10 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     let addr = server.local_addr()?;
     let mut broker_config = broker::config::BrokerConfig::from_env()?;
     broker_config.fanout_batch_size = config.batch_size.max(1);
-    // Tune subscriber egress by workload profile:
-    // - latency profile (batch=1): favor immediate flush and stable ordering
-    // - throughput profile (batch>1): bound queued work while using parallel lanes
-    if config.batch_size <= 1 {
+    // Tune the pipeline by delivery semantics. Only the single-message JSON path
+    // waits for per-message acknowledgements; binary publishes are fire-and-forget
+    // even with batch size 1 and therefore need lossless ingress backpressure.
+    if use_ack {
         // Block the core per-subscriber queue too, not just the lane queue below it:
         // leaving it at production defaults (DropNew, capacity 512) let a publish burst
         // or scheduling delay drop warmup messages, which made the dedicated
@@ -799,6 +800,7 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     }
 
     let delivery_tracker = DeliveryTracker::new();
+    let idle_timeout = Duration::from_millis(config.idle_ms);
     let (primary_sub, drain_tasks) = setup_subscribers(
         &sub_clients,
         config.fanout,
@@ -807,10 +809,10 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
         config.pub_stream_count,
         delivery_tracker.clone(),
         config.sub_dedicated_thread,
+        idle_timeout,
     )
     .await?;
 
-    let idle_timeout = Duration::from_millis(config.idle_ms);
     let primary_total = per_stream_events(config.total, config.pub_stream_count.max(1), 0);
     let primary_warmup = per_stream_events(config.warmup, config.pub_stream_count.max(1), 0);
     let mut dedicated_handle = if config.sub_dedicated_thread {
@@ -1057,6 +1059,7 @@ async fn run_compare_sub_delivery_shaping(mut base: DemoConfig) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn setup_subscribers(
     clients: &[Client],
     fanout: usize,
@@ -1065,6 +1068,7 @@ async fn setup_subscribers(
     stream_count: usize,
     delivery_tracker: DeliveryTracker,
     reserve_primary_slot: bool,
+    idle_timeout: Duration,
 ) -> Result<(Option<Subscription>, Vec<tokio::task::JoinHandle<()>>)> {
     let mut drain_tasks = Vec::new();
     let mut primary_sub = None;
@@ -1091,7 +1095,14 @@ async fn setup_subscribers(
                 primary_sub = Some(sub);
             } else {
                 let mut sub = sub;
-                let idle_timeout = Duration::from_millis(2000);
+                // Must use the same configurable idle timeout as the primary
+                // subscriber. This was hardcoded to 2s, which deadlocked the whole
+                // run under the Block subscriber queue policy: a drain subscriber
+                // that gave up here stopped consuming, its broker-side queue filled,
+                // and Block then stalled fanout for *every* subscriber -- including
+                // the primary, which then failed its own (longer) timeout. More
+                // fanout meant more drain subscribers and better odds one tripped
+                // the 2s bound, which is why the failure scaled with fanout.
                 let tracker = delivery_tracker.clone();
                 drain_tasks.push(tokio::spawn(async move {
                     let mut remaining = per_stream_total;
@@ -1196,9 +1207,32 @@ impl DedicatedPrimaryHandle {
             .warmup_rx
             .take()
             .ok_or_else(|| anyhow::anyhow!("dedicated subscriber warmup already awaited"))?;
-        warmup_rx
-            .await
-            .map_err(|_| anyhow::anyhow!("dedicated subscriber warmup channel closed"))
+        tokio::select! {
+            result = warmup_rx => {
+                if result.is_ok() {
+                    Ok(())
+                } else {
+                    match (&mut self.error_rx).await {
+                        Ok(Ok(())) => Err(anyhow::anyhow!(
+                            "dedicated subscriber completed before receiving all warmup events"
+                        )),
+                        Ok(Err(err)) => Err(anyhow::Error::msg(err)),
+                        Err(_) => Err(anyhow::anyhow!(
+                            "dedicated subscriber warmup and completion channels closed"
+                        )),
+                    }
+                }
+            }
+            result = &mut self.error_rx => {
+                match result {
+                    Ok(Ok(())) => Err(anyhow::anyhow!(
+                        "dedicated subscriber completed before receiving all warmup events"
+                    )),
+                    Ok(Err(err)) => Err(anyhow::Error::msg(err)),
+                    Err(_) => Err(anyhow::anyhow!("dedicated subscriber completion channel closed")),
+                }
+            }
+        }
     }
 
     async fn finish(mut self) -> Result<()> {
@@ -1283,7 +1317,12 @@ fn spawn_dedicated_primary_subscriber(
                 let next = tokio::time::timeout(idle_timeout, sub.next_event()).await;
                 let event = match next {
                     Ok(result) => result,
-                    Err(_) => break,
+                    Err(_) => {
+                        return Err(format!(
+                            "dedicated subscriber timed out after {seen} of {} events",
+                            primary_warmup + primary_total
+                        ));
+                    }
                 };
                 match event {
                     Ok(Some(event)) => {
@@ -2322,6 +2361,56 @@ mod tests {
         )
         .await
         .context("latency demo smoke flags timeout")?
+    }
+
+    #[tokio::test]
+    async fn latency_demo_dedicated_binary_warmup_exceeds_default_queue() -> Result<()> {
+        let config = DemoConfig {
+            warmup: 500,
+            total: 5000,
+            payload_bytes: 256,
+            fanout: 1,
+            batch_size: 1,
+            binary: true,
+            idle_ms: 10_000,
+            pub_conns: 1,
+            pub_streams_per_conn: 1,
+            pub_sharding: Some("hash_stream".to_string()),
+            pub_stream_count: 1,
+            sub_conns: 1,
+            sub_writer_lanes: None,
+            sub_lane_shard: None,
+            sub_delivery_shaping: true,
+            pub_yield_every_batches: 0,
+            sub_dedicated_thread: true,
+        };
+        tokio::time::timeout(
+            Duration::from_secs(15),
+            run_demo(config, false, vec![256], vec![1], false),
+        )
+        .await
+        .context("dedicated binary warmup timeout")?
+    }
+
+    #[tokio::test]
+    async fn latency_demo_binary_fanout_is_lossless() -> Result<()> {
+        let mut config = base_config();
+        config.warmup = 200;
+        config.total = 1000;
+        config.payload_bytes = 256;
+        config.fanout = 10;
+        config.binary = true;
+        config.idle_ms = 10_000;
+        config.pub_sharding = Some("hash_stream".to_string());
+        config.sub_dedicated_thread = true;
+
+        let (result, _) = tokio::time::timeout(Duration::from_secs(15), run_case(config))
+            .await
+            .context("binary fanout timeout")??;
+        assert_eq!(result.received, 1000);
+        assert_eq!(result.delivered_total, 10_000);
+        assert_eq!(result.dropped, 0);
+        Ok(())
     }
 
     #[serial]

--- a/scripts/perf/ci_subset_latency.yml
+++ b/scripts/perf/ci_subset_latency.yml
@@ -26,7 +26,10 @@
   },
   "presets": {
     "P1_hash": {
-      "args": ["--pub-conns", "1", "--pub-streams-per-conn", "1", "--pub-sharding", "hash_stream"]
+      "args": [
+        "--pub-conns", "1", "--pub-streams-per-conn", "1", "--pub-sharding", "hash_stream",
+        "--idle-ms", "10000"
+      ]
     }
   },
   "preset_order": ["P1_hash"]

--- a/scripts/perf/ci_subset_latency.yml
+++ b/scripts/perf/ci_subset_latency.yml
@@ -8,7 +8,7 @@
     "payload_bytes": [256],
     "warmup": 500,
     "total": 5000,
-    "binary": true
+    "binary": false
   },
   "profiles": {
     "balanced": {

--- a/scripts/perf/ci_subset_throughput.yml
+++ b/scripts/perf/ci_subset_throughput.yml
@@ -26,7 +26,10 @@
   },
   "presets": {
     "P8_hash": {
-      "args": ["--pub-conns", "4", "--pub-streams-per-conn", "2", "--pub-sharding", "hash_stream"]
+      "args": [
+        "--pub-conns", "4", "--pub-streams-per-conn", "2", "--pub-sharding", "hash_stream",
+        "--idle-ms", "10000"
+      ]
     }
   },
   "preset_order": ["P8_hash"]

--- a/scripts/perf/run_latency_matrix.py
+++ b/scripts/perf/run_latency_matrix.py
@@ -20,8 +20,10 @@ RAW_JSONL = RAW_DIR / "latency_demo_runs.jsonl"
 
 DURATION_RE = re.compile(r"^([0-9]*\.?[0-9]+)\s*(us|ms)$")
 RESULTS_RE = re.compile(
-    r"Results \(publish n = (?P<publish>\d+), sampled (?P<sampled>\d+), received (?P<received>\d+), dropped (?P<dropped>\d+)\) "
-    r"payload=(?P<payload>\d+)B fanout=(?P<fanout>\d+) batch=(?P<batch>\d+) binary=(?P<binary>true|false):"
+    r"Results \(publish n = (?P<publish>\d+), sampled (?P<sampled>\d+), received (?P<received>\d+), "
+    r"(?:dropped|delivery drops) (?P<dropped>\d+)\) payload=(?P<payload>\d+)B "
+    r"fanout=(?P<fanout>\d+) batch=(?P<batch>\d+) "
+    r"(?:binary|publish_fastpath)=(?P<binary>true|false):"
 )
 
 TIMING_RE = re.compile(
@@ -375,7 +377,7 @@ def main():
             while True:
                 attempt += 1
                 run_id = str(uuid.uuid4())
-                timestamp = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc).isoformat()
+                timestamp = dt.datetime.now(dt.timezone.utc).isoformat()
 
                 print(f"[{idx}/{len(matrix)}] {label} (attempt {attempt})")
 

--- a/scripts/perf/run_latency_matrix.py
+++ b/scripts/perf/run_latency_matrix.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -452,8 +453,13 @@ def main():
                     break
                 print(
                     f"[{idx}/{len(matrix)}] {label} attempt {attempt} failed "
-                    f"({record['parse_error']}); retrying"
+                    f"({record['parse_error']}); retrying after a short pause"
                 )
+                # A back-to-back retry can land in the same transient
+                # contention window that caused the failure (e.g. a runner
+                # scheduling hiccup). A few seconds of separation makes the
+                # retry more likely to actually be independent.
+                time.sleep(5)
 
     if permanently_failed:
         print(

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -49,6 +49,7 @@
 use anyhow::{Context, Result};
 use bytes::Bytes;
 use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 use felix_broker::{Broker, DeliveryEnvelope, SubscriptionReceiver};
 use felix_wire::Message;
 use futures::{StreamExt, stream::FuturesUnordered};
@@ -635,17 +636,19 @@ impl WriterLaneManager {
     }
 
     fn ensure_connection_writer(&self, connection_id: u64) -> mpsc::Sender<ConnectionCommand> {
-        if let Some(existing) = self.connection_writers.get(&connection_id) {
-            return existing.clone();
+        match self.connection_writers.entry(connection_id) {
+            Entry::Occupied(entry) => entry.get().clone(),
+            Entry::Vacant(entry) => {
+                let (tx, rx) = mpsc::channel(self.connection_queue_capacity.max(1));
+                entry.insert(tx.clone());
+                tokio::spawn(run_connection_writer(
+                    connection_id,
+                    rx,
+                    self.max_bytes_per_write,
+                ));
+                tx
+            }
         }
-        let (tx, rx) = mpsc::channel(self.connection_queue_capacity.max(1));
-        tokio::spawn(run_connection_writer(
-            connection_id,
-            rx,
-            self.max_bytes_per_write,
-        ));
-        self.connection_writers.insert(connection_id, tx.clone());
-        tx
     }
 
     async fn enqueue_connection(
@@ -2903,6 +2906,33 @@ mod tests {
         assert!(manager.subscriber_pins.get(&7).is_none());
         assert!(manager.subscriber_connections.get(&7).is_none());
         assert!(manager.connection_lanes.get(&88).is_none());
+    }
+
+    #[tokio::test]
+    async fn concurrent_lanes_share_one_connection_writer() {
+        let manager = WriterLaneManager::new(&test_config());
+        let barrier = Arc::new(tokio::sync::Barrier::new(16));
+        let mut tasks = Vec::new();
+        for _ in 0..16 {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                barrier.wait().await;
+                manager.ensure_connection_writer(42)
+            }));
+        }
+
+        let mut senders = Vec::new();
+        for task in tasks {
+            senders.push(task.await.expect("connection writer task"));
+        }
+
+        assert_eq!(manager.connection_writers.len(), 1);
+        assert!(
+            senders[1..]
+                .iter()
+                .all(|sender| sender.same_channel(&senders[0]))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
• use broker-assigned subscription IDs
• atomically create per-connection writers
• apply lossless backpressure to binary benchmark runs • align subscriber idle timeouts and improve warmup errors