### PR TITLE
Add resource sampling for soak harness

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,101 @@
+name: Soak and Resource Leak Check
+
+# Runs the broker soak harness (#154) on Linux, which is the deployment target.
+# The findings recorded in docs/security/soak-report.md were gathered on macOS;
+# this is the run that should back any production claim about resource behaviour.
+#
+# Not on every PR: a meaningful soak takes minutes and its RSS signal needs
+# several identical cycles to be readable, which is the wrong shape for a
+# per-commit gate. Scheduled weekly, plus manual dispatch when shutdown,
+# connection lifecycle, or subscriber-registry code changes.
+
+on:
+  schedule:
+    # Mondays at 06:00 UTC.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      duration_secs:
+        description: "Seconds per load phase"
+        required: false
+        default: "60"
+      load_cycles:
+        description: "Identical load cycles (raise this to resolve slow RSS growth)"
+        required: false
+        default: "8"
+      restart_cycles:
+        description: "SIGTERM restart cycles"
+        required: false
+        default: "5"
+
+concurrency:
+  group: soak-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # The harness measures the broker, not the instrumentation. Timing collection
+  # is off for the same reason production leaves it off by default.
+  FELIX_DISABLE_TIMINGS: "1"
+
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: "1.97.1"
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+
+      - name: Build soak harness
+        run: cargo build --release -p broker --bin soak
+
+      - name: Raise file descriptor limit
+        # The churn phase opens and closes connections rapidly. The default soft
+        # limit is low enough that hitting it would look like a broker failure
+        # rather than a harness constraint.
+        run: ulimit -n 65536 && ulimit -n
+
+      - name: Run soak
+        id: soak
+        run: |
+          set -euo pipefail
+          ulimit -n 65536
+          mkdir -p data/soak
+          ./target/release/soak \
+            --duration-secs "${{ inputs.duration_secs || '60' }}" \
+            --quiesce-secs 30 \
+            --churn-cycles 500 \
+            --load-cycles "${{ inputs.load_cycles || '8' }}" \
+            --restart-cycles "${{ inputs.restart_cycles || '5' }}" \
+            --timeseries data/soak/ci-linux.jsonl \
+            2>&1 | tee /tmp/soak-output.txt
+
+      - name: Upload soak artifacts
+        # Always: a failing run is exactly the one whose time series is worth
+        # keeping.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-results
+          path: |
+            data/soak/ci-linux.jsonl
+            /tmp/soak-output.txt
+          retention-days: 30
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Soak result"
+            echo
+            echo '```'
+            sed -n '/== Soak report ==/,$p' /tmp/soak-output.txt || cat /tmp/soak-output.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -22,7 +22,7 @@ on:
       load_cycles:
         description: "Identical load cycles (raise this to resolve slow RSS growth)"
         required: false
-        default: "8"
+        default: "20"
       restart_cycles:
         description: "SIGTERM restart cycles"
         required: false
@@ -37,6 +37,8 @@ env:
   # The harness measures the broker, not the instrumentation. Timing collection
   # is off for the same reason production leaves it off by default.
   FELIX_DISABLE_TIMINGS: "1"
+  # Exercise the production core-shard handoff path on the four-CPU hosted runner.
+  FELIX_CORE_SHARDS: "2"
 
 jobs:
   soak:
@@ -56,6 +58,17 @@ jobs:
       - name: Build soak harness
         run: cargo build --release -p broker --bin soak
 
+      - name: Repeat concurrency-sensitive tests
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 10); do
+            echo "concurrency test pass ${attempt}/10"
+            cargo test -p broker --lib transport::quic::handlers::subscribe::tests
+            cargo test -p broker --test quic_publish
+            cargo test -p broker --test quic_subscribe
+            cargo test -p broker --test graceful_shutdown
+          done
+
       - name: Raise file descriptor limit
         # The churn phase opens and closes connections rapidly. The default soft
         # limit is low enough that hitting it would look like a broker failure
@@ -72,7 +85,7 @@ jobs:
             --duration-secs "${{ inputs.duration_secs || '60' }}" \
             --quiesce-secs 30 \
             --churn-cycles 500 \
-            --load-cycles "${{ inputs.load_cycles || '8' }}" \
+            --load-cycles "${{ inputs.load_cycles || '20' }}" \
             --restart-cycles "${{ inputs.restart_cycles || '5' }}" \
             --timeseries data/soak/ci-linux.jsonl \
             2>&1 | tee /tmp/soak-output.txt

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ lcov.info
 /site/
 site/
 .cache/
+data/soak/

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -363,6 +363,24 @@ impl QuicConnection {
         self.inner.stats()
     }
 
+    /// Close the connection, telling the peer why.
+    ///
+    /// Distinct from dropping the connection: a close sends CONNECTION_CLOSE
+    /// immediately, so the peer learns this was deliberate rather than waiting
+    /// for an idle timeout to decide the server vanished. That distinction is
+    /// what makes a graceful drain observable from the client side.
+    ///
+    /// ```no_run
+    /// use felix_transport::QuicConnection;
+    ///
+    /// fn shutdown(connection: &QuicConnection) {
+    ///     connection.close(0u32.into(), b"shutting down");
+    /// }
+    /// ```
+    pub fn close(&self, code: quinn::VarInt, reason: &[u8]) {
+        self.inner.close(code, reason);
+    }
+
     /// Open a bidirectional stream to the peer.
     ///
     /// ```no_run

