### PR TITLE
M1: fix durability, ordering and recovery defects from review

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -242,14 +242,31 @@ impl Broker {
         // storage failure fails the publish instead of delivering a record that
         // a crash would erase. Under `FsyncMode::OnCommit` this await includes
         // the device flush; that latency is the guarantee being bought.
-        if let Some(durable) = &stream_state.durable {
-            let durable_start = t_now_if(sample);
-            durable.append(payloads).await?;
-            if let Some(start) = durable_start {
-                let durable_ns = start.elapsed().as_nanos() as u64;
-                t_histogram!("broker_publish_durable_append_ns").record(durable_ns as f64);
+        //
+        // The commit turn taken afterwards is what keeps the three orders in
+        // agreement. Offsets are assigned concurrently and flushes are shared —
+        // group commit is untouched — but the half that everything else
+        // observes runs strictly in disk order. It is held across the fanout
+        // below, not just the replay-ring append, because a subscriber's
+        // delivery order is as much a part of the stream's order as its
+        // cursors are.
+        let _commit_turn = match &stream_state.durable {
+            None => None,
+            Some(durable) => {
+                let durable_start = t_now_if(sample);
+                let appended = durable.append(payloads).await?;
+                if let Some(start) = durable_start {
+                    let durable_ns = start.elapsed().as_nanos() as u64;
+                    t_histogram!("broker_publish_durable_append_ns").record(durable_ns as f64);
+                }
+                Some(
+                    stream_state
+                        .commit_sequencer
+                        .turn(appended.first_offset, appended.last_offset + 1)
+                        .await,
+                )
             }
-        }
+        };
 
         let append_start = t_now_if(sample);
         // Append to the in-memory log so cursors can replay without touching
@@ -446,6 +463,46 @@ impl Broker {
                 pending: VecDeque::new(),
             },
         ))
+    }
+
+    /// Read persisted records for a durable stream, starting at `from_offset`.
+    ///
+    /// This is the historical replay path, and it is deliberately separate from
+    /// [`Broker::subscribe_with_cursor`]. Cursor replay serves the recent tail
+    /// out of memory and hands back a live subscription in the same call, so it
+    /// cannot also stream an arbitrarily long history without either buffering
+    /// it all or leaving a hole between the history and the live edge.
+    ///
+    /// This call pages instead: it returns at most `max_bytes` of payload (and
+    /// no more than the storage layer's per-read record cap), and the caller
+    /// advances by the last returned offset. An empty result means the reader
+    /// has caught up with the tail.
+    ///
+    /// For a durable stream a cursor's sequence number is the same value as a
+    /// record's offset, so a `Cursor` obtained from [`Broker::cursor_tail`] can
+    /// be used here directly via [`Cursor::next_seq`].
+    ///
+    /// Returns [`BrokerError::StreamNotDurable`] for an in-memory stream, whose
+    /// history exists only in the bounded replay ring.
+    pub async fn read_durable(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        from_offset: u64,
+        max_bytes: usize,
+    ) -> Result<Vec<felix_storage::log::LogRecord>> {
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
+            .await?;
+        let Some(log) = &handle.state.durable else {
+            return Err(BrokerError::StreamNotDurable {
+                tenant_id: tenant_id.to_string(),
+                namespace: namespace.to_string(),
+                stream: stream.to_string(),
+            });
+        };
+        log.read_from(from_offset, max_bytes).await
     }
 
     pub fn cache(&self) -> &(dyn StorageApi + Send) {

--- a/crates/felix-broker/src/commit_order.rs
+++ b/crates/felix-broker/src/commit_order.rs
@@ -1,0 +1,264 @@
+// One authoritative order per durable stream.
+//
+// A durable publish has two halves separated by an `await`:
+//
+//   1. the durable append, which assigns disk offsets under the segment lock
+//      and then waits for the fsync its policy requires, and
+//   2. everything the rest of the broker observes — the in-memory replay ring
+//      and the fanout to subscribers.
+//
+// Without coordination those halves can disagree. Two concurrent publishes A
+// and B take disk offsets in that order, both wait on the same group-commit
+// flush, and then resume in whatever order the scheduler picks. B can reach the
+// replay ring first, so the log on disk reads A, B while a cursor replay and a
+// live subscriber both see B, A. Under `FsyncMode::OnCommit` that window is a
+// whole device flush wide — milliseconds — so it is not a theoretical race.
+//
+// The sequencer closes it. Each publisher waits until every lower offset has
+// been applied, then applies its own and releases the next in line. Disk order
+// becomes the single source of truth for cursor order and delivery order alike.
+//
+// What this deliberately does *not* do is serialise the durable append itself.
+// Offsets are still assigned concurrently and flushes are still shared, so
+// group commit keeps its fan-in; only the cheap post-flush half is ordered.
+
+use std::fmt;
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+use felix_storage::log::Offset;
+
+/// Orders the post-durability half of publishes by their disk offset.
+pub(crate) struct CommitSequencer {
+    state: Mutex<SequenceState>,
+    ready: Notify,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SequenceState {
+    /// Offset whose turn it is. Publishers wait until this reaches their first
+    /// offset.
+    next: Offset,
+    /// Bumped by every reset. A turn acquired before a reset carries
+    /// pre-reset offsets, so releasing it must not move the sequence: the
+    /// reset is authoritative about where the log now ends.
+    generation: u64,
+}
+
+impl fmt::Debug for CommitSequencer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = *self.state.lock();
+        f.debug_struct("CommitSequencer")
+            .field("next", &state.next)
+            .field("generation", &state.generation)
+            .finish()
+    }
+}
+
+impl CommitSequencer {
+    pub(crate) fn new(next: Offset) -> Self {
+        Self {
+            state: Mutex::new(SequenceState {
+                next,
+                generation: 0,
+            }),
+            ready: Notify::new(),
+        }
+    }
+
+    /// Restart the sequence at `next`, used when a stream adopts a recovered
+    /// log and its offsets resume from the durable tail.
+    pub(crate) fn reset(&self, next: Offset) {
+        {
+            let mut state = self.state.lock();
+            state.next = next;
+            state.generation += 1;
+        }
+        // Wake everyone: a waiter parked on an offset the reset just discarded
+        // would otherwise never be released.
+        self.ready.notify_waiters();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn next_offset(&self) -> Offset {
+        self.state.lock().next
+    }
+
+    /// Wait until `first_offset` is next, then hold the turn until the returned
+    /// guard is dropped.
+    ///
+    /// The guard releases the turn on drop, so an error or an early return in
+    /// the caller cannot strand the stream: every publisher behind this one
+    /// would otherwise wait forever.
+    pub(crate) async fn turn(&self, first_offset: Offset, next_offset: Offset) -> CommitTurn<'_> {
+        loop {
+            // Register interest *before* testing, or a release landing between
+            // the test and the await would be missed and this publisher would
+            // sleep until the next unrelated publish woke it.
+            let notified = self.ready.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            let generation = {
+                let state = *self.state.lock();
+                if state.next >= first_offset {
+                    Some(state.generation)
+                } else {
+                    None
+                }
+            };
+            if let Some(generation) = generation {
+                return CommitTurn {
+                    sequencer: self,
+                    next_offset,
+                    generation,
+                };
+            }
+            notified.await;
+        }
+    }
+}
+
+/// Holds a stream's commit turn. Releasing it lets the next offset proceed.
+pub(crate) struct CommitTurn<'a> {
+    sequencer: &'a CommitSequencer,
+    next_offset: Offset,
+    /// Generation this turn was acquired in.
+    generation: u64,
+}
+
+impl Drop for CommitTurn<'_> {
+    fn drop(&mut self) {
+        {
+            let mut state = self.sequencer.state.lock();
+            // A reset while this turn was held means the log was rewritten
+            // underneath it. Its offsets describe a sequence that no longer
+            // exists, so advancing on them would step the stream past records
+            // that are gone.
+            if state.generation == self.generation && self.next_offset > state.next {
+                state.next = self.next_offset;
+            }
+        }
+        self.sequencer.ready.notify_waiters();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn the_first_offset_proceeds_immediately() {
+        let sequencer = CommitSequencer::new(0);
+        let turn = sequencer.turn(0, 1).await;
+        drop(turn);
+        assert_eq!(sequencer.next_offset(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_later_offset_waits_for_its_predecessor() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+
+        // Offset 5 cannot proceed while the sequence is still at 0.
+        let waiter = {
+            let sequencer = Arc::clone(&sequencer);
+            tokio::spawn(async move {
+                let turn = sequencer.turn(5, 6).await;
+                drop(turn);
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished(), "offset 5 ran out of turn");
+
+        // Releasing the intervening range lets it through.
+        drop(sequencer.turn(0, 5).await);
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("waiter should be released")
+            .expect("join");
+        assert_eq!(sequencer.next_offset(), 6);
+    }
+
+    #[tokio::test]
+    async fn turns_are_granted_in_offset_order_regardless_of_arrival_order() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+        let observed = Arc::new(parking_lot::Mutex::new(Vec::new()));
+
+        // Spawn the highest offset first so arrival order is the reverse of
+        // offset order — exactly the interleaving the fsync wait can produce.
+        let mut tasks = Vec::new();
+        for offset in (0..8u64).rev() {
+            let sequencer = Arc::clone(&sequencer);
+            let observed = Arc::clone(&observed);
+            tasks.push(tokio::spawn(async move {
+                let turn = sequencer.turn(offset, offset + 1).await;
+                observed.lock().push(offset);
+                drop(turn);
+            }));
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        for task in tasks {
+            tokio::time::timeout(Duration::from_secs(5), task)
+                .await
+                .expect("no deadlock")
+                .expect("join");
+        }
+
+        assert_eq!(*observed.lock(), (0..8).collect::<Vec<_>>());
+    }
+
+    #[tokio::test]
+    async fn a_dropped_turn_never_strands_the_stream() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+
+        // A publisher that takes its turn and then fails still releases it.
+        let result: std::result::Result<(), ()> = async {
+            let _turn = sequencer.turn(0, 1).await;
+            Err(())
+        }
+        .await;
+        assert!(result.is_err());
+
+        // The next publisher is not blocked by the failure.
+        tokio::time::timeout(Duration::from_secs(5), sequencer.turn(1, 2))
+            .await
+            .expect("must not stall");
+    }
+
+    #[tokio::test]
+    async fn a_reset_releases_waiters_stuck_behind_a_vanished_offset() {
+        let sequencer = Arc::new(CommitSequencer::new(10));
+
+        // After a truncation the tail moves backwards; a publisher waiting on
+        // an offset that no longer exists must be released rather than hang.
+        let waiter = {
+            let sequencer = Arc::clone(&sequencer);
+            tokio::spawn(async move { drop(sequencer.turn(20, 21).await) })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished());
+
+        sequencer.reset(20);
+        tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("reset should release the waiter")
+            .expect("join");
+    }
+
+    #[tokio::test]
+    async fn a_stale_release_cannot_undo_a_reset() {
+        let sequencer = CommitSequencer::new(100);
+        let turn = sequencer.turn(100, 101).await;
+        // A truncation rewinds the log while the turn is held.
+        sequencer.reset(5);
+        drop(turn);
+        assert_eq!(
+            sequencer.next_offset(),
+            5,
+            "stale release moved the sequence"
+        );
+    }
+}

--- a/crates/felix-broker/src/error.rs
+++ b/crates/felix-broker/src/error.rs
@@ -16,6 +16,16 @@ pub enum BrokerError {
     },
     #[error("stream handle {0} is no longer active")]
     StreamHandleInactive(u64),
+    #[error(
+        "changing stream durability requires removal and recreation: tenant={tenant_id} namespace={namespace} stream={stream} current={current} requested={requested}"
+    )]
+    DurabilityChangeRequiresRecreate {
+        tenant_id: String,
+        namespace: String,
+        stream: String,
+        current: bool,
+        requested: bool,
+    },
     #[error("tenant not found: {0}")]
     TenantNotFound(String),
     #[error("namespace not found: tenant={tenant_id} namespace={namespace}")]
@@ -23,9 +33,33 @@ pub enum BrokerError {
         tenant_id: String,
         namespace: String,
     },
-    /// Durable storage refused or failed a write. A publish that hits this is
-    /// never acknowledged: the record is not on disk, so claiming otherwise
-    /// would be the one failure mode durability exists to prevent.
+    /// Historical replay was requested for a stream that keeps no history on
+    /// disk. Its records live only in the bounded in-memory replay ring, which
+    /// is reachable through `subscribe_with_cursor`.
+    #[error("stream {tenant_id}/{namespace}/{stream} is not durable and has no persisted history")]
+    StreamNotDurable {
+        tenant_id: String,
+        namespace: String,
+        stream: String,
+    },
+    /// The stream asks for durability but this broker has none configured.
+    ///
+    /// Separate from [`BrokerError::Storage`] because the two want opposite
+    /// handling: this is a static misconfiguration that will not resolve on
+    /// retry and affects only the stream naming it, while a storage failure
+    /// means the disk is in an unknown state and must never be shrugged off.
+    #[error(
+        "stream {tenant_id}/{namespace}/{stream} is marked durable but this broker has no durable storage configured"
+    )]
+    DurableStorageNotConfigured {
+        tenant_id: String,
+        namespace: String,
+        stream: String,
+    },
+    /// Durable storage refused or failed a write, or a log failed to recover.
+    /// A publish that hits this is never acknowledged: the record is not on
+    /// disk, so claiming otherwise would be the one failure mode durability
+    /// exists to prevent.
     #[error("durable storage error: {0}")]
     Storage(String),
 }

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -7,6 +7,7 @@
 // - `error` / `config`: shared error type, capacity defaults, queue policy.
 // - `keys`: map keys plus their borrowed lookup twins.
 // - `delivery`: shared delivery batches and queue-depth accounting.
