### PR TITLE
M1: fix cancellation, startup and hydration defects; add record header checksum (format v2)

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -254,17 +254,29 @@ impl Broker {
             None => None,
             Some(durable) => {
                 let durable_start = t_now_if(sample);
-                let appended = durable.append(payloads).await?;
+
+                // Offsets are consumed here. The commit order has to be claimed
+                // against them immediately, before the durability wait, because
+                // from this point the records exist on disk and everything
+                // behind them queues on this range. Claiming it only after a
+                // *successful* wait stranded the stream: a failed or cancelled
+                // publish abandoned its range, and every later publish waited
+                // on a turn that could never arrive.
+                let pending = durable.begin_append(payloads).await?;
+                let turn = stream_state
+                    .commit_sequencer
+                    .reserve(pending.first_offset(), pending.last_offset() + 1);
+
+                // From here every exit path — `?`, a panic, or this future being
+                // dropped mid-await — releases the range through `turn`.
+                durable.commit(&pending).await?;
+                turn.wait().await;
+
                 if let Some(start) = durable_start {
                     let durable_ns = start.elapsed().as_nanos() as u64;
                     t_histogram!("broker_publish_durable_append_ns").record(durable_ns as f64);
                 }
-                Some(
-                    stream_state
-                        .commit_sequencer
-                        .turn(appended.first_offset, appended.last_offset + 1)
-                        .await,
-                )
+                Some(turn)
             }
         };
 

--- a/crates/felix-broker/src/commit_order.rs
+++ b/crates/felix-broker/src/commit_order.rs
@@ -85,47 +85,61 @@ impl CommitSequencer {
         self.state.lock().next
     }
 
-    /// Wait until `first_offset` is next, then hold the turn until the returned
-    /// guard is dropped.
+    /// Claim the offset range `[first_offset, next_offset)` in the commit order.
     ///
-    /// The guard releases the turn on drop, so an error or an early return in
-    /// the caller cannot strand the stream: every publisher behind this one
-    /// would otherwise wait forever.
-    pub(crate) async fn turn(&self, first_offset: Offset, next_offset: Offset) -> CommitTurn<'_> {
-        loop {
-            // Register interest *before* testing, or a release landing between
-            // the test and the await would be missed and this publisher would
-            // sleep until the next unrelated publish woke it.
-            let notified = self.ready.notified();
-            tokio::pin!(notified);
-            notified.as_mut().enable();
-
-            let generation = {
-                let state = *self.state.lock();
-                if state.next >= first_offset {
-                    Some(state.generation)
-                } else {
-                    None
-                }
-            };
-            if let Some(generation) = generation {
-                return CommitTurn {
-                    sequencer: self,
-                    next_offset,
-                    generation,
-                };
-            }
-            notified.await;
+    /// Returns immediately and does **not** wait for a turn — call
+    /// [`CommitTurn::wait`] for that. The split matters: the guard must be
+    /// created the moment offsets are consumed, because from then on the range
+    /// exists on disk and every later offset is queued behind it. If the caller
+    /// then fails, or its future is cancelled part-way through the durability
+    /// wait, the guard's `Drop` still releases the range and the stream keeps
+    /// moving. Claiming the range only *after* a successful append is what
+    /// stranded the stream: an abandoned range never released, and every
+    /// subsequent publish waited on a turn that could not arrive.
+    pub(crate) fn reserve(&self, first_offset: Offset, next_offset: Offset) -> CommitTurn<'_> {
+        CommitTurn {
+            sequencer: self,
+            first_offset,
+            next_offset,
+            generation: self.state.lock().generation,
         }
     }
 }
 
-/// Holds a stream's commit turn. Releasing it lets the next offset proceed.
+/// A claim on one offset range. Releasing it lets the next range proceed.
 pub(crate) struct CommitTurn<'a> {
     sequencer: &'a CommitSequencer,
+    first_offset: Offset,
     next_offset: Offset,
-    /// Generation this turn was acquired in.
+    /// Generation this range was claimed in.
     generation: u64,
+}
+
+impl CommitTurn<'_> {
+    /// Wait until every lower offset has been released.
+    ///
+    /// Cancellation-safe: dropping the guard mid-wait releases this range too,
+    /// so a cancelled publisher cannot block the ones behind it.
+    pub(crate) async fn wait(&self) {
+        loop {
+            // Register interest *before* testing, or a release landing between
+            // the test and the await would be missed and this publisher would
+            // sleep until the next unrelated publish woke it.
+            let notified = self.sequencer.ready.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            {
+                let state = *self.sequencer.state.lock();
+                // A reset means the log was rewritten underneath this range, so
+                // there is nothing left to wait for.
+                if state.next >= self.first_offset || state.generation != self.generation {
+                    return;
+                }
+            }
+            notified.await;
+        }
+    }
 }
 
 impl Drop for CommitTurn<'_> {
