### PR TITLE
fix: make lossless publishing lossless end to end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,26 @@ members = [
   "services/broker",
 ]
 
+[profile.dev]
+# Debug builds dominate disk here: a single clean `cargo test --workspace --no-run`
+# produced 6.1 GB, and the accumulated target directory reached 41 GB because cargo
+# keys artifacts by feature set and never garbage-collects the old ones.
+#
+# On macOS `split-debuginfo` defaults to `unpacked`, so DWARF stays in the per-CGU
+# object files rather than being folded into the binary — 17.6 GB of `.o` files at
+# the peak, against only 4.2 GB of actual executables. `line-tables-only` keeps what
+# panics and backtraces need (file, line, symbol) and drops the rest: variable
+# layouts, types, lexical scopes. Step-debugging locals in a debugger is what this
+# gives up; if you need that, raise it back to `debug = true` for the session.
+debug = "line-tables-only"
+
+# Third-party code is the bulk of those object files and is almost never stepped
+# through. Symbols still appear in backtraces; only line numbers inside
+# dependencies are lost. Workspace crates keep their line tables from the setting
+# above, because those are the frames that matter when a test fails.
+[profile.dev.package."*"]
+debug = false
+
 [profile.release]
 # The hot path spans crate boundaries — felix-wire encode/decode, felix-broker
 # fanout, and the broker service's QUIC handlers are separate crates — so

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -90,6 +90,23 @@ tasks:
       # Pre-dating the shared target-dir in .cargo/config.toml, each standalone
       # demo crate built its own ~3 GB target/. Remove any left behind.
       - "rm -rf demos/*/target"
+  clean:stale:
+    desc: "Prune build artifacts cargo will never collect, keeping the current build"
+    # Cargo keys artifacts by package + features + flags and never garbage-collects
+    # the losers, so every distinct build multiplies the directory: default vs
+    # --all-features vs --features in-process, the four standalone demo crates that
+    # resolve features independently, plus release. Measured at 41 GB against a
+    # 4.2 GB single clean build — roughly sevenfold duplication, none of it reachable.
+    #
+    # Unlike `clean-all` this keeps what you are currently working with, so the next
+    # build is incremental rather than from scratch.
+    cmds:
+      - "cargo install cargo-sweep --version 0.8.0 --locked"
+      # Artifacts built by toolchains rustup no longer has are dead weight.
+      - "cargo sweep --installed"
+      # Then anything untouched for a week: old feature combinations, abandoned
+      # branches' dependency graphs, superseded incremental caches.
+      - "cargo sweep --time 7"
   deny:
     cmds:
       - "cargo install cargo-deny --version 0.19.0 --locked"

--- a/demos/cross_tenant_isolation/Cargo.toml
+++ b/demos/cross_tenant_isolation/Cargo.toml
@@ -26,3 +26,13 @@ felix-transport = { path = "../../crates/felix-transport" }
 felix-wire = { path = "../../crates/felix-wire" }
 
 [workspace]
+
+# Each demo declares its own [workspace], so the root workspace's [profile.dev]
+# does not reach it — these have to be repeated here or the demos rebuild the
+# whole dependency tree with full debuginfo into the shared target dir, undoing
+# the saving. See the root Cargo.toml for the reasoning.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/demos/rbac-live/Cargo.toml
+++ b/demos/rbac-live/Cargo.toml
@@ -26,3 +26,13 @@ felix-transport = { path = "../../crates/felix-transport" }
 felix-wire = { path = "../../crates/felix-wire" }
 
 [workspace]
+
+# Each demo declares its own [workspace], so the root workspace's [profile.dev]
+# does not reach it — these have to be repeated here or the demos rebuild the
+# whole dependency tree with full debuginfo into the shared target dir, undoing
+# the saving. See the root Cargo.toml for the reasoning.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/demos/slow-consumer/Cargo.toml
+++ b/demos/slow-consumer/Cargo.toml
@@ -32,3 +32,13 @@ felix-wire = { path = "../../crates/felix-wire" }
 # its UI dependencies never reach `cargo build --workspace` or the broker binary.
 # Same pattern as demos/rbac-live and demos/cross_tenant_isolation.
 [workspace]
+
+# Each demo declares its own [workspace], so the root workspace's [profile.dev]
+# does not reach it — these have to be repeated here or the demos rebuild the
+# whole dependency tree with full debuginfo into the shared target dir, undoing
+# the saving. See the root Cargo.toml for the reasoning.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/demos/state-divergence/Cargo.toml
+++ b/demos/state-divergence/Cargo.toml
@@ -32,3 +32,13 @@ felix-wire = { path = "../../crates/felix-wire" }
 # its UI dependencies never reach `cargo build --workspace` or the broker binary.
 # Same pattern as demos/rbac-live and demos/cross_tenant_isolation.
 [workspace]