--- a/docs-site/docs/development/how-felix-works.md
+++ b/docs-site/docs/development/how-felix-works.md
@@ -1,0 +1,1118 @@
+# How Felix Works
+
+This guide explains Felix from first principles and then follows the current
+implementation through the repository. It is intended for contributors who
+want to understand not only the public API, but also which task owns each piece
+of work, where data is queued, what is copied, what is shared, and what happens
+under overload.
+
+Code references use `path::symbol` rather than line numbers because symbols are
+more stable as the implementation changes.
+
+!!! important "Current implementation versus intended architecture"
+    Felix currently has a highly optimized single-node data plane: QUIC
+    transport, authenticated publish/subscribe, fanout, and an ephemeral cache.
+    The repository also contains foundations for durable storage, routing,
+    consensus, and multi-node operation, but those pieces are not all wired into
+    the running broker. This guide explicitly distinguishes implemented behavior
+    from planned behavior.
+
+## 1. The shortest useful mental model
+
+Felix is a brokered messaging and caching system:
+
+- **Publishers** send byte payloads to named streams.
+- **Subscribers** receive new payloads published to those streams.
+- **Cache clients** store and retrieve values under scoped keys.
+- A **broker** authenticates clients, validates resource scope, accepts traffic,
+  and routes it through bounded queues.
+- A **control plane** owns metadata and authorization state. Brokers periodically
+  synchronize a local view of tenants, namespaces, streams, and caches.
+
+The current pub/sub data path is:
+
+```text
+application
+  -> felix-client Publisher
+  -> client publish admission and worker queue
+  -> QUIC bidirectional stream
+  -> broker frame decoder and authorization
+  -> broker publish admission and global worker queue
+  -> felix-broker StreamState
+  -> per-subscriber broker-core queue
+  -> subscription lane
+  -> per-connection writer
+  -> QUIC unidirectional event stream
+  -> client event router and subscription queues
+  -> application
+```
+
+The important architectural boundary is:
+
+- `crates/felix-broker/src/lib.rs` contains the transport-independent broker
+  core.
+- `services/broker/src/` turns that core into a network service.
+- `crates/felix-client/src/` implements the client-side connection pools and
+  APIs.
+- `crates/felix-wire/src/lib.rs` defines what the two sides exchange.
+- `crates/felix-transport/src/lib.rs` wraps the QUIC implementation.
+
+## 2. Repository map
+
+| Area | Responsibility | Start reading |
+|---|---|---|
+| `crates/felix-wire` | Frame header, protocol messages, binary fast paths | `crates/felix-wire/src/lib.rs` |
+| `crates/felix-transport` | QUIC endpoint, connection, stream, flow-control, and UDP configuration | `crates/felix-transport/src/lib.rs` |
+| `crates/felix-client` | Publisher, subscription, and cache client APIs | `crates/felix-client/src/client/client.rs` |
+| `crates/felix-broker` | Stream registry, in-memory log, subscriber registry, fanout | `crates/felix-broker/src/lib.rs` |
+| `crates/felix-storage` | Cache storage abstraction and ephemeral implementation | `crates/felix-storage/src/lib.rs` |
+| `crates/felix-authz` | Token verification types and permission matching | `crates/felix-authz/src/lib.rs` |
+| `services/broker` | Runnable broker, network handlers, auth, metrics, control-plane sync | `services/broker/src/main.rs` |
+| `services/controlplane` | Metadata APIs, token exchange, JWKS, and RBAC | `services/controlplane/src/main.rs` |
+
+Supporting crates such as `felix-consensus`, `felix-router`, and
+`felix-metadata` represent the direction of the multi-node architecture. Do not
+start with them when learning the current message path.
+
+## 3. Networking foundations: UDP, TLS, and QUIC
+
+### 3.1 What UDP provides
+
+UDP sends independent datagrams between network addresses. It is lightweight,
+but by itself it does not guarantee:
+
+- delivery;
+- ordering;
+- retransmission;
+- congestion control;
+- connection identity; or
+- encryption.
+
+An application built directly on UDP must implement those properties itself if
+it needs them.
+
+### 3.2 What QUIC adds
+
+QUIC is a secure transport protocol implemented over UDP. It adds:
+
+- a connection handshake;
+- TLS 1.3 encryption and peer authentication;
+- reliable delivery and retransmission;
+- congestion control;
+- connection-level and stream-level flow control;
+- multiple logical byte streams inside one connection; and
+- ordered delivery within each stream.
+
+Unlike TCP, independent QUIC streams do not share one connection-wide ordered
+byte sequence. A lost packet affecting one stream does not require unrelated
+streams to wait for that stream's missing bytes. This is one reason Felix can
+use one connection for several independent publish or cache workers.
+
+QUIC does **not** make all application work parallel automatically. Within one
+QUIC stream, bytes are still ordered, and Felix deliberately assigns one writer
+task to each stream. The number of connections and streams therefore controls
+real application parallelism.
+
+Felix uses the [`quinn`](https://github.com/quinn-rs/quinn) Rust implementation.
+The wrapper types are:
+
+- `crates/felix-transport/src/lib.rs::QuicServer`
+- `crates/felix-transport/src/lib.rs::QuicClient`
+- `crates/felix-transport/src/lib.rs::QuicConnection`
+
+`QuicServer::bind` and `QuicClient::bind` create UDP sockets, install Quinn's
+transport configuration, and create endpoints using `quinn::TokioRuntime`.
+
+### 3.3 Connections and streams
+
+A QUIC **connection** is the encrypted relationship between a client endpoint
+and a server endpoint. A connection contains many streams:
+
+- A **bidirectional stream** has one send direction and one receive direction.
+  Either peer may send data on its half.
+- A **unidirectional stream** carries bytes in one direction only.
+
+Felix maps its operations onto these primitives:
+
+| Operation | Stream type | Why |
+|---|---|---|
+| Authentication and acknowledged publish | Bidirectional | Client sends requests; broker sends responses |
+| Subscribe setup | Bidirectional | Client sends `Subscribe`; broker returns `Subscribed` or `Error` |
+| Event delivery | Broker-opened unidirectional | Events flow only from broker to subscriber |
+| Cache put/get | Bidirectional | Each operation is a request/response exchange |
+| Optional high-throughput publish ingress | Client-opened unidirectional | Fire-and-forget traffic does not need responses |
+
+The current Rust client opens authenticated bidirectional workers for its normal
+publish API. The broker also supports unidirectional publish ingress in
+`services/broker/src/transport/quic/streams/uni.rs::run_uni_loop`.
+Fire-and-forget means that the broker does not return a publish response; it
+does not mean that the stream is unauthenticated. A unidirectional publish
+stream must begin with `Message::Auth` before it sends publish frames.
+
+### 3.4 Transport tuning
+
+`crates/felix-transport/src/lib.rs::TransportConfig` controls:
+
+- maximum concurrent streams;
+- connection and per-stream flow-control windows;
+- send window;
+- initial MTU and path-MTU discovery;
+- maximum accepted UDP payload;
+- UDP socket send and receive buffers; and
+- an optional initial congestion window.
+
+`TransportConfig::quinn_transport_config` translates these settings into Quinn
+configuration. `TransportConfig::bind_udp_socket` applies socket buffer sizes
+best-effort, reducing the requested size until the host accepts it.
+
+These settings matter because high-rate messaging can otherwise become limited
+by tiny flow-control windows, excessive small datagrams, or kernel UDP drops.
+They improve capacity; they do not change Felix's delivery semantics.
+
+## 4. Felix's wire protocol
+
+QUIC provides reliable byte streams, but it does not define where one Felix
+message ends and another begins. Felix adds its own framing protocol in
+`crates/felix-wire/src/lib.rs`.
+
+### 4.1 Frame envelope
+
+Every Felix frame begins with `FrameHeader`, a 12-byte header:
+
+```text
+u32 magic    = 0x464C5831 ("FLX1")
+u16 version  = 1
+u16 flags
+u32 payload length
+payload bytes...
+```
+
+`FrameHeader::decode` rejects an invalid magic value, unsupported version, or
+incomplete header before the payload is trusted. Higher-level read helpers also
+enforce configured frame-size limits.
+
+### 4.2 JSON control messages
+
+`crates/felix-wire/src/lib.rs::Message` is the version-one protocol enum. With
+zero flags, `Message::encode` serializes a message as JSON and places it in a
+frame. JSON is used where flexibility and request metadata matter more than
+minimum encoding overhead:
+
+- `Auth`
+- acknowledged `Publish` and `PublishBatch`
+- `Subscribe` and `Subscribed`
+- `EventStreamHello`
+- cache request/response messages
+- acknowledgements and errors
+
+Payload bytes inside JSON messages are Base64 encoded.
+
+### 4.3 Binary data-plane frames
+
+The hot paths avoid JSON:
+
+- `FLAG_BINARY_PUBLISH_BATCH` identifies a binary publish batch.
+- `FLAG_BINARY_EVENT_BATCH` identifies the older event format that includes a
+  subscription ID.
+- `FLAG_BINARY_EVENT_BATCH_SHARED` identifies the current shared event format.
+
+The binary publish encoder
+`felix_wire::binary::encode_publish_batch_bytes_with_stats` writes the resource
+names, item count, and length-prefixed payloads directly into a byte buffer.
+
+The shared event encoder
+`felix_wire::binary::encode_shared_event_batch_bytes` writes only:
+
+```text
+u32 payload_count
+repeated:
+  u32 payload_length
+  payload bytes
+```
+
+It does not repeat tenant, namespace, stream, or subscription identifiers. The
+preceding `EventStreamHello` has already bound that QUIC stream to one
+subscription.
+
+## 5. Felix's resource model
+
+Pub/sub resources are scoped as:
+
+```text
+tenant -> namespace -> stream
+```
+
+Cache resources are scoped as:
+
+```text
+tenant -> namespace -> cache -> key
+```
+
+The broker keeps local registries for these objects in
+`crates/felix-broker/src/lib.rs::Broker`. A stream does not become valid merely
+because a client names it; it must exist in the broker's synchronized metadata.
+
+The running service obtains metadata from the control plane through
+`services/broker/src/controlplane.rs::start_sync`. On cold start,
+`sync_once` fetches full snapshots in dependency order:
+
+1. tenants;
+2. namespaces;
+3. caches;
+4. streams.
+
+Later iterations consume incremental change feeds. Each resource type has its
+own sequence cursor. A failed fetch is retried without advancing that cursor,
+so synchronization is eventually consistent rather than transactional across
+all resource types.
+
+## 6. Broker startup and process lifecycle
+
+The executable starts at `services/broker/src/main.rs::main`, which calls
+`run_with_shutdown`.
+
+Startup proceeds in this order:
+
+1. `observability::init_observability` installs tracing and the Prometheus
+   recorder.
+2. `BrokerConfig::from_env_or_yaml` resolves configuration.
+3. `Broker::new(EphemeralCache::new().into())` creates the in-process broker
+   core with an ephemeral cache backend.
+4. `BrokerAuth::new` creates the broker's control-plane-backed authenticator.
+5. `observability::serve_metrics` starts the health and metrics HTTP server.
+6. `build_server_config` creates the QUIC TLS configuration.
+7. `QuicServer::bind` binds the UDP/QUIC listener.
+8. `quic::serve_with_shutdown` starts the connection accept loop.
+9. `controlplane::start_sync` starts metadata synchronization.
+
+!!! warning "Current TLS certificate behavior"
+    `services/broker/src/main.rs::build_server_config` currently generates a
+    fresh self-signed certificate for `localhost`. The code explicitly marks
+    this as development behavior, not production certificate management.
+
+### 6.1 Graceful shutdown
+
+Shutdown is not a single task abort. `run_with_shutdown` performs an ordered
+drain:
+
+1. mark readiness as draining, so load balancers stop routing here while the
+   broker can still serve;
+2. cancel the QUIC accept loop so no new connections are admitted;
+3. wind down the connections already accepted, and wait for them under one
+   deadline;
+4. stop control-plane synchronization;
+5. stop the metrics server last.
+
+Keeping metrics available during the drain allows operators to observe what is
+still in flight. The shared deadline is implemented through
+`felix_common::lifecycle::DrainBudget`, and it is a *single* budget spanning
+every subsystem rather than a timeout per subsystem, so total shutdown time
+stays bounded no matter how many things are slow.
+
+Step 3 is the subtle one. The same cancellation token reaches every connection
+task, and `handle_connection_with_shutdown` responds by:
+
+1. no longer accepting new streams on that connection;
+2. giving the streams already in flight a bounded grace period — half the
+   process drain budget — to finish; and
+3. closing the QUIC connection with CONNECTION_CLOSE, so the peer learns this
+   was a deliberate shutdown rather than a server that vanished.
+
+The grace has to be bounded because control and subscription streams are
+long-lived by design: a publisher holds one open and streams requests down it, a
+subscriber holds one open to receive events. Neither ends until the *client*
+closes it. Waiting on them unconditionally means shutdown never completes
+cooperatively — it burns the entire deadline and then force-aborts, dropping the
+in-flight work the drain exists to protect. That was the behavior the soak
+harness measured before this was fixed (see §16.1).
+
+## 7. Client connection architecture
+
+`crates/felix-client/src/client/client.rs::Client::connect_with_transport`
+constructs three separate pools.
+
+### 7.1 Publish pool
+
+For each configured publish connection, the client opens several
+bidirectional streams. Each stream:
+
+1. is authenticated by `authenticate_stream`;
+2. receives a bounded `mpsc` queue; and
+3. gets one `run_publisher_writer` task that exclusively owns its Quinn
+   `SendStream` and `RecvStream`.
+
+The single-writer ownership is intentional. It avoids interleaved writes and
+preserves the enqueue order of requests assigned to that worker.
+
+### 7.2 Cache pool
+
+The cache pool also uses multiple connections and multiple bidirectional
+streams per connection. Every stream has a `run_cache_worker` task. Each worker
+performs sequential request/response exchanges, while separate workers allow
+independent cache operations to progress concurrently.
+
+### 7.3 Event pool
+
+Event connections are reserved for subscriptions. Each event connection gets
+one `event_router::run_event_router` task that accepts broker-opened
+unidirectional streams and associates them with subscription IDs.
+
+Separate pools allow publish, cache, and event-delivery flow control to be
+tuned independently and keep one traffic class from consuming all streams in
+another.
+
+## 8. Authentication and authorization
+
+Every client-created control stream begins with authentication. The broker's
+read loop is `services/broker/src/transport/quic/streams/control.rs::run_control_loop`.
+
+Before authentication:
+
+- JSON traffic must be `Message::Auth`.
+- Binary publish frames are rejected with `auth required`.
+
+`services/broker/src/auth.rs::BrokerAuth::authenticate`:
+
+1. ensures the tenant's JWKS is cached;
+2. verifies the token signature and critical claims;
+3. verifies tenant scope;
+4. compiles token permissions into a `PermissionMatcher`; and
+5. returns an `AuthContext`.
+
+After authentication, the control loop authorizes each resource operation with
+the corresponding action and scoped resource:
+
+- stream publish;
+- stream subscribe;
+- cache get; or
+- cache put.
+
+The control plane is the authority for token exchange, public verification
+keys, and RBAC policy. The broker caches enough state to verify and authorize
+the data path locally instead of calling the control plane for every message.
+
+## 9. The complete publish path
+
+This is the central path to understand.
+
+### 9.1 Application to `Publisher`
+
+The application obtains a handle using
+`felix_client::Client::publisher`, then calls:
+
+- `Publisher::publish`; or
+- `Publisher::publish_batch`.
+
+In `crates/felix-client/src/client/publisher.rs`:
+
+- `AckMode::None` selects binary encoding.
+- `AckMode::PerMessage` and `AckMode::PerBatch` currently select JSON because
+  binary acknowledgement framing has not been negotiated.
+
+### 9.2 Client worker selection
+
+`Publisher::select_worker` supports:
+
+- `PublishSharding::RoundRobin`, which distributes calls across workers; and
+- `PublishSharding::HashStream`, which consistently maps
+  `(tenant, namespace, stream)` to one worker.
+
+Hashing a stream to one worker preserves client-side order for that stream and
+avoids moving it between QUIC streams. A bounded `StreamShardCache` avoids
+rehashing frequently used stream names.
+
+Round-robin can provide more parallelism, but publishing the same logical
+stream through several workers weakens the simple per-client ordering model.
+
+### 9.3 Client byte admission
+
+Before enqueueing, `PublishAdmission::acquire` reserves permits equal to the
+estimated or encoded frame size from a byte-counting semaphore.
+
+This is distinct from the worker channel's item capacity:
+
+- the channel limits the number of queued requests;
+- the semaphore limits the number of queued or processing bytes.
+
+The `OwnedSemaphorePermit` is stored inside `PublishRequest`. It remains held
+until the writer has processed the request, so the budget represents resident
+work rather than only admission-time work.
+
+### 9.4 Client encoding and stream writer
+
+For unacknowledged traffic,
+`Publisher::publish_batch_binary` calls
+`felix_wire::binary::encode_publish_batch_bytes_with_stats`, then enqueues
+`PublishRequest::BinaryBytes`.
+
+`run_publisher_writer` is the only task writing to that publish stream. For
+JSON requests it constructs the frame in reusable scratch storage. For binary
+requests it writes the already encoded bytes.
+
+For acknowledged traffic, the writer waits for a response and verifies the
+request ID. For unacknowledged traffic, the public call completes after the
+client writer has handed the frame to QUIC; it does not receive broker
+confirmation.
+
+### 9.5 Broker connection and stream handling
+
+`services/broker/src/transport/quic/conn.rs::serve_with_shutdown` accepts QUIC
+connections and tracks each connection task.
+
+`handle_connection` concurrently accepts:
+
+- bidirectional streams, dispatched to
+  `transport/quic/streams/handlers.rs::handle_stream`; and
+- unidirectional streams, dispatched to
+  `transport/quic/streams/handlers.rs::handle_uni_stream`.
+
+For a bidirectional stream, `handle_stream` creates:
+
+- one outbound response queue;
+- one `run_writer_loop` task owning the stream's `SendStream`;
+- an optional commit-ack waiter task;
+- cancellation and throttling channels; and
+- a per-stream cache of resolved stream handles.
+
+The current task runs `run_control_loop` over incoming frames.
+
+### 9.6 Decode and authorize
+
+`run_control_loop` examines frame flags before JSON decoding. A binary publish
+batch goes directly to `handle_binary_publish_batch_control`.
+
+JSON `Publish` and `PublishBatch` messages are decoded into `Message`, checked
+against the authenticated tenant and permission matcher, and passed to the
+corresponding publish handler.
+
+### 9.7 Resolve the stream once
+
+The broker transport converts the textual stream identity into
+`felix_broker::StreamHandle` through
+`handlers/publish.rs::resolve_stream_cached`.
+
+A `StreamHandle` is a cheap `Arc<StreamState>` plus a dense numeric ID. Once
+resolved:
+
+- the worker can be selected with `handle.id() % worker_count`;
+- the hot path avoids repeatedly hashing three strings; and
+- it avoids repeatedly reading the shared stream registry.
+
+The transport cache has a TTL so metadata changes can eventually invalidate
+old resolutions. Removed stream states are also marked inactive, and
+`Broker::publish_batch_to_handle` checks that bit before publishing.
+
+### 9.8 Broker byte and item admission
+
+The network handler constructs a `PublishJob` and calls
+`services/broker/src/transport/quic/handlers/publish.rs::enqueue_publish`.
+
+Two byte budgets are acquired:
+
+1. a per-connection budget, preventing one publisher connection from occupying
+   the entire broker;
+2. a process-wide budget shared by all publish workers.
+
+The job also enters a bounded worker channel. `EnqueuePolicy` determines what
+happens when capacity is unavailable:
+
+- `Drop`: shed fire-and-forget traffic and increment drop counters;
+- `Fail`: reject acknowledged traffic immediately;
+- `Wait`: wait up to a configured timeout, propagating backpressure.
+
+The permits remain attached to the `PublishJob` until the broker worker
+finishes it.
+
+### 9.9 Global stream-sharded workers
+
+`services/broker/src/transport/quic/conn.rs::build_publish_context` creates a
+process-wide worker pool. It is deliberately not one pool per connection:
+per-connection pools previously multiplied concurrent access to shared stream
+state and increased contention.
+
+Every resolved stream handle maps to one worker. Therefore publishes to the
+same stream are serialized inside the broker even when they arrive through
+different connections.
+
+With `core_shards` enabled, there is exactly one publish worker per shard and
+worker `i` runs on shard runtime `i`.
+
+### 9.10 Broker core append and fanout
+
+The worker calls
+`crates/felix-broker/src/lib.rs::Broker::publish_batch_to_handle`.
+
+That function:
+
+1. verifies that the handle is active;
+2. calls `StreamState::append_batch`;
+3. loads the current subscriber snapshot;
+4. creates one `DeliveryEnvelope`; and
+5. enqueues a clone of that envelope to each subscriber.
+
+`append_batch` takes the stream log mutex once for the whole batch, assigns
+monotonic sequence numbers, appends `Bytes` clones, and trims the oldest
+entries to the configured in-memory capacity.
+
+The subscriber registry itself is protected by a mutex because subscriptions
+are added and removed. The publish hot path does not take that mutex:
+`StreamState` maintains an `ArcSwap<Vec<SubscriberEntry>>` snapshot. Subscribe
+and unsubscribe rebuild the snapshot; publish loads it lock-free.
+
+### 9.11 What is copied during fanout
+
+`DeliveryEnvelope` contains:
+
+- `Arc<[Bytes]>` for the payload batch;
+- the enqueue timestamp; and
+- `Mutex<Option<Bytes>>` for a lazily cached encoded event frame.
+
+Cloning an envelope for ten subscribers increments reference counts. It does
+not clone every payload buffer and does not encode ten event frames.
+
+The first subscriber feeder calling `DeliveryEnvelope::shared_event_frame`
+performs `encode_shared_event_batch_bytes` and stores the result. Other feeders
+receive cheap `Bytes` clones of the same encoded frame.
+
+This reuse applies when the envelope already contains multiple payloads, and in
+the forced single-event mode. In the ordinary one-payload batching path, each
+subscriber feeder may combine that payload with later envelopes according to
+its own timing and then encode its resulting batch. That path can therefore
+perform more than one event-frame encode per original publish. For multi-item
+publish batches—the important throughput case—the shared envelope normally
+reduces serialization from one encode per subscriber to one encode per publish
+batch.
+
+## 10. Acknowledgement semantics
+
+`felix_wire::AckMode` has `None`, `PerMessage`, and `PerBatch`.
+
+The important distinction is broker configuration:
+
+- With `ack_on_commit = false`, an acknowledgement means the broker accepted
+  the job into its ingress queue.
+- With `ack_on_commit = true`, the broker waits until the publish worker
+  completes `publish_batch_to_handle`.
+
+In the current single-node broker, "commit" means the in-memory append and
+fanout operation completed. It does **not** mean a durable disk write or
+replication quorum.
+
+Commit acknowledgements use:
+
+- `handlers/publish.rs::AckWaiterMessage`;
+- a bounded waiter semaphore; and
+- `streams/ack_waiter.rs::run_ack_waiter_loop`.
+
+Acknowledgements carry request IDs and may be emitted out of order, allowing
+independent completed jobs to respond without waiting for an earlier slow job.
+
+Commit acknowledgement is not an exactly-once outcome protocol. The publish job
+is enqueued before the broker reserves and submits all acknowledgement-waiter
+state. If that later step is overloaded, or if `ack_wait_timeout` expires, the
+client can receive an overload or commit-timeout error even though the publish
+was already enqueued and may have completed. A client must not interpret every
+acknowledgement error as proof that the event was not published.
+
+## 11. The complete subscription and fanout path
+
+### 11.1 Client subscribe request
+
+`crates/felix-client/src/client/client.rs::Client::subscribe`:
+
+1. checks that the requested tenant matches the client's authenticated tenant;
+2. selects an event connection round-robin;
+3. opens and authenticates a bidirectional control stream;
+4. sends `Message::Subscribe` with no client-assigned ID;
+5. finishes its send half;
+6. reads `Message::Subscribed`; and
+7. registers the returned ID with the event router.
+
+The broker assigns the ID. This is essential because independent `Client`
+instances otherwise start local counters at the same values and can collide.
+
+### 11.2 Broker subscription registration
+
+The control loop authorizes the request and calls
+`services/broker/src/transport/quic/handlers/subscribe.rs::handle_subscribe_message`.
+
+That function:
+
+1. allocates a globally unique subscription ID if none was supplied;
+2. reserves capacity in the connection's `SubscriptionLimiter`;
+3. calls `Broker::subscribe`;
+4. opens a new broker-to-client unidirectional stream;
+5. writes `EventStreamHello { subscription_id }`;
+6. selects a writer lane;
+7. registers the event stream with that lane;
+8. sends `Subscribed` only after registration succeeds; and
+9. spawns `run_lane_feeder`.
+
+The acknowledgement therefore means that the broker-core queue and event
+writer pipeline are both ready, not merely that the request was parsed.
+
+### 11.3 Broker-core subscriber queue
+
+`Broker::subscribe` resolves the stream and calls
+`StreamState::register_subscriber`.
+
+Registration creates a bounded `mpsc::channel<DeliveryEnvelope>`, stores its
+sender in a `Slab`, rebuilds the publish snapshot, and returns a
+`SubscriptionReceiver`.
+
+Dropping the accompanying `SubscriptionGuard` removes the registry entry and
+rebuilds the snapshot.
+
+### 11.4 Event stream routing on the client
+
+The broker may open the unidirectional event stream before or after the client
+has processed `Subscribed`. Therefore
+`crates/felix-client/src/client/event_router.rs::run_event_router` maintains two
+bounded maps:
+
+- registrations waiting for streams;
+- streams waiting for registrations.
+
+It reads `EventStreamHello` from each new unidirectional stream and joins the
+two sides by subscription ID.
+
+### 11.5 Lane feeder
+
+`run_lane_feeder` receives `DeliveryEnvelope`s from the broker-core queue. It
+either:
+
+- reuses the envelope's shared encoded frame;
+- splits an oversized envelope into bounded frames; or
+- coalesces single-event envelopes until an event count, byte count, or timer
+  limit is reached.
+
+It then sends `LaneCommand::Delivery` to the selected writer lane.
+
+When core sharding is enabled, the feeder is spawned on the same shard that
+owns the stream's publish worker. The enqueue and dequeue sides of the
+broker-core subscriber channel therefore stay core-local.
+
+### 11.6 Writer lanes
+
+`WriterLaneManager` owns a configurable set of bounded lane queues. Lane
+`subscriber_single_writer_per_conn` is checked first; when enabled, every
+subscriber on one connection is forced onto that connection's lane. Otherwise,
+lane assignment follows `SubscriberLaneShard`:
+
+- `Auto` currently hashes the subscription ID;
+- `SubscriberIdHash` explicitly hashes the subscription ID;
+- `ConnectionIdHash` hashes the connection ID when one is available; or
+- `RoundRobinPin` assigns a stable lane once at subscription time.
+
+`run_writer_lane` performs little actual I/O. It receives lane commands and
+forwards them to the writer for the QUIC connection that owns the subscription.
+
+The lane layer bounds parallelism and separates broker-core fanout from
+connection-specific scheduling.
+
+### 11.7 Connection writer
+
+`run_connection_writer` owns the actual `SendStream`s for every subscription on
+one QUIC connection.
+
+For each subscriber it preserves at most one in-flight write. Across different
+subscribers it uses `FuturesUnordered`, so writes proceed concurrently:
+
+- subscriber A may be blocked by QUIC flow control;
+- subscriber B can complete;
+- B can begin its next write without waiting for A.
+
+This continuous pipeline avoids a round barrier where the slowest subscriber
+would delay every other subscriber sharing the connection.
+
+### 11.8 Client subscription pipeline
+
+Once the event router supplies the `RecvStream`,
+`Subscription::spawn_pipeline` creates two tasks:
+
+1. `run_subscription_io_task` reads complete Felix frames from QUIC into a
+   bounded frame queue.
+2. `run_subscription_dispatch_task` decodes those frames and places individual
+   payloads into a bounded event queue.
+
+`Subscription::next_event` receives one payload and returns an `Event` carrying
+the subscription's tenant, namespace, and stream identity.
+
+For `FLAG_BINARY_EVENT_BATCH_SHARED`, dispatch uses
+`felix_wire::binary::decode_shared_event_batch`. The subscription identity does
+not need to be present in each batch because the QUIC stream was already bound
+by `EventStreamHello`.
+
+## 12. Ordering guarantees
+
+Ordering must be described at a specific boundary:
+
+- One client publish worker writes requests in queue order.
+- `HashStream` keeps one logical stream on one client worker.
+- The broker maps one `StreamHandle` to one global publish worker.
+- `StreamState::append_batch` assigns sequence numbers in worker processing
+  order.
+- Each subscriber receives envelopes through one ordered broker-core channel.
+- Lane and connection writers preserve ordering for each subscriber.
+- QUIC preserves byte order within the subscriber's event stream.
+
+There is no universal order across different streams.
+
+When several independent publishers publish concurrently to the same stream,
+the resulting order is the order in which their jobs reach and are dequeued by
+the stream's broker worker. Felix cannot infer a stronger application-level
+causal order between independent producers.
+
+## 13. Backpressure and overload
+
+Felix uses bounded queues instead of allowing memory use to grow without limit.
+There are six main checkpoints in publish-to-delivery order:
+
+| # | Checkpoint | Bounds |
+|---:|---|---|
+| 1 | Client `PublishAdmission` | In-flight publish bytes across client workers |
+| 2 | Client publish worker channel | Queued publish items per worker |
+| 3 | Broker publish admission | Per-connection and process-wide publish bytes |
+| 4 | Broker publish worker channel | Queued publish jobs |
+| 5 | Broker-core subscriber channel | Envelopes waiting for one subscriber |
+| 6 | Writer lane/connection queues | Encoded deliveries waiting for QUIC writers |
+
+QUIC flow control is the final transport-level checkpoint beneath these.
+
+### 13.1 Block versus drop
+
+Broker subscriber queues use `felix_broker::SubQueuePolicy`:
+
+- `Block` waits for capacity;
+- `DropNew` discards the new item when full;
+- `DropOld` is currently accounted separately but implemented as drop-new
+  behavior.
+
+The writer lane has its own independent policy because a subscriber can have
+space in its broker-core queue while its shared connection writer is saturated.
+
+Production defaults favor bounded latency and visible drops. Lossless benchmark
+profiles select blocking queues and `pub_ingress_wait`, allowing pressure to
+propagate backward until publishers slow down.
+
+Neither policy is universally correct:
+
+- dropping isolates healthy publishers and subscribers from a slow consumer;
+- blocking preserves delivery but can let one slow subscriber throttle every
+  producer of that stream.
+
+### 13.2 Why both byte limits and item limits exist
+
+A queue depth of 64 does not express how much memory 64 jobs consume. Jobs may
+contain tiny payloads or multi-megabyte batches.
+
+Felix therefore uses:
+
+- item-count channels for scheduler and queue bounds; and
+- byte-counting semaphores for resident payload bounds.
+
+The permit travels with the work and is released after processing.
+
+## 14. Cache request path
+
+The public methods are:
+
+- `Client::cache_put`;
+- `Client::cache_get`.
+
+Each call:
+
+1. allocates a request ID;
+2. selects a cache worker round-robin;
+3. enqueues a `CacheRequest`; and
+4. waits on a one-shot response channel.
+
+`crates/felix-client/src/client/cache.rs::run_cache_worker` owns one
+bidirectional QUIC stream and performs sequential round trips:
+
+```text
+encode -> write -> read -> decode -> validate request ID
+```
+
+Different cache workers execute concurrently. One worker remains sequential so
+response matching is simple and the stream has one writer.
+
+The broker control loop authorizes `CachePut` or `CacheGet`, then calls the
+broker's `StorageApi`.
+
+### 14.1 Ephemeral cache implementation
+
+`crates/felix-storage/src/lib.rs::StorageApi` defines `put`, `get`, `delete`,
+`len`, and `is_empty`.
+
+The running broker uses
+`crates/felix-storage/src/ephemeral_cache.rs::EphemeralCache`, which stores
+entries in an async `RwLock<HashMap<CacheKey, CacheEntry>>`.
+
+TTL behavior is lazy:
+
+- `put` computes `expires_at = Instant::now() + ttl`;
+- `get` checks the deadline;
+- an expired entry is removed and returned as a miss.
+
+There is no background expiration sweeper. A never-read expired key remains in
+the map until another operation removes it. `EphemeralCache` contains an
+optional capacity limit whose current eviction implementation removes an
+arbitrary key rather than using LRU, but the running broker constructs
+`EphemeralCache::new()` with no maximum entry count. Capacity eviction is
+therefore inactive in the current service.
+
+## 15. Core sharding and CPU ownership
+
+Tokio's normal multi-threaded runtime may run a task on different worker
+threads over time. That is flexible, but a hot stream can pay for:
+
+- cross-core cache-line movement;
+- channel wakeups between cores; and
+- scheduler migration.
+
+`services/broker/src/core_shards.rs::CoreShards` creates dedicated
+single-threaded Tokio runtimes. On Linux, `pin_to_core` uses
+`sched_setaffinity` to pin each runtime thread to a CPU.
+
+A stream handle selects its owner:
+
+```text
+shard = handle_id % shard_count
+```
+
+The same mapping is used for:
+
+- its broker publish worker; and
+- its subscription lane feeders.
+
+Append, fanout enqueue, and feeder dequeue therefore occur on one core. QUIC I/O
+remains on the main runtime because Quinn's endpoint driver performs
+packetization, encryption, and socket I/O independently.
+
+Core sharding scales across **streams**, not within one stream. A workload with
+one logical stream still has one owning shard by design.
+
+## 16. Observability
+
+`services/broker/src/observability.rs::init_observability` installs tracing,
+OpenTelemetry propagation, and a Prometheus recorder.
+
+The broker exposes:
+
+- health and readiness endpoints;
+- Prometheus metrics;
+- queue depth and drop counters;
+- publish-stage timings;
+- subscriber lane and connection-writer timings; and
+- optional frame counters.
+
+Hot-path timing code is feature-gated. The relevant modules are:
+
+- `services/broker/src/timings.rs`
+- `services/broker/src/timings_telemetry.rs`
+- `crates/felix-broker/src/timings.rs`
+- `crates/felix-client/src/timings.rs`
+- `services/broker/src/transport/quic/telemetry.rs`
+
+When investigating missing messages, begin with:
+
+- broker ingress drop/rejection counters;
+- `felix_subscribe_dropped_total`;
+- subscriber lane drop counters;
+- client subscription queue drop counters; and
+- QUIC connection close/write-error logs.
+
+A nonzero drop counter indicates an intentional overload policy before it
+indicates a routing bug.
+
+### 16.1 The soak harness
+
+`services/broker/src/bin/soak/` is the resource-leak and lifecycle harness. Run
+it with:
+
+```bash
+cargo run --release -p broker --bin soak -- --duration-secs 60
+```
+
+It stands up a real broker with real QUIC connections and the real auth path,
+then drives five phases: sustained load, connection churn, slow subscribers
+saturating their queues, repeated identical load cycles, and repeated
+`SIGTERM` restarts of a genuine child process. It samples RSS and open file
+descriptors throughout, scrapes the broker's own gauges after quiescence, and
+exits non-zero on a finding.
+
+Two of its design choices are worth knowing before you read the output:
+
+- **Memory is judged across repeated identical cycles, not against a baseline.**
+  Comparing post-load RSS to pre-load RSS only measures allocator retention —
+  allocators do not return freed pages promptly, so that comparison flags every
+  healthy run. A real leak shows up as peak RSS still climbing on the last
+  identical cycle, where retention plateaus.
+- **File descriptors are the sharpest signal.** Every leaked connection or socket
+  appears there, and unlike RSS there is no caching behavior to explain growth
+  away, so the fd check is exact rather than tolerance-based.
+
+The gauges it asserts must return to zero — `felix_sub_active_connections`,
+`felix_sub_connection_subscribers`, `felix_broker_ingress_queue_depth`,
+`felix_broker_out_ack_depth` — are the registration counters. Anything left in
+them after every client has disconnected is an entry that will never be
+reclaimed.
+
+Findings and the current steady-state envelope are recorded in
+`docs/security/soak-report.md`, alongside the panic audit in
+`docs/security/panic-audit.md`. Both are repository-local audit records rather
+than published pages.
+
+## 17. What is implemented today
+
+The current running system includes:
+
+- encrypted QUIC transport;
+- framed JSON and binary protocol paths;
+- authenticated and authorized client streams;
+- pooled publisher, subscriber, and cache connections;
+- stream-sharded publish workers;
+- an in-memory per-stream replay log in broker core;
+- bounded per-subscriber queues;
+- shared encode-once fanout;
+- writer lanes and pipelined per-connection delivery;
+- ephemeral cache storage with TTL;
+- control-plane metadata synchronization;
+- metrics, tracing, and optional detailed timings;
+- graceful broker shutdown; and
+- optional Linux core pinning.
+
+## 18. What is partial or planned
+
+Do not assume the following are complete production paths:
+
+- **Durable pub/sub storage:** `felix-storage` contains log and tiered-storage
+  foundations, but the running broker service uses the broker core's bounded
+  in-memory log and `EphemeralCache`.
+- **Public cursor replay:** broker core provides `cursor_tail` and
+  `subscribe_with_cursor`, but replay is not yet a complete client-to-broker
+  transport feature.
+- **Hashed pooled subscription streams:** configuration exists, but
+  `handle_subscribe_message` currently records a fallback and uses one
+  unidirectional stream per subscriber.
+- **Multi-node replication and consensus:** relevant crates and design
+  documents exist, but they are not the current data path described here.
+- **Multi-region routing and residency enforcement:** these remain broader
+  architectural work.
+- **Production certificate provisioning:** the broker currently generates a
+  development self-signed certificate.
+- **Per-subsystem shutdown cancellation:** the drain cancels admission and winds
+  connections down under a bounded grace, but publish workers, acknowledgement
+  waiters, and subscription writers are not individually signalled to stop.
+  In-flight work inside the grace window completes; work still running when the
+  grace expires is ended by closing the connection.
+
+## 19. A worked example
+
+Assume one application publishes a binary batch of 64 payloads to
+`tenant-a/orders/updates`, with ten subscribers.
+
+1. `Publisher::publish_batch` sees `AckMode::None` and selects the binary path.
+2. `Publisher::select_worker` hashes the stream to one client publish worker.
+3. The batch is encoded once into a binary Felix frame.
+4. Client `PublishAdmission` reserves the encoded byte count.
+5. The request enters that worker's bounded channel.
+6. `run_publisher_writer` writes the bytes to its authenticated QUIC stream.
+7. The broker control loop recognizes `FLAG_BINARY_PUBLISH_BATCH`.
+8. The broker verifies the authenticated tenant and publish permission.
+9. `resolve_stream_cached` obtains the stream's `StreamHandle`.
+10. Broker per-connection and global byte admission reserve the payload bytes.
+11. `enqueue_publish` sends the job to `handle.id() % worker_count`.
+12. The worker calls `Broker::publish_batch_to_handle`.
+13. `StreamState::append_batch` assigns 64 sequence numbers under one lock.
+14. The broker loads the lock-free subscriber snapshot containing ten senders.
+15. One `DeliveryEnvelope` is created and cloned into ten subscriber queues.
+16. The first awakened feeder encodes one shared event frame; the other nine
+    clone the cached `Bytes`.
+17. Feeders enqueue deliveries through their selected writer lanes.
+18. Lane tasks forward them to the relevant connection writers.
+19. Each connection writer pipelines writes across subscribers while preserving
+    per-subscriber order.
+20. Each client event router has already associated the event stream with its
+    subscription ID.
+21. Subscription I/O tasks read the shared binary event frame.
+22. Dispatch tasks decode the 64 payloads and enqueue them for application
+    consumption.
+23. `Subscription::next_event` returns them one at a time.
+
+The batch was encoded once on publish ingress and once for event fanout, not
+once per subscriber.
+
+## 20. How to study the code
+
+Read in this order and follow each symbol with editor "go to definition":
+
+1. `crates/felix-wire/src/lib.rs`
+   - `FrameHeader`
+   - `Frame`
+   - `Message`
+   - binary publish/event encoders
+2. `crates/felix-transport/src/lib.rs`
+   - `TransportConfig`
+   - `QuicServer`
+   - `QuicClient`
+   - `QuicConnection`
+3. `crates/felix-client/src/client/client.rs`
+   - `Client::connect_with_transport`
+   - `Client::subscribe`
+4. `crates/felix-client/src/client/publisher.rs`
+   - `Publisher::select_worker`
+   - `Publisher::publish_batch_binary`
+   - `run_publisher_writer`
+5. `services/broker/src/transport/quic/conn.rs`
+   - `serve_with_shutdown`
+   - `build_publish_context`
+   - `handle_connection_with_shutdown`
+6. `services/broker/src/transport/quic/streams/handlers.rs`
+   - `handle_stream`
+7. `services/broker/src/transport/quic/streams/control.rs`
+   - `run_control_loop`
+8. `services/broker/src/transport/quic/handlers/publish.rs`
+   - `resolve_stream_cached`
+   - `enqueue_publish`
+9. `crates/felix-broker/src/lib.rs`
+   - `StreamState`
+   - `DeliveryEnvelope`
+   - `Broker::publish_batch_to_handle`
+   - `Broker::subscribe`
+10. `services/broker/src/transport/quic/handlers/subscribe.rs`
+    - `handle_subscribe_message`
+    - `run_lane_feeder`
+    - `run_writer_lane`
+    - `run_connection_writer`
+11. `crates/felix-client/src/client/event_router.rs`
+    - `run_event_router`
+12. `crates/felix-client/src/client/subscription.rs`
+    - `Subscription::spawn_pipeline`
+    - `run_subscription_io_task`
+    - `run_subscription_dispatch_task`
+
+After reading, draw the path yourself and annotate every boundary with:
+
+- the task that owns it;
+- queue capacity and policy;
+- copied versus shared data;
+- ordering guarantee;
+- acknowledgement meaning;
+- failure behavior; and
+- relevant metrics.
+
+If you can explain those annotations without reopening the code, you understand
+the current Felix data plane.
+
+## Related guides
+
+- [System Design](../architecture/system-design.md)
+- [Component Architecture](../architecture/components.md)
+- [Wire Protocol](../architecture/wire-protocol.md)
+- [Internals: The Publish Path](internals-publish.md)
+- [Internals: Subscribe & Fanout](internals-subscribe.md)
+- [Internals: Backpressure & Core Sharding](internals-concurrency.md)
+- [Graceful Shutdown](../deployment/graceful-shutdown.md)
+- [Performance Tuning](../features/performance.md)

--- a/docs/security/soak-report.md
+++ b/docs/security/soak-report.md
@@ -1,0 +1,182 @@
+# Soak and resource-leak report — broker
+
+Evidence record for [#154](https://github.com/gabloe/felix/issues/154), the
+sustained-load half of the M0 concurrency and resource-leak exit criterion. The
+static audit half is recorded separately in [panic-audit.md](panic-audit.md).
+
+## Scope and environment
+
+- Harness: `services/broker/src/bin/soak/`, run via
+  `cargo run --release -p broker --bin soak`.
+- Build: `--release` (fat LTO, `codegen-units = 1`), default features.
+  `FELIX_DISABLE_TIMINGS=1`.
+- Environment: macOS 15 (Darwin 25.6), Apple Silicon, 2026-08-09.
+- Workload: 4 publishers, 4 subscribers, 1 KiB payloads, 12 s per phase, 25 s
+  quiescence, 120 churn cycles, 4 identical load cycles, 3 SIGTERM restarts.
+  Roughly 2M messages published per run.
+- Time series: `data/soak/local-macos.jsonl`.
+
+**This is not Linux evidence.** The deployment target is Linux, and RSS
+accounting, allocator behaviour, and scheduler pressure all differ there. The
+harness is cross-platform and the CI workflow runs it on `ubuntu-latest`; that
+run is the evidence that should back a production claim. What is recorded here
+is the local run that found and validated the fixes below.
+
+## What is exercised
+
+| Phase | What it stresses |
+| --- | --- |
+| `sustained_load` | Steady publish/subscribe through the full QUIC path |
+| `connection_churn` | Connect/publish/disconnect cycles — connection, task, and fd release |
+| `slow_subscribers` | Subscribers that never read: queue saturation and the drop policy |
+| `repeated_load_cycles` | Identical load repeated, to separate a leak from allocator retention |
+| `restart_cycles` | Real `SIGTERM` to a real child process under live traffic |
+
+## Method notes
+
+Two choices matter for reading the numbers:
+
+**Memory is judged across repeated identical cycles, not against a baseline.**
+Comparing post-load RSS to pre-load RSS measures allocator retention, not leaks —
+allocators do not promptly return freed pages, so that comparison flags every
+healthy run. A leak instead shows peak RSS still climbing on the last identical
+cycle, where retention plateaus.
+
+**File descriptors are the exact check.** Every leaked connection or socket shows
+up there and there is no caching behaviour to explain growth away, so fds must
+return to baseline exactly. Baseline is captured *after* the broker is listening,
+so the listener socket is part of it rather than appearing later as a
+one-descriptor "leak".
+
+## Findings
+
+### F1 — Subscriber connection registry never released entries (fixed)
+
+`ACTIVE_SUB_CONN_COUNTS` retained an entry for **every subscriber connection ever
+made**. After a run with 24 subscriber connections, 22 remained registered
+following 30 s of quiescence, and `felix_sub_active_connections` reported 22 with
+zero clients connected.
+
+Cause: an ordering race, not a missing cleanup call. Subscription teardown
+enqueues `LaneCommand::Unregister` and then *immediately* calls
+`unregister_subscriber`, which removes the `subscriber_connections` entry. The
+lane worker dequeues afterwards and used to look the connection up in that map —
+finding nothing, it skipped cleanup entirely, so neither the registry entry nor
+the per-connection metric series was ever released.
+
+Impact: unbounded growth in a long-lived broker with connection churn — both the
+`DashMap` itself and the `felix_sub_connection_subscribers{connection_id=…}`
+metric cardinality, one label value per connection for the life of the process.
+`felix_sub_active_connections` was also permanently wrong, which matters because
+it is the gauge an operator would use to judge connection health.
+
+Fix: `LaneCommand::Unregister` now carries `connection_id`, so the worker does
+not depend on a map entry that teardown races it to delete. Verified by A/B:
+`felix_sub_active_connections` 22 → 0, `felix_sub_connection_subscribers` 24 → 0.
+Regression test:
+`subscribe.rs::lane_unregister_cleans_up_after_teardown_already_removed_the_mapping`,
+confirmed to fail against the pre-fix code.
+
+### F2 — Shutdown always force-aborted rather than draining (fixed)
+
+Every `SIGTERM` restart cycle burned the entire drain deadline and then
+force-cancelled, with both `quic_connections` and `quic_accept_loop` unfinished —
+3/3 cycles, 10.00 s each against a 10 s deadline.
+
+Cause: the drain waited for connection tasks to end, but a connection task only
+ends when the *peer* disconnects. Subscribers hold connections open indefinitely
+by design, so the wait could never complete. Cancelling admission was not enough:
+nothing told the accepted connections to wind down.
+
+This is the gap left when #139 shipped. It meant every rolling update dropped
+in-flight publishes and acknowledgements — the exact failure that issue set out
+to prevent — while appearing to have a graceful shutdown path.
+
+Fix: the shutdown token now reaches every connection task.
+`handle_connection_with_shutdown` stops accepting new streams, gives in-flight
+streams a bounded grace (half the process drain budget), then closes the
+connection with CONNECTION_CLOSE so the peer sees a deliberate shutdown.
+
+The grace must be bounded for the same reason the connection wait had to be:
+control and subscription streams are long-lived, so waiting on them
+unconditionally just relocates the hang one level down. That was observed
+directly — an intermediate fix that waited on streams without a bound reproduced
+the identical 10 s forced abort.
+
+Result: 3/3 cycles now drain cleanly in 3.00 s against a 6 s budget, exit status
+0. Regression test:
+`graceful_shutdown.rs::cancellation_winds_down_accepted_connections`.
+
+That test previously asserted the *opposite* — that accepted connections keep
+running after cancellation. It was encoding the bug, and was rewritten rather
+than worked around.
+
+### F3 — Subscriber queue-depth gauge drifts by a small bounded amount (open)
+
+`felix_sub_queue_len` settles at 1 after quiescence instead of 0.
+
+`SubscriptionReceiver::drop` drains what is queued and decrements the global
+counter, so this is not a general accounting failure. The residue is a narrow
+race: an item enqueued between that drain loop and the channel actually closing
+is counted and never dequeued.
+
+Measured at exactly 1 across runs of very different sizes, including runs
+differing by ~2M messages — so it is bounded per teardown rather than
+proportional to load. Not milestone-blocking, and not fixed here.
+
+The harness allows up to 8 before reporting a finding, so genuine unbounded drift
+is still caught while this known race does not produce noise. **Follow-up issue
+should be filed**; per #154's own instruction, non-blocking improvements get
+separately scoped issues rather than being folded in.
+
+## Steady state after the fixes
+
+From the final local run (exit 0, no findings):
+
+| Measure | Baseline | Peak | After 25 s quiescence |
+| --- | ---: | ---: | ---: |
+| Open file descriptors | 11 | 35 | **11** |
+| RSS (KiB) | 9,312 | 639,296 | 816,784 |
+
+Registration gauges after quiescence, all zero:
+`felix_sub_active_connections`, `felix_sub_connection_subscribers`,
+`felix_sub_conn_queue_len`, `felix_sub_lane_queue_len`,
+`felix_client_sub_queue_len`. `felix_sub_queue_len` is 1, per F3.
+
+Restart cycles: 3/3 clean, 3.00 s each, exit 0, with ~300k messages published
+into each child before its `SIGTERM`.
+
+**On the RSS figure.** It does not return to baseline, and that is expected on
+this platform — macOS `malloc` rarely returns pages. The leak question is
+answered by the repeated-cycle check, not this number. Peak RSS across four
+identical cycles in an earlier run was 663,488 → 690,560 → 701,792 → 735,232 KiB:
++10.8% total, under the 25% tolerance, but **monotonically increasing across all
+four cycles**. That is not a clean plateau. It is the weakest result in this
+report and the reason the Linux CI run matters: four cycles is too few to
+distinguish a slow leak from retention still settling, and the follow-up should
+raise `--load-cycles` substantially on a Linux runner before the "no unbounded
+memory growth" claim is treated as settled.
+
+## Acceptance criteria status
+
+- [x] Sustained-load and churn runs return resource counts to a documented
+      steady-state envelope after quiescence — fds exactly, registration gauges
+      exactly, RSS with the caveat above.
+- [x] No deadlock, connection leak, fd leak, or task leak remains reproducible.
+- [ ] **No unbounded memory growth** — not fully demonstrated. Monotonic growth
+      across four cycles is unresolved; needs a longer Linux run.
+- [x] Audit scope, workload, duration, environment, and findings recorded.
+- [x] Milestone-blocking defects fixed (F1, F2); non-blocking one (F3) documented
+      for a separate issue.
+
+## Residual risk
+
+- The memory result is inconclusive, as above. This is the one criterion this
+  report does not close.
+- Evidence is from macOS; the Linux CI run is what should back a production
+  claim.
+- Lock ordering and core-shard handoff were exercised under load but not
+  systematically reviewed. No deadlock was observed in any run, which is evidence
+  but not proof.
+- Core sharding (`FELIX_CORE_SHARDS`) is disabled by default and was not
+  exercised; its handoff path is unmeasured here.

--- a/docs/security/soak-report.md
+++ b/docs/security/soak-report.md
@@ -48,6 +48,12 @@ return to baseline exactly. Baseline is captured *after* the broker is listening
 so the listener socket is part of it rather than appearing later as a
 one-descriptor "leak".
 
+**Tokio tasks are also checked exactly.** The harness samples
+`Handle::metrics().num_alive_tasks()` at baseline, throughout each phase, and
+after quiescence. The broker and load generators share one runtime, so transient
+phase peaks include both, but after all clients are dropped the count must return
+to the listening-broker baseline exactly.
+
 ## Findings
 
 ### F1 — Subscriber connection registry never released entries (fixed)
@@ -129,6 +135,34 @@ is still caught while this known race does not produce noise. **Follow-up issue
 should be filed**; per #154's own instruction, non-blocking improvements get
 separately scoped issues rather than being folded in.
 
+### F4 — Subscriber writer ownership cycle retained tasks (fixed)
+
+Direct task-count sampling exposed a lifecycle leak that fd sampling had missed.
+After 30 s of quiescence, a short run retained 815 Tokio tasks against a baseline
+of 10, plus one active subscriber registration, even though file descriptors had
+returned exactly to baseline.
+
+Cause: `WriterLaneManager` owned the senders for its lane and per-connection
+writer tasks, while lane tasks and subscription feeders held strong
+`Arc<WriterLaneManager>` references. The connection writer retained subscription
+guards, which kept the broker's subscription sender alive; the feeder therefore
+kept waiting for events while retaining the manager. Dropping the external
+connection context could not break either cycle.
+
+Fix: lane tasks and feeders now hold `Weak<WriterLaneManager>` and upgrade only
+while processing work. When the connection context disappears, dropping the
+manager closes the lane and connection-writer channels, releases subscription
+guards, and lets every feeder terminate. `WriterLaneManager::drop` also releases
+any connection-count entries whose queued unregister command could not run after
+the manager disappeared.
+
+Regression tests:
+`subscribe.rs::writer_lane_tasks_do_not_retain_manager` and
+`subscribe.rs::manager_drop_releases_remaining_connection_counts`.
+The same short soak that previously ended at 815 tasks and one registration now
+returns from 10 tasks to **10**, with both subscriber registration gauges at
+**0** after 30 s.
+
 ## Steady state after the fixes
 
 From the final local run (exit 0, no findings):
@@ -166,8 +200,8 @@ memory growth" claim is treated as settled.
 - [ ] **No unbounded memory growth** — not fully demonstrated. Monotonic growth
       across four cycles is unresolved; needs a longer Linux run.
 - [x] Audit scope, workload, duration, environment, and findings recorded.
-- [x] Milestone-blocking defects fixed (F1, F2); non-blocking one (F3) documented
-      for a separate issue.
+- [x] Milestone-blocking defects fixed (F1, F2, F4); non-blocking one (F3)
+      documented for a separate issue.
 
 ## Residual risk
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - Contributing: development/contributing.md
     - Building & Testing: development/building.md
     - Project Structure: development/project-structure.md
+    - "How Felix Works": development/how-felix-works.md
     - "Internals: The Publish Path": development/internals-publish.md
     - "Internals: Subscribe & Fanout": development/internals-subscribe.md
     - "Internals: Backpressure & Core Sharding": development/internals-concurrency.md

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -29,6 +29,12 @@ path = "../../demos/broker/notifications_demo.rs"
 name = "pubsub-demo-orders"
 path = "../../demos/broker/orders_demo.rs"
 
+# Soak and resource-leak harness (#154). Not a demo: it exits non-zero on a
+# finding so CI can gate on it.
+[[bin]]
+name = "soak"
+path = "src/bin/soak/main.rs"
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.22"
@@ -64,7 +70,10 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-opentelemetry = "0.32.1"
 
-[target.'cfg(target_os = "linux")'.dependencies]
+# Linux-only core pinning (`core_shards`) and Unix-wide SIGTERM delivery in the
+# soak harness both need libc; the pinning call site stays `target_os = "linux"`
+# gated in code.
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]

--- a/services/broker/src/bin/soak/main.rs
+++ b/services/broker/src/bin/soak/main.rs
@@ -1,0 +1,1171 @@
+//! Soak and resource-leak harness for the broker.
+//!
+//! # Purpose
+//! Produces the empirical evidence for M0's concurrency and resource-leak exit
+//! criterion (#154). It drives the broker through sustained load, connection
+//! churn, slow-subscriber saturation, and repeated process restarts, sampling
+//! resource counters throughout, then checks that everything returns to a
+//! steady-state envelope once load stops.
+//!
+//! # Why a binary rather than a test
+//! A soak is a measurement, not an assertion about a single code path. It needs
+//! to run for minutes, emit a time series, and produce a report a human reviews.
+//! `cargo test` is the wrong shape for that. Regression tests for anything this
+//! *finds* belong in the normal test suite.
+//!
+//! # What it exercises
+//! - The real accept loop (`quic::serve_with_shutdown`) and the real drain, not
+//!   a synthetic shutdown future.
+//! - Real QUIC connections over loopback, with the same auth path production
+//!   uses (Ed25519-signed Felix tokens verified against a JWKS).
+//! - A genuine `SIGTERM` to a genuine child process, which is the gap
+//!   `services/broker/tests/graceful_shutdown.rs` could not cover in-process.
+//!
+//! # How to use
+//! ```text
+//! cargo run --release -p broker --bin soak -- --duration-secs 60
+//! cargo run --release -p broker --bin soak -- --serve-child   # internal
+//! ```
+//! Exits non-zero if any steady-state check fails, so CI can gate on it.
+
+use anyhow::{Context, Result, bail};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use broker::auth::{BrokerAuth, ControlPlaneKeyStore};
+use ed25519_dalek::SigningKey as Ed25519SigningKey;
+use felix_authz::{
+    FelixTokenIssuer, Jwk, Jwks, KeyUse, TenantId, TenantKeyCache, TenantKeyMaterial,
+    TenantKeyStore,
+};
+use felix_broker::{Broker, StreamMetadata};
+use felix_client::{Client, ClientConfig};
+use felix_common::lifecycle::{DrainBudget, Readiness};
+use felix_storage::EphemeralCache;
+use felix_transport::{QuicServer, TransportConfig};
+use felix_wire::AckMode;
+use jsonwebtoken::Algorithm;
+use rcgen::generate_simple_self_signed;
+use rustls::RootCertStore;
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+// Fixed keypair so runs are deterministic and need no control plane.
+const TEST_PRIVATE_KEY: [u8; 32] = [37u8; 32];
+// Drain budget the child broker is configured with. Kept short so a restart
+// cycle is quick, and passed to the child via the same env var production uses
+// so the soak exercises the real configuration path. The per-connection grace
+// inside the broker is derived from this, so the child's own deadline must be
+// this value — not a separate constant that could be smaller than the grace it
+// is meant to bound.
+const CHILD_DRAIN_BUDGET_MS: u64 = 6_000;
+const CHILD_DRAIN_DEADLINE: Duration = Duration::from_millis(CHILD_DRAIN_BUDGET_MS);
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "default";
+const STREAM: &str = "soak";
+
+mod resources;
+use resources::ResourceSample;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+struct SoakConfig {
+    // Duration of each load-bearing phase.
+    phase_secs: u64,
+    // How long to wait after load stops before sampling steady state. Must be
+    // long enough for QUIC idle timeouts and connection cleanup to complete,
+    // otherwise "leaked" counts are just work still in progress.
+    quiesce_secs: u64,
+    publishers: usize,
+    subscribers: usize,
+    payload_bytes: usize,
+    // Connect/disconnect iterations in the churn phase.
+    churn_cycles: usize,
+    // SIGTERM start/stop iterations in the restart phase.
+    restart_cycles: usize,
+    // Identical load repetitions used to separate a leak from allocator retention.
+    load_cycles: usize,
+    // Fraction of RSS growth over baseline tolerated after quiescence.
+    rss_growth_tolerance: f64,
+    // Where to write the sampled time series, so a run is reviewable after the
+    // fact rather than only as console output.
+    timeseries_path: Option<String>,
+}
+
+impl Default for SoakConfig {
+    fn default() -> Self {
+        Self {
+            phase_secs: 30,
+            quiesce_secs: 15,
+            publishers: 4,
+            subscribers: 4,
+            payload_bytes: 1024,
+            churn_cycles: 200,
+            restart_cycles: 5,
+            load_cycles: 4,
+            rss_growth_tolerance: 0.25,
+            timeseries_path: None,
+        }
+    }
+}
+
+fn parse_args() -> Result<(SoakConfig, bool)> {
+    let mut config = SoakConfig::default();
+    let mut serve_child = false;
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut idx = 0;
+    while idx < args.len() {
+        let take = |idx: &mut usize| -> Result<String> {
+            *idx += 1;
+            args.get(*idx)
+                .cloned()
+                .with_context(|| format!("missing value for {}", args[*idx - 1]))
+        };
+        match args[idx].as_str() {
+            "--serve-child" => serve_child = true,
+            "--duration-secs" => config.phase_secs = take(&mut idx)?.parse()?,
+            "--quiesce-secs" => config.quiesce_secs = take(&mut idx)?.parse()?,
+            "--publishers" => config.publishers = take(&mut idx)?.parse()?,
+            "--subscribers" => config.subscribers = take(&mut idx)?.parse()?,
+            "--payload" => config.payload_bytes = take(&mut idx)?.parse()?,
+            "--churn-cycles" => config.churn_cycles = take(&mut idx)?.parse()?,
+            "--restart-cycles" => config.restart_cycles = take(&mut idx)?.parse()?,
+            "--load-cycles" => config.load_cycles = take(&mut idx)?.parse()?,
+            "--timeseries" => config.timeseries_path = Some(take(&mut idx)?),
+            other => bail!("unknown argument: {other}"),
+        }
+        idx += 1;
+    }
+    Ok((config, serve_child))
+}
+
+// ---------------------------------------------------------------------------
+// Auth + transport fixtures
+// ---------------------------------------------------------------------------
+
+struct AuthFixture {
+    token: String,
+    broker_auth: Arc<BrokerAuth>,
+}
+
+// Mirrors the conformance runner's fixture: a deterministic Ed25519 keypair and
+// an in-memory JWKS, so the soak needs no control plane while still going
+// through the real token-verification path.
+fn build_auth_fixture() -> Result<AuthFixture> {
+    let signing_key = Ed25519SigningKey::from_bytes(&TEST_PRIVATE_KEY);
+    let public_key = signing_key.verifying_key().to_bytes();
+    let jwks = Jwks {
+        keys: vec![Jwk {
+            kty: "OKP".to_string(),
+            kid: "k1".to_string(),
+            alg: "EdDSA".to_string(),
+            use_field: KeyUse::Sig,
+            crv: Some("Ed25519".to_string()),
+            x: Some(URL_SAFE_NO_PAD.encode(public_key)),
+        }],
+    };
+    let mut keys = HashMap::new();
+    keys.insert(
+        TENANT.to_string(),
+        TenantKeyMaterial {
+            kid: "k1".to_string(),
+            alg: Algorithm::EdDSA,
+            private_key: TEST_PRIVATE_KEY,
+            public_key,
+            jwks: jwks.clone(),
+        },
+    );
+    let key_store: Arc<dyn TenantKeyStore> = Arc::new(keys);
+    let issuer = FelixTokenIssuer::new(
+        "felix-auth",
+        "felix-broker",
+        Duration::from_secs(3600),
+        key_store,
+    );
+    let token = issuer.mint(
+        &TenantId::new(TENANT),
+        "soak",
+        vec![
+            format!("stream.publish:stream:{TENANT}/{NAMESPACE}/*"),
+            format!("stream.subscribe:stream:{TENANT}/{NAMESPACE}/*"),
+        ],
+    )?;
+
+    let cp_store = Arc::new(ControlPlaneKeyStore::new(
+        "http://127.0.0.1:1".to_string(),
+        Arc::new(TenantKeyCache::default()),
+    ));
+    cp_store.insert_jwks(&TenantId::new(TENANT), jwks);
+    Ok(AuthFixture {
+        token,
+        broker_auth: Arc::new(BrokerAuth::with_key_store(cp_store)),
+    })
+}
+
+fn build_server_config() -> Result<(quinn::ServerConfig, CertificateDer<'static>)> {
+    let cert = generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.cert.der().clone();
+    let key_der = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
+    Ok((
+        quinn::ServerConfig::with_single_cert(vec![cert_der.clone()], key_der.into())?,
+        cert_der,
+    ))
+}
+
+fn client_config(cert: &CertificateDer<'static>, auth: &AuthFixture) -> Result<ClientConfig> {
+    let mut roots = RootCertStore::empty();
+    roots.add(cert.clone())?;
+    let quinn = quinn::ClientConfig::with_root_certificates(Arc::new(roots))?;
+    let mut config = ClientConfig::from_env_or_yaml(quinn, None)?;
+    config.auth_tenant_id = Some(TENANT.to_string());
+    config.auth_token = Some(auth.token.clone());
+    Ok(config)
+}
+
+/// A running in-process broker plus the handles needed to drain it.
+struct BrokerHarness {
+    addr: SocketAddr,
+    cert: CertificateDer<'static>,
+    accept_shutdown: CancellationToken,
+    connections: TaskTracker,
+    accept_task: tokio::task::JoinHandle<()>,
+    _server: Arc<QuicServer>,
+}
+
+async fn start_broker(auth: &AuthFixture) -> Result<BrokerHarness> {
+    let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+    broker.register_tenant(TENANT).await?;
+    broker.register_namespace(TENANT, NAMESPACE).await?;
+    broker
+        .register_stream(TENANT, NAMESPACE, STREAM, StreamMetadata::default())
+        .await?;
+
+    let (server_config, cert) = build_server_config()?;
+    let server = Arc::new(QuicServer::bind(
+        "127.0.0.1:0".parse()?,
+        server_config,
+        TransportConfig::default(),
+    )?);
+    let addr = server.local_addr()?;
+
+    let config = broker::config::BrokerConfig::from_env()?;
+    let accept_shutdown = CancellationToken::new();
+    let connections = TaskTracker::new();
+    let accept_task = {
+        let server = Arc::clone(&server);
+        let accept_shutdown = accept_shutdown.clone();
+        let connections = connections.clone();
+        let auth = Arc::clone(&auth.broker_auth);
+        tokio::spawn(async move {
+            if let Err(err) = broker::quic::serve_with_shutdown(
+                server,
+                broker,
+                config,
+                auth,
+                accept_shutdown,
+                connections,
+            )
+            .await
+            {
+                eprintln!("accept loop exited: {err}");
+            }
+        })
+    };
+
+    Ok(BrokerHarness {
+        addr,
+        cert,
+        accept_shutdown,
+        connections,
+        accept_task,
+        _server: server,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Load generators
+// ---------------------------------------------------------------------------
+
+#[derive(Default)]
+struct LoadStats {
+    published: AtomicU64,
+    publish_errors: AtomicU64,
+    received: AtomicU64,
+    connect_errors: AtomicU64,
+}
+
+/// Sustained publish load from `count` independent client connections.
+async fn spawn_publishers(
+    harness: &BrokerHarness,
+    auth: &AuthFixture,
+    stats: Arc<LoadStats>,
+    stop: Arc<AtomicBool>,
+    count: usize,
+    payload_bytes: usize,
+) -> Result<Vec<tokio::task::JoinHandle<()>>> {
+    let mut handles = Vec::with_capacity(count);
+    for _ in 0..count {
+        let config = client_config(&harness.cert, auth)?;
+        let addr = harness.addr;
+        let stats = Arc::clone(&stats);
+        let stop = Arc::clone(&stop);
+        handles.push(tokio::spawn(async move {
+            let client = match Client::connect(addr, "localhost", config).await {
+                Ok(client) => client,
+                Err(_) => {
+                    stats.connect_errors.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+            };
+            let publisher = match client.publisher().await {
+                Ok(publisher) => publisher,
+                Err(_) => return,
+            };
+            let payload = vec![0xABu8; payload_bytes];
+            while !stop.load(Ordering::Relaxed) {
+                match publisher
+                    .publish(TENANT, NAMESPACE, STREAM, payload.clone(), AckMode::None)
+                    .await
+                {
+                    Ok(()) => {
+                        stats.published.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(_) => {
+                        stats.publish_errors.fetch_add(1, Ordering::Relaxed);
+                        // Back off rather than spin on a broken connection.
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                }
+                // Yield so a single publisher cannot monopolise its worker.
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
+    Ok(handles)
+}
+
+/// Subscribers that drain events promptly. `slow` inverts that: they subscribe
+/// and then stop reading, which is what drives queue saturation and the drop
+/// policy on the broker side.
+async fn spawn_subscribers(
+    harness: &BrokerHarness,
+    auth: &AuthFixture,
+    stats: Arc<LoadStats>,
+    stop: Arc<AtomicBool>,
+    count: usize,
+    slow: bool,
+) -> Result<Vec<tokio::task::JoinHandle<()>>> {
+    let mut handles = Vec::with_capacity(count);
+    for _ in 0..count {
+        let config = client_config(&harness.cert, auth)?;
+        let addr = harness.addr;
+        let stats = Arc::clone(&stats);
+        let stop = Arc::clone(&stop);
+        handles.push(tokio::spawn(async move {
+            let client = match Client::connect(addr, "localhost", config).await {
+                Ok(client) => client,
+                Err(_) => {
+                    stats.connect_errors.fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+            };
+            let mut subscription = match client.subscribe(TENANT, NAMESPACE, STREAM).await {
+                Ok(subscription) => subscription,
+                Err(_) => return,
+            };
+            while !stop.load(Ordering::Relaxed) {
+                if slow {
+                    // Hold the subscription open without draining it.
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                    continue;
+                }
+                match tokio::time::timeout(Duration::from_millis(250), subscription.next_event())
+                    .await
+                {
+                    Ok(Ok(Some(_))) => {
+                        stats.received.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Ok(Ok(None)) | Ok(Err(_)) => break,
+                    Err(_) => {}
+                }
+            }
+        }));
+    }
+    Ok(handles)
+}
+
+/// Repeatedly connect, publish, and disconnect. This is the phase most likely to
+/// surface connection, task, or file-descriptor leaks, because each cycle
+/// allocates and must fully release a QUIC connection and its per-connection
+/// broker state.
+async fn run_connection_churn(
+    harness: &BrokerHarness,
+    auth: &AuthFixture,
+    stats: Arc<LoadStats>,
+    cycles: usize,
+    payload_bytes: usize,
+) -> Result<()> {
+    let payload = vec![0x5Au8; payload_bytes];
+    for _ in 0..cycles {
+        let config = client_config(&harness.cert, auth)?;
+        let client = match Client::connect(harness.addr, "localhost", config).await {
+            Ok(client) => client,
+            Err(_) => {
+                stats.connect_errors.fetch_add(1, Ordering::Relaxed);
+                continue;
+            }
+        };
+        if let Ok(publisher) = client.publisher().await
+            && publisher
+                .publish(
+                    TENANT,
+                    NAMESPACE,
+                    STREAM,
+                    payload.clone(),
+                    AckMode::PerMessage,
+                )
+                .await
+                .is_ok()
+        {
+            stats.published.fetch_add(1, Ordering::Relaxed);
+        }
+        // Dropping the client closes the connection; the broker side must
+        // release its per-connection state without being told twice.
+        drop(client);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Phases
+// ---------------------------------------------------------------------------
+
+struct PhaseReport {
+    name: &'static str,
+    samples: Vec<ResourceSample>,
+    published: u64,
+    received: u64,
+    errors: u64,
+}
+
+impl PhaseReport {
+    fn peak_rss_kb(&self) -> u64 {
+        self.samples.iter().map(|s| s.rss_kb).max().unwrap_or(0)
+    }
+    fn peak_fds(&self) -> u64 {
+        self.samples.iter().map(|s| s.open_fds).max().unwrap_or(0)
+    }
+    fn last(&self) -> Option<&ResourceSample> {
+        self.samples.last()
+    }
+}
+
+/// Sample resources on a fixed cadence until `stop` flips.
+async fn sample_until(stop: Arc<AtomicBool>, interval: Duration) -> Vec<ResourceSample> {
+    let mut samples = Vec::new();
+    while !stop.load(Ordering::Relaxed) {
+        samples.push(ResourceSample::capture());
+        tokio::time::sleep(interval).await;
+    }
+    // Always capture a final sample so a phase is never reported empty.
+    samples.push(ResourceSample::capture());
+    samples
+}
+
+async fn drain_broker(harness: BrokerHarness, deadline: Duration) -> Vec<&'static str> {
+    // Exercise the same sequence main.rs uses, so the soak validates the real
+    // drain rather than a bespoke teardown.
+    let readiness = Readiness::ready();
+    readiness.begin_draining();
+    harness.accept_shutdown.cancel();
+
+    let mut budget = DrainBudget::new(deadline);
+    harness.connections.close();
+    budget
+        .drain("quic_connections", harness.connections.wait())
+        .await;
+    let mut accept_task = harness.accept_task;
+    if !budget
+        .drain("quic_accept_loop", async {
+            let _ = (&mut accept_task).await;
+        })
+        .await
+    {
+        accept_task.abort();
+    }
+    budget.unfinished().to_vec()
+}
+
+// ---------------------------------------------------------------------------
+// Child mode: a real broker process for SIGTERM testing
+// ---------------------------------------------------------------------------
+
+/// Run a broker until terminated, printing its address and certificate so the
+/// parent can drive load against it.
+///
+/// This exists so the restart phase sends a genuine `SIGTERM` to a genuine
+/// process. An in-process cancellation token cannot show that the signal
+/// handler is wired up, that the drain completes, or that the process exits
+/// zero — which is exactly the gap left open when #139 shipped.
+async fn run_serve_child() -> Result<()> {
+    let auth = build_auth_fixture()?;
+    let harness = start_broker(&auth).await?;
+    println!(
+        "SOAK_CHILD_READY addr={} cert={}",
+        harness.addr,
+        URL_SAFE_NO_PAD.encode(&harness.cert)
+    );
+    use std::io::Write;
+    std::io::stdout().flush()?;
+
+    felix_common::lifecycle::termination_signal().await;
+    let unfinished = drain_broker(harness, CHILD_DRAIN_DEADLINE).await;
+    // Report the drain outcome rather than failing on it. A forced drain is a
+    // WARN in `main.rs`, not an error exit, and the soak must observe the same
+    // behaviour production does — the parent decides whether it is a finding.
+    println!("SOAK_CHILD_DRAIN unfinished={}", unfinished.join(","));
+    std::io::stdout().flush()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn terminate_child(child: &std::process::Child) -> Result<()> {
+    // SAFETY: `kill` with a pid we own and a valid signal number.
+    let rc = unsafe { libc::kill(child.id() as libc::pid_t, libc::SIGTERM) };
+    if rc != 0 {
+        bail!(
+            "failed to send SIGTERM: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(())
+}
+
+/// Repeated real-process start/SIGTERM/exit cycles, each with live traffic.
+///
+/// Verifies the acceptance criterion that shutdown always terminates within the
+/// configured deadline and exits successfully.
+#[cfg(unix)]
+async fn run_restart_cycles(config: &SoakConfig, auth: &AuthFixture) -> Result<Vec<String>> {
+    use std::io::{BufRead, BufReader};
+    use std::process::{Command, Stdio};
+
+    let mut findings = Vec::new();
+    let mut forced_drains: Vec<usize> = Vec::new();
+    let exe = std::env::current_exe().context("locate soak binary")?;
+
+    for cycle in 0..config.restart_cycles {
+        let mut child = Command::new(&exe)
+            .arg("--serve-child")
+            .env(
+                "FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS",
+                CHILD_DRAIN_BUDGET_MS.to_string(),
+            )
+            .stdout(Stdio::piped())
+            .spawn()
+            .context("spawn child broker")?;
+
+        let stdout = child.stdout.take().context("child stdout")?;
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        reader.read_line(&mut line).context("read child ready")?;
+        let Some((addr, cert)) = parse_child_ready(&line) else {
+            let _ = child.kill();
+            findings.push(format!("cycle {cycle}: child never reported ready"));
+            continue;
+        };
+
+        // Put real traffic in flight so the drain has something to drain.
+        let stats = Arc::new(LoadStats::default());
+        let stop = Arc::new(AtomicBool::new(false));
+        let child_harness = BrokerHarness {
+            addr,
+            cert,
+            accept_shutdown: CancellationToken::new(),
+            connections: TaskTracker::new(),
+            accept_task: tokio::spawn(async {}),
+            _server: Arc::new(QuicServer::bind(
+                "127.0.0.1:0".parse()?,
+                build_server_config()?.0,
+                TransportConfig::default(),
+            )?),
+        };
+        let publishers = spawn_publishers(
+            &child_harness,
+            auth,
+            Arc::clone(&stats),
+            Arc::clone(&stop),
+            2,
+            config.payload_bytes,
+        )
+        .await?;
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let started = Instant::now();
+        terminate_child(&child)?;
+        let status = tokio::task::spawn_blocking(move || child.wait()).await??;
+        let elapsed = started.elapsed();
+
+        stop.store(true, Ordering::Relaxed);
+        for handle in publishers {
+            let _ = handle.await;
+        }
+
+        // Whatever the child printed after the ready line, including its drain
+        // outcome. Read after `wait` so the child has finished writing.
+        let mut trailing = String::new();
+        let _ = reader.read_line(&mut trailing);
+        let forced = trailing
+            .trim()
+            .strip_prefix("SOAK_CHILD_DRAIN unfinished=")
+            .map(|rest| rest.to_string())
+            .filter(|rest| !rest.is_empty());
+
+        if !status.success() {
+            findings.push(format!(
+                "cycle {cycle}: child exited unsuccessfully ({status})"
+            ));
+        }
+        // The child bounds itself at CHILD_DRAIN_DEADLINE; exceeding that plus
+        // scheduling slack would mean the bound is not actually enforced.
+        let bound = CHILD_DRAIN_DEADLINE + Duration::from_secs(5);
+        if elapsed > bound {
+            findings.push(format!(
+                "cycle {cycle}: shutdown took {elapsed:?}, exceeding the {bound:?} bound"
+            ));
+        }
+        if stats.published.load(Ordering::Relaxed) == 0 {
+            findings.push(format!(
+                "cycle {cycle}: no traffic reached the child, so its drain was not exercised"
+            ));
+        }
+        if let Some(unfinished) = &forced {
+            forced_drains.push(cycle);
+            println!("    drain forced at deadline; unfinished: {unfinished}");
+        }
+        println!(
+            "  restart cycle {cycle}: exit={} shutdown={:?} published={} drained_cleanly={}",
+            status.success(),
+            elapsed,
+            stats.published.load(Ordering::Relaxed),
+            forced.is_none()
+        );
+    }
+
+    // A drain forced at the deadline on *every* cycle is a design finding, not
+    // a flake: it means shutdown never completes cooperatively while clients
+    // hold connections open, which is the normal production state for
+    // subscribers. Reported once with that framing rather than per cycle.
+    if forced_drains.len() == config.restart_cycles && config.restart_cycles > 0 {
+        findings.push(format!(
+            "every restart cycle ({}/{}) hit the drain deadline and force-cancelled: connections \
+             with a live peer never end on their own, so shutdown always burns the full deadline. \
+             The drain waits for connection tasks to finish but has no way to tell them to stop.",
+            forced_drains.len(),
+            config.restart_cycles
+        ));
+    }
+    Ok(findings)
+}
+
+#[cfg(not(unix))]
+async fn run_restart_cycles(_config: &SoakConfig, _auth: &AuthFixture) -> Result<Vec<String>> {
+    println!("  restart cycles skipped: SIGTERM is Unix-only");
+    Ok(Vec::new())
+}
+
+fn parse_child_ready(line: &str) -> Option<(SocketAddr, CertificateDer<'static>)> {
+    let rest = line.trim().strip_prefix("SOAK_CHILD_READY ")?;
+    let mut addr = None;
+    let mut cert = None;
+    for field in rest.split_whitespace() {
+        if let Some(value) = field.strip_prefix("addr=") {
+            addr = value.parse().ok();
+        } else if let Some(value) = field.strip_prefix("cert=") {
+            cert = URL_SAFE_NO_PAD.decode(value).ok().map(CertificateDer::from);
+        }
+    }
+    Some((addr?, cert?))
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let (config, serve_child) = parse_args()?;
+    if serve_child {
+        return run_serve_child().await;
+    }
+
+    // A recorder must be installed for the broker's gauges to be readable.
+    let metrics = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .install_recorder()
+        .context("install metrics recorder")?;
+
+    println!("== Felix soak harness ==");
+    println!(
+        "phases {}s, quiesce {}s, {} publishers, {} subscribers, {} churn cycles, {} restart cycles",
+        config.phase_secs,
+        config.quiesce_secs,
+        config.publishers,
+        config.subscribers,
+        config.churn_cycles,
+        config.restart_cycles
+    );
+
+    let auth = build_auth_fixture()?;
+    // Baseline is captured *after* the broker is listening, so the listener
+    // socket and its runtime are part of the baseline rather than showing up
+    // later as a one-descriptor "leak".
+    let harness = start_broker(&auth).await?;
+    let baseline = ResourceSample::capture();
+    println!(
+        "baseline (broker listening, no clients): rss={} KiB fds={}",
+        baseline.rss_kb, baseline.open_fds
+    );
+
+    let mut phases = Vec::new();
+
+    // Phase 1 — sustained publish/subscribe load.
+    phases.push(
+        run_phase("sustained_load", &config, |stats, stop| {
+            let harness = &harness;
+            let auth = &auth;
+            let config = &config;
+            async move {
+                let mut handles = spawn_subscribers(
+                    harness,
+                    auth,
+                    Arc::clone(&stats),
+                    Arc::clone(&stop),
+                    config.subscribers,
+                    false,
+                )
+                .await?;
+                handles.extend(
+                    spawn_publishers(
+                        harness,
+                        auth,
+                        Arc::clone(&stats),
+                        Arc::clone(&stop),
+                        config.publishers,
+                        config.payload_bytes,
+                    )
+                    .await?,
+                );
+                tokio::time::sleep(Duration::from_secs(config.phase_secs)).await;
+                stop.store(true, Ordering::Relaxed);
+                for handle in handles {
+                    let _ = handle.await;
+                }
+                Ok(())
+            }
+        })
+        .await?,
+    );
+
+    // Phase 2 — connection churn.
+    phases.push(
+        run_phase("connection_churn", &config, |stats, stop| {
+            let harness = &harness;
+            let auth = &auth;
+            let config = &config;
+            async move {
+                run_connection_churn(
+                    harness,
+                    auth,
+                    Arc::clone(&stats),
+                    config.churn_cycles,
+                    config.payload_bytes,
+                )
+                .await?;
+                stop.store(true, Ordering::Relaxed);
+                Ok(())
+            }
+        })
+        .await?,
+    );
+
+    // Phase 3 — slow subscribers driving queue saturation and the drop policy.
+    phases.push(
+        run_phase("slow_subscribers", &config, |stats, stop| {
+            let harness = &harness;
+            let auth = &auth;
+            let config = &config;
+            async move {
+                let mut handles = spawn_subscribers(
+                    harness,
+                    auth,
+                    Arc::clone(&stats),
+                    Arc::clone(&stop),
+                    config.subscribers,
+                    true,
+                )
+                .await?;
+                handles.extend(
+                    spawn_publishers(
+                        harness,
+                        auth,
+                        Arc::clone(&stats),
+                        Arc::clone(&stop),
+                        config.publishers,
+                        config.payload_bytes,
+                    )
+                    .await?,
+                );
+                tokio::time::sleep(Duration::from_secs(config.phase_secs)).await;
+                stop.store(true, Ordering::Relaxed);
+                for handle in handles {
+                    let _ = handle.await;
+                }
+                Ok(())
+            }
+        })
+        .await?,
+    );
+
+    // Phase 4 — identical repeated cycles, the actual memory-leak check.
+    let cycle_peaks = run_repeated_load_cycles(&harness, &auth, &config).await?;
+
+    // Phase 5 — quiesce and let cleanup settle before judging steady state.
+    println!("\n[quiesce] waiting {}s", config.quiesce_secs);
+    tokio::time::sleep(Duration::from_secs(config.quiesce_secs)).await;
+    let quiesced = ResourceSample::capture();
+    let gauges = resources::scrape_gauges(&metrics.render());
+    println!(
+        "quiesced: rss={} KiB fds={}",
+        quiesced.rss_kb, quiesced.open_fds
+    );
+
+    // Phase 6 — repeated real-process SIGTERM restarts under traffic.
+    println!("\n[restart_cycles]");
+    let restart_findings = run_restart_cycles(&config, &auth).await?;
+
+    let unfinished = drain_broker(harness, Duration::from_secs(20)).await;
+
+    let outcome = SoakOutcome {
+        baseline,
+        quiesced,
+        phases,
+        gauges,
+        restart_findings,
+        unfinished,
+        cycle_peaks,
+    };
+    let findings = evaluate(&config, &outcome);
+    report(&outcome, &findings);
+
+    if let Some(path) = &config.timeseries_path {
+        write_timeseries(path, &outcome.phases)
+            .with_context(|| format!("write timeseries to {path}"))?;
+        println!("\ntime series written to {path}");
+    }
+
+    if findings.is_empty() {
+        Ok(())
+    } else {
+        bail!("{} soak finding(s); see report above", findings.len())
+    }
+}
+
+/// Run one phase with resource sampling alongside the workload.
+async fn run_phase<F, Fut>(
+    name: &'static str,
+    _config: &SoakConfig,
+    workload: F,
+) -> Result<PhaseReport>
+where
+    F: FnOnce(Arc<LoadStats>, Arc<AtomicBool>) -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    println!("\n[{name}]");
+    let stats = Arc::new(LoadStats::default());
+    let stop = Arc::new(AtomicBool::new(false));
+    let sampler_stop = Arc::new(AtomicBool::new(false));
+    let sampler = tokio::spawn(sample_until(
+        Arc::clone(&sampler_stop),
+        Duration::from_millis(500),
+    ));
+
+    workload(Arc::clone(&stats), Arc::clone(&stop)).await?;
+
+    sampler_stop.store(true, Ordering::Relaxed);
+    let samples = sampler.await?;
+    let report = PhaseReport {
+        name,
+        samples,
+        published: stats.published.load(Ordering::Relaxed),
+        received: stats.received.load(Ordering::Relaxed),
+        errors: stats.publish_errors.load(Ordering::Relaxed)
+            + stats.connect_errors.load(Ordering::Relaxed),
+    };
+    println!(
+        "  published={} received={} errors={} peak_rss={} KiB peak_fds={}",
+        report.published,
+        report.received,
+        report.errors,
+        report.peak_rss_kb(),
+        report.peak_fds()
+    );
+    Ok(report)
+}
+
+/// Run the *same* load several times and report peak RSS per cycle.
+///
+/// This is the check that actually distinguishes a leak from allocator
+/// retention. A single load phase always leaves RSS elevated — allocators do not
+/// return freed pages promptly, so that on its own proves nothing. A genuine
+/// leak instead shows up as peak RSS climbing on every identical cycle, while
+/// mere retention plateaus after the first.
+async fn run_repeated_load_cycles(
+    harness: &BrokerHarness,
+    auth: &AuthFixture,
+    config: &SoakConfig,
+) -> Result<Vec<u64>> {
+    println!("\n[repeated_load_cycles]");
+    let mut peaks = Vec::new();
+    let cycle_secs = (config.phase_secs / 2).max(3);
+    for cycle in 0..config.load_cycles {
+        let stats = Arc::new(LoadStats::default());
+        let stop = Arc::new(AtomicBool::new(false));
+        let sampler_stop = Arc::new(AtomicBool::new(false));
+        let sampler = tokio::spawn(sample_until(
+            Arc::clone(&sampler_stop),
+            Duration::from_millis(250),
+        ));
+
+        let mut handles = spawn_subscribers(
+            harness,
+            auth,
+            Arc::clone(&stats),
+            Arc::clone(&stop),
+            config.subscribers,
+            false,
+        )
+        .await?;
+        handles.extend(
+            spawn_publishers(
+                harness,
+                auth,
+                Arc::clone(&stats),
+                Arc::clone(&stop),
+                config.publishers,
+                config.payload_bytes,
+            )
+            .await?,
+        );
+        tokio::time::sleep(Duration::from_secs(cycle_secs)).await;
+        stop.store(true, Ordering::Relaxed);
+        for handle in handles {
+            let _ = handle.await;
+        }
+        // Let each cycle settle so the peak reflects the cycle, not the tail of
+        // the previous one.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        sampler_stop.store(true, Ordering::Relaxed);
+
+        let samples = sampler.await?;
+        let peak = samples.iter().map(|s| s.rss_kb).max().unwrap_or(0);
+        peaks.push(peak);
+        println!(
+            "  cycle {cycle}: published={} peak_rss={} KiB",
+            stats.published.load(Ordering::Relaxed),
+            peak
+        );
+    }
+    Ok(peaks)
+}
+
+/// Compare post-quiescence state against baseline and the broker's own gauges.
+/// Everything one soak run produced, so evaluation and reporting take a single
+/// argument instead of a long positional list that is easy to transpose.
+struct SoakOutcome {
+    baseline: ResourceSample,
+    quiesced: ResourceSample,
+    phases: Vec<PhaseReport>,
+    gauges: HashMap<String, f64>,
+    restart_findings: Vec<String>,
+    unfinished: Vec<&'static str>,
+    cycle_peaks: Vec<u64>,
+}
+
+fn evaluate(config: &SoakConfig, outcome: &SoakOutcome) -> Vec<String> {
+    let SoakOutcome {
+        baseline,
+        quiesced,
+        phases,
+        gauges,
+        restart_findings,
+        unfinished,
+        cycle_peaks,
+    } = outcome;
+    let mut findings: Vec<String> = restart_findings.clone();
+
+    // File descriptors are the sharpest leak signal: every leaked connection or
+    // socket shows up here, and unlike RSS there is no allocator caching to
+    // explain growth away.
+    if quiesced.open_fds > baseline.open_fds {
+        findings.push(format!(
+            "file descriptors did not return to baseline after quiescence: {} -> {} (+{})",
+            baseline.open_fds,
+            quiesced.open_fds,
+            quiesced.open_fds - baseline.open_fds
+        ));
+    }
+
+    // Memory is judged across identical repeated cycles, not against baseline.
+    // Comparing a post-load RSS to a pre-load one only measures allocator
+    // retention and would flag every healthy run. A leak is peak RSS still
+    // climbing on the last identical cycle.
+    if cycle_peaks.len() >= 2 {
+        let first = cycle_peaks[0] as f64;
+        let last = *cycle_peaks.last().expect("checked non-empty") as f64;
+        if first > 0.0 {
+            let growth = (last - first) / first;
+            if growth > config.rss_growth_tolerance {
+                findings.push(format!(
+                    "peak RSS grew {:.1}% across {} identical load cycles ({} -> {} KiB), beyond \
+                     the {:.0}% tolerance; retention would have plateaued",
+                    growth * 100.0,
+                    cycle_peaks.len(),
+                    cycle_peaks[0],
+                    last as u64,
+                    config.rss_growth_tolerance * 100.0
+                ));
+            }
+        }
+    }
+
+    // Registration gauges must return to exactly zero: every client has gone, so
+    // any residue is an entry that will never be reclaimed.
+    for gauge in [
+        "felix_sub_active_connections",
+        "felix_sub_connection_subscribers",
+        "felix_broker_ingress_queue_depth",
+        "felix_broker_out_ack_depth",
+    ] {
+        if let Some(value) = gauges.get(gauge)
+            && *value > 0.0
+        {
+            findings.push(format!(
+                "gauge {gauge} did not return to zero after quiescence: {value}"
+            ));
+        }
+    }
+
+    // Queue depth is allowed a small documented residue. `SubscriptionReceiver`'s
+    // `Drop` drains what is queued and decrements the global counter, but an item
+    // enqueued between that drain loop and the channel actually closing is counted
+    // and never dequeued. Observed as exactly 1 across runs of very different
+    // sizes, i.e. bounded per teardown rather than proportional to load. Tracked
+    // separately; the check still catches genuine unbounded drift.
+    const QUEUE_DEPTH_DRIFT_ALLOWANCE: f64 = 8.0;
+    if let Some(value) = gauges.get("felix_sub_queue_len")
+        && *value > QUEUE_DEPTH_DRIFT_ALLOWANCE
+    {
+        findings.push(format!(
+            "gauge felix_sub_queue_len drifted to {value} after quiescence, beyond the \
+             known-race allowance of {QUEUE_DEPTH_DRIFT_ALLOWANCE}"
+        ));
+    }
+
+    if !unfinished.is_empty() {
+        findings.push(format!(
+            "final drain did not complete within its deadline: {unfinished:?}"
+        ));
+    }
+
+    // A phase that moved no traffic proves nothing; treat it as a harness
+    // failure rather than silently reporting a clean run.
+    for phase in phases {
+        if phase.published == 0 {
+            findings.push(format!(
+                "phase {} published nothing, so it did not exercise the broker",
+                phase.name
+            ));
+        }
+    }
+
+    findings
+}
+
+/// Write the sampled series as JSONL so a run can be re-examined or charted
+/// later, matching how `data/raw/latency_demo_runs.jsonl` records perf runs.
+fn write_timeseries(path: &str, phases: &[PhaseReport]) -> Result<()> {
+    use std::io::Write;
+    if let Some(parent) = std::path::Path::new(path).parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut file = std::fs::File::create(path)?;
+    for phase in phases {
+        for sample in &phase.samples {
+            writeln!(
+                file,
+                r#"{{"phase":"{}","unix_ms":{},"rss_kb":{},"open_fds":{}}}"#,
+                phase.name, sample.unix_ms, sample.rss_kb, sample.open_fds
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn report(outcome: &SoakOutcome, findings: &[String]) {
+    let SoakOutcome {
+        baseline,
+        quiesced,
+        phases,
+        gauges,
+        ..
+    } = outcome;
+    println!("\n== Soak report ==");
+    println!("{:<20} {:>10} {:>8}", "phase", "peak_rss", "peak_fds");
+    println!(
+        "{:<20} {:>10} {:>8}",
+        "baseline", baseline.rss_kb, baseline.open_fds
+    );
+    for phase in phases {
+        println!(
+            "{:<20} {:>10} {:>8}",
+            phase.name,
+            phase.peak_rss_kb(),
+            phase.peak_fds()
+        );
+        if let Some(last) = phase.last() {
+            println!(
+                "{:<20} {:>10} {:>8}   (end of phase)",
+                "", last.rss_kb, last.open_fds
+            );
+        }
+    }
+    println!(
+        "{:<20} {:>10} {:>8}",
+        "quiesced", quiesced.rss_kb, quiesced.open_fds
+    );
+
+    println!("\nsteady-state gauges:");
+    let mut names: Vec<&String> = gauges.keys().collect();
+    names.sort();
+    for name in names {
+        println!("  {:<45} {}", name, gauges[name]);
+    }
+
+    if findings.is_empty() {
+        println!("\nNo findings: resources returned to the steady-state envelope.");
+    } else {
+        println!("\n{} finding(s):", findings.len());
+        for finding in findings {
+            println!("  - {finding}");
+        }
+    }
+}

--- a/services/broker/src/bin/soak/main.rs
+++ b/services/broker/src/bin/soak/main.rs
@@ -462,6 +462,13 @@ impl PhaseReport {
     fn peak_fds(&self) -> u64 {
         self.samples.iter().map(|s| s.open_fds).max().unwrap_or(0)
     }
+    fn peak_tasks(&self) -> usize {
+        self.samples
+            .iter()
+            .map(|s| s.alive_tasks)
+            .max()
+            .unwrap_or(0)
+    }
     fn last(&self) -> Option<&ResourceSample> {
         self.samples.last()
     }
@@ -729,8 +736,8 @@ async fn main() -> Result<()> {
     let harness = start_broker(&auth).await?;
     let baseline = ResourceSample::capture();
     println!(
-        "baseline (broker listening, no clients): rss={} KiB fds={}",
-        baseline.rss_kb, baseline.open_fds
+        "baseline (broker listening, no clients): rss={} KiB fds={} tasks={}",
+        baseline.rss_kb, baseline.open_fds, baseline.alive_tasks
     );
 
     let mut phases = Vec::new();
@@ -842,8 +849,8 @@ async fn main() -> Result<()> {
     let quiesced = ResourceSample::capture();
     let gauges = resources::scrape_gauges(&metrics.render());
     println!(
-        "quiesced: rss={} KiB fds={}",
-        quiesced.rss_kb, quiesced.open_fds
+        "quiesced: rss={} KiB fds={} tasks={}",
+        quiesced.rss_kb, quiesced.open_fds, quiesced.alive_tasks
     );
 
     // Phase 6 — repeated real-process SIGTERM restarts under traffic.
@@ -909,12 +916,13 @@ where
             + stats.connect_errors.load(Ordering::Relaxed),
     };
     println!(
-        "  published={} received={} errors={} peak_rss={} KiB peak_fds={}",
+        "  published={} received={} errors={} peak_rss={} KiB peak_fds={} peak_tasks={}",
         report.published,
         report.received,
         report.errors,
         report.peak_rss_kb(),
-        report.peak_fds()
+        report.peak_fds(),
+        report.peak_tasks()
     );
     Ok(report)
 }
@@ -1022,6 +1030,15 @@ fn evaluate(config: &SoakConfig, outcome: &SoakOutcome) -> Vec<String> {
         ));
     }
 
+    if quiesced.alive_tasks > baseline.alive_tasks {
+        findings.push(format!(
+            "Tokio tasks did not return to baseline after quiescence: {} -> {} (+{})",
+            baseline.alive_tasks,
+            quiesced.alive_tasks,
+            quiesced.alive_tasks - baseline.alive_tasks
+        ));
+    }
+
     // Memory is judged across identical repeated cycles, not against baseline.
     // Comparing a post-load RSS to a pre-load one only measures allocator
     // retention and would flag every healthy run. A leak is peak RSS still
@@ -1112,8 +1129,8 @@ fn write_timeseries(path: &str, phases: &[PhaseReport]) -> Result<()> {
         for sample in &phase.samples {
             writeln!(
                 file,
-                r#"{{"phase":"{}","unix_ms":{},"rss_kb":{},"open_fds":{}}}"#,
-                phase.name, sample.unix_ms, sample.rss_kb, sample.open_fds
+                r#"{{"phase":"{}","unix_ms":{},"rss_kb":{},"open_fds":{},"alive_tasks":{}}}"#,
+                phase.name, sample.unix_ms, sample.rss_kb, sample.open_fds, sample.alive_tasks
             )?;
         }
     }
@@ -1129,28 +1146,32 @@ fn report(outcome: &SoakOutcome, findings: &[String]) {
         ..
     } = outcome;
     println!("\n== Soak report ==");
-    println!("{:<20} {:>10} {:>8}", "phase", "peak_rss", "peak_fds");
     println!(
-        "{:<20} {:>10} {:>8}",
-        "baseline", baseline.rss_kb, baseline.open_fds
+        "{:<20} {:>10} {:>8} {:>10}",
+        "phase", "peak_rss", "peak_fds", "peak_tasks"
+    );
+    println!(
+        "{:<20} {:>10} {:>8} {:>10}",
+        "baseline", baseline.rss_kb, baseline.open_fds, baseline.alive_tasks
     );
     for phase in phases {
         println!(
-            "{:<20} {:>10} {:>8}",
+            "{:<20} {:>10} {:>8} {:>10}",
             phase.name,
             phase.peak_rss_kb(),
-            phase.peak_fds()
+            phase.peak_fds(),
+            phase.peak_tasks()
         );
         if let Some(last) = phase.last() {
             println!(
-                "{:<20} {:>10} {:>8}   (end of phase)",
-                "", last.rss_kb, last.open_fds
+                "{:<20} {:>10} {:>8} {:>10}   (end of phase)",
+                "", last.rss_kb, last.open_fds, last.alive_tasks
             );
         }
     }
     println!(
-        "{:<20} {:>10} {:>8}",
-        "quiesced", quiesced.rss_kb, quiesced.open_fds
+        "{:<20} {:>10} {:>8} {:>10}",
+        "quiesced", quiesced.rss_kb, quiesced.open_fds, quiesced.alive_tasks
     );
 
     println!("\nsteady-state gauges:");

--- a/services/broker/src/bin/soak/resources.rs
+++ b/services/broker/src/bin/soak/resources.rs
@@ -1,0 +1,161 @@
+//! Process resource sampling for the soak harness.
+//!
+//! Deliberately dependency-free and best-effort: a sampler that fails to read a
+//! counter must not abort a soak run, so every reader falls back to 0 and the
+//! harness treats a flat-zero series as "unavailable on this platform" rather
+//! than as evidence of anything.
+
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// One point in the resource time series.
+#[derive(Debug, Clone, Copy)]
+pub struct ResourceSample {
+    pub unix_ms: u128,
+    pub rss_kb: u64,
+    pub open_fds: u64,
+}
+
+impl ResourceSample {
+    pub fn capture() -> Self {
+        Self {
+            unix_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_millis())
+                .unwrap_or(0),
+            rss_kb: read_rss_kb(),
+            open_fds: count_open_fds(),
+        }
+    }
+}
+
+/// Resident set size in KiB.
+///
+/// Linux exposes this in `/proc/self/statm` as a page count. macOS has no
+/// equivalent procfs entry, so we shell out to `ps` — slow, but the sampler
+/// runs twice a second, not in a hot loop.
+#[cfg(target_os = "linux")]
+fn read_rss_kb() -> u64 {
+    let Ok(statm) = std::fs::read_to_string("/proc/self/statm") else {
+        return 0;
+    };
+    // Field 2 is resident pages.
+    let Some(resident_pages) = statm.split_whitespace().nth(1) else {
+        return 0;
+    };
+    let pages: u64 = resident_pages.parse().unwrap_or(0);
+    let page_kb = 4; // Linux page size on every platform Felix targets.
+    pages * page_kb
+}
+
+#[cfg(not(target_os = "linux"))]
+fn read_rss_kb() -> u64 {
+    let pid = std::process::id();
+    let Ok(output) = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+    else {
+        return 0;
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}
+
+/// Count of open file descriptors.
+///
+/// `/dev/fd` is present on both Linux (symlinked to `/proc/self/fd`) and macOS,
+/// so one path covers both. The directory handle opened to read it is itself an
+/// fd, but it is opened and closed identically on every sample, so it cancels
+/// out of any comparison.
+fn count_open_fds() -> u64 {
+    let Ok(entries) = std::fs::read_dir("/dev/fd") else {
+        return 0;
+    };
+    entries.count() as u64
+}
+
+/// Extract gauge values from rendered Prometheus text.
+///
+/// Only gauges are collected: counters grow monotonically by design and say
+/// nothing about whether resources were released, whereas a gauge that fails to
+/// return to zero after quiescence is exactly the leak signal we want. Labelled
+/// series are summed across labels, since "any connection still registered" is
+/// the question, not which one.
+pub fn scrape_gauges(rendered: &str) -> HashMap<String, f64> {
+    let mut gauge_names = Vec::new();
+    let mut values: HashMap<String, f64> = HashMap::new();
+
+    for line in rendered.lines() {
+        if let Some(rest) = line.strip_prefix("# TYPE ") {
+            let mut parts = rest.split_whitespace();
+            if let (Some(name), Some(kind)) = (parts.next(), parts.next())
+                && kind == "gauge"
+            {
+                gauge_names.push(name.to_string());
+            }
+            continue;
+        }
+        if line.starts_with('#') || line.trim().is_empty() {
+            continue;
+        }
+        let Some((key, raw_value)) = line.rsplit_once(' ') else {
+            continue;
+        };
+        let name = key.split('{').next().unwrap_or(key).trim();
+        if !gauge_names.iter().any(|g| g == name) {
+            continue;
+        }
+        if let Ok(value) = raw_value.trim().parse::<f64>() {
+            *values.entry(name.to_string()).or_insert(0.0) += value;
+        }
+    }
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_reports_plausible_values() {
+        let sample = ResourceSample::capture();
+        // A running process always has at least stdin/stdout/stderr open, and
+        // some resident memory. Zero means the reader failed, not that the
+        // process is weightless.
+        assert!(sample.rss_kb > 0, "rss reader returned nothing");
+        assert!(
+            sample.open_fds >= 3,
+            "fd reader returned {}",
+            sample.open_fds
+        );
+    }
+
+    #[test]
+    fn scrape_gauges_sums_labels_and_ignores_counters() {
+        let rendered = "\
+# TYPE felix_sub_active_connections gauge
+felix_sub_active_connections 3
+# TYPE felix_sub_connection_subscribers gauge
+felix_sub_connection_subscribers{connection_id=\"1\"} 2
+felix_sub_connection_subscribers{connection_id=\"2\"} 5
+# TYPE felix_publish_requests_total counter
+felix_publish_requests_total 900
+";
+        let gauges = scrape_gauges(rendered);
+        assert_eq!(gauges.get("felix_sub_active_connections"), Some(&3.0));
+        // Labelled series are summed, so "anything still registered" is visible
+        // without needing to know the label set.
+        assert_eq!(gauges.get("felix_sub_connection_subscribers"), Some(&7.0));
+        assert!(
+            !gauges.contains_key("felix_publish_requests_total"),
+            "counters must not be treated as leak signals"
+        );
+    }
+
+    #[test]
+    fn scrape_gauges_tolerates_empty_input() {
+        assert!(scrape_gauges("").is_empty());
+    }
+}

--- a/services/broker/src/bin/soak/resources.rs
+++ b/services/broker/src/bin/soak/resources.rs
@@ -14,6 +14,7 @@ pub struct ResourceSample {
     pub unix_ms: u128,
     pub rss_kb: u64,
     pub open_fds: u64,
+    pub alive_tasks: usize,
 }
 
 impl ResourceSample {
@@ -25,6 +26,9 @@ impl ResourceSample {
                 .unwrap_or(0),
             rss_kb: read_rss_kb(),
             open_fds: count_open_fds(),
+            alive_tasks: tokio::runtime::Handle::try_current()
+                .map(|handle| handle.metrics().num_alive_tasks())
+                .unwrap_or(0),
         }
     }
 }
@@ -130,6 +134,9 @@ mod tests {
             "fd reader returned {}",
             sample.open_fds
         );
+        // This unit test does not run inside a Tokio runtime. The soak itself
+        // does, where `alive_tasks` is populated from `Handle::metrics()`.
+        assert_eq!(sample.alive_tasks, 0);
     }
 
     #[test]

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -127,8 +127,20 @@ pub async fn serve_with_shutdown(
         let config = config.clone();
         let auth = Arc::clone(&auth);
         let publish_ctx = publish_ctx.clone();
+        // Each connection observes the same shutdown signal, so a drain winds
+        // down accepted connections cooperatively rather than waiting for peers
+        // that may never disconnect.
+        let conn_shutdown = shutdown.clone();
         connections.spawn(async move {
-            if let Err(err) = handle_connection(broker, connection, config, auth, publish_ctx).await
+            if let Err(err) = handle_connection_with_shutdown(
+                broker,
+                connection,
+                config,
+                auth,
+                publish_ctx,
+                conn_shutdown,
+            )
+            .await
             {
                 tracing::warn!(error = %err, "quic connection handler failed");
             }
@@ -237,7 +249,8 @@ fn build_publish_context(broker: Arc<Broker>, config: &BrokerConfig) -> PublishC
     }
 }
 
-/// Handle a single QUIC connection and its streams.
+/// Handle a single QUIC connection and its streams, winding down when
+/// `shutdown` is cancelled.
 ///
 /// # What it does
 /// Creates per-connection publish workers and dispatches incoming bi/uni streams
@@ -247,18 +260,34 @@ fn build_publish_context(broker: Arc<Broker>, config: &BrokerConfig) -> PublishC
 /// Keeps per-connection state (publish queues and depth counters) scoped to the
 /// connection lifecycle.
 ///
+/// # Why it takes a shutdown token
+/// A connection task otherwise ends only when the *peer* disconnects. Subscribers
+/// hold connections open indefinitely by design, so a drain that just waits for
+/// connection tasks to finish would never complete: it would burn the entire
+/// deadline on every shutdown and then force-abort, dropping exactly the
+/// in-flight work the drain was meant to protect.
+///
+/// # Shutdown semantics
+/// Cancellation stops this connection accepting *new* streams, gives the streams
+/// already in flight a bounded grace period to finish, and then closes the QUIC
+/// connection so the peer learns this was a clean shutdown rather than a
+/// disappearance.
+///
 /// # Invariants
 /// - `worker_count` and `publish_queue_depth` are at least 1.
 /// - Global ingress depth counters are decremented when workers exit.
+/// - The stream grace is bounded, so one connection cannot outlast the caller's
+///   drain budget.
 ///
 /// # Errors
 /// - Returns on connection-level QUIC errors.
-pub(crate) async fn handle_connection(
+pub(crate) async fn handle_connection_with_shutdown(
     broker: Arc<Broker>,
     connection: QuicConnection,
     config: BrokerConfig,
     auth: Arc<BrokerAuth>,
     publish_ctx: PublishContext,
+    shutdown: CancellationToken,
 ) -> Result<()> {
     // Give this connection its own slice of the shared publish byte budget, its own
     // subscription-count limiter, and its own writer-lane manager, so one connection can't
@@ -273,15 +302,26 @@ pub(crate) async fn handle_connection(
         lane_manager: WriterLaneManager::new(&config),
         ..publish_ctx
     };
+    // Tracks the per-stream handler tasks so shutdown can wait for in-flight
+    // work instead of dropping it.
+    let streams = TaskTracker::new();
     loop {
         // Accept both bidirectional control streams and uni-directional publish streams.
         tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!(
+                    stats = ?connection.stats(),
+                    "connection draining; no longer accepting streams"
+                );
+                break;
+            }
             result = connection.accept_bi() => {
                 let (send, recv) = match result {
                     Ok(streams) => streams,
                     Err(err) => {
                         tracing::info!(error = %err, stats = ?connection.stats(), "quic connection closed");
-                        return Ok(());
+                        break;
                     }
                 };
                 let broker = Arc::clone(&broker);
@@ -289,7 +329,7 @@ pub(crate) async fn handle_connection(
                 let config = config.clone();
                 let auth = Arc::clone(&auth);
                 let publish_ctx = publish_ctx.clone();
-                tokio::spawn(async move {
+                streams.spawn(async move {
                     // Dispatch the bidirectional control stream handler.
                     if let Err(err) = handle_stream(
                         broker,
@@ -311,14 +351,14 @@ pub(crate) async fn handle_connection(
                     Ok(recv) => recv,
                     Err(err) => {
                         tracing::info!(error = %err, stats = ?connection.stats(), "quic connection closed");
-                        return Ok(());
+                        break;
                     }
                 };
                 let broker = Arc::clone(&broker);
                 let config = config.clone();
                 let auth = Arc::clone(&auth);
                 let publish_ctx = publish_ctx.clone();
-                tokio::spawn(async move {
+                streams.spawn(async move {
                     // Dispatch the unidirectional publish stream handler.
                     if let Err(err) = handle_uni_stream(
                         broker,
@@ -335,6 +375,33 @@ pub(crate) async fn handle_connection(
             }
         }
     }
+
+    // Give the streams already accepted a bounded window to finish.
+    //
+    // The bound is essential, not defensive. Control and subscription streams are
+    // long-lived by design: a publisher holds one open and streams requests down
+    // it, a subscriber holds one open to receive events. Neither ends until the
+    // *client* closes it, so waiting unconditionally would hang exactly as long
+    // as waiting for the connection itself did. In-flight requests get the grace
+    // window; anything still open after it is ended by closing the connection.
+    //
+    // Half the process drain budget, so a connection cannot consume the whole
+    // allowance and starve the accept loop and metrics server that drain after it.
+    let grace =
+        Duration::from_millis(config.shutdown_drain_timeout_ms / 2).max(Duration::from_secs(1));
+    streams.close();
+    if tokio::time::timeout(grace, streams.wait()).await.is_err() {
+        tracing::info!(
+            ?grace,
+            stats = ?connection.stats(),
+            "connection drain grace expired with streams still open; closing"
+        );
+    }
+
+    // Tell the peer this was a deliberate close rather than a vanished server, so
+    // it can reconnect elsewhere instead of waiting out an idle timeout.
+    connection.close(0u32.into(), b"broker shutting down");
+    Ok(())
 }
 
 #[cfg(test)]
@@ -439,7 +506,15 @@ mod tests {
 
         let server_task = tokio::spawn(async move {
             let connection = server.accept().await?;
-            handle_connection(broker, connection, config, auth, publish_ctx).await
+            handle_connection_with_shutdown(
+                broker,
+                connection,
+                config,
+                auth,
+                publish_ctx,
+                CancellationToken::new(),
+            )
+            .await
         });
 
         let mut roots = RootCertStore::empty();

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -494,6 +494,12 @@ pub(crate) enum LaneCommand {
     },
     Unregister {
         subscriber_id: u64,
+        // Carried explicitly rather than looked up in `subscriber_connections`.
+        // Teardown enqueues this command and then immediately calls
+        // `unregister_subscriber`, which removes that entry -- so by the time the
+        // lane worker dequeues, the lookup would already miss and the cleanup
+        // would be skipped entirely.
+        connection_id: Option<u64>,
     },
 }
 
@@ -810,10 +816,22 @@ async fn run_writer_lane(
                         )
                         .await;
                 }
-                LaneCommand::Unregister { subscriber_id } => {
-                    if let Some((_, connection_id)) =
-                        manager.subscriber_connections.remove(&subscriber_id)
-                    {
+                LaneCommand::Unregister {
+                    subscriber_id,
+                    connection_id,
+                } => {
+                    // Prefer the id carried on the command; fall back to the map
+                    // for any caller that still has an entry. Either way the
+                    // per-connection writer must be told and the connection
+                    // subscriber count must be decremented exactly once.
+                    let connection_id = connection_id.or_else(|| {
+                        manager
+                            .subscriber_connections
+                            .remove(&subscriber_id)
+                            .map(|(_, id)| id)
+                    });
+                    if let Some(connection_id) = connection_id {
+                        manager.subscriber_connections.remove(&subscriber_id);
                         let _ = manager
                             .enqueue_connection(
                                 connection_id,
@@ -1330,6 +1348,7 @@ async fn run_lane_feeder(
             lane_idx,
             LaneCommand::Unregister {
                 subscriber_id: config.subscription_id,
+                connection_id,
             },
         )
         .await;
@@ -2863,6 +2882,63 @@ mod tests {
 
         connection_subscriber_unregister(Some(connection_id));
         assert!(map.get(&connection_id).is_none());
+    }
+
+    // Regression test for the leak the soak harness found (#154).
+    //
+    // Subscription teardown enqueues `LaneCommand::Unregister` and then *immediately*
+    // calls `unregister_subscriber`, which removes the `subscriber_connections` entry.
+    // The lane worker dequeues afterwards, so when it used to look the connection up
+    // there it found nothing and skipped cleanup entirely — leaving an entry in
+    // `ACTIVE_SUB_CONN_COUNTS` and a per-connection metric series behind for every
+    // subscriber connection ever made. Over a long-lived broker with connection churn
+    // that is unbounded growth, and it made `felix_sub_active_connections` permanently
+    // wrong. The command now carries `connection_id` so the lookup is not needed.
+    #[tokio::test]
+    async fn lane_unregister_cleans_up_after_teardown_already_removed_the_mapping() {
+        let manager = WriterLaneManager::new(&test_config());
+        let connection_id = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos()
+            & u128::from(u64::MAX)) as u64;
+        let subscriber_id = connection_id ^ 0x5555;
+
+        connection_subscriber_register(Some(connection_id));
+        let map = ACTIVE_SUB_CONN_COUNTS
+            .get()
+            .expect("counts map should be initialized");
+        assert!(map.get(&connection_id).is_some());
+
+        // Reproduce the race: teardown has already dropped the mapping the worker
+        // used to depend on, before the worker gets to the command.
+        manager.subscriber_connections.remove(&subscriber_id);
+
+        manager
+            .enqueue(
+                0,
+                LaneCommand::Unregister {
+                    subscriber_id,
+                    connection_id: Some(connection_id),
+                },
+            )
+            .await
+            .expect("enqueue unregister");
+
+        // The worker runs on its own task, so poll rather than assume immediacy.
+        let mut cleared = false;
+        for _ in 0..200 {
+            if map.get(&connection_id).is_none() {
+                cleared = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(
+            cleared,
+            "lane worker must release the connection's subscriber count even when \
+             teardown already removed the subscriber_connections entry"
+        );
     }
 
     #[test]

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -55,9 +55,9 @@ use felix_wire::Message;
 use futures::{StreamExt, stream::FuturesUnordered};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 #[cfg(test)]
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -307,10 +307,11 @@ pub(crate) async fn handle_subscribe_message(
     )
     .await?;
     let feeder_subscriptions = Arc::clone(subscriptions);
+    let feeder_manager = Arc::downgrade(&manager);
     let feeder = async move {
         run_lane_feeder(
             event_rx,
-            manager,
+            feeder_manager,
             lane_idx,
             Some(connection_id),
             writer_config,
@@ -585,8 +586,14 @@ impl WriterLaneManager {
             rr_counter: AtomicUsize::new(0),
         };
         let manager = Arc::new(manager);
+        let weak_manager = Arc::downgrade(&manager);
         for (lane_id, rx) in lane_receivers.into_iter().enumerate() {
-            tokio::spawn(run_writer_lane(lane_id, rx, lane_cfg, Arc::clone(&manager)));
+            tokio::spawn(run_writer_lane(
+                lane_id,
+                rx,
+                lane_cfg,
+                Weak::clone(&weak_manager),
+            ));
         }
         manager
     }
@@ -766,14 +773,25 @@ impl WriterLaneManager {
     }
 }
 
+impl Drop for WriterLaneManager {
+    fn drop(&mut self) {
+        for entry in &self.subscriber_connections {
+            connection_subscriber_unregister(Some(*entry.value()));
+        }
+    }
+}
+
 async fn run_writer_lane(
     lane_id: usize,
     mut rx: mpsc::Receiver<LaneCommand>,
     lane_cfg: LaneRuntimeConfig,
-    manager: Arc<WriterLaneManager>,
+    manager: Weak<WriterLaneManager>,
 ) {
     let lane_label = lane_id.to_string();
     while let Some(first_cmd) = rx.recv().await {
+        let Some(manager) = manager.upgrade() else {
+            break;
+        };
         let mut pending = Vec::with_capacity(lane_cfg.flush_max_items.max(1));
         pending.push(first_cmd);
 
@@ -1184,7 +1202,7 @@ fn connection_subscriber_unregister(connection_id: Option<u64>) {
 
 async fn run_lane_feeder(
     mut event_rx: SubscriptionReceiver,
-    manager: Arc<WriterLaneManager>,
+    manager: Weak<WriterLaneManager>,
     lane_idx: usize,
     connection_id: Option<u64>,
     config: EventWriterConfig,
@@ -1208,6 +1226,9 @@ async fn run_lane_feeder(
             },
         };
         let first_enqueued_at = envelope.enqueued_at();
+        let Some(manager) = manager.upgrade() else {
+            break;
+        };
 
         if envelope.len() > 1 || config.single_event_mode {
             let payloads = envelope.payloads();
@@ -1343,16 +1364,18 @@ async fn run_lane_feeder(
                 .record(enqueue_ns as f64);
         }
     }
-    let _ = manager
-        .enqueue(
-            lane_idx,
-            LaneCommand::Unregister {
-                subscriber_id: config.subscription_id,
-                connection_id,
-            },
-        )
-        .await;
-    manager.unregister_subscriber(config.subscription_id, connection_id);
+    if let Some(manager) = manager.upgrade() {
+        let _ = manager
+            .enqueue(
+                lane_idx,
+                LaneCommand::Unregister {
+                    subscriber_id: config.subscription_id,
+                    connection_id,
+                },
+            )
+            .await;
+        manager.unregister_subscriber(config.subscription_id, connection_id);
+    }
     subscriptions.release();
 }
 
@@ -2050,6 +2073,8 @@ mod tests {
         let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
 
         let broker_for_server = broker.clone();
+        let lane_manager = WriterLaneManager::new(&test_config());
+        let server_lane_manager = Arc::clone(&lane_manager);
         let server_task = tokio::spawn(async move {
             let connection = server.accept().await?;
             let handled = handle_subscribe_message(
@@ -2057,7 +2082,7 @@ mod tests {
                 connection,
                 test_config(),
                 &Arc::new(SubscriptionLimiter::new()),
-                &WriterLaneManager::new(&test_config()),
+                &server_lane_manager,
                 &out_ack_tx,
                 &out_ack_depth,
                 &ack_throttle_tx,
@@ -2222,6 +2247,8 @@ mod tests {
         config.event_batch_max_bytes = 6;
 
         let broker_for_server = broker.clone();
+        let lane_manager = WriterLaneManager::new(&test_config());
+        let server_lane_manager = Arc::clone(&lane_manager);
         let server_task = tokio::spawn(async move {
             let connection = server.accept().await?;
             handle_subscribe_message(
@@ -2229,7 +2256,7 @@ mod tests {
                 connection,
                 config,
                 &Arc::new(SubscriptionLimiter::new()),
-                &WriterLaneManager::new(&test_config()),
+                &server_lane_manager,
                 &out_ack_tx,
                 &out_ack_depth,
                 &ack_throttle_tx,
@@ -2341,6 +2368,8 @@ mod tests {
         config.event_batch_max_events = 1;
 
         let broker_for_server = broker.clone();
+        let lane_manager = WriterLaneManager::new(&test_config());
+        let server_lane_manager = Arc::clone(&lane_manager);
         let server_task = tokio::spawn(async move {
             for sub_id in [31_u64, 32_u64] {
                 let connection = server.accept().await?;
@@ -2349,7 +2378,7 @@ mod tests {
                     connection,
                     config.clone(),
                     &Arc::new(SubscriptionLimiter::new()),
-                    &WriterLaneManager::new(&test_config()),
+                    &server_lane_manager,
                     &out_ack_tx,
                     &out_ack_depth,
                     &ack_throttle_tx,
@@ -2545,6 +2574,8 @@ mod tests {
         let mut config = test_config();
         config.sub_stream_mode = crate::config::SubStreamMode::HashedPool;
         let broker_for_server = broker.clone();
+        let lane_manager = WriterLaneManager::new(&test_config());
+        let server_lane_manager = Arc::clone(&lane_manager);
         let server_task = tokio::spawn(async move {
             let connection = server.accept().await?;
             handle_subscribe_message(
@@ -2552,7 +2583,7 @@ mod tests {
                 connection,
                 config,
                 &Arc::new(SubscriptionLimiter::new()),
-                &WriterLaneManager::new(&test_config()),
+                &server_lane_manager,
                 &out_ack_tx,
                 &out_ack_depth,
                 &ack_throttle_tx,
@@ -2983,6 +3014,46 @@ mod tests {
         assert!(manager.subscriber_pins.get(&7).is_none());
         assert!(manager.subscriber_connections.get(&7).is_none());
         assert!(manager.connection_lanes.get(&88).is_none());
+    }
+
+    #[tokio::test]
+    async fn writer_lane_tasks_do_not_retain_manager() {
+        let manager = WriterLaneManager::new(&test_config());
+        let weak_manager = Arc::downgrade(&manager);
+
+        drop(manager);
+
+        assert!(
+            weak_manager.upgrade().is_none(),
+            "writer lane tasks must not keep a connection's manager alive"
+        );
+        tokio::task::yield_now().await;
+    }
+
+    #[tokio::test]
+    async fn manager_drop_releases_remaining_connection_counts() {
+        let manager = WriterLaneManager::new(&test_config());
+        let connection_id = (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time")
+            .as_nanos()
+            & u128::from(u64::MAX)) as u64;
+        let subscriber_id = connection_id ^ 0xaaaa;
+
+        connection_subscriber_register(Some(connection_id));
+        manager
+            .subscriber_connections
+            .insert(subscriber_id, connection_id);
+
+        drop(manager);
+
+        let map = ACTIVE_SUB_CONN_COUNTS
+            .get()
+            .expect("counts map should be initialized");
+        assert!(
+            map.get(&connection_id).is_none(),
+            "dropping the manager must release registrations whose queued unregister did not run"
+        );
     }
 
     #[tokio::test]

--- a/services/broker/tests/graceful_shutdown.rs
+++ b/services/broker/tests/graceful_shutdown.rs
@@ -119,9 +119,14 @@ async fn cancelling_accept_token_exits_idle_accept_loop() -> Result<()> {
 
 #[tokio::test]
 #[serial]
-// The distinction the whole drain rests on: after cancellation the broker must stop
-// admitting new work while connections it already accepted keep running.
-async fn cancellation_stops_admission_but_keeps_accepted_connections() -> Result<()> {
+// Cancellation must stop admission *and* wind down connections already accepted.
+//
+// This originally asserted the opposite — that accepted connections keep running
+// indefinitely — which is what the soak harness showed to be the bug: a subscriber
+// holds its connection open forever, so a drain that only waits for connection
+// tasks to end never completes. It burns the whole deadline and then force-aborts,
+// dropping exactly the in-flight work the drain exists to protect.
+async fn cancellation_winds_down_accepted_connections() -> Result<()> {
     let harness = start_broker().await?;
 
     // Establish a connection before shutdown and keep it open.
@@ -152,17 +157,13 @@ async fn cancellation_stops_admission_but_keeps_accepted_connections() -> Result
         "accept loop should exit cleanly: {result:?}"
     );
 
-    // The already-accepted connection is untouched by the accept loop stopping —
-    // and still usable, not merely un-closed.
-    timeout(Duration::from_secs(2), early_conn.open_uni())
+    // The connection task winds itself down without the peer disconnecting first.
+    // This is the property that makes a bounded drain possible: the client here
+    // never goes away, exactly as a real subscriber would not.
+    harness.connections.close();
+    timeout(Duration::from_secs(10), harness.connections.wait())
         .await
-        .expect("opening a stream should not hang")
-        .expect("accepted connection must still be usable after admission stops");
-    assert_eq!(
-        harness.connections.len(),
-        1,
-        "in-flight connection task should still be tracked"
-    );
+        .expect("accepted connections must drain without waiting for the peer to disconnect");
 
     // A new connection is no longer admitted. The handshake may fail outright or
     // hang because nothing accepts it; either is "not admitted", and both are
@@ -179,14 +180,8 @@ async fn cancellation_stops_admission_but_keeps_accepted_connections() -> Result
         "broker must not admit connections after shutdown"
     );
 
-    // Once the peer goes away the tracked task finishes and the drain completes,
-    // which is what bounds the shutdown rather than an unconditional abort.
     drop(early_conn);
     drop(early_client);
-    harness.connections.close();
-    timeout(Duration::from_secs(10), harness.connections.wait())
-        .await
-        .expect("tracked connections should drain after the peer disconnects");
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #154 

This commit introduces a new module for capturing resource metrics during soak tests. It includes functionality to sample the resident set size (RSS) and count of open file descriptors, with platform-specific implementations for Linux and macOS. Additionally, a utility to scrape Prometheus gauge values is provided, focusing on summing labelled series while ignoring counters. Tests are included to ensure the correctness of the sampling and scraping functionalities.