@@ -153,7 +167,8 @@ mod tests {
     #[tokio::test]
     async fn the_first_offset_proceeds_immediately() {
         let sequencer = CommitSequencer::new(0);
-        let turn = sequencer.turn(0, 1).await;
+        let turn = sequencer.reserve(0, 1);
+        turn.wait().await;
         drop(turn);
         assert_eq!(sequencer.next_offset(), 1);
     }
@@ -166,7 +181,8 @@ mod tests {
         let waiter = {
             let sequencer = Arc::clone(&sequencer);
             tokio::spawn(async move {
-                let turn = sequencer.turn(5, 6).await;
+                let turn = sequencer.reserve(5, 6);
+                turn.wait().await;
                 drop(turn);
             })
         };
@@ -174,7 +190,10 @@ mod tests {
         assert!(!waiter.is_finished(), "offset 5 ran out of turn");
 
         // Releasing the intervening range lets it through.
-        drop(sequencer.turn(0, 5).await);
+        {
+            let turn = sequencer.reserve(0, 5);
+            turn.wait().await;
+        }
         tokio::time::timeout(Duration::from_secs(5), waiter)
             .await
             .expect("waiter should be released")
@@ -194,7 +213,8 @@ mod tests {
             let sequencer = Arc::clone(&sequencer);
             let observed = Arc::clone(&observed);
             tasks.push(tokio::spawn(async move {
-                let turn = sequencer.turn(offset, offset + 1).await;
+                let turn = sequencer.reserve(offset, offset + 1);
+                turn.wait().await;
                 observed.lock().push(offset);
                 drop(turn);
             }));
@@ -216,16 +236,64 @@ mod tests {
 
         // A publisher that takes its turn and then fails still releases it.
         let result: std::result::Result<(), ()> = async {
-            let _turn = sequencer.turn(0, 1).await;
+            let turn = sequencer.reserve(0, 1);
+            turn.wait().await;
             Err(())
         }
         .await;
         assert!(result.is_err());
 
         // The next publisher is not blocked by the failure.
-        tokio::time::timeout(Duration::from_secs(5), sequencer.turn(1, 2))
+        let next = sequencer.reserve(1, 2);
+        tokio::time::timeout(Duration::from_secs(5), next.wait())
             .await
             .expect("must not stall");
+    }
+
+    #[tokio::test]
+    async fn an_abandoned_range_releases_the_ranges_behind_it() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+
+        // A publisher claims offsets 0..3 and is then cancelled before it ever
+        // gets its turn — the shape of a client disconnecting during the fsync
+        // wait, after its records are already on disk holding those offsets.
+        {
+            let _abandoned = sequencer.reserve(0, 3);
+        }
+
+        // The next range must still be reachable. Before the claim moved to
+        // assignment time, an abandoned range released nothing and every later
+        // publish on the stream waited forever.
+        let next = sequencer.reserve(3, 4);
+        tokio::time::timeout(Duration::from_secs(5), next.wait())
+            .await
+            .expect("an abandoned range stranded the stream");
+        assert_eq!(sequencer.next_offset(), 3);
+    }
+
+    #[tokio::test]
+    async fn a_range_cancelled_mid_wait_releases_too() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+        let blocker = sequencer.reserve(0, 5);
+
+        // Waits for a turn that has not arrived, then is cancelled.
+        let waiter = {
+            let sequencer = Arc::clone(&sequencer);
+            tokio::spawn(async move {
+                let turn = sequencer.reserve(5, 9);
+                turn.wait().await;
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        waiter.abort();
+        let _ = waiter.await;
+        drop(blocker);
+
+        // The cancelled range released on drop, so the one behind it proceeds.
+        let after = sequencer.reserve(9, 10);
+        tokio::time::timeout(Duration::from_secs(5), after.wait())
+            .await
+            .expect("a cancelled waiter stranded the stream");
     }
 
     #[tokio::test]
@@ -236,7 +304,10 @@ mod tests {
         // an offset that no longer exists must be released rather than hang.
         let waiter = {
             let sequencer = Arc::clone(&sequencer);
-            tokio::spawn(async move { drop(sequencer.turn(20, 21).await) })
+            tokio::spawn(async move {
+                let turn = sequencer.reserve(20, 21);
+                turn.wait().await;
+            })
         };
         tokio::time::sleep(Duration::from_millis(20)).await;
         assert!(!waiter.is_finished());
@@ -251,7 +322,8 @@ mod tests {
     #[tokio::test]
     async fn a_stale_release_cannot_undo_a_reset() {
         let sequencer = CommitSequencer::new(100);
-        let turn = sequencer.turn(100, 101).await;
+        let turn = sequencer.reserve(100, 101);
+        turn.wait().await;
         // A truncation rewinds the log while the turn is held.
         sequencer.reset(5);
         drop(turn);

--- a/crates/felix-broker/src/durable.rs
+++ b/crates/felix-broker/src/durable.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use felix_storage::DiskLogProvider;
-use felix_storage::disk_log::DiskLog;
+use felix_storage::disk_log::{DiskLog, PendingAppend};
 use felix_storage::log::{
     AppendOnlyLog, AppendRecord, AppendResult, LogConfig, LogRecord, Offset, ReadRange, ShardKey,
 };
@@ -95,6 +95,40 @@ pub struct StreamLog {
 }
 
 impl StreamLog {
+    /// Write a publish batch and return its offsets *before* waiting for
+    /// durability.
+    ///
+    /// The caller must pair this with [`StreamLog::commit`]. The split exists
+    /// so the broker can claim the batch's place in the stream's commit order
+    /// the instant its offsets are consumed: from that point the records are on
+    /// disk holding those offsets, and every later publish queues behind them
+    /// whether this one goes on to succeed, fail, or be cancelled.
+    pub async fn begin_append(&self, payloads: &[Bytes]) -> Result<PendingAppend> {
+        if payloads.is_empty() {
+            return Err(BrokerError::Storage(
+                "cannot append an empty publish batch".to_string(),
+            ));
+        }
+        let timestamp_micros = now_micros();
+        let records: Vec<AppendRecord> = payloads
+            .iter()
+            .map(|payload| AppendRecord {
+                payload: payload.clone(),
+                timestamp_micros,
+            })
+            .collect();
+        self.log
+            .append_pending(&records)
+            .await
+            .map_err(storage_error)
+    }
+
+    /// Wait until a batch from [`StreamLog::begin_append`] satisfies the
+    /// configured fsync policy.
+    pub async fn commit(&self, pending: &PendingAppend) -> Result<()> {
+        self.log.commit(pending).await.map_err(storage_error)
+    }
+
     /// Persist a publish batch, returning the offsets it was assigned.
     ///
     /// Returns only once the configured durability policy is satisfied: under

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -55,50 +55,78 @@ impl Broker {
             return Err(Self::durability_change_error(&key, existing, &metadata));
         }
 
-        // Open durable storage before touching the registries: a stream that
-        // cannot be persisted must not become publishable, or the first publish
-        // would be acknowledged against a guarantee that does not exist.
-        let durable = self
-            .open_durable_log(&key.tenant_id, &key.namespace, &key.stream, &metadata)
-            .await?;
+        // Everything fallible happens before the stream is registered.
+        //
+        // Opening the log and refilling the replay ring both read from disk and
+        // both can fail. Registering first and hydrating after left a window
+        // where a durable stream was already publishable with an empty ring: a
+        // hydration failure meant the stream existed, accepted writes, and
+        // answered `CursorTooOld` for every pre-restart cursor, with nothing
+        // upstream aware that it was never initialised.
+        //
+        // The loop exists because the state has to be built without holding the
+        // registry locks — hydration awaits — so another registration can win
+        // the race in between. The retry then takes the fast path.
+        loop {
+            // Already live: nothing to build, just refresh the metadata.
+            if self.topics.read().await.contains_key(&key) {
+                let mut streams = self.streams.write().await;
+                if let Some(existing) = streams.get(&key)
+                    && existing.durable != metadata.durable
+                {
+                    return Err(Self::durability_change_error(&key, existing, &metadata));
+                }
+                streams.insert(key, metadata);
+                return Ok(());
+            }
 
-        // Keep the documented registry lock order. Recheck after acquiring the
-        // write lock so concurrent first registrations cannot race a durability
-        // transition past the fast-path check above.
-        let mut streams = self.streams.write().await;
-        if let Some(existing) = streams.get(&key)
-            && existing.durable != metadata.durable
-        {
-            return Err(Self::durability_change_error(&key, existing, &metadata));
-        }
-        let mut topics = self.topics.write().await;
-        let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
-        let state = topics
-            .entry(key.clone())
-            .or_insert_with(|| {
-                Arc::new(StreamState::new(
-                    handle_id,
-                    self.topic_capacity,
-                    self.subscriber_queue_policy,
-                    durable,
-                ))
-            })
-            .clone();
-        streams.insert(key, metadata);
-        drop(topics);
-        drop(streams);
+            let durable = self
+                .open_durable_log(&key.tenant_id, &key.namespace, &key.stream, &metadata)
+                .await?;
+            let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
+            let state = Arc::new(StreamState::new(
+                handle_id,
+                self.topic_capacity,
+                self.subscriber_queue_policy,
+                durable,
+            ));
+            self.hydrate_durable_stream(&state).await?;
 
-        // A durable stream that recovered records keeps counting cursors from
-        // where the log left off, and refills its replay ring from disk so a
-        // subscriber's pre-restart cursor still resolves to the same records.
-        // Reading only the ring's worth of tail keeps this bounded: startup
-        // cost does not grow with the size of the log.
-        if let Some(log) = &state.durable {
-            let tail = log.tail_offset().await?;
-            let from = tail.saturating_sub(self.log_capacity as u64);
-            let recent = log.read_from(from, HYDRATE_MAX_BYTES).await?;
-            state.hydrate(recent, tail, self.log_capacity);
+            // Keep the documented registry lock order: streams before topics.
+            let mut streams = self.streams.write().await;
+            if let Some(existing) = streams.get(&key)
+                && existing.durable != metadata.durable
+            {
+                return Err(Self::durability_change_error(&key, existing, &metadata));
+            }
+            let mut topics = self.topics.write().await;
+            if topics.contains_key(&key) {
+                // Lost the race while hydrating; the winner's state is the live
+                // one, so discard this one and take the fast path.
+                drop(topics);
+                drop(streams);
+                continue;
+            }
+            topics.insert(key.clone(), state);
+            streams.insert(key.clone(), metadata);
+            return Ok(());
         }
+    }
+
+    /// Refill a durable stream's replay ring from disk before it is published.
+    ///
+    /// A durable stream that recovered records keeps counting cursors from
+    /// where the log left off, so a subscriber's pre-restart cursor still
+    /// resolves to the same records. Reading only the ring's worth of tail
+    /// keeps this bounded: startup cost does not grow with the size of the log.
+    async fn hydrate_durable_stream(&self, state: &Arc<StreamState>) -> Result<()> {
+        let Some(log) = &state.durable else {
+            return Ok(());
+        };
+        let tail = log.tail_offset().await?;
+        let from = tail.saturating_sub(self.log_capacity as u64);
+        let recent = log.read_from(from, HYDRATE_MAX_BYTES).await?;
+        state.hydrate(recent, tail, self.log_capacity);
         Ok(())
     }
 

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -3,6 +3,7 @@
 // These maps mirror control-plane state and gate every data-path operation. Lock
 // order is tenants -> namespaces -> streams -> topics; keep it that way.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
@@ -117,16 +118,62 @@ impl Broker {
     ///
     /// A durable stream that recovered records keeps counting cursors from
     /// where the log left off, so a subscriber's pre-restart cursor still
-    /// resolves to the same records. Reading only the ring's worth of tail
-    /// keeps this bounded: startup cost does not grow with the size of the log.
+    /// resolves to the same records.
+    ///
+    /// The ring must end at the tail. A single read is bounded by the storage
+    /// layer's per-read record and byte caps, so asking for the ring's worth of
+    /// history can come back short — and keeping that *earliest* prefix while
+    /// still advancing `next_seq` to the real tail leaves a hole. A cursor
+    /// pointing into the hole is then above the ring's oldest entry, so it is
+    /// accepted rather than rejected, and replay answers with silence: the
+    /// subscriber reads "you are caught up" while records are missing. Losing
+    /// history loudly is fine; losing it quietly is not.
+    ///
+    /// So this pages forward to the tail and keeps the newest `log_capacity`
+    /// records, dropping older ones as it goes. Memory stays bounded by the
+    /// ring, and whatever the ring ends up holding is contiguous with
+    /// `next_seq`. If the budget cannot cover even part of the window the ring
+    /// is left empty, and every pre-restart cursor gets `CursorTooOld` — the
+    /// honest answer.
     async fn hydrate_durable_stream(&self, state: &Arc<StreamState>) -> Result<()> {
         let Some(log) = &state.durable else {
             return Ok(());
         };
         let tail = log.tail_offset().await?;
-        let from = tail.saturating_sub(self.log_capacity as u64);
-        let recent = log.read_from(from, HYDRATE_MAX_BYTES).await?;
-        state.hydrate(recent, tail, self.log_capacity);
+        let capacity = self.log_capacity;
+        let mut cursor = tail.saturating_sub(capacity as u64);
+        let mut window: VecDeque<felix_storage::log::LogRecord> = VecDeque::new();
+        let mut bytes = 0usize;
+
+        while cursor < tail {
+            let page = log.read_from(cursor, HYDRATE_MAX_BYTES).await?;
+            let Some(last) = page.last() else {
+                // The tail moved out from under the read, or the range was
+                // trimmed. Stop with what is in hand rather than spinning.
+                break;
+            };
+            cursor = last.offset + 1;
+            for record in page {
+                bytes += record.payload.len();
+                window.push_back(record);
+                // Keep the *newest* end of the window under both bounds.
+                while window.len() > capacity || (bytes > HYDRATE_MAX_BYTES && window.len() > 1) {
+                    if let Some(dropped) = window.pop_front() {
+                        bytes -= dropped.payload.len();
+                    }
+                }
+            }
+        }
+
+        // Only hand over a window that actually reaches the tail. Anything else
+        // would reintroduce the hole this method exists to avoid.
+        let reaches_tail = window.back().is_some_and(|last| last.offset + 1 == tail);
+        let contiguous = if reaches_tail {
+            window.into_iter().collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+        state.hydrate(contiguous, tail, capacity);
         Ok(())
     }
 

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -698,3 +698,40 @@ async fn historical_replay_is_rejected_for_a_non_durable_stream() {
         .expect_err("no persisted history");
     assert!(matches!(err, BrokerError::StreamNotDurable { .. }), "{err}");
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_cancelled_publish_does_not_strand_the_stream() {
+    let dir = tempdir().expect("dir");
+    let (broker, _storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", true).await;
+
+    broker
+        .publish("t1", "default", "orders", payload("first"))
+        .await
+        .expect("publish");
+
+    // Cancel a publish mid-flight. Offsets are assigned synchronously under the
+    // segment lock and the fsync wait happens after, so a timeout landing in
+    // that window drops the future *after* its offsets were consumed.
+    for _ in 0..10 {
+        let _ = tokio::time::timeout(
+            Duration::from_micros(200),
+            broker.publish("t1", "default", "orders", payload("cancelled")),
+        )
+        .await;
+    }
+
+    // The stream must still accept publishes. If a consumed offset range can be
+    // abandoned without releasing its place in the commit order, every later
+    // publish waits for a turn that never comes.
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        broker.publish("t1", "default", "orders", payload("after")),
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "stream deadlocked: a cancelled publish stranded the commit order"
+    );
+    result.expect("timeout").expect("publish");
+}

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -788,3 +788,74 @@ async fn a_failed_hydration_leaves_no_registered_stream() {
         "{publish}"
     );
 }
+
+#[tokio::test]
+async fn hydration_never_leaves_a_gap_between_the_ring_and_the_tail() {
+    let dir = tempdir().expect("dir");
+    // A per-read record cap below the ring's capacity, so the window hydration
+    // wants cannot be satisfied by one read. The same shape occurs in
+    // production whenever the ring's worth of tail exceeds the byte budget.
+    let config = LogConfig {
+        max_records_per_read: 100,
+        ..log_config(FsyncMode::None)
+    };
+
+    async fn boot(dir: &TempDir, config: LogConfig) -> (Broker, DurableStorage) {
+        let storage = DurableStorage::open(dir.path(), config).expect("storage");
+        let broker = Broker::new(EphemeralCache::new().into())
+            .with_durable_storage(storage.clone())
+            .with_log_capacity(500)
+            .expect("capacity");
+        broker.register_tenant("t1").await.expect("tenant");
+        broker
+            .register_namespace("t1", "default")
+            .await
+            .expect("namespace");
+        register(&broker, "orders", true).await;
+        (broker, storage)
+    }
+
+    // A client reads up to offset 550, saves its cursor, then 50 more arrive.
+    let saved_cursor;
+    {
+        let (broker, storage) = boot(&dir, config.clone()).await;
+        for i in 0..550 {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("v{i:04}")))
+                .await
+                .expect("publish");
+        }
+        saved_cursor = broker
+            .cursor_tail("t1", "default", "orders")
+            .await
+            .expect("cursor");
+        assert_eq!(saved_cursor.next_seq(), 550);
+        for i in 550..600 {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("v{i:04}")))
+                .await
+                .expect("publish");
+        }
+        storage.shutdown().await.expect("shutdown");
+    }
+
+    // Restart. Hydration wants offsets 100..600 but one read returns only 100
+    // records. If it keeps that earliest prefix and still advances next_seq to
+    // 600, the ring holds 100..200 with a hole up to the tail — and a cursor at
+    // 550 is accepted (550 >= 100) and answered with silence.
+    let (broker, _storage) = boot(&dir, config).await;
+    let (backlog, _sub) = broker
+        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .await
+        .expect("replay from a saved cursor");
+
+    assert_eq!(
+        backlog.len(),
+        50,
+        "cursor at 550 replayed {} records instead of 50 — an empty or short \
+         backlog here reads as \"you are caught up\" while records are missing",
+        backlog.len()
+    );
+    assert_eq!(backlog[0], payload("v0550"));
+    assert_eq!(backlog[49], payload("v0599"));
+}

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -735,3 +735,56 @@ async fn a_cancelled_publish_does_not_strand_the_stream() {
     );
     result.expect("timeout").expect("publish");
 }
+
+#[tokio::test]
+async fn a_failed_hydration_leaves_no_registered_stream() {
+    let dir = tempdir().expect("dir");
+    let storage = DurableStorage::open(dir.path(), log_config(FsyncMode::None)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage);
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+
+    // Block the shard directory with a file so opening the log fails. The
+    // registration must fail *whole*: a stream that could not be initialised
+    // must not be left publishable, accepting writes it cannot persist or
+    // replay.
+    let shard_dir = felix_storage::disk_log::layout::shard_dir(
+        dir.path(),
+        &felix_storage::log::ShardKey {
+            tenant: "t1".into(),
+            namespace: "default".into(),
+            stream: "orders".into(),
+            shard: 0,
+        },
+    );
+    std::fs::write(&shard_dir, b"not a directory").expect("block the shard dir");
+
+    let err = broker
+        .register_stream(
+            "t1",
+            "default",
+            "orders",
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await
+        .expect_err("registration should fail");
+    assert!(matches!(err, BrokerError::Storage(_)), "{err}");
+
+    // Neither registry may hold it, and publishing must report the stream as
+    // absent rather than silently succeeding into memory.
+    assert!(!broker.stream_exists("t1", "default", "orders").await);
+    let publish = broker
+        .publish("t1", "default", "orders", payload("x"))
+        .await
+        .expect_err("must not be publishable");
+    assert!(
+        matches!(publish, BrokerError::StreamNotFound { .. }),
+        "{publish}"
+    );
+}

--- a/crates/felix-common/src/lifecycle.rs
+++ b/crates/felix-common/src/lifecycle.rs
@@ -45,6 +45,27 @@ impl Readiness {
         }
     }
 
+    /// Create a flag that reports *not* ready until [`Readiness::mark_ready`].
+    ///
+    /// For work that must finish before traffic arrives. Reporting ready first
+    /// and initialising afterwards is worse than a slow start: an orchestrator
+    /// routes to the instance immediately, and requests land on state that does
+    /// not exist yet.
+    pub fn starting() -> Self {
+        Self {
+            ready: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Flip to ready once startup work has finished.
+    ///
+    /// Returns the previous state. Deliberately not the inverse of
+    /// [`Readiness::begin_draining`]: a draining instance must never be brought
+    /// back, so callers only use this during startup.
+    pub fn mark_ready(&self) -> bool {
+        self.ready.swap(true, Ordering::Release)
+    }
+
     /// Whether `/ready` should report success.
     pub fn is_ready(&self) -> bool {
         self.ready.load(Ordering::Acquire)

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -224,6 +224,33 @@ impl DiskLog {
         self.inner.segments.read().descriptors()
     }
 
+    /// Assign offsets and write `records`, without waiting for durability.
+    ///
+    /// Split out of [`AppendOnlyLog::append`] so a caller can learn the offsets
+    /// the moment they are consumed, rather than only once the batch is
+    /// durable. Anything that has to stay consistent with the log's offset
+    /// order — the broker's commit sequencer, for one — has to claim its place
+    /// at *assignment* time: after this returns, the records exist on disk and
+    /// hold their offsets whether or not the durability wait that follows
+    /// succeeds, fails, or is cancelled.
+    ///
+    /// The returned [`PendingAppend`] must be passed to [`DiskLog::commit`] for
+    /// the configured fsync policy to be honoured. Dropping it does not undo
+    /// the write.
+    pub async fn append_pending(&self, records: &[AppendRecord]) -> Result<PendingAppend> {
+        let records = records.to_vec();
+        let inner = Arc::clone(&self.inner);
+        Self::write_batch(inner, records).await
+    }
+
+    /// Wait until a [`PendingAppend`] satisfies the configured fsync policy.
+    pub async fn commit(&self, pending: &PendingAppend) -> Result<()> {
+        if self.inner.durability.acknowledges_before_sync() {
+            return Ok(());
+        }
+        self.inner.ensure_durable(pending.durable_target).await
+    }
+
     /// Force a flush regardless of the configured policy.
     pub async fn sync(&self) -> Result<()> {
         self.inner
@@ -247,62 +274,88 @@ impl DiskLog {
     }
 }
 
+/// A batch that has been written and given offsets, but not yet flushed.
+#[derive(Debug, Clone)]
+pub struct PendingAppend {
+    pub result: AppendResult,
+    /// Exclusive offset bound this batch needs durable.
+    durable_target: Offset,
+}
+
+impl PendingAppend {
+    pub fn first_offset(&self) -> Offset {
+        self.result.first_offset
+    }
+
+    pub fn last_offset(&self) -> Offset {
+        self.result.last_offset
+    }
+}
+
+impl DiskLog {
+    /// Roll if needed, then assign offsets and write the batch.
+    async fn write_batch(
+        inner: Arc<LogInner>,
+        records: Vec<AppendRecord>,
+    ) -> Result<PendingAppend> {
+        if records.is_empty() {
+            return Err(StorageError::InvalidRange);
+        }
+
+        // Rolling a segment seals one file, creates another, and fsyncs both
+        // plus the directory entry. That is real blocking work, so it happens
+        // on a blocking thread rather than inline on a reactor worker.
+        //
+        // Checked under a read lock and re-checked under the write lock:
+        // another publisher may have rolled in between, and rolling twice would
+        // leave an empty segment behind.
+        if inner.segments.read().would_roll(&records) {
+            let roller = Arc::clone(&inner);
+            let batch = records.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut segments = roller.segments.write();
+                if segments.would_roll(&batch) {
+                    segments.roll()?;
+                }
+                Ok::<(), StorageError>(())
+            })
+            .await
+            .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
+        }
+
+        let mut segments = inner.segments.write();
+        let (first_offset, last_offset) = segments.append(&records)?;
+        let durable_target = segments.tail_offset();
+        Ok(PendingAppend {
+            result: AppendResult {
+                first_offset,
+                last_offset,
+            },
+            durable_target,
+        })
+    }
+}
+
 impl AppendOnlyLog for DiskLog {
     fn append(&self, records: &[AppendRecord]) -> BoxFuture<'_, Result<AppendResult>> {
-        // `records` is borrowed for the duration of the future, but the
-        // durability wait may outlive the borrow's usefulness — so the write
+        // `records` is borrowed for the duration of the future, so the write
         // happens first and only offsets cross the await.
         let records = records.to_vec();
         let inner = Arc::clone(&self.inner);
         Box::pin(async move {
-            if records.is_empty() {
-                return Err(StorageError::InvalidRange);
-            }
             let started = std::time::Instant::now();
-
-            // Rolling a segment seals one file, creates another, and fsyncs
-            // both plus the directory entry. That is real blocking work, so it
-            // happens on a blocking thread rather than inline on a reactor
-            // worker — otherwise every `segment_size_bytes` of throughput would
-            // stall a worker for the length of two flushes and show up as a
-            // periodic tail-latency spike.
-            //
-            // Checked under a read lock and re-checked under the write lock:
-            // another publisher may have rolled in between, and rolling twice
-            // would leave an empty segment behind.
-            if inner.segments.read().would_roll(&records) {
-                let roller = Arc::clone(&inner);
-                let batch = records.clone();
-                tokio::task::spawn_blocking(move || {
-                    let mut segments = roller.segments.write();
-                    if segments.would_roll(&batch) {
-                        segments.roll()?;
-                    }
-                    Ok::<(), StorageError>(())
-                })
-                .await
-                .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
-            }
-
-            let (first_offset, last_offset, target) = {
-                let mut segments = inner.segments.write();
-                let (first, last) = segments.append(&records)?;
-                (first, last, segments.tail_offset())
-            };
+            let pending = Self::write_batch(Arc::clone(&inner), records).await?;
 
             // `OnCommit` is the only policy that makes the caller wait. The
             // others acknowledge once the bytes are in the page cache and rely
             // on the periodic flush (or the operating system) from there.
             if !inner.durability.acknowledges_before_sync() {
-                inner.ensure_durable(target).await?;
+                inner.ensure_durable(pending.durable_target).await?;
             }
 
             metrics::histogram!(metrics_names::APPEND_DURATION_SECONDS)
                 .record(started.elapsed().as_secs_f64());
-            Ok(AppendResult {
-                first_offset,
-                last_offset,
-            })
+            Ok(pending.result)
         })
     }
 

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -46,6 +46,13 @@ use crate::log::{
 use crate::segment::{ReadBudget, io::sync_data};
 use crate::{Result, StorageError, metrics_names};
 
+/// Bound on rollover retries in a single append.
+///
+/// Each retry means another publisher won the race to fill the segment; a
+/// handful is generous, and failing loudly beats spinning under a pathological
+/// interleaving.
+const MAX_ROLL_ATTEMPTS: usize = 8;
+
 use segments::SegmentSet;
 use sync::{Durability, PeriodicSyncer};
 
@@ -303,36 +310,58 @@ impl DiskLog {
         }
 
         // Rolling a segment seals one file, creates another, and fsyncs both
-        // plus the directory entry. That is real blocking work, so it happens
-        // on a blocking thread rather than inline on a reactor worker.
+        // plus the directory entry. That is real blocking work, so it must not
+        // run on a reactor worker.
         //
-        // Checked under a read lock and re-checked under the write lock:
-        // another publisher may have rolled in between, and rolling twice would
-        // leave an empty segment behind.
-        if inner.segments.read().would_roll(&records) {
-            let roller = Arc::clone(&inner);
-            let batch = records.clone();
-            tokio::task::spawn_blocking(move || {
-                let mut segments = roller.segments.write();
-                if segments.would_roll(&batch) {
-                    segments.roll()?;
-                }
-                Ok::<(), StorageError>(())
-            })
-            .await
-            .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
+        // Detect-and-retry rather than detect-then-append: a concurrent append
+        // can fill the segment between the check and the write lock, and if
+        // this path then let `SegmentSet::append` roll inline, the flushes
+        // would land on a Tokio worker after all — exactly what moving the roll
+        // off-thread was meant to prevent. So the write lock is released and
+        // the roll retried on a blocking thread instead.
+        //
+        // `would_roll` is false for an empty active segment, so an oversized
+        // record terminates the loop rather than spinning: it gets a segment to
+        // itself, which is the documented policy.
+        for attempt in 0..MAX_ROLL_ATTEMPTS {
+            if inner.segments.read().would_roll(&records) {
+                let roller = Arc::clone(&inner);
+                let batch = records.clone();
+                tokio::task::spawn_blocking(move || {
+                    let mut segments = roller.segments.write();
+                    // Re-checked under the write lock: another publisher may
+                    // have rolled already, and rolling twice leaves an empty
+                    // segment behind.
+                    if segments.would_roll(&batch) {
+                        segments.roll()?;
+                    }
+                    Ok::<(), StorageError>(())
+                })
+                .await
+                .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
+            }
+
+            let mut segments = inner.segments.write();
+            if segments.would_roll(&records) {
+                // Filled again in the gap. Drop the lock and roll off-thread.
+                drop(segments);
+                debug_assert!(attempt + 1 < MAX_ROLL_ATTEMPTS, "rollover retry starved");
+                continue;
+            }
+            let (first_offset, last_offset) = segments.append(&records)?;
+            let durable_target = segments.tail_offset();
+            return Ok(PendingAppend {
+                result: AppendResult {
+                    first_offset,
+                    last_offset,
+                },
+                durable_target,
+            });
         }
 
-        let mut segments = inner.segments.write();
-        let (first_offset, last_offset) = segments.append(&records)?;
-        let durable_target = segments.tail_offset();
-        Ok(PendingAppend {
-            result: AppendResult {
-                first_offset,
-                last_offset,
-            },
-            durable_target,
-        })
+        Err(StorageError::Unsupported(
+            "append could not secure segment capacity; rollover kept losing the race",
+        ))
     }
 }
 

--- a/crates/felix-storage/src/metrics_names.rs
+++ b/crates/felix-storage/src/metrics_names.rs
@@ -37,6 +37,11 @@ pub const SYNC_FAILURES_TOTAL: &str = "felix_storage_sync_failures_total";
 /// Bytes written but not yet flushed: the data a crash would lose right now.
 pub const UNSYNCED_BYTES: &str = "felix_storage_unsynced_bytes";
 
+/// Sparse index writes that failed. Non-fatal: the index is rebuilt on the next
+/// open. A persistently non-zero value means every restart is paying for a
+/// full rebuild scan.
+pub const INDEX_WRITE_FAILURES_TOTAL: &str = "felix_storage_index_write_failures_total";
+
 /// Segment rollovers.
 pub const SEGMENT_ROLL_TOTAL: &str = "felix_storage_segment_roll_total";
 /// Segments currently on disk for a shard.

--- a/crates/felix-storage/src/segment/format.rs
+++ b/crates/felix-storage/src/segment/format.rs
@@ -23,12 +23,18 @@ pub const SEGMENT_MAGIC: u32 = 0x464C_5347;
 /// `"FLSI"` — **F**e**L**ix **S**egment **I**ndex. Identifies a sparse index file.
 pub const INDEX_MAGIC: u32 = 0x464C_5349;
 /// Version of both the segment and index layouts described here.
-pub const FORMAT_VERSION: u16 = 1;
+///
+/// v2 added a record header checksum. v1 segments are rejected on open with
+/// `CorruptionKind::SegmentVersion`, naming the version found — the format was
+/// only ever written by unreleased builds, so the migration path is to discard
+/// the data directory rather than to carry a second decoder. Failing loudly is
+/// the point: a v1 record read as v2 would misparse every field.
+pub const FORMAT_VERSION: u16 = 2;
 
 /// Bytes occupied by a segment file header.
 pub const SEGMENT_HEADER_LEN: u64 = 32;
 /// Bytes occupied by a record header, excluding its payload.
-pub const RECORD_HEADER_LEN: u64 = 24;
+pub const RECORD_HEADER_LEN: u64 = 28;
 /// Bytes occupied by an index file header.
 pub const INDEX_HEADER_LEN: u64 = 24;
 /// Bytes occupied by a single sparse index entry.
@@ -88,6 +94,18 @@ pub enum CorruptionKind {
         expected: u32,
         found: u32,
     },
+    /// The record header did not verify against its own checksum, so
+    /// `payload_len` cannot be trusted.
+    ///
+    /// This is what makes a torn write distinguishable from bit rot. A header
+    /// that verifies means the length is real, so a payload short of it was
+    /// provably never finished; a header that does not verify could be a
+    /// complete, acknowledged record whose length field rotted, and recovery
+    /// must not guess.
+    RecordHeaderChecksum {
+        expected: u32,
+        found: u32,
+    },
     RecordTooLarge {
         payload_len: u32,
         limit: u32,
@@ -126,6 +144,10 @@ impl fmt::Display for CorruptionKind {
             CorruptionKind::RecordChecksum { expected, found } => write!(
                 f,
                 "record checksum mismatch (expected {expected:#010x}, found {found:#010x})"
+            ),
+            CorruptionKind::RecordHeaderChecksum { expected, found } => write!(
+                f,
+                "record header checksum mismatch (expected {expected:#010x}, found {found:#010x})"
             ),
             CorruptionKind::RecordTooLarge { payload_len, limit } => {
                 write!(f, "record payload {payload_len} exceeds limit {limit}")
@@ -331,6 +353,10 @@ pub struct RecordHeader {
     pub payload_len: u32,
     pub offset: Offset,
     pub timestamp_micros: u64,
+    /// CRC-32 over bytes `0..20`. Validated before `payload_len` is used for
+    /// anything, which is what lets recovery tell an unfinished write from a
+    /// rotted length field.
+    pub header_crc: u32,
     pub checksum: u32,
 }
 
@@ -344,6 +370,18 @@ impl RecordHeader {
         if (buf.len() as u64) < RECORD_HEADER_LEN {
             return Err(truncated(RECORD_HEADER_LEN, buf.len() as u64));
         }
+        // The header checksum is verified first, before any field is used.
+        // Everything downstream — the payload length, the offset, how far to
+        // step to the next record — is only meaningful once the header is known
+        // to be intact.
+        let header_crc = read_u32(buf, 20);
+        let found = crc32(&[&buf[0..20]]);
+        if header_crc != found {
+            return Err(Corruption::new(CorruptionKind::RecordHeaderChecksum {
+                expected: header_crc,
+                found,
+            }));
+        }
         let payload_len = read_u32(buf, 0);
         if payload_len > MAX_PAYLOAD_BYTES {
             return Err(Corruption::new(CorruptionKind::RecordTooLarge {
@@ -355,7 +393,8 @@ impl RecordHeader {
             payload_len,
             offset: read_u64(buf, 4),
             timestamp_micros: read_u64(buf, 12),
-            checksum: read_u32(buf, 20),
+            header_crc,
+            checksum: read_u32(buf, 24),
         })
     }
 }
@@ -375,7 +414,11 @@ pub fn encode_record(
     out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
     out.extend_from_slice(&offset.to_be_bytes());
     out.extend_from_slice(&timestamp_micros.to_be_bytes());
-    let checksum = crc32(&[&out[start..start + 20], payload]);
+    // Header checksum first, so a reader can trust `payload_len` without having
+    // read the payload it describes.
+    let header_crc = crc32(&[&out[start..start + 20]]);
+    out.extend_from_slice(&header_crc.to_be_bytes());
+    let checksum = crc32(&[&out[start..start + 24], payload]);
     out.extend_from_slice(&checksum.to_be_bytes());
     out.extend_from_slice(payload);
     (out.len() - start) as u64
@@ -400,7 +443,7 @@ pub fn decode_record(buf: &[u8]) -> DecodeResult<(DecodedRecord, u64)> {
         return Err(truncated(total, buf.len() as u64));
     }
     let payload = &buf[RECORD_HEADER_LEN as usize..total as usize];
-    let found = crc32(&[&buf[0..20], payload]);
+    let found = crc32(&[&buf[0..24], payload]);
     if found != header.checksum {
         return Err(Corruption::new(CorruptionKind::RecordChecksum {
             expected: header.checksum,
@@ -521,11 +564,11 @@ mod tests {
             bytes,
             [
                 0x46, 0x4C, 0x53, 0x47, // magic "FLSG"
-                0x00, 0x01, // version
+                0x00, 0x02, // version
                 0x00, 0x00, // flags
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, // base_offset
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // created_at_micros
-                0xD9, 0x5F, 0x63, 0x18, // header crc32
+                0x7A, 0x09, 0xE5, 0xB1, // header crc32
                 0x00, 0x00, 0x00, 0x00, // reserved
             ]
         );
@@ -541,7 +584,8 @@ mod tests {
                 0x00, 0x00, 0x00, 0x02, // payload_len
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07, // offset
                 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, // timestamp
-                0x63, 0x3D, 0xA1, 0x4E, // checksum
+                0xC6, 0x54, 0xDE, 0x27, // header crc32 (bytes 0..20)
+                0x24, 0x02, 0x15, 0x2C, // checksum (bytes 0..24 + payload)
                 b'h', b'i',
             ]
         );
@@ -604,26 +648,66 @@ mod tests {
     }
 
     #[test]
-    fn header_corruption_fails_the_checksum() {
+    fn header_corruption_fails_the_header_checksum() {
         let mut buf = Vec::new();
         encode_record(&mut buf, 0, 0, b"payload");
-        // Flip a bit in the timestamp, which the checksum also covers.
+        // Flip a bit in the timestamp. The header checksum covers it, so this
+        // is caught without reading the payload at all.
         buf[12] ^= 0x01;
         let err = decode_record(&buf).expect_err("corrupt header");
-        assert!(matches!(err.kind, CorruptionKind::RecordChecksum { .. }));
+        assert!(matches!(
+            err.kind,
+            CorruptionKind::RecordHeaderChecksum { .. }
+        ));
+    }
+
+    #[test]
+    fn a_corrupt_length_is_caught_by_the_header_checksum() {
+        let mut buf = Vec::new();
+        encode_record(&mut buf, 4, 5, b"payload");
+        // Damage only the length field. Before the header checksum this was
+        // indistinguishable from an unfinished write: the claimed extent ran
+        // past the data, so recovery truncated an acknowledged record. Now the
+        // header itself reports the damage.
+        buf[0..4].copy_from_slice(&9_999u32.to_be_bytes());
+        let err = decode_record(&buf).expect_err("corrupt length");
+        assert!(
+            matches!(err.kind, CorruptionKind::RecordHeaderChecksum { .. }),
+            "expected a header checksum failure, got {err}"
+        );
     }
 
     #[test]
     fn oversized_length_is_rejected_before_allocating() {
+        // A header whose length is impossible but whose checksum is valid: the
+        // shape that would reach an allocation if the bound were not checked.
         let mut buf = vec![0u8; RECORD_HEADER_LEN as usize];
         buf[0..4].copy_from_slice(&u32::MAX.to_be_bytes());
+        let header_crc = crc32(&[&buf[0..20]]);
+        buf[20..24].copy_from_slice(&header_crc.to_be_bytes());
+
         let err = decode_record(&buf).expect_err("oversized");
+        assert!(
+            matches!(
+                err.kind,
+                CorruptionKind::RecordTooLarge {
+                    payload_len: u32::MAX,
+                    limit: MAX_PAYLOAD_BYTES,
+                }
+            ),
+            "got {err}"
+        );
+    }
+
+    #[test]
+    fn a_garbage_header_is_rejected_before_its_length_is_believed() {
+        // Random bytes almost never carry a valid header checksum, so the
+        // length they happen to encode is never acted on.
+        let buf = vec![0u8; RECORD_HEADER_LEN as usize];
+        let err = decode_record(&buf).expect_err("garbage");
         assert!(matches!(
             err.kind,
-            CorruptionKind::RecordTooLarge {
-                payload_len: u32::MAX,
-                limit: MAX_PAYLOAD_BYTES,
-            }
+            CorruptionKind::RecordHeaderChecksum { .. }
         ));
     }
 

--- a/crates/felix-storage/src/segment/reader.rs
+++ b/crates/felix-storage/src/segment/reader.rs
@@ -128,26 +128,37 @@ fn is_repairable_tail(
     repair_checksum_tail: bool,
 ) -> bool {
     match kind {
-        // The record does not fit in the file at all: a write that stopped
-        // part-way is the only way to produce this, and nothing can have
-        // acknowledged a record that was never finished.
-        CorruptionKind::Truncated { .. } => true,
-        // The record decodes to a full extent but its contents do not verify.
+        // The header verified, so `payload_len` is the length the writer
+        // actually intended — and the file ends before it. Nothing but an
+        // unfinished write produces that, and nothing can have acknowledged a
+        // record that was never finished. Provably repairable.
         //
-        // This is *not* provably an incomplete write. A torn write and bit rot
-        // on an already-acknowledged record produce the same bytes, and under
-        // `OnCommit` the record may have been fsynced and acknowledged before
-        // rotting. Truncating on a guess would silently delete data the caller
-        // was told was safe, so it happens only when an operator has opted in.
+        // Before v2 this was only *probably* true: a rotted length field on a
+        // complete, acknowledged record produced the same error, and truncating
+        // deleted data the caller had been told was safe. The header checksum
+        // is what turned the guess into a decision.
+        CorruptionKind::Truncated { .. } => true,
+        // The header itself did not verify, so nothing it says can be trusted —
+        // including its length. This may be an unfinished write, or a complete
+        // record whose header rotted after being acknowledged. The two are
+        // indistinguishable from the bytes, so recovery refuses to choose
+        // unless an operator has said which risk they prefer.
+        CorruptionKind::RecordHeaderChecksum { .. } => {
+            repair_checksum_tail && position.saturating_add(RECORD_HEADER_LEN) >= file_len
+        }
+        // The header verified but the payload did not. The record is complete
+        // on disk, so this is rot rather than a torn write, and under
+        // `OnCommit` it may already have been acknowledged.
         CorruptionKind::RecordChecksum { .. } | CorruptionKind::OffsetOutOfOrder { .. } => {
             repair_checksum_tail
                 && claimed_len.is_some_and(|len| position.saturating_add(len) >= file_len)
         }
-        // A garbage length field describing a record that could not possibly
-        // fit in the file: the signature of a half-written header, so provably
-        // incomplete and always repairable.
+        // A verified header carrying an impossible length. The writer rejects
+        // oversized records, so this is damage the checksum did not catch;
+        // treat it as ambiguous rather than assume a torn write.
         CorruptionKind::RecordTooLarge { payload_len, .. } => {
-            position.saturating_add(RECORD_HEADER_LEN + u64::from(*payload_len)) > file_len
+            repair_checksum_tail
+                && position.saturating_add(RECORD_HEADER_LEN + u64::from(*payload_len)) > file_len
         }
         _ => false,
     }
@@ -703,7 +714,32 @@ mod tests {
     }
 
     #[test]
-    fn a_garbage_length_at_the_tail_is_repairable() {
+    fn a_garbage_header_at_the_tail_is_not_repaired_by_default() {
+        let dir = tempdir().expect("dir");
+        let path = dir.path().join("a.log");
+        let mut bytes = write_segment(&path, 0, 1);
+        // Debris that happens to encode a huge length. Its header checksum does
+        // not verify, so the length means nothing — and a record whose header
+        // cannot be trusted might equally be a complete, acknowledged record
+        // that rotted. Recovery refuses to decide.
+        bytes.extend_from_slice(&u32::MAX.to_be_bytes());
+        bytes.extend_from_slice(&[0u8; (RECORD_HEADER_LEN - 4) as usize]);
+        std::fs::write(&path, &bytes).expect("write");
+
+        // Explicitly the default policy, not the permissive test helper.
+        let err = scan_segment(&path, 0, "t/ns/s/0", 4096, ScanStart::Full, false)
+            .expect_err("ambiguous tail must not be truncated silently");
+        let StorageError::Corruption(detail) = err else {
+            panic!("expected corruption");
+        };
+        assert!(matches!(
+            detail.kind,
+            CorruptionKind::RecordHeaderChecksum { .. }
+        ));
+    }
+
+    #[test]
+    fn an_operator_can_opt_in_to_repairing_an_ambiguous_tail() {
         let dir = tempdir().expect("dir");
         let path = dir.path().join("a.log");
         let mut bytes = write_segment(&path, 0, 1);
@@ -711,11 +747,32 @@ mod tests {
         bytes.extend_from_slice(&[0u8; (RECORD_HEADER_LEN - 4) as usize]);
         std::fs::write(&path, &bytes).expect("write");
 
-        let outcome = scan(&path).expect("scan should repair");
+        let outcome =
+            scan_segment(&path, 0, "t/ns/s/0", 4096, ScanStart::Full, true).expect("opt-in repair");
         assert_eq!(outcome.record_count, 1);
         assert!(matches!(
             outcome.torn_tail.expect("tail").cause,
-            CorruptionKind::RecordTooLarge { .. }
+            CorruptionKind::RecordHeaderChecksum { .. }
+        ));
+    }
+
+    #[test]
+    fn a_payload_cut_short_by_a_crash_is_still_repaired_automatically() {
+        let dir = tempdir().expect("dir");
+        let path = dir.path().join("a.log");
+        let full = write_segment(&path, 0, 3);
+        // Cut inside the last record's payload: the header is intact and
+        // verifies, so its length is trustworthy and the shortfall is provably
+        // an unfinished write. This is the ordinary crash case and must not
+        // require operator intervention.
+        std::fs::write(&path, &full[..full.len() - 3]).expect("write");
+
+        let outcome = scan_segment(&path, 0, "t/ns/s/0", 4096, ScanStart::Full, false)
+            .expect("a torn payload is provably incomplete");
+        assert_eq!(outcome.record_count, 2);
+        assert!(matches!(
+            outcome.torn_tail.expect("tail").cause,
+            CorruptionKind::Truncated { .. }
         ));
     }
 

--- a/crates/felix-storage/src/segment/writer.rs
+++ b/crates/felix-storage/src/segment/writer.rs
@@ -69,6 +69,9 @@ pub struct SegmentWriter {
     /// Set when a failed append could not be rolled back. The segment's real
     /// length is then unknown, so further appends are refused.
     poisoned: bool,
+    /// Set when an index write has failed. Purely informational: the index is
+    /// rebuilt from the segment on the next open, so the log stays correct.
+    index_degraded: bool,
 }
 
 impl SegmentWriter {
@@ -114,6 +117,7 @@ impl SegmentWriter {
             staging: Vec::new(),
             sync_handle,
             poisoned: false,
+            index_degraded: false,
         })
     }
 
@@ -161,6 +165,7 @@ impl SegmentWriter {
             staging: Vec::new(),
             sync_handle,
             poisoned: false,
+            index_degraded: false,
         })
     }
 
@@ -287,8 +292,32 @@ impl SegmentWriter {
         self.size_bytes = position;
         self.next_offset = offset;
         self.record_count += records.len() as u64;
+        // The index is an accelerator, not a record of truth: a missing or
+        // stale one is rebuilt from the segment on open, and every read
+        // re-validates the records it lands on. So an index write that fails
+        // must not fail the append.
+        //
+        // Returning `Err` here would be actively harmful. The data write has
+        // already succeeded and the offsets are already spent, so the error
+        // would look retryable to a caller who cannot retry: retrying appends
+        // the batch a second time under new offsets, and not retrying leaves a
+        // publish reported as failed that is in fact durably stored.
         for (offset, position, written) in boundaries {
-            self.index.observe_record(offset, position, written)?;
+            if let Err(err) = self.index.observe_record(offset, position, written) {
+                if !self.index_degraded {
+                    self.index_degraded = true;
+                    tracing::warn!(
+                        segment = self.id,
+                        offset,
+                        error = %err,
+                        "sparse index write failed; the index will be rebuilt on next open"
+                    );
+                    metrics::counter!(metrics_names::INDEX_WRITE_FAILURES_TOTAL).increment(1);
+                }
+                // Stop feeding a writer that is already failing; the remaining
+                // boundaries would only repeat the same error.
+                break;
+            }
         }
 
         metrics::counter!(metrics_names::APPEND_RECORDS_TOTAL).increment(records.len() as u64);

--- a/crates/felix-storage/tests/format_fuzz.rs
+++ b/crates/felix-storage/tests/format_fuzz.rs
@@ -32,6 +32,13 @@ use felix_storage::segment::{ScanStart, scan_segment};
 use felix_storage::{StorageError, segment};
 use tempfile::tempdir;
 
+/// CRC-32 (IEEE), matching what the format uses for its header checksum.
+fn crc32_of(bytes: &[u8]) -> u32 {
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(bytes);
+    hasher.finalize()
+}
+
 /// xorshift64*. Deterministic and dependency-free, so a failing seed printed in
 /// an assertion reproduces the exact byte sequence that broke.
 struct Rng(u64);
@@ -118,6 +125,12 @@ fn a_corrupt_length_field_is_rejected_before_allocation() {
         let mut bytes = vec![0u8; RECORD_HEADER_LEN as usize];
         let claimed = (MAX_PAYLOAD_BYTES as u64 + 1 + rng.next_u64() % u32::MAX as u64) as u32;
         bytes[0..4].copy_from_slice(&claimed.to_be_bytes());
+        // Give the header a valid checksum, or the length is rejected as
+        // untrustworthy before its magnitude is ever considered — which is
+        // itself correct, but not what this test is probing.
+        let header_crc = crc32_of(&bytes[0..20]);
+        bytes[20..24].copy_from_slice(&header_crc.to_be_bytes());
+
         let err = decode_record(&bytes).expect_err("oversized length");
         assert!(
             matches!(

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -843,6 +844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "felix-authz"
 version = "0.1.1"
 dependencies = [
@@ -908,7 +915,12 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "crc32fast",
+ "libc",
+ "metrics",
+ "parking_lot",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1703,6 +1715,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2679,6 +2697,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3380,19 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "term"

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -843,6 +844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "felix-authz"
 version = "0.1.1"
 dependencies = [
@@ -908,7 +915,12 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "crc32fast",
+ "libc",
+ "metrics",
+ "parking_lot",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1703,6 +1715,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2679,6 +2697,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3380,19 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "term"

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -519,6 +520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -899,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "felix-authz"
 version = "0.1.1"
 dependencies = [
@@ -964,7 +980,12 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "crc32fast",
+ "libc",
+ "metrics",
+ "parking_lot",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3411,6 +3432,19 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "term"

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",
@@ -519,6 +520,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -899,6 +909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "felix-authz"
 version = "0.1.1"
 dependencies = [
@@ -964,7 +980,12 @@ version = "0.1.1"
 dependencies = [
  "async-trait",
  "bytes",
+ "crc32fast",
+ "libc",
+ "metrics",
+ "parking_lot",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3411,6 +3432,19 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "term"

--- a/docs/assets/storage/record.svg
+++ b/docs/assets/storage/record.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 882 428" width="882" height="428" role="img" aria-label="Record — 24-byte header, then payload_len bytes">
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 882 474" width="882" height="474" role="img" aria-label="Record byte layout version 2: payload_len, offset, timestamp_micros, header_crc, checksum, then the payload">
   <style>
     .cell    { stroke: var(--edge); stroke-width: 1.25; }
     .id      { fill: var(--c-id); }
@@ -47,8 +46,7 @@
       --c-crc: #fbe9d6; --c-res: #eceff3; --c-pay: #f2ecf8;
     }
   </style>
-
-  <text class="title" x="24" y="24">Record — 24-byte header, then payload_len bytes</text>
+  <text class="title" x="24" y="24">Record — 28-byte header, then payload_len bytes</text>
   <line class="tick" x1="64" y1="58" x2="672" y2="58"/>
   <line class="tick" x1="64" y1="52" x2="64" y2="58"/>
   <text class="ruler" x="140" y="49">byte +0</text>
@@ -69,11 +67,14 @@
   <text class="label" x="368" y="244">timestamp_micros</text>
   <text class="sub" x="368" y="260">u64</text>
   <rect class="cell crc" x="64" y="292" width="608" height="46" rx="3"/>
-  <text class="label" x="368" y="313">checksum</text>
-  <text class="sub" x="368" y="329">u32 — CRC-32</text>
-  <rect class="cell pay dash" x="64" y="338" width="608" height="46" rx="3"/>
-  <text class="label" x="368" y="359">payload</text>
-  <text class="sub" x="368" y="375">payload_len bytes, opaque</text>
+  <text class="label" x="368" y="313">header_crc</text>
+  <text class="sub" x="368" y="329">u32 — CRC-32 over bytes 0..20</text>
+  <rect class="cell crc" x="64" y="338" width="608" height="46" rx="3"/>
+  <text class="label" x="368" y="359">checksum</text>
+  <text class="sub" x="368" y="375">u32 — CRC-32 over bytes 0..24 and the payload</text>
+  <rect class="cell pay dash" x="64" y="384" width="608" height="46" rx="3"/>
+  <text class="label" x="368" y="405">payload</text>
+  <text class="sub" x="368" y="421">payload_len bytes, opaque</text>
   <text class="gutter" x="54" y="50">offset</text>
   <text class="offset" x="54" y="89">0</text>
   <text class="offset" x="54" y="135">4</text>
@@ -82,9 +83,11 @@
   <text class="offset" x="54" y="273">16</text>
   <text class="offset" x="54" y="319">20</text>
   <text class="offset" x="54" y="365">24</text>
+  <text class="offset" x="54" y="411">28</text>
   <path class="brace" d="M 679 66 q 7 0 7 9 L 686 168 q 0 9 7 9 q -7 0 -7 9 L 686 279 q 0 9 -7 9"/>
-  <text class="braceTx" x="703" y="166">checksum covers</text>
-  <text class="braceTx" x="703" y="182">bytes 0..20</text>
-  <text class="braceTx" x="703" y="198">and the payload</text>
-  <text class="note" x="24" y="414">payload_len comes first and is covered by the checksum, so the next record starts at position + 24 + payload_len without decoding any payload.</text>
+  <text class="braceTx" x="703" y="158">header_crc covers</text>
+  <text class="braceTx" x="703" y="174">bytes 0..20 — verified</text>
+  <text class="braceTx" x="703" y="190">before payload_len</text>
+  <text class="braceTx" x="703" y="206">is believed</text>
+  <text class="note" x="24" y="460">A verified header makes a short payload provably an unfinished write; an unverified one is ambiguous, and recovery refuses to guess.</text>
 </svg>

--- a/docs/storage-format.md
+++ b/docs/storage-format.md
@@ -1,4 +1,4 @@
-# Felix Durable Segment Format (v1)
+# Felix Durable Segment Format (v2)
 
 This document defines the on-disk representation of a durable Felix stream. It is
 the source of truth for anyone reading, writing, repairing, or replicating
@@ -83,7 +83,7 @@ file:
 | Offset | Size | Field | Value |
 | --- | --- | --- | --- |
 | 0 | 4 | `magic` | `0x464C5347` (`"FLSG"`) |
-| 4 | 2 | `version` | `1` |
+| 4 | 2 | `version` | `2` |
 | 6 | 2 | `flags` | `0`; any other value is rejected |
 | 8 | 8 | `base_offset` | logical offset of this segment's first record |
 | 16 | 8 | `created_at_micros` | wall clock at creation, informational |
@@ -104,11 +104,19 @@ segment, so damage here is never a torn write — it is always an error.
 | 0 | 4 | `payload_len` | ≤ `MAX_PAYLOAD_BYTES` (64 MiB) |
 | 4 | 8 | `offset` | logical offset; ascends by exactly 1 within a segment |
 | 12 | 8 | `timestamp_micros` | publish time |
-| 20 | 4 | `checksum` | CRC-32 over bytes `0..20` **followed by** the payload |
-| 24 | n | `payload` | opaque bytes |
+| 20 | 4 | `header_crc` | CRC-32 over bytes `0..20` |
+| 24 | 4 | `checksum` | CRC-32 over bytes `0..24` **followed by** the payload |
+| 28 | n | `payload` | opaque bytes |
 
-`payload_len` comes first and is covered by the checksum, so a reader can step to
-the next record with `position + 24 + payload_len` without touching payload
+`header_crc` is what makes recovery decidable. It is verified *before* any other
+field is used, so `payload_len` is only ever acted on once it is known to be
+intact. Without it, a bit flip in the length field produced exactly the same
+symptom as an unfinished write — a record claiming more bytes than the file
+holds — and recovery had to guess. Guessing wrong meant silently truncating a
+record that had been fsynced and acknowledged.
+
+`payload_len` comes first and is covered by both checksums, so a reader can step
+to the next record with `position + 28 + payload_len` without touching payload
 bytes. That property is what makes the index rebuild and the recovery scan cost
 proportional to record *count* rather than to bytes decoded.
 
@@ -131,7 +139,7 @@ its segment. Consequently they carry no checksums.
 | Offset | Size | Field | Value |
 | --- | --- | --- | --- |
 | 0 | 4 | `magic` | `0x464C5349` (`"FLSI"`) |
-| 4 | 2 | `version` | `1` |
+| 4 | 2 | `version` | `2` |
 | 6 | 2 | `flags` | `0` |
 | 8 | 8 | `base_offset` | must equal the segment's `base_offset` |
 | 16 | 8 | `reserved` | `0` |
@@ -163,6 +171,7 @@ the file is read up to the last whole entry.
 | Non-zero `flags` | Reject: `SegmentFlags`. Unknown bits may change the layout behind them, so they are not masked off |
 | Bad header CRC | Reject: `SegmentHeaderChecksum` |
 | Short read | `Truncated { needed, available }` — the one shape recovery may repair |
+| Bad record header CRC | `RecordHeaderChecksum` — the length cannot be trusted |
 | Bad record CRC | `RecordChecksum` |
 | `payload_len` over the limit | `RecordTooLarge`, raised *before* any allocation |
 | Offset gap within a segment | `OffsetOutOfOrder` |
@@ -175,14 +184,25 @@ position, because "corruption detected" is not enough to act on at 3am.
 Recovery truncates **only** damage confined to the end of the newest segment,
 because only there can a record have been mid-write when the process died:
 
-- A `Truncated` failure is always repairable.
-- A `RecordChecksum` or `OffsetOutOfOrder` failure is repairable only when the
-  record's claimed extent reaches end of file — that is, when nothing follows it.
-  If committed bytes exist beyond the damage, dropping it would open a gap, so it
-  is an error instead.
-- A `RecordTooLarge` failure is repairable only when the record it claims could
-  not fit in the file, which is the signature of a half-written header.
+- A `Truncated` failure is always repairable. The header verified, so
+  `payload_len` is the length the writer intended, and a file ending short of it
+  is *provably* an unfinished write — nothing can have acknowledged a record that
+  was never finished. This is the ordinary crash case and needs no operator
+  involvement.
+- A `RecordHeaderChecksum` failure is **not** repairable by default. The header
+  cannot be trusted, so this may equally be an unfinished write or a complete,
+  acknowledged record whose header rotted. `repair_checksum_tail` opts in.
+- A `RecordChecksum` or `OffsetOutOfOrder` failure is likewise opt-in: the header
+  verified, so the record is complete on disk and the damage is rot rather than a
+  torn write.
+- A `RecordTooLarge` failure is opt-in for the same reason — the writer rejects
+  oversized records, so a verified header carrying an impossible length is damage
+  the checksums did not catch.
 - Segment-header damage is never repairable.
+
+The dividing line is whether the length is trustworthy. When it is, recovery can
+prove the write was unfinished; when it is not, recovery refuses to choose
+between "unfinished" and "rotted" and fails loudly instead.
 
 The full rules live in `is_repairable_tail` in
 [`segment/reader.rs`](../crates/felix-storage/src/segment/reader.rs).
@@ -195,19 +215,33 @@ migration path.
 
 ```text
 SegmentHeader::new(base_offset = 1, created_at_micros = 2):
-  46 4C 53 47  00 01  00 00
+  46 4C 53 47  00 02  00 00
   00 00 00 00 00 00 00 01
   00 00 00 00 00 00 00 02
-  D9 5F 63 18
+  7A 09 E5 B1
   00 00 00 00
 
 encode_record(offset = 7, timestamp = 9, payload = "hi"):
   00 00 00 02
   00 00 00 00 00 00 00 07
   00 00 00 00 00 00 00 09
-  63 3D A1 4E
+  C6 54 DE 27
+  24 02 15 2C
   68 69
 ```
+
+## Version history
+
+| Version | Change |
+| --- | --- |
+| 1 | Initial format. Unreleased. |
+| 2 | Added `header_crc` to the record header (24 → 28 bytes), making a corrupted length field detectable without reading the payload. |
+
+A v1 segment is rejected on open with `CorruptionKind::SegmentVersion`, naming
+the version found. v1 was only ever written by unreleased builds, so the
+migration path is to discard the data directory rather than carry a second
+decoder — and rejecting is the safe failure, because a v1 record read as v2
+would misparse every field after the length.
 
 ## Versioning policy
 

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -282,12 +282,25 @@ struct Cache {
 ///
 /// Fires `seeded` after the first full sync.
 ///
+/// Most callers want [`start_sync`], which is this with no signal.
+///
 /// A broker with durable storage uses that signal to hold readiness until its
 /// streams exist. Until the first sync lands the catalog has not been applied
 /// and no durable stream has been recovered — reporting ready before then
 /// invites an orchestrator to route traffic at an instance whose durable
 /// streams are, as far as any client can tell, missing. Pass `None` to start
 /// syncing without gating anything on it.
+/// Polls the control plane forever, applying changes as they arrive.
+///
+/// Kept as the plain entry point because it is part of this crate's public API
+/// and has consumers outside the workspace — `demos/rbac-live` is a standalone
+/// crate, so `cargo clippy --workspace` cannot see that it is used and reports
+/// this as dead code in the binary target. It is not.
+#[allow(dead_code)]
+pub async fn start_sync(broker: Arc<Broker>, base_url: String, interval: Duration) -> Result<()> {
+    start_sync_with_signal(broker, base_url, interval, None).await
+}
+
 pub async fn start_sync_with_signal(
     broker: Arc<Broker>,
     base_url: String,

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -279,13 +279,32 @@ struct Cache {
 /// - It intentionally sleeps for `interval` between change feed polls.
 /// - Apply-time errors are logged and retried on the next iteration so transient
 ///   ordering races (for example namespace before tenant) do not stop sync.
-pub async fn start_sync(broker: Arc<Broker>, base_url: String, interval: Duration) -> Result<()> {
+///
+/// Fires `seeded` after the first full sync.
+///
+/// A broker with durable storage uses that signal to hold readiness until its
+/// streams exist. Until the first sync lands the catalog has not been applied
+/// and no durable stream has been recovered — reporting ready before then
+/// invites an orchestrator to route traffic at an instance whose durable
+/// streams are, as far as any client can tell, missing. Pass `None` to start
+/// syncing without gating anything on it.
+pub async fn start_sync_with_signal(
+    broker: Arc<Broker>,
+    base_url: String,
+    interval: Duration,
+    mut seeded: Option<tokio::sync::oneshot::Sender<()>>,
+) -> Result<()> {
     let client = reqwest::Client::new();
     // Sequence cursors for each change feed; 0 means "not yet seeded".
     let mut state = SyncState::new();
     loop {
         match sync_once(&broker, &client, &base_url, state).await {
-            Ok(next_state) => state = next_state,
+            Ok(next_state) => {
+                state = next_state;
+                if let Some(signal) = seeded.take() {
+                    let _ = signal.send(());
+                }
+            }
             Err(err) => {
                 tracing::warn!(error = %err, "control plane sync iteration failed; retrying")
             }
@@ -1675,10 +1694,11 @@ mod tests {
 
             let (addr, shutdown_tx, handle) = serve_router(router).await?;
             let base_url = format!("http://{}", addr);
-            let sync_task = tokio::spawn(start_sync(
+            let sync_task = tokio::spawn(start_sync_with_signal(
                 Arc::clone(&broker),
                 base_url,
                 Duration::from_millis(10),
+                None,
             ));
 
             let deadline = tokio::time::Instant::now() + Duration::from_secs(2);

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -80,7 +80,18 @@ where
     // endpoint has to outlive the drain — that is how an operator watches the drain
     // happen. `connections` tracks per-connection tasks so the drain can wait for
     // in-flight work instead of aborting it.
-    let readiness = Readiness::ready();
+    // Durable brokers start *not* ready. Their streams do not exist until the
+    // control plane has been applied and each durable log recovered, and an
+    // instance that reports ready before then invites an orchestrator to route
+    // traffic at streams that are, from any client's point of view, missing.
+    // An in-memory broker has nothing to recover and keeps the old behaviour.
+    let durable_storage_configured = DurableStorageConfig::from_env()?.is_some();
+    let gate_readiness_on_sync = durable_storage_configured && config.controlplane_url.is_some();
+    let readiness = if gate_readiness_on_sync {
+        Readiness::starting()
+    } else {
+        Readiness::ready()
+    };
     let accept_shutdown = CancellationToken::new();
     let sync_shutdown = CancellationToken::new();
     let metrics_shutdown = CancellationToken::new();
@@ -184,10 +195,12 @@ where
 
     // Optional: start a periodic control-plane sync to keep tenant/namespace/stream metadata
     // refreshed. When disabled, the broker relies solely on local registrations.
+    let (seeded_tx, seeded_rx) = tokio::sync::oneshot::channel();
     let controlplane_task = if let Some(base_url) = config.controlplane_url.clone() {
         let interval_ms = config.controlplane_sync_interval_ms;
         let broker = Arc::clone(&broker);
         let sync_shutdown = sync_shutdown.clone();
+        let seeded_tx = gate_readiness_on_sync.then_some(seeded_tx);
         Some(tokio::spawn(async move {
             // `start_sync` polls forever, so cancellation is what ends it. Dropping
             // it mid-iteration is safe: the sync is a read-only metadata refresh
@@ -197,10 +210,11 @@ where
                 _ = sync_shutdown.cancelled() => {
                     tracing::info!("control plane sync stopped");
                 }
-                result = controlplane::start_sync(
+                result = controlplane::start_sync_with_signal(
                     broker,
                     base_url,
                     Duration::from_millis(interval_ms),
+                    seeded_tx,
                 ) => {
                     if let Err(err) = result {
                         tracing::warn!(error = %err, "control plane sync exited");
@@ -215,6 +229,21 @@ where
 
     // Block until the shutdown signal resolves so the process stays alive.
     shutdown.await;
+
+    // Flip to ready once the catalog has been applied and every durable stream
+    // it named has been recovered. Deliberately a task rather than an await:
+    // the listener is already accepting and `/ready` already reports false, so
+    // holding startup here would only delay the point at which an operator can
+    // see the broker's state.
+    if gate_readiness_on_sync {
+        let readiness = readiness.clone();
+        tokio::spawn(async move {
+            if seeded_rx.await.is_ok() {
+                readiness.mark_ready();
+                tracing::info!("initial control-plane sync applied; reporting ready");
+            }
+        });
+    }
 
     // Step 1: stop advertising readiness. Load balancers and the Kubernetes
     // endpoints controller drop this instance from rotation while it can still


### PR DESCRIPTION
## What is fixed

### Commit sequencing is now cancellation-safe

Offsets are consumed synchronously under the segment lock; the durability wait happens after it is released. The sequencer claimed its turn only *after* that wait succeeded — so a publish whose fsync failed, or whose future was simply dropped (a client disconnect or request timeout does this routinely), walked away holding offsets already written to disk having released nothing. Every later range then waited on a turn that could never arrive.

**Reproduced before fixing:** the stream deadlocked for the full 10s test timeout.

`CommitSequencer::reserve` now returns the guard when offsets are *consumed*, with `CommitTurn::wait` separate, so the guard spans the durability wait and `Drop` releases the range on every exit path — `?`, panic, or cancellation. This required splitting `DiskLog::append_pending` / `commit`; `AppendOnlyLog::append` is those two composed, so no existing caller changes.

### A durable broker no longer reports ready before its streams exist

Two separate holes. Registration inserted metadata **before** the fallible hydration read, so a failure left a stream that was registered and publishable with an empty ring — accepting writes and answering `CursorTooOld` for every pre-restart cursor, with nothing upstream aware it was never initialised. All fallible work now happens before either registry is touched.

Separately, readiness started true and the listener bound long before any durable stream was recovered. `Readiness::starting()` holds `/ready` false until the first control-plane sync has been applied. Gated on durable storage *and* a control plane being configured, so an in-memory broker keeps its current startup behaviour.

### A failed index write no longer fails the append

The review offered two options; I took the first, because the second is wrong here. Returning `Err` after the data write succeeded is *actively harmful*: the offsets are already spent, so the error looks retryable to a caller who cannot retry — retrying appends the batch again under new offsets, and not retrying reports a publish as failed that is in fact durably stored. The index is rebuilt on open and every read re-validates what it lands on, so an index failure is not an append failure. Logged once per segment and counted.

### Rollover can no longer land on a Tokio worker

The pre-check rolled off-thread, but a concurrent append could fill the segment in the gap and the in-lock fallback then rolled inline — putting two fsyncs and a directory sync back on a reactor worker. The write lock is now released and the roll retried on a blocking thread. `would_roll` is false for an empty segment, so an oversized record terminates the loop rather than spinning.

### Hydration never leaves a hole in the replay ring

This one no review caught until the fourth, and it is the nastiest shape of bug in the set.

Hydration asked for the ring's worth of tail in a **single** read, which the storage layer caps by records and bytes. Reads page *forward*, so a short read returns the **earliest** part of the window — and `next_seq` still advanced to the real tail, leaving a hole. A cursor pointing into that hole is *above* the ring's oldest entry, so it is accepted rather than rejected, and replay returns nothing.

To the subscriber that is indistinguishable from "you are caught up". It had history to read, was told it did not, and moved on. Losing history loudly is acceptable; losing it quietly is not.

**Reproduced before fixing:** `cursor at 550 replayed 0 records instead of 50`.

Hydration now pages forward to the tail keeping the *newest* records, so memory stays bounded by the ring and whatever survives is contiguous with `next_seq`. If the budget cannot cover any of it the ring is left empty and cursors get `CursorTooOld` — the honest answer.

### Length-field corruption is now decidable (format v2) — BREAKING

An acknowledged record whose length field rotted was indistinguishable from an unfinished write: both produce a record claiming more bytes than the file holds. Recovery had to guess, and guessing wrong silently deleted a record that had been fsynced and acknowledged.

Gating that case behind the existing opt-in was not acceptable either — a payload cut short by end of file is the **normal** outcome of a crash, so it would make every SIGKILL recovery require manual operator intervention.

So the format now carries the metadata needed to decide. `header_crc` covers bytes `0..20` and is verified *before* any other field is used, so `payload_len` is only acted on once it is known intact:

```
header verifies + payload short  ->  provably unfinished  ->  truncate
header does not verify           ->  ambiguous            ->  fail loudly
```

The ordinary crash case stays automatic, which is what makes the strict default liveable, and the dangerous case fails instead of guessing. `RecordChecksum`, `RecordTooLarge` and `OffsetOutOfOrder` join it behind `repair_checksum_tail` — all three imply a header that verified, so the record is complete on disk and the damage is rot, not a torn write.

**Breaking:** record headers grow 24 → 28 bytes (~3% at 128-byte payloads) and `FORMAT_VERSION` goes to 2. v1 segments are rejected on open naming the version found. v1 was only ever written by unreleased builds, so discarding the data directory is the migration path rather than carrying a second decoder — and rejecting is the safe failure, since a v1 record read as v2 misparses every field after the length.

## Residual behaviour, stated rather than hidden

A cancelled durable publish can leave a record on disk that live subscribers never received, because the bytes are committed before the caller goes away. Replay and post-restart hydration surface it. That is inherent to acknowledging durability before delivery, and is the correct trade — the alternative is a record that was fsynced and then pretended away.

## Verification

- **1,036 tests pass** with `--all-features`; clippy and fmt clean.
- Both headline fixes have regression tests **verified failing on the previous code** (10s deadlock; 0-instead-of-50 replay).
- Also fixes a `-D warnings` clippy failure and updates the one in-tree caller of the replaced sync entry point.

## Still open

#177 (public resumable replay over the wire) and #172 (tiered storage) are unaffected by this PR and remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