+
+# Each demo declares its own [workspace], so the root workspace's [profile.dev]
+# does not reach it — these have to be repeated here or the demos rebuild the
+# whole dependency tree with full debuginfo into the shared target dir, undoing
+# the saving. See the root Cargo.toml for the reasoning.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false

--- a/demos/state-divergence/src/main.rs
+++ b/demos/state-divergence/src/main.rs
@@ -264,5 +264,14 @@ mod tests {
              consumers: {:?}",
             run.consumers
         );
+        assert!(
+            run.consumers
+                .iter()
+                .all(|consumer| consumer.applied == run.published),
+            "blocking at every checkpoint should deliver every published change; \
+             published={}, consumers: {:?}",
+            run.published,
+            run.consumers
+        );
     }
 }

--- a/demos/state-divergence/src/scenario.rs
+++ b/demos/state-divergence/src/scenario.rs
@@ -17,7 +17,7 @@ use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, mpsc};
 
 pub const TENANT: &str = "t1";
 pub const NAMESPACE: &str = "default";
@@ -429,28 +429,41 @@ where
 
     let stop = Arc::new(AtomicBool::new(false));
     let mut tasks = Vec::new();
+    let (ready_tx, mut ready_rx) = mpsc::channel(config.consumers);
 
     for consumer in &consumers {
         let client_cfg = client_config(&harness.cert, &auth, config.mode)?;
         let addr = harness.addr;
         let consumer = Arc::clone(consumer);
         let stop = Arc::clone(&stop);
+        let ready_tx = ready_tx.clone();
         let keys = config.keys;
         tasks.push(tokio::spawn(async move {
             let client = match Client::connect(addr, "localhost", client_cfg).await {
                 Ok(client) => client,
                 Err(err) => {
-                    eprintln!("consumer connect failed: {err}");
+                    let _ = ready_tx
+                        .send(Err(
+                            err.context(format!("{} failed to connect", consumer.name))
+                        ))
+                        .await;
                     return;
                 }
             };
             let mut subscription = match client.subscribe(TENANT, NAMESPACE, STREAM).await {
                 Ok(sub) => sub,
                 Err(err) => {
-                    eprintln!("subscribe failed: {err}");
+                    let _ = ready_tx
+                        .send(Err(
+                            err.context(format!("{} failed to subscribe", consumer.name))
+                        ))
+                        .await;
                     return;
                 }
             };
+            if ready_tx.send(Ok(())).await.is_err() {
+                return;
+            }
             while !stop.load(Ordering::Relaxed) {
                 if consumer.stalled.load(Ordering::Relaxed) {
                     tokio::time::sleep(Duration::from_millis(50)).await;
@@ -483,7 +496,13 @@ where
         }));
     }
 
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    drop(ready_tx);
+    for _ in 0..consumers.len() {
+        tokio::time::timeout(Duration::from_secs(10), ready_rx.recv())
+            .await
+            .context("timed out waiting for consumers to subscribe")?
+            .context("consumer readiness channel closed")??;
+    }
 
     let publish_stop = Arc::new(AtomicBool::new(false));
     let publisher_task = {

--- a/docs-site/src/content/docs/development/internals-concurrency.md
+++ b/docs-site/src/content/docs/development/internals-concurrency.md
@@ -24,7 +24,7 @@ In publish → delivery order:
 | 1 | Client `PublishAdmission` | in-flight publish **bytes**, shared across all client workers | — (always waits) | `publish_inflight_bytes` = 4 MiB |
 | 2 | Client worker mpsc channel | queued publish **items** per stream-worker | — (backpressure via channel) | `publish_queue_depth` = 64 |
 | 3 | Broker `PublishAdmission` | in-flight publish **bytes**, process-wide | — (always waits, within `EnqueuePolicy::Wait`'s timeout) | `pub_inflight_bytes` = 64 MiB |
-| 4 | Broker worker mpsc channel | queued publish **items**, process-wide (or per-shard) | `EnqueuePolicy`: `Drop` / `Fail` / `Wait` | `pub_queue_depth` = 64, `Drop` unless `pub_ingress_wait` |
+| 4 | Broker worker mpsc channel | queued publish **items**, process-wide (or per-shard) | `EnqueuePolicy`: `Drop` / `Fail` / `Wait` / `Backpressure` | `pub_queue_depth` = 64, `Drop` unless `pub_ingress_wait` (then `Backpressure`) |
 | 5 | Broker-core subscriber channel | queued `DeliveryEnvelope`s per subscriber | `subscriber_queue_policy`: `Block` / `DropNew` / `DropOld` | `subscriber_queue_capacity` = 512, `drop_new` |
 | 6 | Writer lane channel | queued `LaneCommand`s per lane | `subscriber_lane_queue_policy`: same three | `subscriber_lane_queue_depth` = 64, `drop_new` |
 

--- a/docs/broker-config.md
+++ b/docs/broker-config.md
@@ -126,6 +126,14 @@ subscriber_max_bytes_per_write: 65536
 ```
 
 !!! note
+    `publish_queue_wait_timeout_ms` bounds *acked* publishes only. With
+    `pub_ingress_wait: true`, un-acked publishes use unbounded, cancellable
+    backpressure instead: there is no ack channel on which a timeout could be
+    reported, so a bounded wait there could only end in a silent drop. Such a
+    publish waits for capacity and is abandoned only if the connection is torn
+    down.
+
+!!! note
     Lossless pacing (`block` queues + `pub_ingress_wait: true`) is a
     deliberate opt-in for pipelines that cannot tolerate drops, or for
     benchmarking sustainable throughput. Production defaults favor shedding

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -2,7 +2,7 @@
 //!
 //! This module is the “publish ingestion glue” between QUIC stream handlers and the broker core.
 //! It owns:
-//! - **Ingress enqueue policy** (Drop/Fail/Wait) into the publish worker queues.
+//! - **Ingress enqueue policy** (Drop/Fail/Wait/Backpressure) into the publish worker queues.
 //! - **Worker sharding** (deterministic hashing of tenant/namespace/stream to pick a worker).
 //! - **Ack semantics + backpressure** for control-stream publishes (including commit-ack waiting).
 //! - **Depth tracking** for ingress and outbound-ack queues (local + global gauges).
@@ -19,7 +19,8 @@
 //!   Higher latency; bounded by `ack_waiters` and `ack_waiter_tx` to avoid unbounded in-flight acks.
 //!
 //! Backpressure strategy:
-//! - Ingress queue uses `EnqueuePolicy` (Drop/Fail/Wait) to shed load or apply bounded waiting.
+//! - Ingress queue uses `EnqueuePolicy` (Drop/Fail/Wait/Backpressure) to shed load, wait within
+//!   a single bounded budget, or apply true unbounded-but-cancellable backpressure.
 //! - Outbound ack queue maintains a high-water throttle signal (`ack_throttle_tx`) and records
 //!   enqueue failures/timeouts to decide when to cooperatively cancel the control stream.
 //! - Depth counters are tracked both per-stream and globally to support observability and tuning.
@@ -116,7 +117,8 @@ pub(crate) struct PublishJob {
 /// - `workers`: per-worker `mpsc::Sender<PublishJob>` queues.
 /// - `worker_count`: cached length for fast hashing.
 /// - `depth`: best-effort local depth tracking for this publish queue set.
-/// - `wait_timeout`: bound used by `EnqueuePolicy::Wait`.
+/// - `wait_timeout`: the *total* budget for one `EnqueuePolicy::Wait` enqueue, spanning
+///   admission and the queue send together. Not used by `Backpressure`, which has no timer.
 /// - `admission`: shared in-flight-byte budget across all workers (see [`PublishAdmission`]).
 /// - `conn_admission`: this connection's slice of `admission`. `workers`/`admission`/`depth` are
 ///   intentionally process-wide (see `build_publish_context`'s note on avoiding per-connection
@@ -140,18 +142,26 @@ pub(crate) struct PublishContext {
     /// `handle_connection` — see that type's doc comment for why it's no longer a
     /// process-wide cache.
     pub(crate) lane_manager: Arc<WriterLaneManager>,
-    /// When true, un-acked publishes wait (bounded) for ingress capacity instead
-    /// of being shed. Production keeps this off so fire-and-forget load sheds
-    /// visibly under overload; benchmarks and lossless pipelines turn it on so
-    /// backpressure propagates through QUIC flow control to the publisher.
+    /// When true, un-acked publishes wait for ingress capacity instead of being
+    /// shed. Production keeps this off so fire-and-forget load sheds visibly under
+    /// overload; benchmarks and lossless pipelines turn it on so backpressure
+    /// propagates through QUIC flow control to the publisher.
+    ///
+    /// The wait is [`EnqueuePolicy::Backpressure`]: unbounded but cancellable. It
+    /// deliberately has no timeout, because an unacked publish has no channel on
+    /// which to report one — a bounded wait here could only end in a silent drop,
+    /// which is the opposite of what enabling this is asking for.
     pub(crate) ingress_wait: bool,
 }
 
 impl PublishContext {
     /// Overflow policy for publishes that carry no ack (fire-and-forget).
+    /// Unacked publishes get `Backpressure`, never `Wait`: with no ack there is no
+    /// channel on which to report a timeout, so a bounded wait could only end in a
+    /// silent drop. See [`EnqueuePolicy`].
     pub(crate) fn overflow_policy(&self) -> EnqueuePolicy {
         if self.ingress_wait {
-            EnqueuePolicy::Wait
+            EnqueuePolicy::Backpressure
         } else {
             EnqueuePolicy::Drop
         }

--- a/services/broker/src/transport/quic/handlers/publish/ack.rs
+++ b/services/broker/src/transport/quic/handlers/publish/ack.rs
@@ -83,12 +83,24 @@ impl AckEncoding {
 ///
 /// - `Drop`: shed load silently (best for fire-and-forget / non-acked traffic).
 /// - `Fail`: reject immediately with an error (best for acked traffic when you prefer fast failure).
-/// - `Wait`: apply bounded backpressure by waiting up to `publish_ctx.wait_timeout`.
-///   Used for commit-ack publishes so the client is less likely to be stranded by overload.
+/// - `Wait`: bounded backpressure, capped by a single `publish_ctx.wait_timeout`
+///   deadline spanning *both* admission and the queue send. Only for publishes
+///   that carry an ack, because a timeout here surfaces to the client as a
+///   `PublishError` it can retry.
+/// - `Backpressure`: unbounded but cancellable. Never sheds and never times out;
+///   it ends only when capacity frees up or the connection is torn down.
+///
+/// The split between the last two is the point. `Wait` and `Backpressure` used to
+/// be one policy, and applying a wall-clock timeout to an *unacked* publish turned
+/// overload back into silent loss — the exact outcome the wait existed to prevent,
+/// with no way to tell the client. A timer is the wrong bound for backpressure:
+/// the right one is liveness, so `Backpressure` waits on capacity and gives up only
+/// when the connection does.
 pub(crate) enum EnqueuePolicy {
     Drop,
     Fail,
     Wait,
+    Backpressure,
 }
 
 /// Result reported by the ack-waiter task for commit-ack publishes.

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -25,6 +25,7 @@ use crate::transport::quic::handlers::publish::{
 };
 use crate::transport::quic::telemetry::{log_decode_error, t_consume_instant, t_now_if};
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn handle_binary_publish_batch_control(
     broker: &Broker,
     stream_cache: &mut StreamHandleCache,
@@ -33,6 +34,9 @@ pub(crate) async fn handle_binary_publish_batch_control(
     frame: &Frame,
     auth_ctx: Option<&AuthContext>,
     sample: bool,
+    // Bounds the unacked backpressure wait: without a timer, teardown is what
+    // ends it.
+    cancel_tx: &watch::Sender<bool>,
 ) -> Result<()> {
     let decode_start = t_now_if(sample);
     let batch = match felix_wire::binary::decode_publish_batch(frame)
@@ -113,6 +117,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
             admission_permit: None,
         },
         publish_ctx.overflow_policy(),
+        Some(cancel_tx.subscribe()),
     )
     .await;
     match r {
@@ -440,6 +445,7 @@ pub(crate) async fn handle_publish_message(
         } else {
             EnqueuePolicy::Fail
         },
+        Some(cancel_tx.subscribe()),
     )
     .await;
     if let Some(start) = enqueue_start {
@@ -802,6 +808,7 @@ pub(crate) async fn handle_publish_batch_message(
         } else {
             EnqueuePolicy::Fail
         },
+        Some(cancel_tx.subscribe()),
     )
     .await;
     if let Some(start) = fanout_start {

--- a/services/broker/src/transport/quic/handlers/publish/ingress.rs
+++ b/services/broker/src/transport/quic/handlers/publish/ingress.rs
@@ -5,13 +5,14 @@ use bytes::Bytes;
 use felix_broker::StreamHandle;
 #[cfg(test)]
 use std::collections::hash_map::DefaultHasher;
+use std::future::Future;
 #[cfg(test)]
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(feature = "perf_debug")]
 use std::time::Instant;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 
 use crate::transport::quic::GLOBAL_INGRESS_DEPTH;
 use crate::transport::quic::handlers::publish::ack::EnqueuePolicy;
@@ -52,21 +53,58 @@ pub(crate) fn publish_worker_index(
     (hasher.finish() as usize) % worker_count
 }
 
+/// Await `fut` unless the connection is cancelled first.
+///
+/// `None` means cancellation won. A dropped sender counts as cancelled: the owner
+/// of the control stream is gone, so there is nobody left to deliver for.
+async fn until_cancelled<F: Future>(
+    fut: F,
+    cancel: &mut Option<watch::Receiver<bool>>,
+) -> Option<F::Output> {
+    let Some(rx) = cancel else {
+        return Some(fut.await);
+    };
+    // Pinned so a watch wake-up that turns out not to be a cancellation can go
+    // back to waiting on the same future instead of restarting it.
+    tokio::pin!(fut);
+    loop {
+        if *rx.borrow() {
+            return None;
+        }
+        tokio::select! {
+            out = &mut fut => return Some(out),
+            changed = rx.changed() => {
+                // A dropped sender means the connection is gone; anything else
+                // loops round to re-read the flag.
+                if changed.is_err() {
+                    return None;
+                }
+            }
+        }
+    }
+}
+
 /// Enqueue a publish job into the appropriate worker queue with explicit overload semantics.
 ///
 /// Return value:
 /// - `Ok(true)`  → job enqueued
 /// - `Ok(false)` → job intentionally dropped (policy = Drop)
-/// - `Err(...)`  → failure to enqueue (policy = Fail, closed queue, timeout, etc.)
+/// - `Err(...)`  → failure to enqueue (policy = Fail, closed queue, timeout, cancellation)
+///
+/// `cancel` is the connection's teardown signal. It is what bounds
+/// [`EnqueuePolicy::Backpressure`], which has no timer; `None` means the caller has
+/// no teardown signal to offer (the uni-stream paths), and such a wait ends only
+/// when capacity frees or the worker queue closes.
 ///
 /// Implementation detail:
 /// - We try `try_send` first to keep the common path allocation-free and to make overload observable
-///   (`Full` vs `Closed`). Only `Wait` does an async `send` with a timeout.
+///   (`Full` vs `Closed`).
 /// - Any path that successfully enqueues must increment both local and global depth **exactly once**.
 pub(crate) async fn enqueue_publish(
     publish_ctx: &PublishContext,
     mut job: PublishJob,
     policy: EnqueuePolicy,
+    mut cancel: Option<watch::Receiver<bool>>,
 ) -> Result<bool> {
     let worker_index = match &job.target {
         PublishTarget::Resolved(handle) => handle.id() as usize % publish_ctx.worker_count.max(1),
@@ -91,19 +129,33 @@ pub(crate) async fn enqueue_publish(
     // job and are released together once the job is done (or dropped without ever being
     // enqueued).
     let job_bytes: usize = job.payloads.iter().map(Bytes::len).sum();
+    // One deadline for the whole enqueue, not one per stage. Admission and the
+    // queue send used to get a full `wait_timeout` each, so a publish could block
+    // for twice the configured budget while the knob read as a single bound — and
+    // because this runs inline in the control-stream read loop, that doubled the
+    // head-of-line stall on the connection too.
+    let deadline = tokio::time::Instant::now() + publish_ctx.wait_timeout;
+    let acquire_both = async {
+        let conn_permit = publish_ctx.conn_admission.acquire(job_bytes).await?;
+        let permit = publish_ctx.admission.acquire(job_bytes).await?;
+        Ok::<_, tokio::sync::AcquireError>((conn_permit, permit))
+    };
     let (conn_permit, permit) = match policy {
-        EnqueuePolicy::Wait => {
-            let acquire_both = async {
-                let conn_permit = publish_ctx.conn_admission.acquire(job_bytes).await?;
-                let permit = publish_ctx.admission.acquire(job_bytes).await?;
-                Ok::<_, tokio::sync::AcquireError>((conn_permit, permit))
-            };
-            match tokio::time::timeout(publish_ctx.wait_timeout, acquire_both).await {
-                Ok(Ok(permits)) => permits,
-                Ok(Err(_)) => return Err(anyhow!("publish admission closed")),
-                Err(_) => return Err(anyhow!("publish admission timed out")),
+        EnqueuePolicy::Wait => match tokio::time::timeout_at(deadline, acquire_both).await {
+            Ok(Ok(permits)) => permits,
+            Ok(Err(_)) => return Err(anyhow!("publish admission closed")),
+            Err(_) => return Err(anyhow!("publish admission timed out")),
+        },
+        EnqueuePolicy::Backpressure => match until_cancelled(acquire_both, &mut cancel).await {
+            Some(Ok(permits)) => permits,
+            Some(Err(_)) => return Err(anyhow!("publish admission closed")),
+            None => {
+                t_counter!("felix_broker_ingress_backpressure_cancelled_total").increment(1);
+                return Err(anyhow!(
+                    "publish cancelled while waiting for ingress capacity"
+                ));
             }
-        }
+        },
         EnqueuePolicy::Drop | EnqueuePolicy::Fail => {
             let conn_permit = match publish_ctx.conn_admission.try_acquire(job_bytes) {
                 Ok(permit) => permit,
@@ -120,7 +172,9 @@ pub(crate) async fn enqueue_publish(
                                 "publish ingress per-connection byte budget exhausted"
                             ))
                         }
-                        EnqueuePolicy::Wait => unreachable!("Wait handled above"),
+                        EnqueuePolicy::Wait | EnqueuePolicy::Backpressure => {
+                            unreachable!("waiting policies handled above")
+                        }
                     };
                 }
             };
@@ -137,7 +191,9 @@ pub(crate) async fn enqueue_publish(
                             t_counter!("felix_broker_ingress_rejected_total").increment(1);
                             Err(anyhow!("publish ingress byte budget exhausted"))
                         }
-                        EnqueuePolicy::Wait => unreachable!("Wait handled above"),
+                        EnqueuePolicy::Wait | EnqueuePolicy::Backpressure => {
+                            unreachable!("waiting policies handled above")
+                        }
                     };
                 }
             }
@@ -186,13 +242,27 @@ pub(crate) async fn enqueue_publish(
                     t_counter!("felix_broker_ingress_rejected_total").increment(1);
                     Err(anyhow!("publish queue full"))
                 }
-                EnqueuePolicy::Wait => {
-                    // Acked publishes with ack_on_commit use Wait; otherwise we Fail/Drop.
+                EnqueuePolicy::Wait | EnqueuePolicy::Backpressure => {
+                    // Acked publishes with ack_on_commit use Wait; unacked publishes
+                    // with `pub_ingress_wait` use Backpressure.
                     t_counter!("felix_broker_ingress_waited_total").increment(1);
-                    let send_result =
-                        tokio::time::timeout(publish_ctx.wait_timeout, worker.send(job))
+                    let send_result = match policy {
+                        // Shares the deadline computed above with the admission
+                        // stage, so the two together cannot exceed `wait_timeout`.
+                        EnqueuePolicy::Wait => tokio::time::timeout_at(deadline, worker.send(job))
                             .await
-                            .map_err(|_| anyhow!("publish enqueue timed out"))?;
+                            .map_err(|_| anyhow!("publish enqueue timed out"))?,
+                        _ => match until_cancelled(worker.send(job), &mut cancel).await {
+                            Some(result) => result,
+                            None => {
+                                t_counter!("felix_broker_ingress_backpressure_cancelled_total")
+                                    .increment(1);
+                                return Err(anyhow!(
+                                    "publish cancelled while waiting for ingress queue"
+                                ));
+                            }
+                        },
+                    };
                     send_result.map_err(|_| anyhow!("publish queue closed"))?;
                     // Local depth is per publish context; global depth is used for cross-connection observability.
                     let _local = publish_ctx.depth.fetch_add(1, Ordering::Relaxed) + 1;

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -93,7 +93,7 @@ async fn enqueue_publish_drop_sheds_load_when_byte_budget_exhausted() {
     // 7-byte payload, so the job must be shed even though the item-count queue is empty.
     let mut job = make_job();
     job.payloads = vec![Bytes::from_static(b"payload")];
-    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop)
+    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop, None)
         .await
         .unwrap();
     assert!(!result);
@@ -116,7 +116,7 @@ async fn enqueue_publish_drop_sheds_load_when_conn_byte_budget_exhausted() {
     };
     let mut job = make_job();
     job.payloads = vec![Bytes::from_static(b"payload")];
-    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop)
+    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop, None)
         .await
         .unwrap();
     assert!(!result);
@@ -150,7 +150,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     let mut big_job = make_job();
     big_job.payloads = vec![Bytes::from_static(b"01234567")]; // 8 bytes > A's 4-byte share
     assert!(
-        !enqueue_publish(&ctx_a, big_job, EnqueuePolicy::Drop)
+        !enqueue_publish(&ctx_a, big_job, EnqueuePolicy::Drop, None)
             .await
             .unwrap()
     );
@@ -159,7 +159,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     let mut small_job = make_job();
     small_job.payloads = vec![Bytes::from_static(b"ok")]; // 2 bytes, fits B's 4-byte share
     assert!(
-        enqueue_publish(&ctx_b, small_job, EnqueuePolicy::Drop)
+        enqueue_publish(&ctx_b, small_job, EnqueuePolicy::Drop, None)
             .await
             .unwrap()
     );
@@ -239,7 +239,7 @@ async fn enqueue_publish_drop_returns_false_when_full() {
     let (ctx, _rx, tx) = make_publish_context(1);
     tx.try_send(make_job()).unwrap();
     let job = make_job();
-    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop)
+    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Drop, None)
         .await
         .unwrap();
     assert!(!result);
@@ -250,7 +250,7 @@ async fn enqueue_publish_fail_returns_error_when_full() {
     let (ctx, _rx, tx) = make_publish_context(1);
     tx.try_send(make_job()).unwrap();
     let job = make_job();
-    let err = enqueue_publish(&ctx, job, EnqueuePolicy::Fail)
+    let err = enqueue_publish(&ctx, job, EnqueuePolicy::Fail, None)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("publish queue full"));
@@ -265,7 +265,7 @@ async fn enqueue_publish_wait_enqueues_when_receiver_ready() {
         let _ = rx.recv().await;
     });
     let job = make_job();
-    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Wait)
+    let result = enqueue_publish(&ctx, job, EnqueuePolicy::Wait, None)
         .await
         .unwrap();
     assert!(result);
@@ -287,7 +287,7 @@ async fn enqueue_publish_wait_times_out_when_queue_full() {
         lane_manager: test_lane_manager(),
         ingress_wait: false,
     };
-    let err = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Wait)
+    let err = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Wait, None)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("publish enqueue timed out"));
@@ -308,7 +308,7 @@ async fn enqueue_publish_returns_error_when_queue_closed() {
         lane_manager: test_lane_manager(),
         ingress_wait: false,
     };
-    let err = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Fail)
+    let err = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Fail, None)
         .await
         .unwrap_err();
     assert!(err.to_string().contains("publish queue closed"));
@@ -516,6 +516,7 @@ async fn handle_binary_publish_batch_control_requires_auth() {
         &frame,
         None,
         false,
+        &watch::channel(false).0,
     )
     .await
     .expect_err("auth required");
@@ -538,6 +539,7 @@ async fn handle_binary_publish_batch_control_tenant_mismatch() {
         &frame,
         Some(&auth_ctx),
         false,
+        &watch::channel(false).0,
     )
     .await
     .expect_err("tenant mismatch");
@@ -560,6 +562,7 @@ async fn handle_binary_publish_batch_control_forbidden() {
         &frame,
         Some(&auth_ctx),
         false,
+        &watch::channel(false).0,
     )
     .await
     .expect_err("forbidden");
@@ -582,6 +585,7 @@ async fn handle_binary_publish_batch_control_missing_stream_is_ok() {
         &frame,
         Some(&auth_ctx),
         false,
+        &watch::channel(false).0,
     )
     .await;
     assert!(result.is_ok());
@@ -620,6 +624,7 @@ async fn handle_binary_publish_batch_control_enqueue_dropped_is_ok() {
         &frame,
         Some(&auth_ctx),
         false,
+        &watch::channel(false).0,
     )
     .await;
     assert!(result.is_ok());
@@ -656,6 +661,7 @@ async fn handle_binary_publish_batch_control_enqueue_error_is_ok() {
         &frame,
         Some(&auth_ctx),
         false,
+        &watch::channel(false).0,
     )
     .await;
     assert!(result.is_ok());
@@ -2481,4 +2487,119 @@ async fn handle_publish_batch_message_ack_waiter_queue_closed() {
         }
         _ => panic!("unexpected outgoing"),
     }
+}
+
+// --- ingress waiting semantics -------------------------------------------
+//
+// Three properties, one per defect that used to be here:
+//   1. `Wait` spends one `wait_timeout` across both stages, not one each.
+//   2. `Backpressure` never sheds — it waits for capacity however long that takes.
+//   3. `Backpressure` still ends promptly when the connection is torn down.
+
+/// Admission and the queue send each used to get a full `wait_timeout`, so the
+/// worst case was twice the configured budget. Here admission is held for most of
+/// the budget and the queue is left full, so the send has to wait too; the whole
+/// call must still finish within one budget.
+#[tokio::test(start_paused = true)]
+async fn wait_policy_spends_one_budget_across_both_stages() {
+    let payload = b"payload".len();
+    let (mut ctx, _rx, _tx) = make_publish_context(1);
+    ctx.wait_timeout = Duration::from_millis(100);
+    // Room for the primed job plus one held permit, so a third job must wait for
+    // admission *and then* find the queue still full.
+    ctx.admission = Arc::new(PublishAdmission::new(payload * 2));
+    ctx.conn_admission = Arc::new(PublishAdmission::new(payload * 2));
+
+    // Fill the only queue slot. This job keeps its admission permit while queued.
+    enqueue_publish(&ctx, make_job(), EnqueuePolicy::Drop, None)
+        .await
+        .expect("prime the queue");
+
+    // Hold the remaining admission and release it partway through the budget.
+    let held = ctx
+        .admission
+        .clone()
+        .acquire(payload)
+        .await
+        .expect("hold admission");
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        drop(held);
+    });
+
+    let start = tokio::time::Instant::now();
+    let result = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Wait, None).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        result.is_err(),
+        "the queue never drains, so this must time out rather than enqueue"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(60),
+        "admission should have blocked until the held permit was released, took {elapsed:?}"
+    );
+    // Before the fix each stage got its own budget, so this was ~160ms.
+    assert!(
+        elapsed <= Duration::from_millis(100),
+        "Wait must not exceed one wait_timeout across both stages, took {elapsed:?}"
+    );
+}
+
+/// The whole point of `Backpressure`: overload becomes slowness, never loss. A
+/// timer here would have turned this into a silent drop, with no ack channel to
+/// report it on.
+#[tokio::test(start_paused = true)]
+async fn backpressure_waits_for_capacity_instead_of_shedding() {
+    let (ctx, mut rx, _tx) = make_publish_context(1);
+    // Fill the single queue slot so the next enqueue has to wait.
+    enqueue_publish(&ctx, make_job(), EnqueuePolicy::Drop, None)
+        .await
+        .expect("prime the queue");
+
+    // Drain long after any plausible timeout would have fired.
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        let _ = rx.recv().await;
+        // Hold the receiver open so the channel does not close under the waiter.
+        tokio::time::sleep(Duration::from_secs(3600)).await;
+        drop(rx);
+    });
+
+    let accepted = enqueue_publish(&ctx, make_job(), EnqueuePolicy::Backpressure, None)
+        .await
+        .expect("backpressure must not fail on a full queue");
+    assert!(
+        accepted,
+        "backpressure must enqueue once capacity frees, never report a drop"
+    );
+}
+
+/// Unbounded does not mean unstoppable: teardown is what ends the wait, which is
+/// why the policy needs the connection's cancel signal rather than a clock.
+#[tokio::test(start_paused = true)]
+async fn backpressure_gives_up_when_the_connection_is_cancelled() {
+    let (ctx, _rx, _tx) = make_publish_context(1);
+    enqueue_publish(&ctx, make_job(), EnqueuePolicy::Drop, None)
+        .await
+        .expect("prime the queue");
+
+    let (cancel_tx, cancel_rx) = watch::channel(false);
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let _ = cancel_tx.send(true);
+    });
+
+    let err = enqueue_publish(
+        &ctx,
+        make_job(),
+        EnqueuePolicy::Backpressure,
+        Some(cancel_rx),
+    )
+    .await
+    .expect_err("cancellation must surface as an error, not a silent drop");
+    assert!(
+        err.to_string().contains("cancelled"),
+        "unexpected error: {err}"
+    );
 }

--- a/services/broker/src/transport/quic/handlers/publish/uni.rs
+++ b/services/broker/src/transport/quic/handlers/publish/uni.rs
@@ -90,6 +90,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
             admission_permit: None,
         },
         publish_ctx.overflow_policy(),
+        None,
     )
     .await
     {
@@ -148,6 +149,7 @@ pub(crate) async fn handle_publish_message_uni(
             admission_permit: None,
         },
         publish_ctx.overflow_policy(),
+        None,
     )
     .await;
     match r {
@@ -210,6 +212,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
             admission_permit: None,
         },
         publish_ctx.overflow_policy(),
+        None,
     )
     .await;
     match r {

--- a/services/broker/src/transport/quic/streams/control.rs
+++ b/services/broker/src/transport/quic/streams/control.rs
@@ -202,6 +202,7 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
                     &frame,
                     auth_ctx.as_ref(),
                     sample,
+                    &cancel_tx,
                 )
                 .await?;
             }


### PR DESCRIPTION
Three fixes that all surfaced from one flaky CI run in the state-divergence demo.

Ingress backpressure (services/broker)

EnqueuePolicy::Wait charged its wait_timeout budget twice, once for admission and once for the queue send, so a publish could block for double the configured bound while the knob read as a single one. Both stages now share one deadline. Since the enqueue runs inline in the control-stream read loop, this also halves the worst-case head-of-line stall on the connection.

Worse, pub_ingress_wait applied that same bounded wait to *unacked* publishes, where a timeout can only end in a silent drop because there is no ack channel on which to report it. That made "lossless" mode quietly lossy under sustained backpressure. Unacked publishes now use a new EnqueuePolicy::Backpressure: unbounded but cancellable, ending when capacity frees or the connection is torn down. A timer was always the wrong bound for backpressure; liveness is the right one.

Each fix has a test that fails without it. The deadline test measures 160ms against the old two-budget behaviour; the backpressure tests assert that a full queue waits rather than sheds, and that teardown still ends the wait.

Demo startup race (demos/state-divergence)

Consumers were spawned and publishing began after a fixed 300ms sleep. On a loaded runner a consumer could subscribe late and permanently miss the opening changes, which is what made lossless_mode_converges_every_consumer flaky. It had failed on branches carrying no Rust changes at all. Replaced with an explicit all-subscribers-ready barrier, and strengthened the assertion to compare applied against published so a missing event is caught even when a later write to the same key happens to repair the state.

Reproduced in a 2-CPU container under competing load: 5 failures in 16 runs before, 0 in 32 after.

Build artifact size

target/ had reached 41 GB against a 4.2 GB clean build. Debug builds default to full DWARF, and on macOS split-debuginfo=unpacked keeps it in the object files, so 17.6 GB of .o sat next to 4.2 GB of actual binaries. [profile.dev] now uses line-tables-only with dependencies at debug=false, which keeps file and line in panics and backtraces for workspace code. Measured 6.1 GB -> 4.2 GB on an identical clean build with no change in build time.

The demo crates declare their own [workspace], so the profile is repeated in each; otherwise they rebuild the dependency tree at full debuginfo into the shared target dir and undo the saving.

The remaining bulk was accumulation rather than per-build size: cargo keys artifacts by features and flags and never collects the losers, so every distinct build keeps a parallel set. task clean:stale prunes them with cargo-sweep.