### PR TITLE
feat: update licensing and metadata for multiple crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,8 @@ jobs:
       - name: cargo-deny
         run: task deny
 
+      - name: Publish-readiness and licence split
+        run: task publish:check
+
       - name: RSA dependency check (non-controlplane crates)
         run: task deny:rsa:default

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,16 @@ edition = "2024"
 # `version.workspace = true`; bumping a release means editing this line only.
 # Non-member demos under demos/ keep their own literal version.
 version = "0.1.1"
-license = "Apache-2.0"
+# Fail-closed default: a new crate inherits the *restrictive* licence unless it
+# deliberately opts into Apache-2.0. The permissive crates (felix-wire,
+# felix-common, felix-transport, felix-client, felix-conformance) set
+# `license = "Apache-2.0"` explicitly. See LICENSING.md for the authoritative
+# table; `task publish:check` fails CI if a crate drifts from it.
+license = "Elastic-2.0"
 rust-version = "1.97"
+repository = "https://github.com/gabloe/felix"
+homepage = "https://github.com/gabloe/felix"
+readme = "README.md"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -18,8 +18,27 @@ service.
 
 The root [`LICENSE`](LICENSE) file is Elastic License 2.0 (the license for
 the project as a whole / the deployable server). [`LICENSE-APACHE`](LICENSE-APACHE)
-holds the Apache-2.0 text; each Apache-licensed directory above also carries
-its own `LICENSE` file, which takes precedence for that subtree.
+holds the Apache-2.0 text.
+
+**Every crate directory carries its own `LICENSE` file**, holding the text that
+applies to that subtree, and it takes precedence for that subtree. This is not
+just tidiness: `cargo package` only bundles files from inside the crate
+directory, so a crate without its own `LICENSE` would publish to a registry with
+no license text at all.
+
+## How the split is kept honest
+
+The table above is the authoritative statement, and it is enforced rather than
+trusted. `Cargo.toml`'s `[workspace.package]` sets `license = "Elastic-2.0"` as a
+**fail-closed default**: a crate added without thinking inherits the restrictive
+license, and the five permissive crates opt in by setting
+`license = "Apache-2.0"` explicitly. The previous default was Apache-2.0, which
+meant a new server crate that forgot to override became silently permissive.
+
+`task publish:check` (run in CI) asserts that every workspace member's resolved
+license matches this table, that a crate is not left unclassified, that each has
+its own `LICENSE` file, and that the `publish` flags are what we intend. Adding a
+crate fails CI until it is deliberately classified here.
 
 ## What Elastic License 2.0 actually restricts
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,6 +89,10 @@ tasks:
     cmds:
       - "cargo install cargo-deny --version 0.19.0 --locked"
       - "cargo-deny check"
+  publish:check:
+    desc: "Assert the LICENSING.md licence split and crates.io publish-readiness"
+    cmds:
+      - "python3 scripts/check_publish_metadata.py"
   deny:rsa:default:
     cmds:
       - |

--- a/crates/felix-authz/Cargo.toml
+++ b/crates/felix-authz/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-authz"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Tenant-scoped token issuance and authorization for Felix"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "authorization", "jwt"]
+categories = ["network-programming", "authentication"]
 
 [dependencies]
 ed25519-dalek = { version = "2", features = ["pkcs8"] }

--- a/crates/felix-authz/LICENSE
+++ b/crates/felix-authz/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-broker/Cargo.toml
+++ b/crates/felix-broker/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-broker"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Broker core: stream registry, fanout, and per-subscriber queues for Felix"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "broker", "pubsub", "messaging"]
+categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 bytes = { workspace = true }

--- a/crates/felix-broker/LICENSE
+++ b/crates/felix-broker/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-client/Cargo.toml
+++ b/crates/felix-client/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-client"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 rust-version.workspace = true
+description = "Rust client SDK for the Felix pub/sub and cache broker"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "client", "pubsub", "messaging", "quic"]
+categories = ["network-programming", "api-bindings"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -39,3 +45,7 @@ rustls = "0.23"
 serial_test = "3"
 tempfile = "3"
 tracing-subscriber = { workspace = true }
+
+[package.metadata.docs.rs]
+# `in-process` and `telemetry` are off by default; document them anyway.
+all-features = true

--- a/crates/felix-common/Cargo.toml
+++ b/crates/felix-common/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-common"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 rust-version.workspace = true
+description = "Shared identifiers, configuration, and error types for Felix crates"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "messaging", "config"]
+categories = ["network-programming"]
 
 [dependencies]
 serde = { workspace = true }
