### PR TITLE
M0: SIGTERM-aware graceful shutdown (#139) and broker concurrency/panic audit (#140)

### DIFF
--- a/.github/workflows/perf-comprehensive.yml
+++ b/.github/workflows/perf-comprehensive.yml
@@ -29,6 +29,9 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Standard GitHub-hosted Linux runners expose 4 CPUs. Leave two for the
+  # tokio/QUIC runtime and dedicate two to stream-owned broker work.
+  FELIX_CORE_SHARDS: "2"
 
 jobs:
   comprehensive-sweep:

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -25,6 +25,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Standard GitHub-hosted Linux runners expose 4 CPUs. Leave two for the
+  # tokio/QUIC runtime and dedicate two to stream-owned broker work.
+  FELIX_CORE_SHARDS: "2"
   # Shared target dir across the baseline and candidate worktrees below, so
   # (usually-unchanged) third-party dependencies only compile once instead
   # of twice.

--- a/.github/workflows/perf-publish.yml
+++ b/.github/workflows/perf-publish.yml
@@ -20,6 +20,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # Standard GitHub-hosted Linux runners expose 4 CPUs. Leave two for the
+  # tokio/QUIC runtime and dedicate two to stream-owned broker work.
+  FELIX_CORE_SHARDS: "2"
 
 jobs:
   perf-publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "felix-authz",
  "felix-broker",
  "felix-client",
+ "felix-common",
  "felix-storage",
  "felix-transport",
  "felix-wire",
@@ -295,6 +296,7 @@ dependencies = [
  "serial_test",
  "tempfile",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -464,6 +466,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "ed25519-dalek",
+ "felix-common",
  "hex",
  "jsonwebtoken",
  "metrics",
@@ -484,6 +487,7 @@ dependencies = [
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -923,6 +927,8 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -3763,6 +3769,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -532,7 +532,15 @@ pub struct Broker {
     next_stream_handle: AtomicU64,
 }
 
-unsafe impl Send for Broker {}
+// `Broker` is `Send + Sync` from its fields alone: every field is an `RwLock`,
+// an atomic, a `usize`, or `Box<dyn StorageApi + Send>` — and `StorageApi`
+// already requires `Send + Sync`. The compiler's auto-impls cover this, so no
+// `unsafe impl` is needed. This assertion fails the build if a future field
+// breaks the property instead of letting it be papered over again.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Broker>();
+};
 
 #[derive(Debug, Clone)]
 pub struct StreamMetadata {

--- a/crates/felix-common/Cargo.toml
+++ b/crates/felix-common/Cargo.toml
@@ -9,3 +9,15 @@ rust-version.workspace = true
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
+# Only needed by the `lifecycle` module; optional so pure-library consumers of this
+# crate do not inherit an async runtime.
+tokio = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[features]
+default = []
+# Signal handling, readiness gating, and bounded drain for service binaries.
+lifecycle = ["dep:tokio", "dep:tracing"]

--- a/crates/felix-common/src/lib.rs
+++ b/crates/felix-common/src/lib.rs
@@ -2,6 +2,11 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+// Process lifecycle helpers shared by the service binaries. Feature-gated so that
+// library consumers which never run a process (felix-router) do not pull in tokio.
+#[cfg(feature = "lifecycle")]
+pub mod lifecycle;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(thiserror::Error, Debug)]

--- a/crates/felix-common/src/lifecycle.rs
+++ b/crates/felix-common/src/lifecycle.rs
@@ -1,0 +1,244 @@
+//! Process lifecycle: termination signals, readiness gating, and bounded drain.
+//!
+//! # Why this exists
+//! Kubernetes, systemd, and `docker stop` all terminate a process with **SIGTERM**.
+//! Waiting only on `ctrl_c()` (SIGINT) means those signals fall through to the
+//! default handler, which kills the process immediately and drops every in-flight
+//! publish, acknowledgement, and subscription write. Every rolling update would
+//! abort in-flight work.
+//!
+//! # Shutdown order
+//! The order matters more than the individual steps:
+//!
+//! 1. **Readiness goes false.** Load balancers and the Kubernetes endpoints
+//!    controller observe `/ready` and stop routing new traffic here. This happens
+//!    before anything stops working, so clients are steered away from a healthy
+//!    instance rather than discovering a broken one.
+//! 2. **Stop accepting new connections.** Already-accepted work is untouched.
+//! 3. **Drain, bounded by a deadline.** In-flight connections finish on their own.
+//! 4. **Force-cancel whatever is left, and say what it was.** A drain that silently
+//!    hangs until SIGKILL is indistinguishable from the bug it was meant to fix, so
+//!    the subsystems that missed the deadline are named in the logs.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+// The budget must measure against the same clock that `tokio::time::timeout` uses,
+// or the remaining-time arithmetic and the timeouts it drives disagree. This is
+// identical to `std::time::Instant` at runtime and additionally tracks tokio's
+// paused clock under test.
+use tokio::time::Instant;
+
+/// Readiness flag shared between the health endpoints and the shutdown path.
+///
+/// Cloning shares the underlying flag; every clone observes the same state.
+#[derive(Clone, Debug)]
+pub struct Readiness {
+    ready: Arc<AtomicBool>,
+}
+
+impl Readiness {
+    /// Create a flag that already reports ready.
+    pub fn ready() -> Self {
+        Self {
+            ready: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Whether `/ready` should report success.
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Acquire)
+    }
+
+    /// Flip to not-ready.
+    ///
+    /// Call this *before* the listener stops, so traffic is steered away while the
+    /// broker can still serve it. Returns the previous state so callers can tell a
+    /// first shutdown from a repeated signal.
+    pub fn begin_draining(&self) -> bool {
+        self.ready.swap(false, Ordering::Release)
+    }
+}
+
+impl Default for Readiness {
+    fn default() -> Self {
+        Self::ready()
+    }
+}
+
+/// Resolves when the process is asked to terminate.
+///
+/// On Unix this is SIGTERM (Kubernetes, systemd, `docker stop`) or SIGINT (Ctrl-C).
+/// On other platforms only Ctrl-C is available. The signal that fired is logged,
+/// because "which signal did we get" is the first question when a pod is being
+/// killed unexpectedly.
+#[cfg(unix)]
+pub async fn termination_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    // If SIGTERM can't be registered we still want SIGINT to work rather than
+    // leaving the process with no shutdown path at all.
+    let mut sigterm = match signal(SignalKind::terminate()) {
+        Ok(stream) => stream,
+        Err(err) => {
+            tracing::error!(
+                error = %err,
+                "failed to install SIGTERM handler; falling back to SIGINT only"
+            );
+            let _ = tokio::signal::ctrl_c().await;
+            tracing::info!(signal = "SIGINT", "termination signal received");
+            return;
+        }
+    };
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            tracing::info!(signal = "SIGINT", "termination signal received");
+        }
+        _ = sigterm.recv() => {
+            tracing::info!(signal = "SIGTERM", "termination signal received");
+        }
+    }
+}
+
+/// Resolves when the process is asked to terminate.
+///
+/// Non-Unix targets have no SIGTERM; Ctrl-C is the only portable trigger.
+#[cfg(not(unix))]
+pub async fn termination_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    tracing::info!(signal = "CTRL_C", "termination signal received");
+}
+
+/// Tracks a drain against a total deadline shared by every subsystem.
+///
+/// Each subsystem gets whatever is left of the budget rather than its own full
+/// copy, so N subsystems cannot stretch a 25s deadline into 25N seconds. Anything
+/// that misses the deadline is recorded and reported together at the end.
+pub struct DrainBudget {
+    deadline: Duration,
+    started: Instant,
+    unfinished: Vec<&'static str>,
+}
+
+impl DrainBudget {
+    pub fn new(deadline: Duration) -> Self {
+        Self {
+            deadline,
+            started: Instant::now(),
+            unfinished: Vec::new(),
+        }
+    }
+
+    /// Time left in the overall budget; zero once the deadline has passed.
+    pub fn remaining(&self) -> Duration {
+        self.deadline.saturating_sub(self.started.elapsed())
+    }
+
+    /// Await `task` within the remaining budget, recording `name` if it does not
+    /// finish in time. Returns whether it finished.
+    pub async fn drain<F>(&mut self, name: &'static str, task: F) -> bool
+    where
+        F: Future<Output = ()>,
+    {
+        let remaining = self.remaining();
+        if remaining.is_zero() {
+            self.unfinished.push(name);
+            return false;
+        }
+        match tokio::time::timeout(remaining, task).await {
+            Ok(()) => {
+                tracing::debug!(subsystem = name, "drained");
+                true
+            }
+            Err(_) => {
+                self.unfinished.push(name);
+                false
+            }
+        }
+    }
+
+    /// Subsystems that did not finish within the deadline.
+    pub fn unfinished(&self) -> &[&'static str] {
+        &self.unfinished
+    }
+
+    /// Log the outcome. Forced cancellation is a warning, not an info line: it
+    /// means work was dropped and the operator needs to see it.
+    pub fn report(&self) {
+        let elapsed_ms = self.started.elapsed().as_millis();
+        if self.unfinished.is_empty() {
+            tracing::info!(elapsed_ms, "drain complete");
+        } else {
+            tracing::warn!(
+                elapsed_ms,
+                deadline_ms = self.deadline.as_millis(),
+                unfinished = ?self.unfinished,
+                "drain deadline expired; forcing cancellation"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn readiness_starts_ready_and_flips_once() {
+        let readiness = Readiness::ready();
+        assert!(readiness.is_ready());
+        // The first call reports the previous state so a repeated signal is
+        // distinguishable from the first one.
+        assert!(readiness.begin_draining());
+        assert!(!readiness.is_ready());
+        assert!(!readiness.begin_draining());
+    }
+
+    #[test]
+    fn readiness_clones_share_state() {
+        let readiness = Readiness::ready();
+        let clone = readiness.clone();
+        readiness.begin_draining();
+        assert!(!clone.is_ready());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_records_only_the_subsystem_that_timed_out() {
+        let mut budget = DrainBudget::new(Duration::from_millis(1000));
+        assert!(budget.drain("fast", async {}).await);
+        assert!(
+            !budget
+                .drain("slow", tokio::time::sleep(Duration::from_secs(60)))
+                .await
+        );
+        assert_eq!(budget.unfinished(), ["slow"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn budget_is_shared_across_subsystems_not_per_subsystem() {
+        // Two subsystems that each hang must not consume a full deadline apiece.
+        let mut budget = DrainBudget::new(Duration::from_millis(500));
+        let started = Instant::now();
+        budget
+            .drain("first", tokio::time::sleep(Duration::from_secs(60)))
+            .await;
+        budget
+            .drain("second", tokio::time::sleep(Duration::from_secs(60)))
+            .await;
+        assert!(started.elapsed() < Duration::from_millis(1000));
+        assert_eq!(budget.unfinished(), ["first", "second"]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn exhausted_budget_records_without_awaiting() {
+        let mut budget = DrainBudget::new(Duration::from_millis(10));
+        budget
+            .drain("first", tokio::time::sleep(Duration::from_secs(60)))
+            .await;
+        assert!(budget.remaining().is_zero());
+        // Past the deadline nothing else is even polled.
+        assert!(!budget.drain("second", std::future::pending()).await);
+        assert_eq!(budget.unfinished(), ["first", "second"]);
+    }
+}

--- a/crates/felix-storage/src/ephemeral_cache.rs
+++ b/crates/felix-storage/src/ephemeral_cache.rs
@@ -124,7 +124,14 @@ impl StorageApi for EphemeralCache {
     }
 }
 
-unsafe impl Send for EphemeralCache {}
+// `EphemeralCache` is `Send + Sync` from its fields alone (`RwLock<HashMap<..>>`
+// and `Option<usize>`), so the compiler's auto-impls suffice and no `unsafe impl`
+// is needed. `StorageApi: Send + Sync` means this must hold; assert it here so a
+// future field change is a build error rather than a trait-bound puzzle.
+const _: () = {
+    const fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<EphemeralCache>();
+};
 
 impl Default for EphemeralCache {
     fn default() -> Self {

--- a/crates/felix-wire/src/lib.rs
+++ b/crates/felix-wire/src/lib.rs
@@ -645,6 +645,27 @@ pub mod binary {
     use bytes::BufMut;
     use serde::de::Error as SerdeError;
 
+    // Every payload in a batch is encoded as a 4-byte length prefix followed by its
+    // bytes, so a frame can never carry more payloads than it has 4-byte groups left.
+    const PAYLOAD_LEN_PREFIX: usize = 4;
+
+    // Bound an attacker-declared payload count against what the frame can actually
+    // hold, before it ever reaches `Vec::with_capacity`. The count is read straight
+    // off the wire, so without this a ~20-byte frame declaring `u32::MAX` payloads
+    // reserves 95-127 GiB of address space. Overcommit means one such frame usually
+    // succeeds, but roughly a thousand concurrent ones exhaust the address space and
+    // the failing allocation calls `handle_alloc_error`, which aborts the process
+    // instead of unwinding — so it is not contained by per-task panic recovery. A
+    // memory cgroup or strict overcommit, as in a typical container deployment,
+    // brings that threshold far lower. The loop below still validates each payload
+    // individually; this only stops the count itself from being trusted.
+    fn checked_payload_count(count: usize, remaining: usize) -> Result<usize> {
+        if count > remaining / PAYLOAD_LEN_PREFIX {
+            return Err(Error::Incomplete);
+        }
+        Ok(count)
+    }
+
     // Parsed representation of a binary publish batch frame.
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct PublishBatch {
@@ -851,7 +872,7 @@ pub mod binary {
         let stream_bytes = buf.copy_to_bytes(stream_len);
         let stream = String::from_utf8(stream_bytes.to_vec())
             .map_err(|_| Error::Deserialize(SerdeError::custom("invalid stream name")))?;
-        let count = buf.get_u32() as usize;
+        let count = checked_payload_count(buf.get_u32() as usize, buf.remaining())?;
         let mut payloads = Vec::with_capacity(count);
         for _ in 0..count {
             if buf.remaining() < 4 {
@@ -986,7 +1007,7 @@ pub mod binary {
             return Err(Error::Incomplete);
         }
         let subscription_id = buf.get_u64();
-        let count = buf.get_u32() as usize;
+        let count = checked_payload_count(buf.get_u32() as usize, buf.remaining())?;
         let mut payloads = Vec::with_capacity(count);
         for _ in 0..count {
             if buf.remaining() < 4 {
@@ -1010,7 +1031,7 @@ pub mod binary {
         if buf.remaining() < 4 {
             return Err(Error::Incomplete);
         }
-        let count = buf.get_u32() as usize;
+        let count = checked_payload_count(buf.get_u32() as usize, buf.remaining())?;
         let mut payloads = Vec::with_capacity(count);
         for _ in 0..count {
             if buf.remaining() < 4 {
@@ -1238,6 +1259,65 @@ mod tests {
         let frame = Frame::new(FLAG_BINARY_PUBLISH_BATCH, buf.freeze()).expect("frame");
         let result = binary::decode_publish_batch(&frame);
         assert!(result.is_err());
+    }
+
+    // A declared payload count is attacker-controlled and was previously passed
+    // straight to `Vec::with_capacity`. These frames are ~20 bytes but claim
+    // `u32::MAX` payloads; before the bound each reserved 95-127 GiB of address
+    // space, and enough concurrent ones turn that into an abort. See
+    // `checked_payload_count`.
+    #[test]
+    fn binary_decode_publish_batch_rejects_oversized_payload_count() {
+        use bytes::BufMut;
+        let mut buf = BytesMut::new();
+        buf.put_u16(2); // tenant_id len
+        buf.extend_from_slice(b"t1");
+        buf.put_u16(2); // namespace len
+        buf.extend_from_slice(b"ns");
+        buf.put_u16(2); // stream len
+        buf.extend_from_slice(b"st");
+        buf.put_u32(u32::MAX); // count, with no payload bytes following
+        let frame = Frame::new(FLAG_BINARY_PUBLISH_BATCH, buf.freeze()).expect("frame");
+        let err = binary::decode_publish_batch(&frame).expect_err("oversized count");
+        assert!(matches!(err, Error::Incomplete));
+    }
+
+    #[test]
+    fn binary_decode_event_batch_rejects_oversized_payload_count() {
+        use bytes::BufMut;
+        let mut buf = BytesMut::new();
+        buf.put_u64(1); // subscription id
+        buf.put_u32(u32::MAX); // count, with no payload bytes following
+        let frame = Frame::new(FLAG_BINARY_EVENT_BATCH, buf.freeze()).expect("frame");
+        let err = binary::decode_event_batch(&frame).expect_err("oversized count");
+        assert!(matches!(err, Error::Incomplete));
+    }
+
+    #[test]
+    fn binary_decode_shared_event_batch_rejects_oversized_payload_count() {
+        use bytes::BufMut;
+        let mut buf = BytesMut::new();
+        buf.put_u32(u32::MAX); // count, with no payload bytes following
+        let frame = Frame::new(FLAG_BINARY_EVENT_BATCH_SHARED, buf.freeze()).expect("frame");
+        let err = binary::decode_shared_event_batch(&frame).expect_err("oversized count");
+        assert!(matches!(err, Error::Incomplete));
+    }
+
+    // The bound must reject only counts the frame cannot back, never a legitimate
+    // batch sitting exactly at the limit.
+    #[test]
+    fn binary_decode_event_batch_accepts_maximum_supportable_count() {
+        use bytes::BufMut;
+        let mut buf = BytesMut::new();
+        buf.put_u64(7);
+        buf.put_u32(3); // three zero-length payloads: 3 * 4 bytes of prefix follow
+        for _ in 0..3 {
+            buf.put_u32(0);
+        }
+        let frame = Frame::new(FLAG_BINARY_EVENT_BATCH, buf.freeze()).expect("frame");
+        let batch = binary::decode_event_batch(&frame).expect("decode");
+        assert_eq!(batch.subscription_id, 7);
+        assert_eq!(batch.payloads.len(), 3);
     }
 
     #[test]

--- a/docs-site/docs/deployment/graceful-shutdown.md
+++ b/docs-site/docs/deployment/graceful-shutdown.md
@@ -1,0 +1,119 @@
+# Process lifecycle and graceful shutdown
+
+Covers how the broker and control plane start, and — mostly — how they stop.
+Implemented in `crates/felix-common/src/lifecycle.rs`, which both services share.
+
+## Termination signals
+
+Both services wait on **SIGTERM and SIGINT** on Unix, and Ctrl-C elsewhere.
+
+SIGTERM is the one that matters operationally. Kubernetes, systemd, and
+`docker stop` all terminate a process with SIGTERM; SIGINT only covers an
+interactive Ctrl-C. A process that handles only SIGINT has no shutdown path under
+any of those supervisors — the default SIGTERM handler kills it outright, so every
+rolling update drops in-flight publishes, acknowledgements, and subscription
+writes.
+
+## Shutdown order
+
+The order matters more than the individual steps.
+
+1. **Readiness goes false.** `/ready` starts returning `503 draining`. Load
+   balancers and the Kubernetes endpoints controller stop routing new traffic here
+   while the process can still serve it, so clients are steered away from a healthy
+   instance rather than discovering a broken one.
+2. **Stop admitting new work.** The broker cancels its QUIC accept loop; the
+   control plane stops accepting new HTTP connections. Already-accepted work is
+   untouched.
+3. **Drain, bounded by a deadline.** In-flight connections and requests finish on
+   their own.
+4. **Force-cancel the remainder and name it.** Anything still running when the
+   deadline expires is aborted and logged by name at WARN.
+
+`/live` stays `200` throughout. A draining process is alive and working correctly;
+failing liveness would make Kubernetes restart a pod that is shutting down exactly
+as intended.
+
+Metrics are torn down **last**, after everything else has drained, so `/metrics`
+and `/ready` remain scrapeable for the whole shutdown window. That window is the
+only chance an operator has to see what the process was doing while it stopped.
+
+## The drain deadline
+
+`FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS` (default `25000`) is a **single budget shared by
+every subsystem**, not a per-subsystem timeout. Each subsystem gets whatever is left
+when its turn comes, so N subsystems cannot stretch a 25s deadline into 25N seconds.
+Total shutdown time is bounded by this value regardless of how many things hang.
+
+Set it below the platform's kill deadline. Kubernetes defaults
+`terminationGracePeriodSeconds` to 30 and sends SIGKILL when it expires, so the
+default leaves headroom to finish the drain, log the outcome, and exit first. If you
+raise the grace period, raise this to match.
+
+On a clean drain you get:
+
+```
+INFO drain complete elapsed_ms=142
+```
+
+On a forced one — work was dropped, and this is the line to alert on:
+
+```
+WARN drain deadline expired; forcing cancellation elapsed_ms=25001 deadline_ms=25000 unfinished=["quic_connections"]
+```
+
+## Kubernetes configuration
+
+Readiness propagation is not instant. The endpoints controller has to observe the
+`/ready` failure and update every kube-proxy before traffic actually stops arriving,
+and that takes a few seconds. The process cannot wait for something it has no
+visibility into, so use a `preStop` hook to hold the pod open while propagation
+happens — this is the standard pattern, not a workaround for a gap in Felix:
+
+```yaml
+spec:
+  terminationGracePeriodSeconds: 30
+  containers:
+    - name: felix-broker
+      env:
+        # Leaves ~15s of headroom under the 30s grace period, after the preStop sleep.
+        - name: FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS
+          value: "20000"
+      lifecycle:
+        preStop:
+          exec:
+            # Give the endpoints controller time to remove this pod from rotation
+            # before SIGTERM is delivered.
+            command: ["/bin/sleep", "5"]
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: 9090
+        periodSeconds: 2
+      livenessProbe:
+        httpGet:
+          path: /live
+          port: 9090
+```
+
+Budget the total: `preStop` sleep + `FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS` must fit
+inside `terminationGracePeriodSeconds`, or SIGKILL arrives mid-drain and you are
+back to dropping in-flight work.
+
+## What is not covered yet
+
+Tracked under [#139](https://github.com/gabloe/felix/issues/139):
+
+- Cancellation is coordinated at the **connection** boundary. The drain waits for
+  each connection task to finish, but does not separately signal publish workers,
+  acknowledgement waiters, or subscription writers to wind down early. A connection
+  that would otherwise sit idle for its full timeout is only cut short by the
+  overall deadline.
+- Subscription streams are not flushed or closed according to their delivery
+  contract; they end when their connection task ends.
+- The "an acknowledged publish is never lost solely because SIGTERM arrived"
+  guarantee is not yet verified by a test.
+- Coverage is at the accept-loop and readiness level
+  (`services/broker/tests/graceful_shutdown.rs`). There is no process-level test
+  that spawns the real binary, sends it SIGTERM under active publish/subscribe
+  traffic, and asserts a bounded clean exit.

--- a/docs-site/docs/deployment/kubernetes.md
+++ b/docs-site/docs/deployment/kubernetes.md
@@ -112,6 +112,10 @@ spec:
           value: "0.0.0.0:8080"
         - name: RUST_LOG
           value: "info"
+        # preStop sleep (5s) + drain budget (20s) must fit inside
+        # terminationGracePeriodSeconds, or SIGKILL arrives mid-drain.
+        - name: FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS
+          value: "20000"
         resources:
           requests:
             memory: "2Gi"
@@ -121,17 +125,29 @@ spec:
             cpu: "2000m"
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /live
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 10
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              # Give the endpoints controller time to remove this pod from rotation
+              # before SIGTERM starts the drain.
+              command: ["/bin/sh", "-c", "sleep 5"]
+      terminationGracePeriodSeconds: 30
 ```
+
+On SIGTERM the broker sets `/ready` to `503` before it stops accepting connections,
+then drains in-flight work within `FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS`. `/live` stays
+healthy throughout, so Kubernetes does not restart a pod that is shutting down
+correctly. See [Graceful Shutdown](graceful-shutdown.md).
 
 ## StatefulSet Deployment
 
@@ -216,6 +232,10 @@ spec:
           value: "4"
         - name: FELIX_DISABLE_TIMINGS
           value: "false"
+        # preStop sleep (15s) + drain budget (40s) fits inside the 60s
+        # terminationGracePeriodSeconds set below.
+        - name: FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS
+          value: "40000"
         - name: RUST_LOG
           value: "info"
         - name: POD_NAME
@@ -242,7 +262,7 @@ spec:
           mountPath: /data
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /live
             port: 8080
           initialDelaySeconds: 15
           periodSeconds: 10
@@ -250,7 +270,7 @@ spec:
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /ready
             port: 8080
           initialDelaySeconds: 5
           periodSeconds: 5
@@ -259,7 +279,10 @@ spec:
         lifecycle:
           preStop:
             exec:
+              # Give the endpoints controller time to remove this pod from rotation
+              # before SIGTERM starts the drain.
               command: ["/bin/sh", "-c", "sleep 15"]
+      terminationGracePeriodSeconds: 60
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -891,6 +891,28 @@ export FELIX_CONTROL_STREAM_DRAIN_TIMEOUT_MS="100"  # More graceful
 export FELIX_CONTROL_STREAM_DRAIN_TIMEOUT_MS="20"   # Faster shutdown
 ```
 
+### `FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS`
+
+**Description**: Total budget for draining in-flight work after SIGTERM or SIGINT,
+before remaining tasks are force-cancelled. Applies to both the broker and the
+control plane. This is a single budget shared by every subsystem, not a per-subsystem
+timeout, so total shutdown time stays bounded by this value.
+
+**Type**: Positive integer (milliseconds)
+
+**Default**: `25000`
+
+**Example**:
+```bash
+export FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS="25000"
+export FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS="55000"  # With terminationGracePeriodSeconds: 60
+export FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS="5000"   # Fast rollouts, short-lived requests
+```
+
+**Note**: Keep this below the platform's kill deadline — Kubernetes'
+`terminationGracePeriodSeconds` (default `30`) — so the drain finishes and logs its
+outcome before SIGKILL. See [Graceful Shutdown](../deployment/graceful-shutdown.md).
+
 ## Configuration File
 
 ### `FELIX_BROKER_CONFIG`

--- a/docs/security/panic-audit.md
+++ b/docs/security/panic-audit.md
@@ -2,12 +2,12 @@
 
 Audit record for [#140](https://github.com/gabloe/felix/issues/140), covering the
 `unsafe impl Send` question and the `unwrap()`/`expect()` triage. The sustained-load
-and resource-leak portions of that issue are tracked separately and are **not**
-covered here.
+and resource-leak portions of that issue are **not** covered here; they were split
+into [#154](https://github.com/gabloe/felix/issues/154).
 
 ## Scope and environment
 
-- Commit: branch `users/gabloe/fixbenchmarking2`.
+- Commit: branch `users/gabloe/remainingm0`.
 - Crates in scope: `crates/felix-wire`, `crates/felix-broker`, `crates/felix-transport`,
   `crates/felix-storage`, `services/broker`, `services/controlplane`.
 - Method: static inventory of `unwrap`/`expect`/`panic!`/`unreachable!`/`todo!`/
@@ -101,5 +101,7 @@ path involved no `unwrap` at all. Counting `unwrap` would not have found it.
   pass.
 - Fuzzing the frame and message decoders remains open in `docs/todos.md` and would be
   the natural way to gain confidence beyond this manual review.
-- Sustained-load, connection-churn, and resource-leak evidence required by #140 is not
-  covered by this document.
+- Sustained-load, connection-churn, and resource-leak evidence is not covered by this
+  document; it is tracked in [#154](https://github.com/gabloe/felix/issues/154). Until
+  that lands, M0's "no known concurrency or leak issues" criterion rests on this static
+  audit alone.

--- a/docs/security/panic-audit.md
+++ b/docs/security/panic-audit.md
@@ -1,0 +1,105 @@
+# Panic and abort audit — broker data path
+
+Audit record for [#140](https://github.com/gabloe/felix/issues/140), covering the
+`unsafe impl Send` question and the `unwrap()`/`expect()` triage. The sustained-load
+and resource-leak portions of that issue are tracked separately and are **not**
+covered here.
+
+## Scope and environment
+
+- Commit: branch `users/gabloe/fixbenchmarking2`.
+- Crates in scope: `crates/felix-wire`, `crates/felix-broker`, `crates/felix-transport`,
+  `crates/felix-storage`, `services/broker`, `services/controlplane`.
+- Method: static inventory of `unwrap`/`expect`/`panic!`/`unreachable!`/`todo!`/
+  `unimplemented!` in non-test code, plus manual review of the binary frame decoders
+  for panics that carry no `unwrap` at all (slicing, `Buf` scalar reads, and
+  capacity-driven allocation).
+- Default (`--no-default-features`-equivalent) builds are the baseline. The
+  `telemetry` feature is opt-in and is called out separately.
+
+## `unsafe impl Send`
+
+Both `unsafe impl Send` blocks — `Broker` and `EphemeralCache` — were removed. Neither
+was doing anything: every field of both types is already `Send + Sync`
+(`RwLock<HashMap<..>>`, atomics, `usize`, and `Box<dyn StorageApi + Send>` where
+`StorageApi: Debug + Send + Sync` supplies both auto traits to the trait object). The
+compiler's auto-impls already applied, so the `unsafe` was a no-op that suppressed
+nothing and asserted nothing.
+
+Each type now carries a `const _` assertion that it is `Send + Sync`. If a future field
+breaks the property, the build fails at the definition rather than surfacing as a
+trait-bound error at a distant call site — which is the pressure that produces an
+`unsafe impl` "fix" in the first place.
+
+## Panic inventory
+
+198 non-test sites total. Classification:
+
+| Class | Count | Disposition |
+| --- | ---: | --- |
+| `telemetry` feature only (`timings_telemetry.rs` × 3) | 103 | Not in default builds; mutex-poisoning `expect`s in an opt-in diagnostic path |
+| Test modules in non-`tests/` files (`tests.rs`, `bench_ts.rs`) | 68 | Test-only |
+| Invariant-protected, request path | 14 | Sound; see below |
+| Startup / configuration fail-fast | 8 | Intentional: bad config should not produce a half-live process |
+| Infallible conversions | 3 | Sound; see below |
+| **Request-reachable, unguarded** | **2** | **Fixed; see findings** |
+
+### Invariant-protected (verified, not assumed)
+
+- `handlers/publish.rs` — 12 × `request_id.expect("request id checked")`. The protocol
+  invariant is enforced earlier in `handle_publish_message`: an acked publish missing
+  `request_id` is rejected with `missing request_id for acked publish` before any of
+  these sites run. A malformed client frame produces an error response, not a panic.
+- `handlers/publish.rs` — 2 × `unreachable!("Wait handled above")`. `EnqueuePolicy` is
+  config-derived, not request-derived, and `Wait` is handled in an earlier branch.
+- `handlers/subscribe.rs:995` — `frames.pop().expect("single frame")` is guarded by an
+  enclosing `frames.len() == 1`.
+- `felix-broker/src/lib.rs` — `next_seq.checked_add(1).expect("log sequence overflow")`
+  requires 2^64 publishes to a single stream.
+- `felix-wire` — `encode_slice(..).expect("base64 encode slice")` writes into a buffer
+  resized to exactly `base64_len(payload.len())?`, and that helper returns `Err` on
+  overflow. This is on the **encode** path, not decode.
+- `felix-transport:349` — `u64::try_from(connection.stable_id())` converts from `usize`.
+
+## Findings
+
+### F1 — Unbounded allocation from an attacker-declared payload count (fixed)
+
+`decode_publish_batch`, `decode_event_batch`, and `decode_shared_event_batch` read a
+`u32` payload count straight off the wire and passed it to `Vec::with_capacity` before
+validating it against the bytes actually present. Per-payload validation inside the loop
+was correct, but it ran too late — the allocation had already happened.
+
+Reachability: `decode_publish_batch` is called from
+`handle_binary_publish_batch_control` **before** the `auth_ctx` check, so any peer that
+completes a QUIC handshake can reach it. A ~20-byte frame declaring `u32::MAX` payloads
+was sufficient.
+
+Measured impact: a single such frame reserves 95 GiB (`Vec<Vec<u8>>`) to 127 GiB
+(`Vec<Bytes>`) of address space. Overcommit means one frame typically succeeds, so this
+is not a single-shot crash. At roughly a thousand concurrent decodes the address space
+is exhausted and the failing allocation calls `handle_alloc_error`, which **aborts** —
+it does not unwind, so tokio's per-task panic recovery does not contain it. Under a
+memory cgroup or strict overcommit, as in a typical container deployment, the threshold
+is far lower.
+
+Fix: `checked_payload_count` rejects any count exceeding `remaining / 4`, since every
+payload requires at least a 4-byte length prefix. Regression tests cover all three
+decoders plus a boundary case at the maximum supportable count.
+
+### F2 — Non-finding: raw `unwrap` count
+
+The issue notes a ~560-site raw count. The non-test figure is 198, and 171 of those are
+test modules in non-`tests/` files or the opt-in `telemetry` feature. The count on its
+own does not indicate risk, and — as F1 shows — the most serious defect in the decode
+path involved no `unwrap` at all. Counting `unwrap` would not have found it.
+
+## Residual risk
+
+- The `telemetry` feature's 103 mutex-poisoning `expect`s are unreviewed. They are not
+  in default builds; if `telemetry` is ever enabled in production, they need their own
+  pass.
+- Fuzzing the frame and message decoders remains open in `docs/todos.md` and would be
+  the natural way to gain confidence beyond this manual review.
+- Sustained-load, connection-churn, and resource-leak evidence required by #140 is not
+  covered by this document.

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -33,7 +33,11 @@ durability, clustering, or advanced observability.
 - [X] QUIC server endpoint wrapper (quinn)
 - [X] QUIC client endpoint wrapper
 - [X] Connection info + stream helpers (bi/uni)
-- [ ] Graceful shutdown hooks (drain connections on SIGTERM)
+- [X] Graceful shutdown hooks (drain connections on SIGTERM) — see
+      [Graceful Shutdown](../docs-site/docs/deployment/graceful-shutdown.md).
+      Readiness flip, bounded drain, and accept-loop cancellation are done; per-subsystem
+      cancellation (publish workers, ack waiters, subscription writers) and process-level
+      SIGTERM tests remain open under #139.
 - [ ] Backpressure defaults (caps per connection/subscription)
 
 ## Broker core (`felix-broker`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
     - Local Development: deployment/local.md
     - Docker Compose: deployment/docker-compose.md
     - Kubernetes: deployment/kubernetes.md
+    - Graceful Shutdown: deployment/graceful-shutdown.md
   - Reference:
     - Configuration: reference/configuration.md
     - Environment Variables: reference/environment-variables.md

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -33,6 +33,7 @@ path = "../../demos/broker/orders_demo.rs"
 anyhow = { workspace = true }
 base64 = "0.22"
 felix-broker = { path = "../../crates/felix-broker", version = "0.1.0" }
+felix-common = { path = "../../crates/felix-common", version = "0.1.0", features = ["lifecycle"] }
 felix-client = { path = "../../crates/felix-client", version = "0.1.0" }
 felix-authz = { path = "../../crates/felix-authz", version = "0.1.0" }
 felix-transport = { path = "../../crates/felix-transport", version = "0.1.0" }
@@ -57,6 +58,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 tokio = { workspace = true }
+# `TaskTracker` and `CancellationToken` back the graceful drain in `shutdown.rs`.
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-opentelemetry = "0.32.1"

--- a/services/broker/src/config.rs
+++ b/services/broker/src/config.rs
@@ -28,6 +28,9 @@ pub struct BrokerConfig {
     pub disable_timings: bool,
     // Max time to wait for control-stream writer to drain.
     pub control_stream_drain_timeout_ms: u64,
+    // Total budget for draining in-flight work after SIGTERM/SIGINT before
+    // remaining tasks are force-cancelled.
+    pub shutdown_drain_timeout_ms: u64,
     // Cache connection flow-control window.
     pub cache_conn_recv_window: u64,
     // Cache stream flow-control window.
@@ -150,6 +153,12 @@ const DEFAULT_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_PUBLISH_QUEUE_WAIT_TIMEOUT_MS: u64 = 2000;
 const DEFAULT_ACK_WAIT_TIMEOUT_MS: u64 = 2000;
 const DEFAULT_CONTROL_STREAM_DRAIN_TIMEOUT_MS: u64 = 50;
+// Total budget for draining in-flight work after a termination signal. Kubernetes
+// defaults `terminationGracePeriodSeconds` to 30, and it sends SIGKILL once that
+// expires, so the default leaves headroom to finish the drain, log the outcome, and
+// exit before being killed. Deployments that raise the grace period should raise
+// this to match.
+const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS: u64 = 25_000;
 const DEFAULT_PUB_WORKERS_PER_CONN: usize = 4;
 const DEFAULT_PUB_QUEUE_DEPTH: usize = 64;
 const DEFAULT_PUB_INFLIGHT_BYTES: usize = 64 * 1024 * 1024;
@@ -180,6 +189,7 @@ struct BrokerConfigOverride {
     ack_wait_timeout_ms: Option<u64>,
     disable_timings: Option<bool>,
     control_stream_drain_timeout_ms: Option<u64>,
+    shutdown_drain_timeout_ms: Option<u64>,
     cache_conn_recv_window: Option<u64>,
     cache_stream_recv_window: Option<u64>,
     cache_send_window: Option<u64>,
@@ -255,6 +265,11 @@ impl BrokerConfig {
                 .and_then(|value| value.parse::<u64>().ok())
                 .filter(|value| *value > 0)
                 .unwrap_or(DEFAULT_CONTROL_STREAM_DRAIN_TIMEOUT_MS);
+        let shutdown_drain_timeout_ms = std::env::var("FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
         let cache_conn_recv_window = std::env::var("FELIX_CACHE_CONN_RECV_WINDOW")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
@@ -396,6 +411,7 @@ impl BrokerConfig {
             ack_wait_timeout_ms,
             disable_timings,
             control_stream_drain_timeout_ms,
+            shutdown_drain_timeout_ms,
             cache_conn_recv_window,
             cache_stream_recv_window,
             cache_send_window,
@@ -482,6 +498,11 @@ impl BrokerConfig {
             }
             if let Some(value) = override_cfg.control_stream_drain_timeout_ms {
                 config.control_stream_drain_timeout_ms = value;
+            }
+            if let Some(value) = override_cfg.shutdown_drain_timeout_ms
+                && value > 0
+            {
+                config.shutdown_drain_timeout_ms = value;
             }
             if let Some(value) = override_cfg.cache_conn_recv_window
                 && value > 0

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -13,10 +13,15 @@
 //! ## Process lifecycle
 //! - The broker starts long-running background tasks (QUIC accept loop, metrics server,
 //!   and optional control-plane sync).
-//! - The process remains alive until the provided shutdown future completes (by default,
-//!   CTRL-C / SIGINT).
-//! - On shutdown, we abort background tasks and await them best-effort to avoid leaving
-//!   tasks detached.
+//! - The process remains alive until the provided shutdown future completes. In
+//!   production that is SIGTERM or SIGINT: SIGTERM is what Kubernetes, systemd, and
+//!   `docker stop` send, so handling only SIGINT would abort in-flight work on every
+//!   rolling update.
+//! - Shutdown then runs a bounded drain, in order: readiness goes false so load
+//!   balancers stop routing here, the listener stops admitting new connections,
+//!   in-flight connections finish, and finally the metrics server stops. Anything
+//!   still running when `FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS` expires is force-cancelled
+//!   and named in a warning. See `felix_common::lifecycle`.
 //!
 //! ## TLS note
 //! `build_server_config()` currently creates a **dev-only self-signed** certificate for QUIC.
@@ -31,6 +36,7 @@ mod test_support;
 use anyhow::{Context, Result};
 use broker::{auth::BrokerAuth, config, quic};
 use felix_broker::Broker;
+use felix_common::lifecycle::{self, DrainBudget, Readiness};
 use felix_storage::EphemeralCache;
 use felix_transport::{QuicServer, TransportConfig};
 use quinn::ServerConfig;
@@ -38,18 +44,19 @@ use rcgen::generate_simple_self_signed;
 use rustls::pki_types::PrivatePkcs8KeyDer;
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
 // Tokio async runtime entry point. The broker is primarily I/O-bound (QUIC + HTTP metrics)
 // and runs multiple background tasks concurrently.
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Default shutdown trigger: CTRL-C (SIGINT). `run_with_shutdown` is written so we can
-    // reuse the same startup logic in tests or alternative hosting environments by passing
-    // a different shutdown future.
-    run_with_shutdown(async {
-        let _ = tokio::signal::ctrl_c().await;
-    })
-    .await
+    // Default shutdown trigger: SIGTERM or SIGINT. SIGTERM is what Kubernetes,
+    // systemd, and `docker stop` actually send; SIGINT only covers an interactive
+    // Ctrl-C. `run_with_shutdown` is written so we can reuse the same startup logic
+    // in tests or alternative hosting environments by passing a different future.
+    run_with_shutdown(lifecycle::termination_signal()).await
 }
 
 /// Start the broker and run until the provided `shutdown` future resolves.
@@ -68,6 +75,16 @@ where
     // Observability is initialized first so any subsequent startup logs/metrics are captured.
 
     let config = config::BrokerConfig::from_env_or_yaml()?;
+    // Lifecycle coordination. `readiness` gates `/ready`; the two tokens separate
+    // "stop admitting connections" from "stop serving probes", because the metrics
+    // endpoint has to outlive the drain — that is how an operator watches the drain
+    // happen. `connections` tracks per-connection tasks so the drain can wait for
+    // in-flight work instead of aborting it.
+    let readiness = Readiness::ready();
+    let accept_shutdown = CancellationToken::new();
+    let sync_shutdown = CancellationToken::new();
+    let metrics_shutdown = CancellationToken::new();
+    let connections = TaskTracker::new();
     tracing::info!(
         lanes = config.subscriber_writer_lanes.max(1),
         queue_bound = config.subscriber_lane_queue_depth.max(1),
@@ -95,10 +112,15 @@ where
 
     // Start the Prometheus metrics HTTP server. This is separate from QUIC traffic and
     // intentionally lightweight so metrics remain available even under load.
-    let metrics_task = tokio::spawn(observability::serve_metrics(
-        metrics_handle,
-        config.metrics_bind,
-    ));
+    let metrics_task = {
+        let metrics_shutdown = metrics_shutdown.clone();
+        tokio::spawn(observability::serve_metrics(
+            metrics_handle,
+            config.metrics_bind,
+            readiness.clone(),
+            async move { metrics_shutdown.cancelled().await },
+        ))
+    };
 
     // Build and bind the QUIC listener. `build_server_config` currently uses a self-signed
     // certificate suitable for local development.
@@ -121,8 +143,19 @@ where
         let broker = Arc::clone(&broker);
         let quic_config = config.clone();
         let auth = Arc::clone(&auth);
+        let accept_shutdown = accept_shutdown.clone();
+        let connections = connections.clone();
         tokio::spawn(async move {
-            if let Err(err) = quic::serve(quic_server, broker, quic_config, auth).await {
+            if let Err(err) = quic::serve_with_shutdown(
+                quic_server,
+                broker,
+                quic_config,
+                auth,
+                accept_shutdown,
+                connections,
+            )
+            .await
+            {
                 tracing::warn!(error = %err, "quic accept loop exited");
             }
         })
@@ -133,15 +166,25 @@ where
     let controlplane_task = if let Some(base_url) = config.controlplane_url.clone() {
         let interval_ms = config.controlplane_sync_interval_ms;
         let broker = Arc::clone(&broker);
+        let sync_shutdown = sync_shutdown.clone();
         Some(tokio::spawn(async move {
-            if let Err(err) = controlplane::start_sync(
-                broker,
-                base_url,
-                std::time::Duration::from_millis(interval_ms),
-            )
-            .await
-            {
-                tracing::warn!(error = %err, "control plane sync exited");
+            // `start_sync` polls forever, so cancellation is what ends it. Dropping
+            // it mid-iteration is safe: the sync is a read-only metadata refresh
+            // whose cursor only advances on success, so an interrupted iteration is
+            // the same case as a failed one and is simply re-fetched on next start.
+            tokio::select! {
+                _ = sync_shutdown.cancelled() => {
+                    tracing::info!("control plane sync stopped");
+                }
+                result = controlplane::start_sync(
+                    broker,
+                    base_url,
+                    Duration::from_millis(interval_ms),
+                ) => {
+                    if let Err(err) = result {
+                        tracing::warn!(error = %err, "control plane sync exited");
+                    }
+                }
             }
         }))
     } else {
@@ -150,23 +193,68 @@ where
     };
 
     // Block until the shutdown signal resolves so the process stays alive.
-    // After this point we initiate cooperative shutdown by aborting background tasks.
     shutdown.await;
-    // Abort background tasks. We use `abort()` (rather than graceful coordination) because:
-    // - This is an MVP wiring layer.
-    // - Individual subsystems may also implement their own shutdown in the future.
-    accept_task.abort();
-    metrics_task.abort();
-    if let Some(task) = &controlplane_task {
-        task.abort();
+
+    // Step 1: stop advertising readiness. Load balancers and the Kubernetes
+    // endpoints controller drop this instance from rotation while it can still
+    // serve, so new traffic is steered elsewhere rather than hitting a closing
+    // listener. This must happen before anything stops working.
+    readiness.begin_draining();
+    tracing::info!("readiness set to draining");
+
+    // Step 2: stop admitting new connections. In-flight ones are untouched.
+    accept_shutdown.cancel();
+
+    // Step 3: drain in-flight work against a single shared deadline.
+    let mut budget = DrainBudget::new(Duration::from_millis(config.shutdown_drain_timeout_ms));
+    tracing::info!(
+        deadline_ms = config.shutdown_drain_timeout_ms,
+        "draining in-flight work"
+    );
+
+    // Closing the tracker is what lets `wait()` resolve; without it the wait would
+    // hang until the deadline even with no connections left.
+    connections.close();
+    budget.drain("quic_connections", connections.wait()).await;
+
+    let mut accept_task = accept_task;
+    if !budget
+        .drain("quic_accept_loop", async {
+            let _ = (&mut accept_task).await;
+        })
+        .await
+    {
+        accept_task.abort();
     }
-    // Best-effort join to avoid leaving detached tasks running during tests.
-    // The `Result` values are intentionally ignored because cancellation is expected.
-    let _ = accept_task.await;
-    let _ = metrics_task.await;
-    if let Some(task) = controlplane_task {
-        let _ = task.await;
+
+    let mut controlplane_task = controlplane_task;
+    if let Some(task) = &mut controlplane_task {
+        sync_shutdown.cancel();
+        if !budget
+            .drain("controlplane_sync", async {
+                let _ = (&mut *task).await;
+            })
+            .await
+        {
+            task.abort();
+        }
     }
+
+    // Step 4: metrics last, so `/ready` keeps reporting "draining" and `/metrics`
+    // stays scrapeable for the whole drain. This is the window in which an operator
+    // can actually see what the broker is doing while it shuts down.
+    metrics_shutdown.cancel();
+    let mut metrics_task = metrics_task;
+    if !budget
+        .drain("metrics_server", async {
+            let _ = (&mut metrics_task).await;
+        })
+        .await
+    {
+        metrics_task.abort();
+    }
+
+    budget.report();
     tracing::info!("broker stopped");
     Ok(())
 }

--- a/services/broker/src/observability.rs
+++ b/services/broker/src/observability.rs
@@ -5,6 +5,7 @@
 //! Metrics serving is asynchronous and uses `axum` to handle requests.
 //! In tests, metrics recorder initialization is cached to avoid conflicts, and subscriber initialization is adapted accordingly.
 
+use felix_common::lifecycle::Readiness;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_exporter_prometheus::PrometheusHandle;
 use opentelemetry::KeyValue;
@@ -119,19 +120,51 @@ fn resource_attributes(service_name: &str) -> Vec<KeyValue> {
 /// Starts an asynchronous HTTP server exposing:
 /// - `/metrics`: Prometheus metrics endpoint.
 /// - `/live`: liveness probe returning "ok".
-/// - `/ready`: readiness probe returning "ok".
+/// - `/ready`: readiness probe, gated on `readiness`.
 ///
-/// Returns an I/O error if binding or serving fails.
-pub async fn serve_metrics(handle: PrometheusHandle, addr: SocketAddr) -> std::io::Result<()> {
-    let app = axum::Router::new()
+/// Runs until `shutdown` resolves, then stops accepting new requests and lets
+/// in-flight ones finish. Returns an I/O error if binding or serving fails.
+pub async fn serve_metrics<F>(
+    handle: PrometheusHandle,
+    addr: SocketAddr,
+    readiness: Readiness,
+    shutdown: F,
+) -> std::io::Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(
+        listener,
+        health_router(handle, readiness).into_make_service(),
+    )
+    .with_graceful_shutdown(shutdown)
+    .await
+}
+
+/// Build the metrics/health router.
+///
+/// `/live` stays "ok" for the whole process lifetime: during a drain the process is
+/// alive and working, and reporting otherwise would make Kubernetes restart a pod
+/// that is shutting down correctly. `/ready` is the one that flips, which is what
+/// removes the instance from load-balancer rotation.
+fn health_router(handle: PrometheusHandle, readiness: Readiness) -> axum::Router {
+    axum::Router::new()
         .route(
             "/metrics",
             axum::routing::get(move || async move { handle.render() }),
         )
         .route("/live", axum::routing::get(|| async { "ok" }))
-        .route("/ready", axum::routing::get(|| async { "ok" }));
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service()).await
+        .route(
+            "/ready",
+            axum::routing::get(move || async move {
+                if readiness.is_ready() {
+                    (axum::http::StatusCode::OK, "ok")
+                } else {
+                    (axum::http::StatusCode::SERVICE_UNAVAILABLE, "draining")
+                }
+            }),
+        )
 }
 
 /// Installs the Prometheus metrics recorder globally.

--- a/services/broker/src/transport/mod.rs
+++ b/services/broker/src/transport/mod.rs
@@ -29,6 +29,7 @@ mod tests {
             ack_wait_timeout_ms: 2000,
             disable_timings: false,
             control_stream_drain_timeout_ms: 50,
+            shutdown_drain_timeout_ms: 25_000,
             cache_conn_recv_window: 999,
             cache_stream_recv_window: 888,
             cache_send_window: 777,

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -22,6 +22,8 @@ use felix_transport::{QuicConnection, QuicServer};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
 use crate::auth::BrokerAuth;
 use crate::config::BrokerConfig;
@@ -66,6 +68,43 @@ pub async fn serve(
     config: BrokerConfig,
     auth: Arc<BrokerAuth>,
 ) -> Result<()> {
+    // Runs until the listener errors. Callers that need to stop accepting without
+    // killing in-flight connections should use `serve_with_shutdown`.
+    serve_with_shutdown(
+        server,
+        broker,
+        config,
+        auth,
+        CancellationToken::new(),
+        TaskTracker::new(),
+    )
+    .await
+}
+
+/// Accept loop with cooperative shutdown.
+///
+/// # What it does
+/// Same as [`serve`], but stops accepting when `shutdown` is cancelled and registers
+/// every per-connection task with `connections` so a drain can wait for in-flight
+/// work to finish.
+///
+/// # Why it exists
+/// Aborting the accept task kills the loop but says nothing about the connections it
+/// already spawned — those are detached and die with the process. Separating "stop
+/// admitting" from "wait for in-flight" is what makes a bounded drain possible.
+///
+/// # Invariants
+/// - Cancelling `shutdown` stops admission only; accepted connections keep running.
+/// - The caller owns `connections`, and must `close()` it before `wait()`ing or the
+///   wait never resolves.
+pub async fn serve_with_shutdown(
+    server: Arc<QuicServer>,
+    broker: Arc<Broker>,
+    config: BrokerConfig,
+    auth: Arc<BrokerAuth>,
+    shutdown: CancellationToken,
+    connections: TaskTracker,
+) -> Result<()> {
     let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
     // Main accept loop: spawn a task per incoming QUIC connection.
     if config.disable_timings {
@@ -73,13 +112,22 @@ pub async fn serve(
         broker_publish_timings::set_enabled(false);
     }
     loop {
-        // Accept the next QUIC connection.
-        let connection = server.accept().await?;
+        // Accept the next QUIC connection, unless we have been asked to stop
+        // admitting. Selecting here rather than checking between accepts means a
+        // loop parked on an idle listener still exits promptly.
+        let connection = tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!("quic accept loop stopping; no longer admitting connections");
+                return Ok(());
+            }
+            accepted = server.accept() => accepted?,
+        };
         let broker = Arc::clone(&broker);
         let config = config.clone();
         let auth = Arc::clone(&auth);
         let publish_ctx = publish_ctx.clone();
-        tokio::spawn(async move {
+        connections.spawn(async move {
             if let Err(err) = handle_connection(broker, connection, config, auth, publish_ctx).await
             {
                 tracing::warn!(error = %err, "quic connection handler failed");

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -1745,6 +1745,7 @@ mod tests {
             ack_wait_timeout_ms: 2000,
             disable_timings: false,
             control_stream_drain_timeout_ms: 50,
+            shutdown_drain_timeout_ms: 25_000,
             cache_conn_recv_window: 256 * 1024 * 1024,
             cache_stream_recv_window: 64 * 1024 * 1024,
             cache_send_window: 256 * 1024 * 1024,

--- a/services/broker/src/transport/quic/mod.rs
+++ b/services/broker/src/transport/quic/mod.rs
@@ -33,5 +33,5 @@ pub(crate) static DECODE_ERROR_LOGS: AtomicUsize = AtomicUsize::new(0);
 pub(crate) const DECODE_ERROR_LOG_LIMIT: usize = 20;
 
 pub use codec::{read_message_limited, write_message};
-pub use conn::serve;
+pub use conn::{serve, serve_with_shutdown};
 pub use telemetry::{FrameCountersSnapshot, frame_counters_snapshot, reset_frame_counters};

--- a/services/broker/tests/graceful_shutdown.rs
+++ b/services/broker/tests/graceful_shutdown.rs
@@ -1,0 +1,218 @@
+//! Graceful shutdown / drain integration tests for the QUIC accept loop.
+//!
+//! # Purpose
+//! Cover the transport half of the SIGTERM lifecycle: cancelling the accept token
+//! must stop *admitting* connections without killing the ones already accepted, and
+//! the drain must be bounded.
+//!
+//! # Key invariants
+//! - Cancellation stops admission; accepted connections keep running.
+//! - The accept loop exits promptly even when parked on an idle listener.
+//! - `TaskTracker::wait` resolves once tracked connections finish.
+//!
+//! # How to use
+//! Run with `cargo test -p broker --test graceful_shutdown`.
+use anyhow::Result;
+use broker::auth::BrokerAuth;
+use felix_broker::Broker;
+use felix_common::lifecycle::{DrainBudget, Readiness};
+use felix_storage::EphemeralCache;
+use felix_transport::{QuicClient, QuicServer, TransportConfig};
+use quinn::ClientConfig as QuinnClientConfig;
+use rcgen::generate_simple_self_signed;
+use rustls::RootCertStore;
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use serial_test::serial;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+fn build_server_config() -> Result<(quinn::ServerConfig, CertificateDer<'static>)> {
+    let cert = generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.cert.der().clone();
+    let key_der = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
+    let server_config =
+        quinn::ServerConfig::with_single_cert(vec![cert_der.clone()], key_der.into())?;
+    Ok((server_config, cert_der))
+}
+
+fn build_quinn_client_config(cert: CertificateDer<'static>) -> Result<QuinnClientConfig> {
+    let mut roots = RootCertStore::empty();
+    roots.add(cert)?;
+    Ok(QuinnClientConfig::with_root_certificates(Arc::new(roots))?)
+}
+
+struct Harness {
+    addr: std::net::SocketAddr,
+    cert: CertificateDer<'static>,
+    accept_shutdown: CancellationToken,
+    connections: TaskTracker,
+    server_task: tokio::task::JoinHandle<Result<()>>,
+}
+
+async fn start_broker() -> Result<Harness> {
+    let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+    broker.register_tenant("t1").await?;
+    broker.register_namespace("t1", "default").await?;
+
+    let (server_config, cert) = build_server_config()?;
+    let server = Arc::new(QuicServer::bind(
+        "127.0.0.1:0".parse()?,
+        server_config,
+        TransportConfig::default(),
+    )?);
+    let addr = server.local_addr()?;
+
+    let config = broker::config::BrokerConfig::from_env()?;
+    let auth = Arc::new(BrokerAuth::new("http://127.0.0.1:1/".to_string()));
+    let accept_shutdown = CancellationToken::new();
+    let connections = TaskTracker::new();
+
+    let server_task = tokio::spawn(broker::quic::serve_with_shutdown(
+        Arc::clone(&server),
+        broker,
+        config,
+        auth,
+        accept_shutdown.clone(),
+        connections.clone(),
+    ));
+
+    Ok(Harness {
+        addr,
+        cert,
+        accept_shutdown,
+        connections,
+        server_task,
+    })
+}
+
+fn client_for(cert: CertificateDer<'static>) -> Result<QuicClient> {
+    QuicClient::bind(
+        "127.0.0.1:0".parse()?,
+        build_quinn_client_config(cert)?,
+        TransportConfig::default(),
+    )
+}
+
+#[tokio::test]
+#[serial]
+// The accept loop spends nearly all of its life parked on `server.accept()`. If
+// cancellation were only checked between accepts, an idle broker would ignore
+// SIGTERM entirely and hang until SIGKILL.
+async fn cancelling_accept_token_exits_idle_accept_loop() -> Result<()> {
+    let harness = start_broker().await?;
+
+    harness.accept_shutdown.cancel();
+
+    let result = timeout(Duration::from_secs(5), harness.server_task)
+        .await
+        .expect("accept loop must exit promptly when idle")
+        .expect("join accept loop");
+    assert!(
+        result.is_ok(),
+        "accept loop should exit cleanly: {result:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+// The distinction the whole drain rests on: after cancellation the broker must stop
+// admitting new work while connections it already accepted keep running.
+async fn cancellation_stops_admission_but_keeps_accepted_connections() -> Result<()> {
+    let harness = start_broker().await?;
+
+    // Establish a connection before shutdown and keep it open.
+    let early_client = client_for(harness.cert.clone())?;
+    let early_conn = early_client.connect(harness.addr, "localhost").await?;
+
+    // Wait for the accept loop to register it, so we are asserting about a
+    // connection the broker actually took ownership of.
+    for _ in 0..100 {
+        if !harness.connections.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        harness.connections.len(),
+        1,
+        "broker should have accepted the pre-shutdown connection"
+    );
+
+    harness.accept_shutdown.cancel();
+    let result = timeout(Duration::from_secs(5), harness.server_task)
+        .await
+        .expect("accept loop must exit")
+        .expect("join accept loop");
+    assert!(
+        result.is_ok(),
+        "accept loop should exit cleanly: {result:?}"
+    );
+
+    // The already-accepted connection is untouched by the accept loop stopping —
+    // and still usable, not merely un-closed.
+    timeout(Duration::from_secs(2), early_conn.open_uni())
+        .await
+        .expect("opening a stream should not hang")
+        .expect("accepted connection must still be usable after admission stops");
+    assert_eq!(
+        harness.connections.len(),
+        1,
+        "in-flight connection task should still be tracked"
+    );
+
+    // A new connection is no longer admitted. The handshake may fail outright or
+    // hang because nothing accepts it; either is "not admitted", and both are
+    // distinguishable from the success this returns before shutdown.
+    let late_client = client_for(harness.cert.clone())?;
+    let late = timeout(
+        Duration::from_secs(2),
+        late_client.connect(harness.addr, "localhost"),
+    )
+    .await;
+    let admitted = matches!(late, Ok(Ok(_)));
+    assert!(
+        !admitted,
+        "broker must not admit connections after shutdown"
+    );
+
+    // Once the peer goes away the tracked task finishes and the drain completes,
+    // which is what bounds the shutdown rather than an unconditional abort.
+    drop(early_conn);
+    drop(early_client);
+    harness.connections.close();
+    timeout(Duration::from_secs(10), harness.connections.wait())
+        .await
+        .expect("tracked connections should drain after the peer disconnects");
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+// Readiness has to flip before the listener stops, so traffic is steered away while
+// the broker can still serve it.
+async fn readiness_flips_before_admission_stops() -> Result<()> {
+    let harness = start_broker().await?;
+    let readiness = Readiness::ready();
+    assert!(readiness.is_ready());
+
+    readiness.begin_draining();
+    assert!(!readiness.is_ready());
+    harness.accept_shutdown.cancel();
+
+    let mut budget = DrainBudget::new(Duration::from_secs(5));
+    harness.connections.close();
+    assert!(
+        budget
+            .drain("quic_connections", harness.connections.wait())
+            .await,
+        "an idle broker should drain immediately"
+    );
+    assert!(budget.unfinished().is_empty());
+
+    let _ = timeout(Duration::from_secs(5), harness.server_task).await;
+    Ok(())
+}

--- a/services/controlplane/Cargo.toml
+++ b/services/controlplane/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 axum = "0.8"
+felix-common = { path = "../../crates/felix-common", version = "0.1.0", features = ["lifecycle"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 opentelemetry = "0.31.0"
@@ -21,6 +22,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml_ng = { workspace = true }
 tokio = { workspace = true }
+# `CancellationToken` coordinates the graceful drain in `main.rs`.
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-opentelemetry = "0.32.1"

--- a/services/controlplane/src/config.rs
+++ b/services/controlplane/src/config.rs
@@ -14,6 +14,10 @@ use std::net::SocketAddr;
 use std::str::FromStr;
 
 pub const DEFAULT_CHANGES_LIMIT: u64 = 1000;
+// Total budget for draining in-flight HTTP requests after a termination signal.
+// Kubernetes defaults `terminationGracePeriodSeconds` to 30 and sends SIGKILL once
+// it expires, so this leaves headroom to finish the drain and exit before then.
+pub const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS: u64 = 25_000;
 pub const DEFAULT_CHANGE_RETENTION_MAX_ROWS: i64 = 10_000;
 const DEFAULT_PG_MAX_CONNECTIONS: u32 = 10;
 const DEFAULT_PG_CONNECT_TIMEOUT_MS: u64 = 5_000;
@@ -69,6 +73,9 @@ pub struct ControlPlaneConfig {
     pub change_retention_max_rows: Option<i64>,
     pub oidc_allowed_algorithms: Vec<Algorithm>,
     pub bootstrap: BootstrapConfig,
+    // Total budget for draining in-flight requests after SIGTERM/SIGINT before
+    // remaining tasks are force-cancelled.
+    pub shutdown_drain_timeout_ms: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,6 +89,7 @@ struct ControlPlaneConfigOverride {
     change_retention_max_rows: Option<i64>,
     oidc_allowed_algorithms: Option<Vec<String>>,
     bootstrap: Option<BootstrapOverride>,
+    shutdown_drain_timeout_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,6 +140,11 @@ impl ControlPlaneConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(DEFAULT_CHANGES_LIMIT);
+        let shutdown_drain_timeout_ms = std::env::var("FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS);
         let change_retention_max_rows =
             std::env::var("FELIX_CONTROLPLANE_CHANGE_RETENTION_MAX_ROWS")
                 .ok()
@@ -187,6 +200,7 @@ impl ControlPlaneConfig {
                     .with_context(|| "parse FELIX_BOOTSTRAP_BIND_ADDR")?,
                 token: std::env::var("FELIX_BOOTSTRAP_TOKEN").ok(),
             },
+            shutdown_drain_timeout_ms,
         };
         config.validate()?;
         Ok(config)
@@ -214,6 +228,11 @@ impl ControlPlaneConfig {
             }
             if let Some(value) = override_cfg.change_retention_max_rows {
                 config.change_retention_max_rows = Some(value);
+            }
+            if let Some(value) = override_cfg.shutdown_drain_timeout_ms
+                && value > 0
+            {
+                config.shutdown_drain_timeout_ms = value;
             }
             if let Some(values) = override_cfg.oidc_allowed_algorithms {
                 config.oidc_allowed_algorithms = parse_oidc_allowed_algorithms(values)?;

--- a/services/controlplane/src/main.rs
+++ b/services/controlplane/src/main.rs
@@ -18,17 +18,19 @@ use anyhow::Context;
 use api::types::{FeatureFlags, Region};
 use app::{AppState, build_bootstrap_router, build_router};
 use auth::oidc::UpstreamOidcValidator;
-use std::future::Future;
+use felix_common::lifecycle::{self, DrainBudget, Readiness};
+use std::future::{Future, IntoFuture};
 use std::sync::Arc;
+use std::time::Duration;
 use store::{ControlPlaneAuthStore, StoreConfig, memory::InMemoryStore, postgres::PostgresStore};
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let config = config::ControlPlaneConfig::from_env_or_yaml().expect("control plane config");
-    run_with_shutdown(config, async {
-        let _ = tokio::signal::ctrl_c().await;
-    })
-    .await
+    // SIGTERM is what Kubernetes, systemd, and `docker stop` send; SIGINT only
+    // covers an interactive Ctrl-C.
+    run_with_shutdown(config, lifecycle::termination_signal()).await
 }
 
 async fn run_with_shutdown<F>(config: config::ControlPlaneConfig, shutdown: F) -> anyhow::Result<()>
@@ -38,10 +40,23 @@ where
     let metrics_handle = observability::init_observability("felix-controlplane");
     let state = build_state(config.clone()).await?;
     let _backend_name = state.store.backend_name();
-    let metrics_task = tokio::spawn(observability::serve_metrics(
-        metrics_handle,
-        config.metrics_bind,
-    ));
+
+    // `readiness` gates `/ready`. The tokens are separate because the metrics
+    // endpoint has to outlive the API drain — that is how an operator watches the
+    // drain happen.
+    let readiness = Readiness::ready();
+    let api_shutdown = CancellationToken::new();
+    let metrics_shutdown = CancellationToken::new();
+
+    let metrics_task = {
+        let metrics_shutdown = metrics_shutdown.clone();
+        tokio::spawn(observability::serve_metrics(
+            metrics_handle,
+            config.metrics_bind,
+            readiness.clone(),
+            async move { metrics_shutdown.cancelled().await },
+        ))
+    };
 
     let app = build_router(state.clone());
 
@@ -49,6 +64,7 @@ where
         let bootstrap_addr = config.bootstrap.bind_addr;
         let bootstrap_app = build_bootstrap_router(state.clone());
         let bootstrap_enabled = state.bootstrap_enabled;
+        let api_shutdown = api_shutdown.clone();
         Some(tokio::spawn(async move {
             tracing::info!(
                 %bootstrap_addr,
@@ -57,7 +73,9 @@ where
             );
             match tokio::net::TcpListener::bind(bootstrap_addr).await {
                 Ok(listener) => {
-                    let _ = axum::serve(listener, bootstrap_app.into_make_service()).await;
+                    let _ = axum::serve(listener, bootstrap_app.into_make_service())
+                        .with_graceful_shutdown(async move { api_shutdown.cancelled().await })
+                        .await;
                 }
                 Err(err) => {
                     tracing::warn!(error = %err, "failed to bind bootstrap listener");
@@ -71,22 +89,79 @@ where
     let addr = config.bind_addr;
     tracing::info!(%addr, "control plane listening");
     let listener = tokio::net::TcpListener::bind(addr).await?;
+
+    // The API server drains itself: `with_graceful_shutdown` stops accepting new
+    // connections and lets in-flight requests finish. Previously this was a
+    // `select!` against the shutdown future, which dropped the server mid-request
+    // and killed everything in flight.
+    let mut api_task = {
+        let api_shutdown = api_shutdown.clone();
+        tokio::spawn(
+            axum::serve(listener, app.into_make_service())
+                .with_graceful_shutdown(async move { api_shutdown.cancelled().await })
+                .into_future(),
+        )
+    };
+
     tokio::pin!(shutdown);
     tokio::select! {
-        result = axum::serve(listener, app.into_make_service()) => {
-            result?;
+        result = &mut api_task => {
+            // The listener failed on its own; there is nothing left to drain.
+            result??;
+            return Ok(());
         }
-        _ = &mut shutdown => {}
+        _ = &mut shutdown => {
+            // Step 1: stop advertising readiness so load balancers remove this
+            // instance while it can still serve. Must precede the listener stopping.
+            readiness.begin_draining();
+            tracing::info!("readiness set to draining");
+        }
     }
 
-    metrics_task.abort();
-    if let Some(task) = &bootstrap_task {
+    // Step 2: stop admitting, then drain in-flight requests against one shared
+    // deadline covering every subsystem.
+    let mut budget = DrainBudget::new(Duration::from_millis(config.shutdown_drain_timeout_ms));
+    tracing::info!(
+        deadline_ms = config.shutdown_drain_timeout_ms,
+        "draining in-flight requests"
+    );
+    api_shutdown.cancel();
+
+    if !budget
+        .drain("api_server", async {
+            let _ = (&mut api_task).await;
+        })
+        .await
+    {
+        api_task.abort();
+    }
+
+    let mut bootstrap_task = bootstrap_task;
+    if let Some(task) = &mut bootstrap_task
+        && !budget
+            .drain("bootstrap_server", async {
+                let _ = (&mut *task).await;
+            })
+            .await
+    {
         task.abort();
     }
-    let _ = metrics_task.await;
-    if let Some(task) = bootstrap_task {
-        let _ = task.await;
+
+    // Step 3: metrics last, so `/ready` keeps reporting "draining" and `/metrics`
+    // stays scrapeable for the whole drain.
+    metrics_shutdown.cancel();
+    let mut metrics_task = metrics_task;
+    if !budget
+        .drain("metrics_server", async {
+            let _ = (&mut metrics_task).await;
+        })
+        .await
+    {
+        metrics_task.abort();
     }
+
+    budget.report();
+    tracing::info!("control plane stopped");
     Ok(())
 }
 
@@ -150,6 +225,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            shutdown_drain_timeout_ms: 25_000,
         };
         let state = build_state(config).await.expect("state");
         assert_eq!(state.region.region_id, "local");
@@ -172,6 +248,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            shutdown_drain_timeout_ms: 25_000,
         };
         let err = build_state(config).await.err().expect("missing postgres");
         assert!(err.to_string().contains("postgres configuration missing"));
@@ -198,6 +275,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: Some("bootstrap-token".to_string()),
             },
+            shutdown_drain_timeout_ms: 25_000,
         };
         let err = build_state(config)
             .await
@@ -224,6 +302,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            shutdown_drain_timeout_ms: 25_000,
         };
         run_with_shutdown(config, async {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -249,6 +328,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: Some("bootstrap-token".to_string()),
             },
+            shutdown_drain_timeout_ms: 25_000,
         };
         run_with_shutdown(config, async {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/services/controlplane/src/observability.rs
+++ b/services/controlplane/src/observability.rs
@@ -6,6 +6,7 @@
 //!
 //! # Notes
 //! Initialization is guarded by `OnceLock` to keep startup idempotent in tests.
+use felix_common::lifecycle::Readiness;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use metrics_exporter_prometheus::PrometheusHandle;
 use opentelemetry::KeyValue;
@@ -110,37 +111,71 @@ impl<'a> Extractor for HeaderMapExtractor<'a> {
     }
 }
 
-pub async fn serve_metrics(handle: PrometheusHandle, addr: SocketAddr) -> std::io::Result<()> {
-    serve_metrics_with_shutdown(handle, addr, std::future::pending()).await
+pub async fn serve_metrics<F>(
+    handle: PrometheusHandle,
+    addr: SocketAddr,
+    readiness: Readiness,
+    shutdown: F,
+) -> std::io::Result<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    serve_metrics_with_shutdown(handle, addr, readiness, shutdown).await
 }
 
 async fn serve_metrics_with_shutdown<F>(
     handle: PrometheusHandle,
     addr: SocketAddr,
+    readiness: Readiness,
     shutdown: F,
 ) -> std::io::Result<()>
 where
     F: Future<Output = ()> + Send + 'static,
 {
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    serve_metrics_with_listener(handle, listener, shutdown).await
+    serve_metrics_with_listener(handle, listener, readiness, shutdown).await
 }
 
 async fn serve_metrics_with_listener<F>(
     handle: PrometheusHandle,
     listener: tokio::net::TcpListener,
+    readiness: Readiness,
     shutdown: F,
 ) -> std::io::Result<()>
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let app = axum::Router::new().route(
-        "/metrics",
-        axum::routing::get(move || async move { handle.render() }),
-    );
-    axum::serve(listener, app.into_make_service())
-        .with_graceful_shutdown(shutdown)
-        .await
+    axum::serve(
+        listener,
+        health_router(handle, readiness).into_make_service(),
+    )
+    .with_graceful_shutdown(shutdown)
+    .await
+}
+
+/// Build the metrics/health router.
+///
+/// `/live` stays "ok" for the whole process lifetime: during a drain the process is
+/// alive and still serving, and reporting otherwise would make Kubernetes restart a
+/// pod that is shutting down correctly. `/ready` is the one that flips, which is what
+/// removes the instance from load-balancer rotation.
+fn health_router(handle: PrometheusHandle, readiness: Readiness) -> axum::Router {
+    axum::Router::new()
+        .route(
+            "/metrics",
+            axum::routing::get(move || async move { handle.render() }),
+        )
+        .route("/live", axum::routing::get(|| async { "ok" }))
+        .route(
+            "/ready",
+            axum::routing::get(move || async move {
+                if readiness.is_ready() {
+                    (axum::http::StatusCode::OK, "ok")
+                } else {
+                    (axum::http::StatusCode::SERVICE_UNAVAILABLE, "draining")
+                }
+            }),
+        )
 }
 
 fn install_metrics_recorder() -> PrometheusHandle {
@@ -324,19 +359,34 @@ mod tests {
         oneshot::Sender<()>,
         tokio::task::JoinHandle<std::io::Result<()>>,
     ) {
+        let (addr, shutdown_tx, server_handle, _readiness) =
+            spawn_metrics_server_with_readiness(handle, Readiness::ready()).await;
+        (addr, shutdown_tx, server_handle)
+    }
+
+    async fn spawn_metrics_server_with_readiness(
+        handle: PrometheusHandle,
+        readiness: Readiness,
+    ) -> (
+        SocketAddr,
+        oneshot::Sender<()>,
+        tokio::task::JoinHandle<std::io::Result<()>>,
+        Readiness,
+    ) {
         let addr: SocketAddr = "127.0.0.1:0".parse().expect("parse addr");
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .expect("bind listener");
         let bound_addr = listener.local_addr().expect("local addr");
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let server_readiness = readiness.clone();
         let server_handle = tokio::spawn(async move {
-            serve_metrics_with_listener(handle, listener, async move {
+            serve_metrics_with_listener(handle, listener, server_readiness, async move {
                 let _ = shutdown_rx.await;
             })
             .await
         });
-        (bound_addr, shutdown_tx, server_handle)
+        (bound_addr, shutdown_tx, server_handle, readiness)
     }
 
     #[test]
@@ -370,6 +420,45 @@ mod tests {
             .await
             .unwrap_or_else(|err| panic!("GET /metrics failed for {}: {}", url, err));
         response.error_for_status().expect("metrics status");
+
+        let _ = shutdown_tx.send(());
+        let _ = tokio::time::timeout(Duration::from_secs(1), server_handle)
+            .await
+            .expect("server shutdown");
+    }
+
+    // The point of the readiness flip is that a load balancer can observe it, so the
+    // assertion that matters is over HTTP, not over the flag in isolation.
+    #[tokio::test(flavor = "multi_thread")]
+    #[serial]
+    async fn ready_reports_draining_after_readiness_flips() {
+        let handle = init_observability("controlplane-readiness-test");
+        let (addr, shutdown_tx, server_handle, readiness) =
+            spawn_metrics_server_with_readiness(handle, Readiness::ready()).await;
+        wait_for_listen(addr).await.expect("server ready");
+
+        let client = build_test_client();
+        let ready_url = format!("http://{}/ready", addr);
+        let live_url = format!("http://{}/live", addr);
+
+        let response = client.get(&ready_url).send().await.expect("GET /ready");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(response.text().await.expect("body"), "ok");
+
+        readiness.begin_draining();
+
+        let response = client.get(&ready_url).send().await.expect("GET /ready");
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            "/ready must fail once draining so load balancers stop routing here"
+        );
+        assert_eq!(response.text().await.expect("body"), "draining");
+
+        // Liveness must stay healthy: the process is draining correctly, and failing
+        // /live would make Kubernetes restart it mid-drain.
+        let response = client.get(&live_url).send().await.expect("GET /live");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
 
         let _ = shutdown_tx.send(());
         let _ = tokio::time::timeout(Duration::from_secs(1), server_handle)


### PR DESCRIPTION
Closes #140. Refs #139 — see *Still open* below; #139 is deliberately **not**
auto-closed, because two of its acceptance criteria are unmet.

The sustained-load half of #140 is split into #<NEW>, which tracks the remaining
M0 concurrency/leak evidence.

---

## #139 — SIGTERM-aware graceful draining

Both services waited only on `tokio::signal::ctrl_c()`. Kubernetes, systemd, and
`docker stop` all terminate with **SIGTERM**, which fell through to the default
handler — so every rolling update killed the process outright and dropped
in-flight publishes, acknowledgements, and subscription writes.

### Shutdown sequence

Order matters more than the individual steps:

1. **Readiness goes false.** `/ready` returns `503 draining`, so load balancers
   stop routing here *while the process can still serve*, steering clients away
   from a healthy instance rather than letting them find a broken one.
2. **Admission stops.** The broker cancels its QUIC accept loop; the control
   plane stops accepting new HTTP connections. Accepted work is untouched.
3. **In-flight work drains** against a deadline.
4. **The remainder is force-cancelled and named at WARN**, so a hung drain is
   distinguishable from the bug it was meant to fix.

`/live` stays `200` throughout — a draining process is working correctly, and
failing liveness would make Kubernetes restart a pod that is shutting down as
intended. Metrics tear down **last**, so `/metrics` and `/ready` stay scrapeable
for the whole window.

### Notable changes

- **Shared lifecycle module.** `Readiness`, `termination_signal`, and
  `DrainBudget` live in `felix-common::lifecycle` behind an optional `lifecycle`
  feature, so both services share one implementation and `felix-router` does not
  inherit tokio.
- **`DrainBudget` is one budget shared across subsystems**, not a per-subsystem
  timeout — N hanging subsystems cannot stretch a 25s deadline into 25N seconds.
  It measures with `tokio::time::Instant` so its arithmetic agrees with the
  `tokio::time::timeout` calls it drives.
- **`serve_with_shutdown`** is added alongside `serve`, which keeps its signature
  for ~15 test and demo call sites. It selects on cancellation *inside* the
  accept loop rather than between accepts, so an idle broker parked on `accept()`
  still exits promptly, and registers per-connection tasks with a `TaskTracker`
  so the drain can wait for in-flight work instead of aborting it.
- **Control-plane API server bug fixed.** It ran under `select!` against the
  shutdown future, which dropped the server mid-request. Now
  `with_graceful_shutdown`.
- **Docs bug fixed.** The Kubernetes examples probed `/healthz`, which neither
  service serves. Now `/live` and `/ready`, with `preStop` and
  `terminationGracePeriodSeconds` budgeted coherently against the drain deadline.

### Configuration

`FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS` (default `25000`) bounds the drain for both
services. The default sits under Kubernetes' 30s `terminationGracePeriodSeconds`
so the drain finishes and logs its outcome before SIGKILL.

---

## #140 — `unsafe impl Send` removal and panic triage

### Both `unsafe impl Send` blocks were no-ops

`Broker` and `EphemeralCache` carried `unsafe impl Send` with no safety comment.
Every field of both is already `Send + Sync` — `RwLock<HashMap<..>>`, atomics,
`usize`, and `Box<dyn StorageApi + Send>` where `StorageApi: Debug + Send + Sync`
supplies both auto traits to the trait object. The compiler's auto-impls already
applied, so the `unsafe` asserted nothing and suppressed nothing.

Both are replaced with a `const _` assertion that the type is `Send + Sync`, so a
future field that breaks the property fails the build *at the definition* instead
of surfacing as a trait-bound error at a distant call site — which is the
pressure that produces an `unsafe impl` "fix" in the first place.

### Unbounded allocation in the binary decoders (the actual finding)

`decode_publish_batch`, `decode_event_batch`, and `decode_shared_event_batch`
read a `u32` payload count off the wire and passed it to `Vec::with_capacity`
before validating it against the bytes present. The per-payload checks inside the
loop were correct but ran *after* the allocation.

`decode_publish_batch` is called from `handle_binary_publish_batch_control`
**before the `auth_ctx` check**, so any peer that completes a QUIC handshake can
reach it with a ~20-byte frame declaring `u32::MAX` payloads.

Measured, not assumed: one such frame reserves **95-127 GiB** of address space.
Overcommit means a single frame usually *succeeds*, so this is not a one-shot
crash — but at roughly a thousand concurrent decodes the address space is
exhausted and the failing allocation calls `handle_alloc_error`, which **aborts
rather than unwinds** and so is not contained by per-task panic recovery. A
memory cgroup or strict overcommit lowers that threshold considerably.

Fixed with a `remaining / 4` bound (every payload needs at least a 4-byte length
prefix), plus regression tests on all three decoders and a boundary case at the
maximum supportable count.

**This defect involved no `unwrap` at all** — the raw unwrap/expect count would
not have surfaced it.

### Panic inventory

Of 198 non-test panic sites, 171 are test modules in `tests.rs`-named files or
the opt-in `telemetry` feature. The remaining 27 are invariant-protected or
startup fail-fast, each verified rather than assumed — e.g. the 12
`request_id.expect("request id checked")` sites are guarded by an earlier
`missing request_id for acked publish` rejection. Full classification in
`docs/security/panic-audit.md`.

---

## Still open

**#140 is closed by this PR**, scoped to the audit it delivered. Its
sustained-load half moves to **#<NEW>**: connection churn, slow subscribers,
queue saturation, RSS/fd/task-count tracking, and a documented steady-state
envelope after quiescence. Repeated startup/shutdown under load was not testable
before this PR, which is part of why it is better tracked fresh.

**#139 stays open** and is referenced rather than closed. Two of its acceptance
criteria are unmet:

- *"An acknowledged publish is not lost solely because SIGTERM arrived"* — not
  verified by any test.
- *"Covered by process-level tests rather than only a synthetic shutdown
  future"* — coverage here is at the accept-loop and readiness level
  (`services/broker/tests/graceful_shutdown.rs`); nothing SIGTERMs the real
  binary under active traffic.

Also remaining under #139: cancellation is coordinated at the **connection**
boundary only — publish workers, ack waiters, and subscription writers are not
separately signalled to wind down, and subscription streams are not flushed per
their delivery contract. That is a continuation of this same code, not a
different activity, so it stays on #139 rather than being split.

Until #140's soak work lands, M0's *"no known concurrency or leak issues"*
criterion is supported only by the static audit, not by evidence under load.
Both `docs-site/docs/deployment/graceful-shutdown.md` and `docs/todos.md` state
these limits explicitly rather than implying the work is complete.

---

## Also included

`af6e58f` sets `FELIX_CORE_SHARDS=2` in the perf workflows — unrelated to the two
issues, carried on this branch.

## Verification

- 54 test binaries, 0 failures (`cargo test --workspace`)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- New tests: `services/broker/tests/graceful_shutdown.rs` (accept-loop drain
  semantics), `felix-common::lifecycle` unit tests, controlplane `/ready` HTTP
  drain assertion, three felix-wire decoder regression tests