+// - `commit_order`: one authoritative publish order per durable stream.
 // - `stream_state`: per-stream subscriber registry, snapshot, and replay log.
 // - `durable`: disk-backed logs for streams registered with `durable: true`.
 // - `subscription`: subscriber-facing receive handles.
@@ -20,6 +21,7 @@
 mod telemetry;
 
 mod broker;
+mod commit_order;
 mod config;
 mod delivery;
 pub mod durable;

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -11,6 +11,14 @@ use crate::error::{BrokerError, Result};
 use crate::keys::{CacheKey, CacheKeyRef, NamespaceKey, NamespaceKeyRef, StreamKey, StreamKeyRef};
 use crate::stream_state::StreamState;
 
+/// Byte ceiling on the replay ring refill at startup.
+///
+/// The record count is already capped by the ring's capacity; this bounds the
+/// payload bytes a single pathological stream can pull in while a broker is
+/// starting, so one stream of very large records cannot stall registration of
+/// every other stream behind it.
+const HYDRATE_MAX_BYTES: usize = 64 * 1024 * 1024;
+
 impl Broker {
     pub async fn register_stream(
         &self,
@@ -36,6 +44,17 @@ impl Broker {
         }
         let key = StreamKey::new(tenant_id, namespace, stream);
 
+        // Cursor sequence numbers and durable offsets share one identity. An
+        // existing ephemeral stream may already have cursor history that was
+        // never written to disk, so toggling durability in place would make
+        // those two sequences disagree. Require an explicit remove/recreate,
+        // which also invalidates old handles and subscriptions.
+        if let Some(existing) = self.streams.read().await.get(&key)
+            && existing.durable != metadata.durable
+        {
+            return Err(Self::durability_change_error(&key, existing, &metadata));
+        }
+
         // Open durable storage before touching the registries: a stream that
         // cannot be persisted must not become publishable, or the first publish
         // would be acknowledged against a guarantee that does not exist.
@@ -43,23 +62,42 @@ impl Broker {
             .open_durable_log(&key.tenant_id, &key.namespace, &key.stream, &metadata)
             .await?;
 
-        self.streams.write().await.insert(key.clone(), metadata);
-        let mut guard = self.topics.write().await;
+        // Keep the documented registry lock order. Recheck after acquiring the
+        // write lock so concurrent first registrations cannot race a durability
+        // transition past the fast-path check above.
+        let mut streams = self.streams.write().await;
+        if let Some(existing) = streams.get(&key)
+            && existing.durable != metadata.durable
+        {
+            return Err(Self::durability_change_error(&key, existing, &metadata));
+        }
+        let mut topics = self.topics.write().await;
         let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
-        let state = guard.entry(key).or_insert_with(|| {
-            Arc::new(StreamState::new(
-                handle_id,
-                self.topic_capacity,
-                self.subscriber_queue_policy,
-                durable,
-            ))
-        });
+        let state = topics
+            .entry(key.clone())
+            .or_insert_with(|| {
+                Arc::new(StreamState::new(
+                    handle_id,
+                    self.topic_capacity,
+                    self.subscriber_queue_policy,
+                    durable,
+                ))
+            })
+            .clone();
+        streams.insert(key, metadata);
+        drop(topics);
+        drop(streams);
+
         // A durable stream that recovered records keeps counting cursors from
-        // where the log left off, so a subscriber's pre-restart cursor still
-        // means what it meant before.
+        // where the log left off, and refills its replay ring from disk so a
+        // subscriber's pre-restart cursor still resolves to the same records.
+        // Reading only the ring's worth of tail keeps this bounded: startup
+        // cost does not grow with the size of the log.
         if let Some(log) = &state.durable {
             let tail = log.tail_offset().await?;
-            state.resume_at(tail);
+            let from = tail.saturating_sub(self.log_capacity as u64);
+            let recent = log.read_from(from, HYDRATE_MAX_BYTES).await?;
+            state.hydrate(recent, tail, self.log_capacity);
         }
         Ok(())
     }
@@ -76,9 +114,11 @@ impl Broker {
             return Ok(None);
         }
         let Some(storage) = &self.durable_storage else {
-            return Err(BrokerError::Storage(format!(
-                "stream {tenant_id}/{namespace}/{stream} is marked durable but this broker has no durable storage configured"
-            )));
+            return Err(BrokerError::DurableStorageNotConfigured {
+                tenant_id: tenant_id.to_string(),
+                namespace: namespace.to_string(),
+                stream: stream.to_string(),
+            });
         };
         // The broker keeps one log per stream today. `metadata.shards` is
         // carried through to the shard key so that when the data path is
@@ -110,6 +150,20 @@ impl Broker {
         let key = CacheKey::new(tenant_id, namespace, cache);
         self.caches.write().await.insert(key, metadata);
         Ok(())
+    }
+
+    fn durability_change_error(
+        key: &StreamKey,
+        current: &StreamMetadata,
+        requested: &StreamMetadata,
+    ) -> BrokerError {
+        BrokerError::DurabilityChangeRequiresRecreate {
+            tenant_id: key.tenant_id.clone(),
+            namespace: key.namespace.clone(),
+            stream: key.stream.clone(),
+            current: current.durable,
+            requested: requested.durable,
+        }
     }
 
     pub async fn remove_cache(

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -10,10 +10,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::mpsc;
 
+use crate::commit_order::CommitSequencer;
 use crate::config::SubQueuePolicy;
 use crate::delivery::QueuedDelivery;
 use crate::durable::StreamLog;
 use crate::subscription::SubscriptionReceiver;
+use felix_storage::log::LogRecord;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Cursor {
@@ -53,6 +55,10 @@ pub(crate) struct StreamState {
     // fanout read from, and dropping it for durable streams would put a file
     // read on the fanout path.
     pub(crate) durable: Option<StreamLog>,
+    // Orders the post-durability half of a publish by disk offset, so cursor
+    // replay and subscriber delivery agree with what is on disk. Only durable
+    // streams use it; an ephemeral stream has no disk offsets to order by.
+    pub(crate) commit_sequencer: CommitSequencer,
 }
 
 #[derive(Debug, Default)]
@@ -94,6 +100,7 @@ impl StreamState {
             subscriber_queue_policy,
             queued_items: Arc::new(AtomicUsize::new(0)),
             durable,
+            commit_sequencer: CommitSequencer::new(0),
         }
     }
 
@@ -102,11 +109,46 @@ impl StreamState {
     /// A durable stream that recovered records from disk must not restart its
     /// cursor numbering at zero, or a subscriber resuming from a pre-restart
     /// cursor would silently receive the wrong records.
-    pub(crate) fn resume_at(&self, next_seq: u64) {
+    /// Refill the replay ring from a recovered durable log.
+    ///
+    /// Without this, a restart leaves the ring empty while `next_seq` jumps to
+    /// the durable tail, so every cursor a client held from before the restart
+    /// looks older than the oldest entry and `subscribe_with_cursor` answers
+    /// `CursorTooOld` — even though the records are sitting on disk. Hydrating
+    /// restores the same replay window the stream had before it stopped.
+    ///
+    /// `records` is already bounded by the caller to the ring's capacity; the
+    /// ring is a fixed-size cache of the tail, not a second copy of the log.
+    ///
+    /// For durable streams a record's cursor sequence *is* its disk offset:
+    /// both start at zero and advance by one per record, and this is what keeps
+    /// them in step across a restart. The entries are therefore seeded with
+    /// their on-disk offsets rather than renumbered.
+    pub(crate) fn hydrate(&self, records: Vec<LogRecord>, next_seq: u64, capacity: usize) {
         let mut state = self.log_state.lock();
-        if state.log.is_empty() {
-            state.next_seq = next_seq;
+        // Only ever seeds a fresh stream. A re-registration of a live stream
+        // must not disturb a ring that is already serving cursors.
+        if !state.log.is_empty() {
+            return;
         }
+        for record in records {
+            if record.offset >= next_seq {
+                continue;
+            }
+            state.log.push_back(LogEntry {
+                seq: record.offset,
+                payload: record.payload,
+            });
+        }
+        let overflow = state.log.len().saturating_sub(capacity);
+        if overflow > 0 {
+            state.log.drain(..overflow);
+        }
+        state.next_seq = next_seq;
+        // The commit order is keyed on disk offsets, so it has to restart from
+        // the recovered tail too, or the first publish after a restart would
+        // wait for an offset that has already been written.
+        self.commit_sequencer.reset(next_seq);
     }
 
     pub(crate) fn deactivate(&self) {

--- a/crates/felix-broker/src/timings.rs
+++ b/crates/felix-broker/src/timings.rs
@@ -31,13 +31,30 @@ pub use telemetry::*;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    // The tests below drive the process-global timing collector. With the
+    // `telemetry` feature on these are the real functions rather than the no-op
+    // stubs: `enable_collection` resets `sample_every` and *clears every sample
+    // vector*, and the record functions push into those same vectors.
+    //
+    // Unserialised they race the `#[serial]` tests in `timings_telemetry.rs`,
+    // wiping samples between a test recording them and reading them back, which
+    // surfaces as `take_samples_clears_collected_data` asserting `0 == 1`.
+    // `serial_test` only serialises against other `#[serial]` tests, so both
+    // sides have to opt in — marking one side of a race is no protection.
+    //
+    // The window is narrow, so this shows up under coverage instrumentation
+    // (slow enough to widen it) far more often than in a plain test run.
 
     #[test]
+    #[serial]
     fn enable_collection_does_not_panic() {
         enable_collection(10);
     }
 
     #[test]
+    #[serial]
     fn set_enabled_does_not_panic() {
         set_enabled(true);
         set_enabled(false);
@@ -50,6 +67,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn record_functions_do_not_panic() {
         record_lookup_ns(100);
         record_append_ns(200);

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -250,6 +250,99 @@ async fn durable_and_non_durable_streams_coexist() {
 }
 
 #[tokio::test]
+async fn upgrading_a_live_stream_to_durable_requires_recreation() {
+    let dir = tempdir().expect("dir");
+    let (broker, storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", false).await;
+
+    broker
+        .publish("t1", "default", "orders", payload("before"))
+        .await
+        .expect("publish");
+    let err = broker
+        .register_stream(
+            "t1",
+            "default",
+            "orders",
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await
+        .expect_err("live durability change");
+    assert!(matches!(
+        err,
+        BrokerError::DurabilityChangeRequiresRecreate {
+            current: false,
+            requested: true,
+            ..
+        }
+    ));
+
+    broker
+        .publish("t1", "default", "orders", payload("after"))
+        .await
+        .expect("stream remains ephemeral");
+    assert_eq!(
+        std::fs::read_dir(storage.root())
+            .expect("read root")
+            .filter_map(|entry| entry.ok())
+            .count(),
+        0,
+        "a rejected upgrade must not create durable state"
+    );
+}
+
+#[tokio::test]
+async fn downgrading_a_live_durable_stream_requires_recreation() {
+    let dir = tempdir().expect("dir");
+    let (broker, storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", true).await;
+    broker
+        .publish("t1", "default", "orders", payload("before"))
+        .await
+        .expect("publish");
+
+    let err = broker
+        .register_stream(
+            "t1",
+            "default",
+            "orders",
+            StreamMetadata {
+                durable: false,
+                shards: 1,
+            },
+        )
+        .await
+        .expect_err("live durability change");
+    assert!(matches!(
+        err,
+        BrokerError::DurabilityChangeRequiresRecreate {
+            current: true,
+            requested: false,
+            ..
+        }
+    ));
+
+    broker
+        .publish("t1", "default", "orders", payload("after"))
+        .await
+        .expect("stream remains durable");
+    let log = storage
+        .open_stream("t1", "default", "orders", 0)
+        .expect("log");
+    let records = log.read_from(0, usize::MAX).await.expect("read");
+    assert_eq!(
+        records
+            .into_iter()
+            .map(|record| record.payload)
+            .collect::<Vec<_>>(),
+        vec![payload("before"), payload("after")]
+    );
+}
+
+#[tokio::test]
 async fn registering_a_durable_stream_without_storage_is_rejected() {
     let broker = Broker::new(EphemeralCache::new().into());
     broker.register_tenant("t1").await.expect("tenant");
@@ -270,7 +363,13 @@ async fn registering_a_durable_stream_without_storage_is_rejected() {
         )
         .await
         .expect_err("no storage configured");
-    assert!(matches!(err, BrokerError::Storage(_)));
+    // A distinct variant from `Storage`, so the control-plane watcher can skip
+    // a stream this broker will never be able to host while still failing hard
+    // on a real storage failure.
+    assert!(
+        matches!(err, BrokerError::DurableStorageNotConfigured { .. }),
+        "{err}"
+    );
 
     // The stream must not exist: a half-registered durable stream would accept
     // publishes it cannot persist.
@@ -380,4 +479,222 @@ async fn a_batch_publish_lands_as_one_contiguous_run() {
         assert_eq!(record.offset, index as u64);
         assert_eq!(record.payload, batch[index]);
     }
+}
+
+/// End-to-end check that the three orders agree.
+///
+/// This is a smoke test, not a regression test: it passes with the commit
+/// sequencer removed, because the reordering window needs a scheduler
+/// interleaving that 32 publishers on a 4-worker runtime do not reliably
+/// produce. The deterministic proof that turns are granted in offset order
+/// regardless of arrival order lives in `commit_order`'s unit tests, which fail
+/// immediately if the primitive stops ordering. What this test does buy is
+/// coverage of the wiring - that the sequencer is actually on the publish path
+/// and that holding a turn across fanout does not deadlock or drop records.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn disk_order_cursor_order_and_delivery_order_agree_under_concurrency() {
+    let dir = tempdir().expect("dir");
+    let (broker, storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", true).await;
+
+    let cursor = broker
+        .cursor_tail("t1", "default", "orders")
+        .await
+        .expect("cursor");
+    let mut sub = broker
+        .subscribe("t1", "default", "orders")
+        .await
+        .expect("subscribe");
+
+    const PUBLISHERS: u32 = 32;
+    let mut tasks = Vec::new();
+    for i in 0..PUBLISHERS {
+        let broker = Arc::clone(&broker);
+        tasks.push(tokio::spawn(async move {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("v{i:03}")))
+                .await
+                .expect("publish");
+        }));
+    }
+    for task in tasks {
+        task.await.expect("join");
+    }
+
+    // 1. The order on disk.
+    let log = storage
+        .open_stream("t1", "default", "orders", 0)
+        .expect("log");
+    let on_disk: Vec<String> = log
+        .read_from(0, usize::MAX)
+        .await
+        .expect("read")
+        .into_iter()
+        .map(|r| String::from_utf8(r.payload.to_vec()).expect("utf8"))
+        .collect();
+    assert_eq!(on_disk.len(), PUBLISHERS as usize);
+
+    // 2. The order a subscriber received them in.
+    let mut delivered = Vec::new();
+    while delivered.len() < PUBLISHERS as usize {
+        let msg = tokio::time::timeout(Duration::from_secs(10), sub.recv())
+            .await
+            .expect("delivery timeout")
+            .expect("message");
+        delivered.push(String::from_utf8(msg.to_vec()).expect("utf8"));
+    }
+
+    // 3. The order cursor replay returns them in.
+    let (replayed, _) = broker
+        .subscribe_with_cursor("t1", "default", "orders", cursor)
+        .await
+        .expect("replay");
+    let replayed: Vec<String> = replayed
+        .into_iter()
+        .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
+        .collect();
+
+    // All three must be the same sequence.
+    assert_eq!(
+        delivered, on_disk,
+        "delivery order disagrees with disk order"
+    );
+    assert_eq!(replayed, on_disk, "cursor replay disagrees with disk order");
+
+    storage.shutdown().await.expect("shutdown");
+}
+
+#[tokio::test]
+async fn a_pre_restart_cursor_still_replays_after_a_restart() {
+    let dir = tempdir().expect("dir");
+    let saved_cursor;
+    {
+        let (broker, storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+        register(&broker, "orders", true).await;
+
+        // A client subscribes, reads a few records, and remembers where it got
+        // to — the ordinary resume pattern.
+        saved_cursor = broker
+            .cursor_tail("t1", "default", "orders")
+            .await
+            .expect("cursor");
+        for i in 0..20 {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("v{i:02}")))
+                .await
+                .expect("publish");
+        }
+        storage.shutdown().await.expect("shutdown");
+    }
+
+    // The broker restarts. Before the replay ring was hydrated from disk this
+    // returned CursorTooOld: the ring was empty, so its "oldest" was the
+    // recovered tail and every saved cursor looked ancient.
+    let (broker, _storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", true).await;
+
+    let (backlog, mut sub) = broker
+        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .await
+        .expect("replay after restart");
+    let replayed: Vec<String> = backlog
+        .into_iter()
+        .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
+        .collect();
+    assert_eq!(replayed.len(), 20, "pre-restart history was not replayed");
+    assert_eq!(replayed[0], "v00");
+    assert_eq!(replayed[19], "v19");
+
+    // And the subscription is live from the point the backlog ended, with no
+    // gap and no duplicate across the seam.
+    broker
+        .publish("t1", "default", "orders", payload("after"))
+        .await
+        .expect("publish");
+    let next = tokio::time::timeout(Duration::from_secs(5), sub.recv())
+        .await
+        .expect("timeout")
+        .expect("message");
+    assert_eq!(next, payload("after"));
+}
+
+#[tokio::test]
+async fn hydration_is_bounded_by_the_replay_ring_capacity() {
+    let dir = tempdir().expect("dir");
+    {
+        let (broker, storage) = broker_with_storage(&dir, FsyncMode::None).await;
+        register(&broker, "orders", true).await;
+        for i in 0..300 {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("v{i:04}")))
+                .await
+                .expect("publish");
+        }
+        storage.shutdown().await.expect("shutdown");
+    }
+
+    // A small ring: hydration must fill it with the *tail* of the log and stop,
+    // not pull the whole history into memory.
+    let storage = DurableStorage::open(dir.path(), log_config(FsyncMode::None)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into())
+        .with_durable_storage(storage)
+        .with_topic_capacity(16)
+        .expect("capacity")
+        .with_log_capacity(16)
+        .expect("log capacity");
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+    register(&broker, "orders", true).await;
+
+    // Cursors inside the ring window resolve from memory...
+    let (backlog, _sub) = broker
+        .subscribe_with_cursor("t1", "default", "orders", {
+            let tail = broker
+                .cursor_tail("t1", "default", "orders")
+                .await
+                .expect("cursor");
+            assert_eq!(tail.next_seq(), 300, "cursor did not resume at the tail");
+            tail
+        })
+        .await
+        .expect("subscribe at tail");
+    assert!(backlog.is_empty(), "a tail cursor should have no backlog");
+
+    // ...and everything older is reachable through the paged replay API rather
+    // than by growing the ring.
+    let mut seen = Vec::new();
+    let mut offset = 0u64;
+    loop {
+        let page = broker
+            .read_durable("t1", "default", "orders", offset, 4096)
+            .await
+            .expect("read_durable");
+        if page.is_empty() {
+            break;
+        }
+        offset = page.last().expect("last").offset + 1;
+        seen.extend(
+            page.into_iter()
+                .map(|r| String::from_utf8(r.payload.to_vec()).expect("utf8")),
+        );
+    }
+    assert_eq!(seen.len(), 300, "paged replay did not cover the whole log");
+    assert_eq!(seen[0], "v0000");
+    assert_eq!(seen[299], "v0299");
+}
+
+#[tokio::test]
+async fn historical_replay_is_rejected_for_a_non_durable_stream() {
+    let dir = tempdir().expect("dir");
+    let (broker, _storage) = broker_with_storage(&dir, FsyncMode::None).await;
+    register(&broker, "ephemeral", false).await;
+
+    let err = broker
+        .read_durable("t1", "default", "ephemeral", 0, 4096)
+        .await
+        .expect_err("no persisted history");
+    assert!(matches!(err, BrokerError::StreamNotDurable { .. }), "{err}");
 }

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -18,6 +18,10 @@
 //   append path performs it inline. Handing it to `spawn_blocking` would add
 //   more scheduling latency than the syscall itself costs, and this project
 //   cares about p999.
+// * A *rollover* is the exception on that path: sealing a segment and creating
+//   its successor fsync two files and a directory. Appends that trigger one
+//   roll on a blocking thread first, so the flush cost never lands on a
+//   reactor worker.
 // * An `fsync` genuinely blocks, for milliseconds on real hardware. It always
 //   runs on `spawn_blocking` so it cannot stall a reactor thread — and because
 //   flushes are grouped, one blocking task serves many appends.
@@ -182,11 +186,7 @@ impl DiskLog {
                         // The log is gone; report the highest offset so the
                         // task simply stops doing work.
                         None => Ok(Offset::MAX),
-                        Some(inner) => {
-                            let durable = inner.clone().flush().await?;
-                            inner.durability.note_durable(durable);
-                            Ok(durable)
-                        }
+                        Some(inner) => inner.durability.force_flush(|| inner.clone().flush()).await,
                     }
                 }
             })?;
@@ -226,8 +226,10 @@ impl DiskLog {
 
     /// Force a flush regardless of the configured policy.
     pub async fn sync(&self) -> Result<()> {
-        let durable = Arc::clone(&self.inner).flush().await?;
-        self.inner.durability.note_durable(durable);
+        self.inner
+            .durability
+            .force_flush(|| Arc::clone(&self.inner).flush())
+            .await?;
         Ok(())
     }
 
@@ -257,6 +259,30 @@ impl AppendOnlyLog for DiskLog {
                 return Err(StorageError::InvalidRange);
             }
             let started = std::time::Instant::now();
+
+            // Rolling a segment seals one file, creates another, and fsyncs
+            // both plus the directory entry. That is real blocking work, so it
+            // happens on a blocking thread rather than inline on a reactor
+            // worker — otherwise every `segment_size_bytes` of throughput would
+            // stall a worker for the length of two flushes and show up as a
+            // periodic tail-latency spike.
+            //
+            // Checked under a read lock and re-checked under the write lock:
+            // another publisher may have rolled in between, and rolling twice
+            // would leave an empty segment behind.
+            if inner.segments.read().would_roll(&records) {
+                let roller = Arc::clone(&inner);
+                let batch = records.clone();
+                tokio::task::spawn_blocking(move || {
+                    let mut segments = roller.segments.write();
+                    if segments.would_roll(&batch) {
+                        segments.roll()?;
+                    }
+                    Ok::<(), StorageError>(())
+                })
+                .await
+                .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
+            }
 
             let (first_offset, last_offset, target) = {
                 let mut segments = inner.segments.write();
@@ -319,14 +345,15 @@ impl AppendOnlyLog for DiskLog {
     fn truncate(&self, offset: Offset) -> BoxFuture<'_, Result<()>> {
         let inner = Arc::clone(&self.inner);
         Box::pin(async move {
+            let _flush_guard = inner.durability.lock_flushes().await;
+            let operation = Arc::clone(&inner);
             tokio::task::spawn_blocking(move || {
-                let mut segments = inner.segments.write();
+                let mut segments = operation.segments.write();
                 segments.truncate(offset)?;
-                // Truncation removes offsets that may already have been reported
-                // durable; the bound must not claim records that no longer
-                // exist. `Durability` is monotonic, so re-open is the only way
-                // to lower it — instead, flush so the shorter file is durable.
-                segments.active_mut().sync()
+                segments.active_mut().sync()?;
+                let tail = segments.tail_offset();
+                operation.durability.reset_after_truncate(tail);
+                Ok(())
             })
             .await
             .map_err(|err| StorageError::Io(std::io::Error::other(err)))?

--- a/crates/felix-storage/src/disk_log/recovery.rs
+++ b/crates/felix-storage/src/disk_log/recovery.rs
@@ -174,6 +174,7 @@ fn recover_existing(
         label,
         config.index_spacing_bytes,
         ScanStart::Full,
+        config.repair_checksum_tail,
     )?;
     if let Some(expected) = expected_base
         && expected != outcome.header.base_offset
@@ -259,6 +260,9 @@ fn open_sealed(dir: &Path, label: &str, config: &LogConfig, id: SegmentId) -> Re
                     position: last.position,
                     next_offset: last.offset,
                 },
+                // A sealed segment was synced and trimmed when it was sealed,
+                // so nothing in it can be an unfinished write.
+                false,
             )?;
             (index, outcome)
         }
@@ -272,6 +276,7 @@ fn open_sealed(dir: &Path, label: &str, config: &LogConfig, id: SegmentId) -> Re
                 label,
                 config.index_spacing_bytes,
                 ScanStart::Full,
+                false,
             )?;
             outcome.index.persist(&dir.join(index_file_name(id)))?;
             (outcome.index.clone(), outcome)

--- a/crates/felix-storage/src/disk_log/segments.rs
+++ b/crates/felix-storage/src/disk_log/segments.rs
@@ -105,18 +105,32 @@ impl SegmentSet {
             .collect()
     }
 
+    /// Whether appending `records` would first require a rollover.
+    ///
+    /// Exposed so the async layer can perform the roll — which seals a segment,
+    /// creates another, and fsyncs both plus the directory — on a blocking
+    /// thread instead of inline on a reactor worker.
+    pub fn would_roll(&self, records: &[AppendRecord]) -> bool {
+        self.active.projected_size(records) > self.config.segment_size_bytes
+            && self.active.record_count() > 0
+    }
+
     /// Append a batch, rolling to a new segment first if it would not fit.
     ///
     /// A batch is never split across segments: offsets stay contiguous either
     /// way, but keeping a batch whole means one `write` call and one index
     /// update per append regardless of where the boundary falls.
     pub fn append(&mut self, records: &[AppendRecord]) -> Result<(Offset, Offset)> {
-        let projected = self.active.projected_size(records);
         // An empty active segment must accept the batch even when it is
         // oversized — otherwise a record larger than `segment_size_bytes` could
         // never be written at all. Such a record gets a segment to itself and
         // the next append rolls again.
-        if projected > self.config.segment_size_bytes && self.active.record_count() > 0 {
+        //
+        // Normally `DiskLog::append` has already rolled off-thread by this
+        // point; this is the fallback for a roll that became necessary in the
+        // window since that check, and for callers that drive `SegmentSet`
+        // directly.
+        if self.would_roll(records) {
             self.roll()?;
         }
         self.active.append(records)
@@ -254,6 +268,7 @@ impl SegmentSet {
             &self.label,
             self.config.index_spacing_bytes,
             ScanStart::Full,
+            self.config.repair_checksum_tail,
         )?;
         self.active = SegmentWriter::reopen(
             &self.dir,

--- a/crates/felix-storage/src/disk_log/sync.rs
+++ b/crates/felix-storage/src/disk_log/sync.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use tokio::sync::{Mutex, Notify, watch};
+use tokio::sync::{Mutex, MutexGuard, Notify, watch};
 
 use crate::Result;
 use crate::log::{FsyncMode, Offset};
@@ -84,6 +84,32 @@ impl Durability {
                 false
             }
         });
+    }
+
+    /// Prevent flush progress from racing an operation that rewrites the log.
+    pub async fn lock_flushes(&self) -> MutexGuard<'_, ()> {
+        self.flush_lock.lock().await
+    }
+
+    /// Lower the durable bound after truncation.
+    ///
+    /// The caller must hold [`Self::lock_flushes`] and the segment write lock,
+    /// so no flush can publish stale progress and no append can observe the
+    /// truncated tail before this reset.
+    pub fn reset_after_truncate(&self, durable_upto: Offset) {
+        self.durable_tx.send_replace(durable_upto);
+    }
+
+    /// Run an unconditional flush under the same lock used by group commit.
+    pub async fn force_flush<F, Fut>(&self, flush: F) -> Result<Offset>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<Offset>>,
+    {
+        let _guard = self.flush_lock.lock().await;
+        let durable_upto = flush().await?;
+        self.note_durable(durable_upto);
+        Ok(durable_upto)
     }
 
     /// Whether an append must wait for a flush before it may be acknowledged.
@@ -371,6 +397,14 @@ mod tests {
         assert_eq!(durability.durable_upto(), 9);
         durability.note_durable(2);
         assert_eq!(durability.durable_upto(), 9);
+    }
+
+    #[tokio::test]
+    async fn truncation_can_lower_the_durable_bound_exclusively() {
+        let durability = Durability::new(FsyncMode::OnCommit, 9);
+        let _guard = durability.lock_flushes().await;
+        durability.reset_after_truncate(3);
+        assert_eq!(durability.durable_upto(), 3);
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -373,6 +373,28 @@ async fn truncate_drops_the_suffix_and_survives_reopen() {
 }
 
 #[tokio::test]
+async fn on_commit_reflushes_offsets_reused_after_truncation() {
+    let dir = tempdir().expect("dir");
+    let log = open(&dir, FsyncMode::OnCommit);
+
+    log.append(&records(&["zero", "one", "two"]))
+        .await
+        .expect("initial append");
+    assert_eq!(log.durable_offset(), 3);
+
+    log.truncate(1).await.expect("truncate");
+    assert_eq!(log.durable_offset(), 1);
+
+    let replacement = log
+        .append(&records(&["replacement"]))
+        .await
+        .expect("replacement append");
+    assert_eq!(replacement.first_offset, 1);
+    assert_eq!(log.durable_offset(), 2);
+    assert_eq!(log.unsynced_bytes(), 0);
+}
+
+#[tokio::test]
 async fn sealing_reports_a_descriptor_and_checksum() {
     let dir = tempdir().expect("dir");
     let log = open(&dir, FsyncMode::None);
@@ -473,6 +495,71 @@ async fn provider_logs_reopen_with_their_data() {
         DiskLogProvider::new(root.path(), config(FsyncMode::OnCommit)).expect("provider");
     let log = provider.open(&shard).await.expect("open");
     assert_eq!(read_all(&log, 0).await, vec!["persisted"]);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_appends_across_a_rollover_stay_contiguous() {
+    let dir = tempdir().expect("dir");
+    // Segments small enough that this run crosses many boundaries, so the
+    // off-thread pre-roll and the in-lock fallback both get exercised, and
+    // concurrent publishers race the roll itself.
+    let log = std::sync::Arc::new(
+        DiskLog::open(
+            dir.path(),
+            "t/ns/s/0",
+            LogConfig {
+                segment_size_bytes: crate::segment::SEGMENT_HEADER_LEN + 200,
+                ..config(FsyncMode::None)
+            },
+        )
+        .expect("open"),
+    );
+
+    let mut tasks = Vec::new();
+    for i in 0..64u32 {
+        let log = std::sync::Arc::clone(&log);
+        tasks.push(tokio::spawn(async move {
+            log.append(&records(&[&format!("value-{i:03}")]))
+                .await
+                .expect("append")
+        }));
+    }
+    let mut assigned: Vec<Offset> = Vec::new();
+    for task in tasks {
+        assigned.push(task.await.expect("join").first_offset);
+    }
+    log.sync().await.expect("sync");
+
+    // Every append got a distinct offset and the log holds exactly them, with
+    // no gap or duplicate introduced by a rollover racing an append.
+    assigned.sort_unstable();
+    assert_eq!(assigned, (0..64).collect::<Vec<_>>());
+    assert!(log.segments().len() > 2, "expected several rollovers");
+
+    let stored = read_all(&log, 0).await;
+    assert_eq!(stored.len(), 64);
+    let mut unique = stored.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(
+        unique.len(),
+        64,
+        "duplicate or lost records across a rollover"
+    );
+
+    // And it reopens cleanly, which is where a segment left empty or
+    // double-rolled would surface.
+    log.shutdown().await.expect("shutdown");
+    let reopened = DiskLog::open(
+        dir.path(),
+        "t/ns/s/0",
+        LogConfig {
+            segment_size_bytes: crate::segment::SEGMENT_HEADER_LEN + 200,
+            ..config(FsyncMode::None)
+        },
+    )
+    .expect("reopen");
+    assert_eq!(reopened.tail_offset().await.expect("tail"), 64);
 }
 
 #[tokio::test]

--- a/crates/felix-storage/src/log.rs
+++ b/crates/felix-storage/src/log.rs
@@ -52,6 +52,20 @@ pub struct LogConfig {
     /// append path; disable on filesystems where reservations are expensive or
     /// where thin provisioning makes them counter-productive.
     pub preallocate_segments: bool,
+    /// Truncate a *complete* trailing record whose checksum does not verify.
+    ///
+    /// Off by default, and the default is the conservative one. A torn write
+    /// and bit rot on an acknowledged record produce identical bytes: a
+    /// full-length record that fails its checksum. Recovery cannot tell them
+    /// apart, so it refuses to guess and fails to start, naming the segment and
+    /// position. Provably *incomplete* writes - a record cut short by end of
+    /// file - are still repaired automatically, because nothing could have
+    /// acknowledged them.
+    ///
+    /// Turn this on only where losing the last record is preferable to a broker
+    /// that will not start, which is a defensible trade under `FsyncMode::None`
+    /// and is not one under `OnCommit`.
+    pub repair_checksum_tail: bool,
     /// Checksum every record of every segment at open time.
     ///
     /// Off by default: startup would otherwise cost one full pass over all data
@@ -72,6 +86,7 @@ impl Default for LogConfig {
             },
             max_records_per_read: 10_000,
             preallocate_segments: true,
+            repair_checksum_tail: false,
             verify_all_on_open: false,
         }
     }

--- a/crates/felix-storage/src/segment/reader.rs
+++ b/crates/felix-storage/src/segment/reader.rs
@@ -125,19 +125,27 @@ fn is_repairable_tail(
     position: u64,
     claimed_len: Option<u64>,
     file_len: u64,
+    repair_checksum_tail: bool,
 ) -> bool {
     match kind {
         // The record does not fit in the file at all: a write that stopped
-        // part-way is the only way to produce this.
+        // part-way is the only way to produce this, and nothing can have
+        // acknowledged a record that was never finished.
         CorruptionKind::Truncated { .. } => true,
         // The record decodes to a full extent but its contents do not verify.
-        // Safe to drop only when nothing follows it — if bytes exist past this
-        // record, they were written after it and dropping it would open a gap.
+        //
+        // This is *not* provably an incomplete write. A torn write and bit rot
+        // on an already-acknowledged record produce the same bytes, and under
+        // `OnCommit` the record may have been fsynced and acknowledged before
+        // rotting. Truncating on a guess would silently delete data the caller
+        // was told was safe, so it happens only when an operator has opted in.
         CorruptionKind::RecordChecksum { .. } | CorruptionKind::OffsetOutOfOrder { .. } => {
-            claimed_len.is_some_and(|len| position.saturating_add(len) >= file_len)
+            repair_checksum_tail
+                && claimed_len.is_some_and(|len| position.saturating_add(len) >= file_len)
         }
-        // A garbage length field. Only a tail if the record it claims could not
-        // possibly fit, which is the signature of a half-written header.
+        // A garbage length field describing a record that could not possibly
+        // fit in the file: the signature of a half-written header, so provably
+        // incomplete and always repairable.
         CorruptionKind::RecordTooLarge { payload_len, .. } => {
             position.saturating_add(RECORD_HEADER_LEN + u64::from(*payload_len)) > file_len
         }
@@ -155,6 +163,7 @@ struct ScanState {
     bytes_since_entry: u64,
     spacing: u64,
     rebuild_index: bool,
+    repair_checksum_tail: bool,
 }
 
 impl ScanState {
@@ -189,7 +198,13 @@ impl ScanState {
         shard_label: &str,
         segment_id: SegmentId,
     ) -> Result<ScanOutcome> {
-        if is_repairable_tail(&err.kind, self.position, claimed_len, file_len) {
+        if is_repairable_tail(
+            &err.kind,
+            self.position,
+            claimed_len,
+            file_len,
+            self.repair_checksum_tail,
+        ) {
             return Ok(self.torn(file_len, err.kind));
         }
         let position = self.position;
@@ -249,12 +264,16 @@ pub enum ScanStart {
 ///
 /// `record_count` counts the records this scan validated, which for a
 /// [`ScanStart::Resume`] scan is only those after the resume point.
+///
+/// `repair_checksum_tail` mirrors [`crate::log::LogConfig::repair_checksum_tail`]:
+/// when false, only a provably incomplete trailing record is truncated.
 pub fn scan_segment(
     path: &Path,
     segment_id: SegmentId,
     shard_label: &str,
     index_spacing_bytes: u64,
     start: ScanStart,
+    repair_checksum_tail: bool,
 ) -> Result<ScanOutcome> {
     let file = File::open(path)?;
     let file_len = file.metadata()?.len();
@@ -295,6 +314,7 @@ pub fn scan_segment(
             u64::MAX
         },
         rebuild_index,
+        repair_checksum_tail,
     };
 
     while state.position < file_len {
@@ -523,7 +543,7 @@ mod tests {
     }
 
     fn scan(path: &Path) -> Result<ScanOutcome> {
-        scan_segment(path, 0, "t/ns/s/0", 4096, ScanStart::Full)
+        scan_segment(path, 0, "t/ns/s/0", 4096, ScanStart::Full, true)
     }
 
     fn read_all(path: &Path, outcome: &ScanOutcome, start: Offset) -> Vec<LogRecord> {
@@ -705,7 +725,7 @@ mod tests {
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 20);
 
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
         assert!(outcome.index.len() > 1);
         for entry in outcome.index.entries() {
             assert!(entry.position >= SEGMENT_HEADER_LEN);
@@ -740,7 +760,7 @@ mod tests {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 10);
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
 
         let out = read_all(&path, &outcome, 4);
         let offsets: Vec<Offset> = out.iter().map(|r| r.offset).collect();
@@ -753,7 +773,7 @@ mod tests {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 10);
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
         let reader = SegmentReader::open(&path, 0, 0).expect("open");
 
         let mut budget = ReadBudget::new(1, usize::MAX);
@@ -790,7 +810,7 @@ mod tests {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 10);
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
         let reader = SegmentReader::open(&path, 0, 0).expect("open");
 
         let mut budget = ReadBudget::new(usize::MAX, 3);
@@ -828,7 +848,7 @@ mod tests {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 10);
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
         let reader = SegmentReader::open(&path, 0, 0).expect("open");
 
         // Pretend only the first three records were committed.
@@ -858,7 +878,7 @@ mod tests {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         write_segment(&path, 0, 4);
-        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full).expect("scan");
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 64, ScanStart::Full, true).expect("scan");
         assert!(read_all(&path, &outcome, 99).is_empty());
     }
 
@@ -881,6 +901,7 @@ mod tests {
 
     #[test]
     fn repairable_tail_rules() {
+        // Provably incomplete: repaired regardless of policy.
         assert!(is_repairable_tail(
             &CorruptionKind::Truncated {
                 needed: 10,
@@ -888,8 +909,11 @@ mod tests {
             },
             100,
             None,
-            102
+            102,
+            false
         ));
+        // A complete-but-unverifiable tail: repaired only when opted in,
+        // because it is indistinguishable from rot on acknowledged data.
         assert!(is_repairable_tail(
             &CorruptionKind::RecordChecksum {
                 expected: 1,
@@ -897,7 +921,8 @@ mod tests {
             },
             100,
             Some(50),
-            150
+            150,
+            true
         ));
         assert!(!is_repairable_tail(
             &CorruptionKind::RecordChecksum {
@@ -906,13 +931,26 @@ mod tests {
             },
             100,
             Some(50),
-            300
+            150,
+            false
+        ));
+        // Committed records follow it, so it is interior damage either way.
+        assert!(!is_repairable_tail(
+            &CorruptionKind::RecordChecksum {
+                expected: 1,
+                found: 2
+            },
+            100,
+            Some(50),
+            300,
+            true
         ));
         assert!(!is_repairable_tail(
             &CorruptionKind::SegmentMagic { found: 0 },
             0,
             None,
-            100
+            100,
+            true
         ));
     }
 }

--- a/crates/felix-storage/src/segment/writer.rs
+++ b/crates/felix-storage/src/segment/writer.rs
@@ -66,6 +66,9 @@ pub struct SegmentWriter {
     /// A duplicate descriptor used only for flushing, so a sync never has to
     /// hold the lock that guards `file`.
     sync_handle: Arc<File>,
+    /// Set when a failed append could not be rolled back. The segment's real
+    /// length is then unknown, so further appends are refused.
+    poisoned: bool,
 }
 
 impl SegmentWriter {
@@ -110,6 +113,7 @@ impl SegmentWriter {
             record_count: 0,
             staging: Vec::new(),
             sync_handle,
+            poisoned: false,
         })
     }
 
@@ -156,6 +160,7 @@ impl SegmentWriter {
             record_count,
             staging: Vec::new(),
             sync_handle,
+            poisoned: false,
         })
     }
 
@@ -227,6 +232,12 @@ impl SegmentWriter {
     pub fn append(&mut self, records: &[AppendRecord]) -> Result<(Offset, Offset)> {
         debug_assert!(!records.is_empty());
 
+        if self.poisoned {
+            return Err(StorageError::Unsupported(
+                "segment writer is poisoned after a failed append could not be rolled back",
+            ));
+        }
+
         for record in records {
             if record.payload.len() > MAX_PAYLOAD_BYTES as usize {
                 return Err(StorageError::Unsupported(
@@ -255,7 +266,23 @@ impl SegmentWriter {
         }
 
         // One syscall for the whole batch.
-        self.file.write_all(&self.staging)?;
+        //
+        // A failure here can still have written some of the buffer: `write_all`
+        // loops over partial writes, so an error means "some prefix landed",
+        // not "nothing happened". Left alone, those bytes sit past the last
+        // record this writer knows about, the file cursor points past them, and
+        // the next append lands after the debris - turning a failed write into
+        // interior corruption that recovery must refuse to start on, or into a
+        // duplicate if the caller retries.
+        //
+        // So a failed append rewinds the file to the last good byte. If the
+        // rewind itself fails there is no way to restore the invariant, and the
+        // writer refuses further appends rather than building on a file whose
+        // shape it no longer knows.
+        if let Err(err) = self.file.write_all(&self.staging) {
+            self.rewind_after_failed_write()?;
+            return Err(StorageError::Io(err));
+        }
 
         self.size_bytes = position;
         self.next_offset = offset;
@@ -290,6 +317,29 @@ impl SegmentWriter {
         metrics::histogram!(metrics_names::SYNC_DURATION_SECONDS)
             .record(started.elapsed().as_secs_f64());
         Ok(())
+    }
+
+    /// Restore the file to the last byte this writer accounts for.
+    ///
+    /// Called only after a failed append, so that a partial write leaves no
+    /// trace and the segment stays exactly as it was before the attempt.
+    fn rewind_after_failed_write(&mut self) -> Result<()> {
+        let valid = self.size_bytes;
+        let restore = self
+            .file
+            .set_len(valid)
+            .and_then(|()| self.file.seek(SeekFrom::Start(valid)).map(|_| ()));
+        match restore {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                // The segment's on-disk shape no longer matches this writer's
+                // idea of it, and nothing here can reconcile them.
+                self.poisoned = true;
+                Err(StorageError::Io(std::io::Error::other(format!(
+                    "append failed and the segment could not be rewound to {valid}: {err}"
+                ))))
+            }
+        }
     }
 
     /// Record that everything up to `bytes` is now durable.
@@ -344,6 +394,7 @@ mod tests {
             "t/ns/s/0",
             4096,
             ScanStart::Full,
+            true,
         )
         .expect("scan")
     }
@@ -571,6 +622,71 @@ mod tests {
     }
 
     #[test]
+    fn a_partially_written_batch_is_rewound_and_leaves_no_debris() {
+        use std::io::{Seek as _, SeekFrom as _SeekFrom, Write as _};
+
+        let dir = tempdir().expect("dir");
+        let mut writer = new_writer(&dir, 0);
+        writer.append(&[record("first")]).expect("append");
+        let good_len = writer.size_bytes();
+
+        // Stand in for a `write_all` that failed part-way: bytes on disk past
+        // the last byte the writer accounts for. This is what the OS can leave
+        // behind on ENOSPC or EIO mid-batch.
+        {
+            let path = dir.path().join(segment_file_name(0));
+            let mut handle = OpenOptions::new().write(true).open(&path).expect("open");
+            handle.seek(_SeekFrom::End(0)).expect("seek");
+            handle.write_all(&[0xAB; 11]).expect("write debris");
+            handle.sync_all().expect("sync");
+        }
+        assert_eq!(
+            std::fs::metadata(dir.path().join(segment_file_name(0)))
+                .expect("meta")
+                .len(),
+            good_len + 11
+        );
+
+        writer.rewind_after_failed_write().expect("rewind");
+
+        // The debris is gone and the file matches the writer's own accounting.
+        assert_eq!(
+            std::fs::metadata(dir.path().join(segment_file_name(0)))
+                .expect("meta")
+                .len(),
+            good_len
+        );
+
+        // And the segment keeps working: the next append lands contiguously
+        // rather than after a hole, so a scan stays clean.
+        writer
+            .append(&[record("second")])
+            .expect("append after rewind");
+        writer.sync().expect("sync");
+        let outcome = scan(&dir);
+        assert_eq!(outcome.record_count, 2);
+        assert!(
+            outcome.torn_tail.is_none(),
+            "rewound segment should scan clean, got {:?}",
+            outcome.torn_tail
+        );
+    }
+
+    #[test]
+    fn a_poisoned_writer_refuses_further_appends() {
+        let dir = tempdir().expect("dir");
+        let mut writer = new_writer(&dir, 0);
+        writer.append(&[record("a")]).expect("append");
+        // A rewind that cannot be performed leaves the segment's real length
+        // unknown; building on it would compound the damage.
+        writer.poisoned = true;
+        assert!(matches!(
+            writer.append(&[record("b")]).expect_err("poisoned"),
+            StorageError::Unsupported(_)
+        ));
+    }
+
+    #[test]
     fn seal_trims_preallocated_space() {
         let dir = tempdir().expect("dir");
         // Reserve far more than the records need.
@@ -614,6 +730,7 @@ mod tests {
             "t/ns/s/0",
             64,
             ScanStart::Full,
+            true,
         )
         .expect("scan")
         .index;

--- a/crates/felix-storage/tests/format_fuzz.rs
+++ b/crates/felix-storage/tests/format_fuzz.rs
@@ -189,7 +189,7 @@ fn truncating_a_segment_anywhere_never_panics_and_never_invents_records() {
     let mut previous_count = None;
     for cut in (SEGMENT_HEADER_LEN as usize)..full.len() {
         std::fs::write(&path, &full[..cut]).expect("write");
-        let outcome = scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full)
+        let outcome = scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full, true)
             .unwrap_or_else(|err| panic!("cut at {cut}: {err}"));
 
         // Truncation can only ever remove records, never add them, and the
@@ -223,7 +223,7 @@ fn corrupting_committed_bytes_is_reported_rather_than_dropped() {
         bytes[position] ^= 1u8 << rng.below(8);
         std::fs::write(&path, &bytes).expect("write");
 
-        match scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full) {
+        match scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full, true) {
             // Loud failure is the correct outcome for interior damage.
             Err(StorageError::Corruption(detail)) => {
                 assert!(detail.site.position.is_some());
@@ -264,7 +264,7 @@ fn arbitrary_files_are_rejected_without_panicking() {
         let bytes = rng.bytes_below(256);
         std::fs::write(&path, &bytes).expect("write");
         // Garbage must be an error, never a panic and never a plausible log.
-        match scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full) {
+        match scan_segment(&path, 0, "fuzz/shard/0", 128, ScanStart::Full, true) {
             Ok(outcome) => assert_eq!(outcome.record_count, 0),
             Err(StorageError::Corruption(_)) | Err(StorageError::Io(_)) => {}
             Err(other) => panic!("unexpected error kind: {other}"),

--- a/docs-site/src/content/docs/architecture/durable-storage.md
+++ b/docs-site/src/content/docs/architecture/durable-storage.md
@@ -20,6 +20,11 @@ in-memory only, and a stream the control plane marks durable is *rejected at
 registration* rather than silently downgraded to a guarantee the broker cannot
 keep.
 
+Durability is immutable while a stream is registered. Remove and recreate a
+stream to change it between ephemeral and durable; this explicitly invalidates
+old handles and prevents durable offsets from diverging from existing in-memory
+cursors.
+
 ## Ordering: append, then fanout, then ack
 
 ```mermaid
@@ -202,6 +207,7 @@ optimisation are in
 | `FELIX_DURABLE_MAX_RECORDS_PER_READ` | `10000` | Record cap on one range read |
 | `FELIX_DURABLE_PREALLOCATE` | `true` | Reserve segment blocks at creation |
 | `FELIX_DURABLE_VERIFY_ALL_ON_OPEN` | `false` | Checksum every segment at startup |
+| `FELIX_DURABLE_REPAIR_CHECKSUM_TAIL` | `false` | Truncate a complete trailing record that fails its checksum (see below) |
 
 Invalid combinations fail at startup, not at the first publish.
 

--- a/docs-site/src/content/docs/architecture/semantics.md
+++ b/docs-site/src/content/docs/architecture/semantics.md
@@ -35,7 +35,9 @@ Messages can be lost when:
 - Subscriber falls behind buffer capacity
 - Network partition between broker and subscriber
 - Subscriber disconnects without draining buffer
-- Broker restarts (no durability in MVP)
+- Broker restarts — for **ephemeral** streams. A stream registered with
+  `durable: true` persists each record before acknowledging it, and replays it
+  after a restart; see [Durable Storage](/felix/architecture/durable-storage/).
 :::
 **Example at-most-once workload**:
 

--- a/docs-site/src/content/docs/architecture/system-design.md
+++ b/docs-site/src/content/docs/architecture/system-design.md
@@ -240,7 +240,11 @@ sequenceDiagram
 
 ## Storage Architecture
 
-### Ephemeral (Current MVP)
+Storage is selected per stream. A stream registered with `durable: false` — the
+default — behaves exactly as it always has; `durable: true` writes every publish
+to disk before it is fanned out or acknowledged.
+
+### Ephemeral (default)
 
 - **In-memory only:** No disk writes on hot path
 - **Bounded buffers:** Ring buffers with fixed capacity
@@ -254,18 +258,26 @@ sequenceDiagram
 - Temporary caching
 - Non-critical event streams
 
-### Durable (Planned)
+### Durable (`durable: true`)
 
-- **Write-Ahead Log (WAL):** Append-only log segments
-- **Segmented storage:** Rotate segments based on time/size
-- **Retention policies:** Time-based and size-based limits
-- **Snapshots:** Periodic state snapshots for faster recovery
+- **Segmented append-only log:** versioned, checksummed segments per stream
+  shard, with sparse offset indexes. Not write-ahead logging — the log *is* the
+  data, not a journal protecting another structure.
+- **Configurable fsync:** `none`, `periodic { interval }`, or `on_commit`, which
+  acknowledges only after the record is on the device
+- **Crash recovery:** a provably incomplete tail is repaired; anything else
+  fails startup loudly rather than discarding acknowledged records
+- **Historical replay:** paged reads from disk by offset
+
+Not yet implemented: **retention policies**, **snapshots/compaction**, and
+**tiered storage**. Nothing currently deletes segments on age or size.
+
+See [Durable Storage](/felix/architecture/durable-storage/).
 
 **Use cases:**
 
 - Production event streaming
 - Critical message delivery
-- Long-term event retention
 - Replay and audit trails
 
 ## Consistency Model
@@ -273,8 +285,11 @@ sequenceDiagram
 ### Single-Node (MVP)
 
 - **Delivery:** At-most-once (best-effort)
-- **Ordering:** Per-stream ordering preserved per subscriber
-- **Durability:** None (ephemeral only)
+- **Ordering:** Per-stream ordering preserved per subscriber. For a durable
+  stream, the order on disk is authoritative and cursor replay and live
+  delivery both follow it.
+- **Durability:** Per stream. Ephemeral by default; `durable: true` persists
+  every publish before acknowledging it.
 
 ### Multi-Node (Planned)
 

--- a/docs-site/src/content/docs/features/performance.md
+++ b/docs-site/src/content/docs/features/performance.md
@@ -589,8 +589,13 @@ QUIC benefits from:
 
 ### Disk
 
-- **MVP**: Not used (ephemeral only)
-- **Future (durable mode)**: NVMe SSD for WAL and segments
+- **Ephemeral streams**: not used at all — no disk I/O on the hot path
+- **Durable streams**: NVMe SSD strongly recommended. Under `fsync_mode =
+  on_commit` each commit costs one device flush (~4ms on a typical NVMe), which
+  group commit amortises across concurrent publishers; under `periodic` the
+  flush is off the append path entirely. Measured figures and a regression
+  budget are in
+  [storage-performance.md](https://github.com/gabloe/felix/blob/main/docs/storage-performance.md).
 
 ## Best Practices Summary
 

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -162,11 +162,19 @@ for behavior at thousands of subscribers or across a network.
 - **At-most-once.** No redelivery, no publisher-visible confirmation that a
   subscriber received anything.
 - **Per-stream ordering** preserved for a given subscriber. No ordering across streams.
-- **Tail-only subscriptions.** A subscriber receives events published after it
-  subscribes. There is no offset, cursor, or replay parameter on `Subscribe`.
+- **Tail-only subscriptions over the wire.** A subscriber receives events
+  published after it subscribes; `Subscribe` still carries no offset or replay
+  parameter. Cursor replay and paged historical reads exist on the in-process
+  broker API for durable streams, but are not yet exposed through the wire
+  protocol.
 - **Slow subscribers drop** under the default policy, and lag is surfaced to the
   subscriber. Publishers never block on subscriber speed.
-- **In-memory only.** Nothing survives broker restart.
+- **Ephemeral by default.** Nothing survives a broker restart unless the stream
+  was registered with `durable: true`, which persists each record before
+  acknowledging it and replays it afterwards. Durable storage is opt-in per
+  stream and off unless the broker is started with `FELIX_DURABLE_STORAGE_DIR`.
+  Retention and tiering are not implemented, so a durable stream grows without
+  bound today.
 
 ---
 

--- a/docs-site/src/content/docs/reference/faq.md
+++ b/docs-site/src/content/docs/reference/faq.md
@@ -154,14 +154,22 @@ When backpressure triggers:
 - Data lost on broker restart
 - Suitable for real-time data, metrics, logs
 
-**Durable streams** (planned):
-- WAL + segmented log on persistent storage
-- Survive restarts
-- Replay capability
-- Higher latency (disk writes)
+**Durable streams** (`durable: true`):
+- Segmented, checksummed append-only log on persistent storage
+- Survive restarts, including an abrupt kill
+- Replay from disk by offset
+- Higher latency when `fsync_mode` is `on_commit` (one device flush per commit,
+  amortised across concurrent publishers by group commit); effectively free
+  under `periodic`
 - Suitable for business events, audit logs
 
-Currently, Felix MVP supports **ephemeral only**. Durability is planned.
+Both are available today. Durable storage is opt-in per stream and requires the
+broker to be started with `FELIX_DURABLE_STORAGE_DIR`; without it, a stream
+marked durable is rejected rather than silently downgraded.
+
+Retention and tiered storage are **not** implemented yet: nothing deletes
+segments on age or size. See
+[Durable Storage](/felix/architecture/durable-storage/).
 
 ### How does clustering work?
 

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -116,6 +116,22 @@ sequenceDiagram
     B-->>C: ack
 ```
 
+### One order, not three
+
+Offsets are assigned under the segment lock, but the fsync wait happens after it
+is released — so two concurrent publishes can resume from a shared group-commit
+flush in either order. Left alone, the log on disk could read `A, B` while a
+cursor replay and a live subscriber both saw `B, A`.
+
+A per-stream commit sequencer closes that gap. After its durable append, each
+publisher waits until every lower offset has been applied, then appends to the
+replay ring and fans out before releasing the next in line. Disk order is the
+single source of truth for cursor order and delivery order alike.
+
+This deliberately does not serialise the durable append: offsets are still
+assigned concurrently and flushes are still shared, so group commit keeps its
+fan-in. Only the cheap post-flush half is ordered.
+
 The append happens **before** fanout and **before** the acknowledgement. The
 alternative is unrecoverable: a record delivered to subscribers and acknowledged
 to the publisher but lost in a crash is a silent hole in a log that consumers
@@ -260,9 +276,18 @@ flowchart TD
 
 Four properties:
 
-1. **A torn tail is repaired.** A crash mid-append leaves a partial record at the
-   end of the newest segment. It was never acknowledged under any policy, so it
-   is truncated away.
+1. **A provably incomplete tail is repaired.** A crash mid-append leaves a
+   partial record at the end of the newest segment — one cut short by end of
+   file, or claiming a length that could not fit. Nothing could have
+   acknowledged a record that was never finished, so it is truncated away.
+
+   A *complete* trailing record that fails its checksum is a different case and
+   is **not** repaired by default. A torn write and bit rot on an already
+   acknowledged record produce identical bytes, and under `OnCommit` that record
+   may have been fsynced and acknowledged before rotting. Recovery refuses to
+   guess: it fails to start, naming the segment and position.
+   `repair_checksum_tail` opts in to truncating it, which is defensible under
+   `FsyncMode::None` and is not under `OnCommit`.
 2. **Committed data is never silently discarded.** Corruption anywhere else is a
    startup error naming the shard, segment and byte position. Refusing to start
    is better than losing acknowledged records quietly.
@@ -295,6 +320,11 @@ in-memory only, and a stream the control plane marks `durable: true` is **reject
 at registration** rather than silently downgraded to a guarantee the broker
 cannot keep.
 
+Durability is immutable while a stream is registered. Remove and recreate a
+stream to change it between ephemeral and durable; this explicitly invalidates
+old handles and prevents durable offsets from diverging from existing in-memory
+cursors.
+
 | Variable | Default | Meaning |
 | --- | --- | --- |
 | `FELIX_DURABLE_STORAGE_DIR` | unset | Root directory; setting it enables durable streams |
@@ -305,6 +335,7 @@ cannot keep.
 | `FELIX_DURABLE_MAX_RECORDS_PER_READ` | `10000` | Record cap on one range read |
 | `FELIX_DURABLE_PREALLOCATE` | `true` | Reserve segment blocks at creation |
 | `FELIX_DURABLE_VERIFY_ALL_ON_OPEN` | `false` | Checksum every segment at startup |
+| `FELIX_DURABLE_REPAIR_CHECKSUM_TAIL` | `false` | Truncate a complete trailing record that fails its checksum (see below) |
 
 Invalid combinations fail at startup, not at the first publish.
 

--- a/services/broker/src/config.rs
+++ b/services/broker/src/config.rs
@@ -94,6 +94,51 @@ pub struct BrokerConfig {
     pub sub_stream_mode: SubStreamMode,
 }
 
+impl Default for BrokerConfig {
+    fn default() -> Self {
+        Self {
+            quic_bind: SocketAddr::from(([0, 0, 0, 0], 5000)),
+            metrics_bind: SocketAddr::from(([0, 0, 0, 0], 8080)),
+            controlplane_url: None,
+            controlplane_sync_interval_ms: 2000,
+            ack_on_commit: false,
+            max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+            publish_queue_wait_timeout_ms: DEFAULT_PUBLISH_QUEUE_WAIT_TIMEOUT_MS,
+            ack_wait_timeout_ms: DEFAULT_ACK_WAIT_TIMEOUT_MS,
+            disable_timings: DEFAULT_DISABLE_TIMINGS,
+            control_stream_drain_timeout_ms: DEFAULT_CONTROL_STREAM_DRAIN_TIMEOUT_MS,
+            shutdown_drain_timeout_ms: DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS,
+            cache_conn_recv_window: DEFAULT_CACHE_CONN_RECV_WINDOW,
+            cache_stream_recv_window: DEFAULT_CACHE_STREAM_RECV_WINDOW,
+            cache_send_window: DEFAULT_CACHE_SEND_WINDOW,
+            event_batch_max_events: 64,
+            event_batch_max_bytes: 64 * 1024,
+            event_batch_max_delay_us: DEFAULT_EVENT_BATCH_MAX_DELAY_US,
+            fanout_batch_size: 64,
+            pub_workers_per_conn: DEFAULT_PUB_WORKERS_PER_CONN,
+            pub_queue_depth: DEFAULT_PUB_QUEUE_DEPTH,
+            pub_inflight_bytes: DEFAULT_PUB_INFLIGHT_BYTES,
+            pub_conn_inflight_bytes: DEFAULT_PUB_CONN_INFLIGHT_BYTES,
+            pub_ingress_wait: false,
+            core_shards: 0,
+            subscriber_queue_capacity: DEFAULT_SUBSCRIBER_QUEUE_CAPACITY,
+            max_subscriptions_per_conn: DEFAULT_MAX_SUBSCRIPTIONS_PER_CONN,
+            subscriber_queue_policy: DEFAULT_SUBSCRIBER_QUEUE_POLICY,
+            subscriber_writer_lanes: DEFAULT_SUBSCRIBER_WRITER_LANES,
+            subscriber_lane_queue_depth: DEFAULT_SUBSCRIBER_LANE_QUEUE_DEPTH,
+            subscriber_lane_queue_policy: DEFAULT_SUBSCRIBER_LANE_QUEUE_POLICY,
+            max_subscriber_writer_lanes: DEFAULT_MAX_SUBSCRIBER_WRITER_LANES,
+            subscriber_lane_shard: DEFAULT_SUBSCRIBER_LANE_SHARD,
+            subscriber_single_writer_per_conn: false,
+            subscriber_flush_max_items: DEFAULT_SUBSCRIBER_FLUSH_MAX_ITEMS,
+            subscriber_flush_max_delay_us: DEFAULT_SUBSCRIBER_FLUSH_MAX_DELAY_US,
+            subscriber_max_bytes_per_write: DEFAULT_SUBSCRIBER_MAX_BYTES_PER_WRITE,
+            sub_streams_per_conn: DEFAULT_SUB_STREAMS_PER_CONN,
+            sub_stream_mode: DEFAULT_SUB_STREAM_MODE,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum SubscriberLaneShard {

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -677,26 +677,40 @@ async fn apply_stream_upsert(
 
     match outcome {
         Ok(_) => Ok(()),
-        // A durable stream this broker cannot persist — typically because it is
-        // running without `FELIX_DURABLE_STORAGE_DIR` — is skipped loudly rather
-        // than failing the sync. Aborting here would stop the watcher from
-        // applying *every other* stream in the catalog, turning one
+        // A broker with no durable storage configured cannot host this stream,
+        // and never will until it is restarted with different configuration.
+        // Skipping it loudly beats failing the sync, which would stop the
+        // watcher applying *every other* stream in the catalog and turn one
         // misconfigured stream into a broker-wide outage.
         //
         // The stream stays unregistered, so publishes to it fail with
-        // `StreamNotFound`. That is the point: no false durability guarantee is
-        // ever offered, and the next sync retries in case an operator fixes the
-        // configuration.
-        Err(BrokerError::Storage(detail)) => {
+        // `StreamNotFound`: no false durability guarantee is ever offered.
+        Err(BrokerError::DurableStorageNotConfigured { .. }) => {
             tracing::error!(
                 tenant_id = %tenant_id,
                 namespace = %namespace,
                 stream = %stream,
-                error = %detail,
-                "skipping stream: durable storage is unavailable"
+                "skipping stream: this broker has no durable storage configured"
             );
             metrics::counter!("felix_broker_durable_stream_skipped_total").increment(1);
             Ok(())
+        }
+        // A storage *failure* is the opposite case and must not be skipped.
+        // Corruption or an I/O error means the log is in an unknown state;
+        // swallowing it here would advance the control-plane cursor, leave the
+        // stream permanently absent, and keep the broker reporting ready while
+        // a durable stream silently does not exist. Fail the sync so the error
+        // is visible and the cursor does not move past it.
+        Err(err @ BrokerError::Storage(_)) => {
+            tracing::error!(
+                tenant_id = %tenant_id,
+                namespace = %namespace,
+                stream = %stream,
+                error = %err,
+                "durable storage failed while registering a stream"
+            );
+            metrics::counter!("felix_broker_durable_stream_failed_total").increment(1);
+            Err(err.into())
         }
         Err(err) => Err(err.into()),
     }
@@ -1425,6 +1439,111 @@ mod tests {
         )
         .await?;
         assert!(broker.stream_exists("t1", "ns1", "orders").await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_stream_upsert_propagates_storage_failures() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = felix_broker::DurableStorage::open(
+            dir.path(),
+            felix_storage::log::LogConfig {
+                fsync_mode: felix_storage::log::FsyncMode::None,
+                preallocate_segments: false,
+                ..Default::default()
+            },
+        )
+        .expect("storage");
+        let broker =
+            Arc::new(Broker::new(EphemeralCache::new().into()).with_durable_storage(storage));
+
+        // Corrupt the shard directory so opening the log fails. A file where
+        // the segment directory belongs is the simplest way to make recovery
+        // return an I/O error rather than a clean empty log.
+        let shard_dir = felix_storage::disk_log::layout::shard_dir(
+            dir.path(),
+            &felix_storage::log::ShardKey {
+                tenant: "t1".into(),
+                namespace: "ns1".into(),
+                stream: "orders".into(),
+                shard: 0,
+            },
+        );
+        std::fs::write(&shard_dir, b"not a directory").expect("block the shard dir");
+
+        let err = apply_stream_upsert(
+            &broker,
+            "t1".to_string(),
+            "ns1".to_string(),
+            "orders".to_string(),
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await
+        .expect_err("storage failure must not be skipped");
+
+        // The sync fails rather than advancing its cursor past a durable stream
+        // it could not create. Skipping here would leave the broker ready with
+        // the stream permanently missing.
+        assert!(err.to_string().contains("durable storage error"), "{err}");
+        assert!(!broker.stream_exists("t1", "ns1", "orders").await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn apply_stream_upsert_rejects_live_durability_changes() -> Result<()> {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = felix_broker::DurableStorage::open(
+            dir.path(),
+            felix_storage::log::LogConfig {
+                fsync_mode: felix_storage::log::FsyncMode::None,
+                preallocate_segments: false,
+                ..Default::default()
+            },
+        )
+        .expect("storage");
+        let broker =
+            Arc::new(Broker::new(EphemeralCache::new().into()).with_durable_storage(storage));
+
+        apply_stream_upsert(
+            &broker,
+            "t1".to_string(),
+            "ns1".to_string(),
+            "orders".to_string(),
+            StreamMetadata {
+                durable: false,
+                shards: 1,
+            },
+        )
+        .await?;
+        let err = apply_stream_upsert(
+            &broker,
+            "t1".to_string(),
+            "ns1".to_string(),
+            "orders".to_string(),
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await
+        .expect_err("live durability change");
+
+        assert!(
+            err.to_string().contains("requires removal and recreation"),
+            "{err}"
+        );
+        assert!(broker.stream_exists("t1", "ns1", "orders").await);
+        assert_eq!(
+            std::fs::read_dir(dir.path())
+                .expect("read storage root")
+                .filter_map(|entry| entry.ok())
+                .count(),
+            0,
+            "a rejected control-plane update must not create durable state"
+        );
         Ok(())
     }
 

--- a/services/broker/src/durable_config.rs
+++ b/services/broker/src/durable_config.rs
@@ -46,6 +46,8 @@ impl DurableStorageConfig {
                 .unwrap_or(LogConfig::default().preallocate_segments),
             verify_all_on_open: parse_bool_env("FELIX_DURABLE_VERIFY_ALL_ON_OPEN")?
                 .unwrap_or(LogConfig::default().verify_all_on_open),
+            repair_checksum_tail: parse_bool_env("FELIX_DURABLE_REPAIR_CHECKSUM_TAIL")?
+                .unwrap_or(LogConfig::default().repair_checksum_tail),
         };
         // Fail at startup rather than at the first durable publish.
         log.validate()
@@ -146,6 +148,7 @@ mod tests {
         "FELIX_DURABLE_MAX_RECORDS_PER_READ",
         "FELIX_DURABLE_PREALLOCATE",
         "FELIX_DURABLE_VERIFY_ALL_ON_OPEN",
+        "FELIX_DURABLE_REPAIR_CHECKSUM_TAIL",
     ];
 
     fn with_env<T>(pairs: &[(&str, &str)], body: impl FnOnce() -> T) -> T {

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -425,10 +425,12 @@ mod tests {
             .register_stream("t1", "default", "demo", Default::default())
             .await?;
 
-        let mut config = BrokerConfig::from_env()?;
-        config.pub_workers_per_conn = 0;
-        config.pub_queue_depth = 0;
-        config.publish_queue_wait_timeout_ms = 17;
+        let config = BrokerConfig {
+            pub_workers_per_conn: 0,
+            pub_queue_depth: 0,
+            publish_queue_wait_timeout_ms: 17,
+            ..BrokerConfig::default()
+        };
         let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
         assert_eq!(publish_ctx.worker_count, 1);
         assert_eq!(publish_ctx.workers.len(), 1);
@@ -457,7 +459,7 @@ mod tests {
         let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
         broker.register_tenant("t1").await?;
         broker.register_namespace("t1", "default").await?;
-        let config = BrokerConfig::from_env()?;
+        let config = BrokerConfig::default();
         let publish_ctx = build_publish_context(broker, &config);
 
         let (response_tx, response_rx) = oneshot::channel();
@@ -488,7 +490,7 @@ mod tests {
         broker.register_tenant("t1").await?;
         broker.register_namespace("t1", "default").await?;
 
-        let config = BrokerConfig::from_env()?;
+        let config = BrokerConfig::default();
         let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
         let auth = Arc::new(BrokerAuth::new("http://127.0.0.1".to_string()));
 

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -13,7 +13,7 @@ use tokio::sync::{mpsc, watch};
 // These publish-path tests don't exercise subscription delivery; this just gives
 // `PublishContext::lane_manager` a real (if unused) instance to satisfy the type.
 fn test_lane_manager() -> Arc<WriterLaneManager> {
-    WriterLaneManager::new(&crate::config::BrokerConfig::from_env().expect("test config"))
+    WriterLaneManager::new(&crate::config::BrokerConfig::default())
 }
 
 fn reset_global_ack_depth() {

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -184,7 +184,7 @@ async fn cache_put_get_round_trip() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -289,7 +289,7 @@ async fn publish_rejects_unknown_stream() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -394,8 +394,10 @@ async fn publish_ack_on_commit_smoke() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let mut config = BrokerConfig::from_env()?;
-    config.ack_on_commit = true;
+    let config = BrokerConfig {
+        ack_on_commit: true,
+        ..BrokerConfig::default()
+    };
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -462,7 +464,7 @@ async fn publish_sharding_preserves_stream_order() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let server_task = tokio::spawn(crate::transport::quic::serve(
         Arc::clone(&server),
         Arc::clone(&broker),
@@ -553,7 +555,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
         admission: Arc::new(PublishAdmission::unlimited()),
         conn_admission: Arc::new(PublishAdmission::unlimited()),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
-        lane_manager: WriterLaneManager::new(&BrokerConfig::from_env().expect("test config")),
+        lane_manager: WriterLaneManager::new(&BrokerConfig::default()),
         ingress_wait: false,
     }
 }
@@ -727,7 +729,7 @@ async fn control_loop_handles_publish_and_cache_requests() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -762,7 +764,7 @@ async fn control_loop_rejects_second_auth() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -792,7 +794,7 @@ async fn control_loop_rejects_auth_failed() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -819,7 +821,7 @@ async fn control_loop_rejects_binary_publish_batch_without_auth() -> Result<()> 
         Arc::clone(&broker),
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -854,7 +856,7 @@ async fn control_loop_rejects_publish_batch_forbidden() -> Result<()> {
         Arc::clone(&broker),
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -881,7 +883,7 @@ async fn control_loop_publish_without_auth_sends_error() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -911,7 +913,7 @@ async fn control_loop_publish_forbidden_without_request_id_sends_error() -> Resu
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -941,7 +943,7 @@ async fn control_loop_publish_tenant_mismatch_sends_error() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -969,7 +971,7 @@ async fn control_loop_subscribe_forbidden_sends_error() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -997,7 +999,7 @@ async fn control_loop_subscribe_returns_true() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(result);
@@ -1021,7 +1023,7 @@ async fn control_loop_subscribe_tenant_mismatch_sends_error() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -1052,7 +1054,7 @@ async fn control_loop_cache_put_forbidden_sends_error() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -1116,7 +1118,7 @@ async fn control_loop_cache_put_best_effort_closed_reports_error() -> Result<()>
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -1160,7 +1162,7 @@ async fn control_loop_cache_put_missing_scope_with_request_id_continues() -> Res
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(result);
@@ -1185,7 +1187,7 @@ async fn control_loop_rejects_subscribe_without_auth() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -1217,7 +1219,7 @@ async fn control_loop_cache_get_missing_scope_with_request_id_continues() -> Res
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(result);
@@ -1257,7 +1259,7 @@ async fn control_loop_cache_put_records_timing_and_ack() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(result);
@@ -1283,7 +1285,7 @@ async fn control_loop_cache_get_rejects_missing_auth() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -1314,7 +1316,7 @@ async fn control_loop_cache_put_rejects_tenant_mismatch() -> Result<()> {
         broker,
         Arc::clone(&auth.auth),
         frames,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
     )
     .await?;
     assert!(!result);
@@ -1376,7 +1378,7 @@ async fn control_loop_handles_binary_and_decode_error() -> Result<()> {
             &mut source,
             Arc::clone(&broker),
             connection,
-            BrokerConfig::from_env()?,
+            BrokerConfig::default(),
             Arc::clone(&auth.auth),
             publish_ctx,
             HashMap::new(),
@@ -1446,7 +1448,7 @@ async fn control_loop_handles_cancel_and_graceful_close() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -1510,7 +1512,7 @@ async fn control_loop_handles_cancel_toggle_and_continues() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -1592,7 +1594,7 @@ async fn control_loop_cache_put_best_effort_full_and_closed() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -1623,7 +1625,7 @@ async fn control_loop_cache_put_best_effort_full_and_closed() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         connection_clone,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::clone(&broker)).await,
         HashMap::new(),
@@ -1686,7 +1688,7 @@ async fn uni_loop_publish_and_errors() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         UniLoopArgs {
-            config: BrokerConfig::from_env()?,
+            config: BrokerConfig::default(),
             auth: Arc::clone(&auth.auth),
             publish_ctx,
             stream_cache: HashMap::new(),
@@ -1704,7 +1706,7 @@ async fn uni_loop_publish_and_errors() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         UniLoopArgs {
-            config: BrokerConfig::from_env()?,
+            config: BrokerConfig::default(),
             auth: Arc::clone(&auth.auth),
             publish_ctx: build_publish_context(Arc::clone(&broker)).await,
             stream_cache: HashMap::new(),
@@ -1723,7 +1725,7 @@ async fn uni_loop_publish_and_errors() -> Result<()> {
             &mut source,
             Arc::clone(&broker),
             UniLoopArgs {
-                config: BrokerConfig::from_env()?,
+                config: BrokerConfig::default(),
                 auth: Arc::clone(&auth.auth),
                 publish_ctx: build_publish_context(Arc::clone(&broker)).await,
                 stream_cache: HashMap::new(),
@@ -2033,7 +2035,7 @@ async fn handle_stream_drain_timeout_branch() -> Result<()> {
     let server_task = tokio::spawn(async move {
         let connection = server.accept().await?;
         let (send, recv) = connection.accept_bi().await?;
-        let config = BrokerConfig::from_env()?;
+        let config = BrokerConfig::default();
         let publish_ctx =
             build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await;
         handle_stream(
@@ -2078,7 +2080,7 @@ async fn control_stream_rejects_unexpected_message() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -2127,7 +2129,7 @@ async fn cache_put_unknown_cache_closes_stream() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -2195,7 +2197,7 @@ async fn cache_get_unknown_cache_closes_stream() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let max_frame_bytes = config.max_frame_bytes;
     let mut frame_scratch = BytesMut::with_capacity(max_frame_bytes.min(64 * 1024));
     let server_task = tokio::spawn(crate::transport::quic::serve(
@@ -2264,7 +2266,7 @@ async fn uni_stream_rejects_non_publish() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::from_env()?;
+    let config = BrokerConfig::default();
     let server_task = tokio::spawn(crate::transport::quic::serve(
         Arc::clone(&server),
         Arc::clone(&broker),
@@ -2835,7 +2837,7 @@ async fn control_loop_pre_canceled_exits() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -2901,7 +2903,7 @@ async fn control_loop_cancel_changed_breaks() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -2969,7 +2971,7 @@ async fn control_loop_cancel_changed_continues() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -3038,7 +3040,7 @@ async fn control_loop_subscribe_done_true() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -3119,7 +3121,7 @@ async fn control_loop_cache_get_records_lookup_timing() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -3210,7 +3212,7 @@ async fn control_loop_cache_timings_recorded() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         publish_ctx,
         HashMap::new(),
@@ -3279,7 +3281,7 @@ async fn control_loop_cache_get_missing_no_request_id_returns_true() -> Result<(
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -3350,7 +3352,7 @@ async fn control_loop_cache_put_missing_no_request_id_returns_true() -> Result<(
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -3414,7 +3416,7 @@ async fn control_loop_error_message_returns_false() -> Result<()> {
         &mut source,
         broker,
         connection,
-        BrokerConfig::from_env()?,
+        BrokerConfig::default(),
         Arc::clone(&auth.auth),
         build_publish_context(Arc::new(Broker::new(EphemeralCache::new().into()))).await,
         HashMap::new(),
@@ -3457,7 +3459,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
         admission: Arc::new(PublishAdmission::unlimited()),
         conn_admission: Arc::new(PublishAdmission::unlimited()),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
-        lane_manager: WriterLaneManager::new(&BrokerConfig::from_env()?),
+        lane_manager: WriterLaneManager::new(&BrokerConfig::default()),
         ingress_wait: false,
     };
     let mut scratch = BytesMut::with_capacity(64 * 1024);
@@ -3471,7 +3473,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         UniLoopArgs {
-            config: BrokerConfig::from_env()?,
+            config: BrokerConfig::default(),
             auth: Arc::clone(&auth.auth),
             publish_ctx: publish_ctx.clone(),
             stream_cache: HashMap::new(),
@@ -3496,7 +3498,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         UniLoopArgs {
-            config: BrokerConfig::from_env()?,
+            config: BrokerConfig::default(),
             auth: Arc::clone(&auth.auth),
             publish_ctx: publish_ctx.clone(),
             stream_cache: HashMap::new(),
@@ -3521,7 +3523,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
         &mut source,
         Arc::clone(&broker),
         UniLoopArgs {
-            config: BrokerConfig::from_env()?,
+            config: BrokerConfig::default(),
             auth: Arc::clone(&auth.auth),
             publish_ctx,
             stream_cache: HashMap::new(),
@@ -3557,7 +3559,7 @@ async fn handle_uni_stream_smoke() -> Result<()> {
         let recv = connection.accept_uni().await?;
         handle_uni_stream(
             broker,
-            BrokerConfig::from_env()?,
+            BrokerConfig::default(),
             auth_for_server,
             publish_ctx,
             recv,
@@ -3632,13 +3634,15 @@ async fn handle_stream_drain_timeout_sleep_branch() -> Result<()> {
             admission: Arc::new(PublishAdmission::unlimited()),
             conn_admission: Arc::new(PublishAdmission::unlimited()),
             subscriptions: Arc::new(SubscriptionLimiter::new()),
-            lane_manager: WriterLaneManager::new(&BrokerConfig::from_env()?),
+            lane_manager: WriterLaneManager::new(&BrokerConfig::default()),
             ingress_wait: false,
         };
-        let mut config = BrokerConfig::from_env()?;
-        config.ack_on_commit = true;
-        config.ack_wait_timeout_ms = 1000;
-        config.control_stream_drain_timeout_ms = 1;
+        let config = BrokerConfig {
+            ack_on_commit: true,
+            ack_wait_timeout_ms: 1000,
+            control_stream_drain_timeout_ms: 1,
+            ..BrokerConfig::default()
+        };
         handle_stream(
             broker,
             connection,


### PR DESCRIPTION
Follow-up to #173, closing the correctness defects two reviews found in the durable log.

Every finding was verified against the code before being acted on — all seven were real, including one that was my own regression from #173.

## Blockers

| # | Defect | Fix |
|---|---|---|
| 1 | Truncation could invalidate `OnCommit` | Watermark reset now happens under the group-commit flush lock *(fixed by @gabloe)* |
| 2 | Durability changes applied to live streams | Reject; removal and recreation required *(fixed by @gabloe)* |
| 3 | Appends were not failure-atomic | Rewind to the last good byte; poison the writer if the rewind itself fails |
| 4 | Disk / cursor / delivery order could disagree | Per-stream commit sequencer |
| 5 | Recovery could silently delete acknowledged data | Strict by default; only provably incomplete writes are repaired |
| 6 | Recovery failures suppressed after readiness | Split "not configured" (skip) from "storage failed" (fail the sync) |
| 7 | Rollover fsync on a reactor worker | Rolls run on `spawn_blocking` |

### Blocker 4 — publish ordering

Offsets are assigned under the segment lock, but the fsync wait happens *after* it is released. Two concurrent publishes could resume from a shared group-commit flush in either order: disk reads `A, B` while a cursor replay and a live subscriber both see `B, A`. Under `OnCommit` that window is a whole device flush wide.

A per-stream commit sequencer closes it — each publisher waits until every lower offset has been applied, then appends to the replay ring and fans out before releasing the next. The turn is held **across fanout**, not just the ring append: a subscriber's delivery order is as much part of a stream's order as its cursors are. The durable append itself is deliberately *not* serialised, so group commit keeps its fan-in.

### Blocker 5 — a design disagreement I resolved in the reviewer's favour

#173 treated a *complete* trailing record failing its checksum as a repairable torn write. It isn't provably one: a torn write and bit rot on an already-acknowledged record produce identical bytes, and under `OnCommit` that record may have been fsynced and acknowledged before rotting. Truncating on a guess silently deletes data the caller was told was safe.

Now only provably incomplete writes are repaired — a record cut short by EOF, or claiming a length that cannot fit. `repair_checksum_tail` opts back in, which is defensible under `FsyncMode::None` and is not under `OnCommit`. **The SIGKILL crash tests still pass under the strict default**, which is the evidence that real crashes truncate rather than corrupt.

### Blocker 6 — my regression from #173

`storage_error` flattened every `StorageError` — including corruption and I/O — into one string, and the watcher skip I added then swallowed them all equally. A corrupt durable stream would be silently absent while the broker reported ready and the control-plane cursor advanced past it.

`DurableStorageNotConfigured` is now distinct from `Storage`. The first is a static misconfiguration affecting only the stream naming it, so the watcher skips it and keeps applying the rest of the catalog. The second means the log is in an unknown state, and now fails the sync.

## Durable replay after restart

The second review's main finding. Recovery resumed the sequence number but left the replay ring empty, so `oldest` became the recovered tail and every pre-restart cursor got `CursorTooOld` — with the records sitting on disk.

- The ring is now **hydrated from disk** at registration, bounded by its own capacity so startup cost does not grow with the log.
- **`Broker::read_durable`** pages history older than the ring. Deliberately separate from `subscribe_with_cursor`, which returns a backlog *and* a live subscription together and so cannot also stream unbounded history without buffering it all or leaving a hole at the seam.

## Performance

CI flagged **-12.4%** on `P8_hash fanout=10 batch=64` in #173. It does not reproduce locally:

| Measurement | Result |
|---|---|
| CI (4-vCPU shared runner, 5 trials) | -12.4%, p=0.0018 |
| Local, clean (10 trials) | **-1.9%, p=0.14** — below the 3% practical-effect threshold |

Supporting evidence: baseline-vs-baseline drift between two local runs was **+6.7% with no code change**, and a non-durable publish newly touches exactly one thing — a discriminant check on `stream_state.durable` that is always `None`. The CI signature was also odd: -12.4% throughput alongside +0.7%/+1.3% latencies at p≈0.74.

**Not fully ruled out.** A 16-core machine is not a 4-vCPU shared runner, and a contention-sensitive effect could appear there and not here. Worth watching whether it recurs rather than treating it as settled.

## Docs

Five pages still told readers nothing survives a restart — `system-design.md`, `faq.md`, `semantics.md`, `what-felix-is-for.md`, `performance.md`. Each now says durability is opt-in per stream *and* what is still missing: retention, snapshots and tiering are not implemented, so a durable stream grows without bound today.

## Verification

- **1,088 tests pass**; clippy, fmt, and Linux cross-check clean.
- Each of the 3 commits builds standalone (verified in a detached worktree).
- Also fixes 3 `-D warnings` clippy failures that would have broken CI.

## Reviewer notes

1. **The commit sequencer is new code carrying a correctness guarantee** and deserves the most attention. My own unit test caught a bug in it during development: the `Drop` path silently undid a truncation reset. Fixed with a generation counter.
2. **The blocker-4 integration test is a smoke test, not a regression test** — it passes with the sequencer removed, because the reordering window needs a scheduler interleaving that 32 publishers on a 4-worker runtime do not reliably produce. The deterministic proof is in `commit_order`'s unit tests. The replay test *is* a real regression test: verified failing with `CursorTooOld { oldest: 20, requested: 0 }`.
3. **Still not reachable over the wire.** `Subscribe` carries no offset and `Event` carries no offset, so no network client can resume or checkpoint. Durability is real at the storage layer and is not yet a durable-streaming product. Untracked by any roadmap issue — worth filing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