@@ -21,3 +27,8 @@ tokio = { workspace = true }
 default = []
 # Signal handling, readiness gating, and bounded drain for service binaries.
 lifecycle = ["dep:tokio", "dep:tracing"]
+
+[package.metadata.docs.rs]
+# `lifecycle` is off by default so library consumers do not inherit tokio;
+# docs.rs should still show it.
+all-features = true

--- a/crates/felix-conformance/Cargo.toml
+++ b/crates/felix-conformance/Cargo.toml
@@ -2,8 +2,17 @@
 name = "felix-conformance"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 rust-version.workspace = true
+description = "Conformance runner validating third-party Felix protocol implementations"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "conformance", "protocol"]
+categories = ["network-programming", "development-tools"]
+# Not a library anyone consumes from a registry: service binaries and a
+# dev/CI tool with hard Elastic-2.0 dependencies.
+publish = false
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/felix-conformance/README.md
+++ b/crates/felix-conformance/README.md
@@ -1,0 +1,24 @@
+# felix-conformance
+
+Conformance runner for the Felix wire protocol.
+
+It drives a real broker over QUIC and asserts that publish, subscribe, and cache
+behaviour match the v1 protocol described in [`docs/protocol.md`](../../docs/protocol.md),
+using the test vectors in [`crates/felix-wire/tests/vectors/`](../felix-wire/tests/vectors/).
+The intent is that a third-party client or server implementation in any language
+can be validated against the same checks the reference implementation passes.
+
+```bash
+cargo run -p felix-conformance
+```
+
+## Licensing
+
+This crate is Apache-2.0, matching `felix-wire`, so that protocol conformance is
+not gated behind a restrictive licence. It links against Elastic-2.0 crates
+(`felix-broker`, `felix-storage`, `felix-authz`) to run its checks against the
+reference broker — normal for a dev/CI tool, and it does not change this crate's
+own licence. See [`LICENSING.md`](../../LICENSING.md).
+
+Because of those dependencies it is marked `publish = false`: it is a test
+harness rather than something to depend on from a registry.

--- a/crates/felix-consensus/Cargo.toml
+++ b/crates/felix-consensus/Cargo.toml
@@ -2,7 +2,13 @@
 name = "felix-consensus"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Consensus primitives for multi-node Felix deployments"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "consensus"]
+categories = ["network-programming"]
 
 [dependencies]

--- a/crates/felix-consensus/LICENSE
+++ b/crates/felix-consensus/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-crypto/Cargo.toml
+++ b/crates/felix-crypto/Cargo.toml
@@ -2,7 +2,13 @@
 name = "felix-crypto"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Cryptographic primitives used by the Felix control plane and broker"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "cryptography"]
+categories = ["cryptography"]
 
 [dependencies]

--- a/crates/felix-crypto/LICENSE
+++ b/crates/felix-crypto/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-metadata/Cargo.toml
+++ b/crates/felix-metadata/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-metadata"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Metadata model for Felix tenants, namespaces, streams, and caches"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "metadata"]
+categories = ["network-programming"]
 
 [dependencies]
 tokio = { workspace = true }

--- a/crates/felix-metadata/LICENSE
+++ b/crates/felix-metadata/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-router/Cargo.toml
+++ b/crates/felix-router/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-router"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Request routing and placement logic for multi-node Felix deployments"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "routing"]
+categories = ["network-programming"]
 
 [dependencies]
 felix-common = { path = "../felix-common", version = "0.1.1" }

--- a/crates/felix-router/LICENSE
+++ b/crates/felix-router/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-storage/Cargo.toml
+++ b/crates/felix-storage/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-storage"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Storage backends and ephemeral cache implementation for the Felix broker"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "storage", "cache"]
+categories = ["network-programming", "caching"]
 
 [dependencies]
 bytes = { workspace = true }

--- a/crates/felix-storage/LICENSE
+++ b/crates/felix-storage/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-transport/Cargo.toml
+++ b/crates/felix-transport/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-transport"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 rust-version.workspace = true
+description = "QUIC transport primitives shared by Felix clients and brokers"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "quic", "transport", "networking"]
+categories = ["network-programming", "asynchronous"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/felix-wire/Cargo.toml
+++ b/crates/felix-wire/Cargo.toml
@@ -2,8 +2,14 @@
 name = "felix-wire"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "Apache-2.0"
 rust-version.workspace = true
+description = "Wire protocol, frame codec, and test vectors for the Felix messaging system"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+keywords = ["felix", "protocol", "messaging", "codec", "quic"]
+categories = ["network-programming", "encoding"]
 
 [dependencies]
 base64 = "0.22"

--- a/scripts/check_publish_metadata.py
+++ b/scripts/check_publish_metadata.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Enforce the licence split and crates.io publish-readiness across the workspace.
+
+Run via `task publish:check`.
+
+# Why this exists
+The licence split in LICENSING.md is a legal boundary that lives in fifteen
+separate manifests. Nothing structural stops a new crate from silently landing on
+the wrong side of it, and the failure is invisible until someone reads the
+manifest. This turns the LICENSING.md table into an assertion.
+
+# Why it shells out to `cargo metadata`
+Manifests use workspace inheritance (`license.workspace = true`), so parsing the
+raw TOML sees the string "workspace" rather than the resolved licence and would
+validate nothing while appearing to pass. `cargo metadata` reports resolved
+values, which is the only trustworthy source.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# The authoritative table, mirroring LICENSING.md. Adding a crate to the
+# workspace without adding it here is itself a failure: the point is that
+# classification is deliberate rather than inherited by accident.
+APACHE = {
+    "felix-wire",
+    "felix-client",
+    "felix-transport",
+    "felix-common",
+    "felix-conformance",
+}
+ELASTIC = {
+    "felix-broker",
+    "felix-storage",
+    "felix-metadata",
+    "felix-authz",
+    "felix-crypto",
+    "felix-consensus",
+    "felix-router",
+    "broker",
+    "controlplane",
+    "agent",
+}
+
+# Service binaries and a dev/CI tool with hard Elastic-2.0 dependencies. Nobody
+# consumes these from a registry, and `broker`/`controlplane`/`agent` are generic
+# names that would collide besides.
+NOT_PUBLISHABLE = {"broker", "controlplane", "agent", "felix-conformance"}
+
+# crates.io hard requirement is `description`; the rest are discoverability
+# fields we want set before a first publish rather than bolted on after.
+REQUIRED_FIELDS = ("description", "repository", "keywords", "categories")
+
+
+def workspace_members() -> list[dict]:
+    raw = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    meta = json.loads(raw)
+    ids = set(meta["workspace_members"])
+    return [p for p in meta["packages"] if p["id"] in ids]
+
+
+def check() -> list[str]:
+    failures: list[str] = []
+    packages = workspace_members()
+    seen = {p["name"] for p in packages}
+
+    unclassified = seen - APACHE - ELASTIC
+    for name in sorted(unclassified):
+        failures.append(
+            f"{name}: not listed in this script's licence table. Add it to APACHE or "
+            f"ELASTIC and to the table in LICENSING.md — a new crate must be "
+            f"classified deliberately."
+        )
+
+    stale = (APACHE | ELASTIC) - seen
+    for name in sorted(stale):
+        failures.append(
+            f"{name}: listed in this script's licence table but is no longer a "
+            f"workspace member; remove it here and from LICENSING.md."
+        )
+
+    for pkg in sorted(packages, key=lambda p: p["name"]):
+        name = pkg["name"]
+        expected = (
+            "Apache-2.0" if name in APACHE else "Elastic-2.0" if name in ELASTIC else None
+        )
+        actual = pkg.get("license")
+        if expected and actual != expected:
+            failures.append(
+                f"{name}: licence is {actual!r}, expected {expected!r} per LICENSING.md."
+            )
+
+        # `publish` is null when unrestricted, or a list of allowed registries.
+        # An empty list is how `publish = false` surfaces here.
+        publishable = pkg.get("publish") != []
+        should_publish = name not in NOT_PUBLISHABLE
+        if publishable and not should_publish:
+            failures.append(
+                f"{name}: must set `publish = false` — it is a service binary or a "
+                f"dev tool, not a library to consume from a registry."
+            )
+        if not publishable and should_publish:
+            failures.append(
+                f"{name}: has `publish = false` but is expected to be publishable."
+            )
+
+        # Only crates that could actually reach crates.io need the metadata.
+        if should_publish:
+            for field in REQUIRED_FIELDS:
+                if not pkg.get(field):
+                    failures.append(
+                        f"{name}: missing `{field}`. crates.io rejects a publish "
+                        f"without `description`; the rest are required before a "
+                        f"first publish."
+                    )
+
+        # `cargo package` only bundles files inside the crate directory, so a
+        # crate without its own LICENSE ships with no licence text even though
+        # the repository root has one.
+        crate_dir = pathlib.Path(pkg["manifest_path"]).parent
+        if not (crate_dir / "LICENSE").is_file():
+            failures.append(
+                f"{name}: no LICENSE file in {crate_dir.relative_to(REPO_ROOT)}/. "
+                f"cargo package does not reach the repository root."
+            )
+
+        readme = pkg.get("readme")
+        if should_publish and readme and not (crate_dir / readme).is_file():
+            failures.append(
+                f"{name}: readme is {readme!r} but that file does not exist in "
+                f"{crate_dir.relative_to(REPO_ROOT)}/."
+            )
+
+    return failures
+
+
+def main() -> int:
+    failures = check()
+    if failures:
+        print("Publish-readiness check FAILED:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        print(
+            "\nSee LICENSING.md for the authoritative licence table.",
+            file=sys.stderr,
+        )
+        return 1
+    count = len(workspace_members())
+    print(f"Publish-readiness check passed for {count} workspace members.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/services/agent/Cargo.toml
+++ b/services/agent/Cargo.toml
@@ -2,8 +2,15 @@
 name = "agent"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Felix node agent service"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+# Not a library anyone consumes from a registry: service binaries and a
+# dev/CI tool with hard Elastic-2.0 dependencies.
+publish = false
 
 [[bin]]
 name = "felix-agent"

--- a/services/agent/LICENSE
+++ b/services/agent/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -2,8 +2,15 @@
 name = "broker"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Felix broker service binary"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+# Not a library anyone consumes from a registry: service binaries and a
+# dev/CI tool with hard Elastic-2.0 dependencies.
+publish = false
 
 [[bin]]
 name = "felix-broker"

--- a/services/broker/LICENSE
+++ b/services/broker/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/services/controlplane/Cargo.toml
+++ b/services/controlplane/Cargo.toml
@@ -2,8 +2,15 @@
 name = "controlplane"
 version.workspace = true
 edition.workspace = true
-license = "Elastic-2.0"
+license.workspace = true
 rust-version.workspace = true
+description = "Felix control-plane HTTP service binary"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+# Not a library anyone consumes from a registry: service binaries and a
+# dev/CI tool with hard Elastic-2.0 dependencies.
+publish = false
 
 [[bin]]
 name = "felix-controlplane"

--- a/services/controlplane/LICENSE
+++ b/services/controlplane/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.


### PR DESCRIPTION
- Updated `Cargo.toml` for `controlplane` to set workspace-level license and prevent publishing.
- Added `LICENSE` files for `felix-authz`, `felix-broker`, `felix-consensus`, `felix-crypto`, `felix-metadata`, `felix-router`, `felix-storage`, `agent`, and `broker` with Elastic License 2.0.
- Created `README.md` for `felix-conformance` detailing its purpose and licensing.
- Introduced `check_publish_metadata.py` script to enforce licensing and publish readiness across the workspace.