### PR TITLE
M1: fix out-of-order commit release, readiness arming, and false seeding

### DIFF
--- a/crates/felix-broker/src/commit_order.rs
+++ b/crates/felix-broker/src/commit_order.rs
@@ -22,6 +22,7 @@
 // Offsets are still assigned concurrently and flushes are still shared, so
 // group commit keeps its fan-in; only the cheap post-flush half is ordered.
 
+use std::collections::BTreeMap;
 use std::fmt;
 
 use parking_lot::Mutex;
@@ -35,22 +36,48 @@ pub(crate) struct CommitSequencer {
     ready: Notify,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 struct SequenceState {
     /// Offset whose turn it is. Publishers wait until this reaches their first
     /// offset.
     next: Offset,
+    /// Ranges that have resolved out of order, keyed by their first offset.
+    ///
+    /// A range resolves when its guard drops — whether it applied cleanly or
+    /// was abandoned. Resolving is *not* the same as being next: a range behind
+    /// an unfinished predecessor has to wait its turn to be counted, or a
+    /// cancelled range would hand its successors permission to overtake the
+    /// range still in flight ahead of them, and the replay ring would receive
+    /// offsets out of order. Entries live here only until the prefix catches
+    /// up, so this holds at most one entry per publish in flight.
+    resolved: BTreeMap<Offset, Offset>,
     /// Bumped by every reset. A turn acquired before a reset carries
     /// pre-reset offsets, so releasing it must not move the sequence: the
     /// reset is authoritative about where the log now ends.
     generation: u64,
 }
 
+impl SequenceState {
+    /// Record a resolved range and advance through whatever contiguous prefix
+    /// that completes.
+    fn resolve(&mut self, first_offset: Offset, next_offset: Offset) {
+        if next_offset > self.next {
+            self.resolved.insert(first_offset, next_offset);
+        }
+        // Walk forward only while the next range in line has resolved. A gap
+        // stops the walk, which is exactly the range still in flight.
+        while let Some(end) = self.resolved.remove(&self.next) {
+            self.next = self.next.max(end);
+        }
+    }
+}
+
 impl fmt::Debug for CommitSequencer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let state = *self.state.lock();
+        let state = self.state.lock();
         f.debug_struct("CommitSequencer")
             .field("next", &state.next)
+            .field("pending_resolutions", &state.resolved.len())
             .field("generation", &state.generation)
             .finish()
     }
@@ -61,6 +88,7 @@ impl CommitSequencer {
         Self {
             state: Mutex::new(SequenceState {
                 next,
+                resolved: BTreeMap::new(),
                 generation: 0,
             }),
             ready: Notify::new(),
@@ -73,6 +101,8 @@ impl CommitSequencer {
         {
             let mut state = self.state.lock();
             state.next = next;
+            // Pending resolutions describe a sequence that no longer exists.
+            state.resolved.clear();
             state.generation += 1;
         }
         // Wake everyone: a waiter parked on an offset the reset just discarded
@@ -130,7 +160,7 @@ impl CommitTurn<'_> {
             notified.as_mut().enable();
 
             {
-                let state = *self.sequencer.state.lock();
+                let state = self.sequencer.state.lock();
                 // A reset means the log was rewritten underneath this range, so
                 // there is nothing left to wait for.
                 if state.next >= self.first_offset || state.generation != self.generation {
@@ -146,12 +176,12 @@ impl Drop for CommitTurn<'_> {
     fn drop(&mut self) {
         {
             let mut state = self.sequencer.state.lock();
-            // A reset while this turn was held means the log was rewritten
+            // A reset while this range was held means the log was rewritten
             // underneath it. Its offsets describe a sequence that no longer
-            // exists, so advancing on them would step the stream past records
+            // exists, so resolving on them would step the stream past records
             // that are gone.
-            if state.generation == self.generation && self.next_offset > state.next {
-                state.next = self.next_offset;
+            if state.generation == self.generation {
+                state.resolve(self.first_offset, self.next_offset);
             }
         }
         self.sequencer.ready.notify_waiters();
@@ -294,6 +324,36 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), after.wait())
             .await
             .expect("a cancelled waiter stranded the stream");
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_range_does_not_let_later_ranges_overtake_an_unfinished_one() {
+        let sequencer = Arc::new(CommitSequencer::new(0));
+
+        // A is in flight and has not applied yet.
+        let a = sequencer.reserve(0, 3);
+        // B reserves behind it, then is cancelled while waiting.
+        {
+            let _b = sequencer.reserve(3, 6);
+        }
+
+        // C must still wait: A has not applied, so nothing at or after offset 3
+        // may reach the replay ring yet. If the cancelled B advanced the
+        // sequence straight to 6, C would overtake A and the disk order would
+        // disagree with the cursor order.
+        let c = sequencer.reserve(6, 9);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), c.wait())
+                .await
+                .is_err(),
+            "offset 6 overtook an unfinished range at offset 0"
+        );
+
+        // Once A applies, the contiguous prefix resolves and C proceeds.
+        drop(a);
+        tokio::time::timeout(Duration::from_secs(5), c.wait())
+            .await
+            .expect("C should be released once A completes");
     }
 
     #[tokio::test]

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -53,6 +53,23 @@ struct SyncState {
 }
 
 impl SyncState {
+    /// Whether every cold-start snapshot has been fetched and applied.
+    ///
+    /// A cursor of 0 is this module's existing definition of "not yet seeded" —
+    /// it is what makes the snapshot blocks re-fetch — so the same test decides
+    /// whether the catalog is actually present. It matters because `sync_once`
+    /// returns `Ok` even when every snapshot fetch failed: the failures are
+    /// logged and retried, which is right for a background refresh, but means
+    /// "the iteration completed" says nothing about whether any tenant,
+    /// namespace, cache or stream was restored. Readiness needs the stronger
+    /// statement.
+    fn is_seeded(&self) -> bool {
+        self.next_tenant_seq != 0
+            && self.next_namespace_seq != 0
+            && self.next_cache_seq != 0
+            && self.next_stream_seq != 0
+    }
+
     fn new() -> Self {
         Self {
             next_tenant_seq: 0,
@@ -314,7 +331,13 @@ pub async fn start_sync_with_signal(
         match sync_once(&broker, &client, &base_url, state).await {
             Ok(next_state) => {
                 state = next_state;
-                if let Some(signal) = seeded.take() {
+                // Only signal once the catalog is genuinely in place. An
+                // iteration can succeed having applied nothing at all, and
+                // reporting ready off the back of that would advertise a broker
+                // whose streams — durable ones included — do not exist.
+                if state.is_seeded()
+                    && let Some(signal) = seeded.take()
+                {
                     let _ = signal.send(());
                 }
             }
@@ -1471,6 +1494,66 @@ mod tests {
         )
         .await?;
         assert!(broker.stream_exists("t1", "ns1", "orders").await);
+        Ok(())
+    }
+
+    #[test]
+    fn a_partially_seeded_state_is_not_seeded() {
+        // Every cursor must be non-zero. A snapshot that failed leaves its
+        // cursor at 0 and `sync_once` still returns Ok, so this is the only
+        // thing standing between a failed cold start and a ready broker.
+        let mut state = SyncState::new();
+        assert!(!state.is_seeded(), "a fresh state is not seeded");
+
+        state.next_tenant_seq = 2;
+        state.next_namespace_seq = 2;
+        state.next_cache_seq = 2;
+        assert!(!state.is_seeded(), "streams never arrived");
+
+        state.next_stream_seq = 2;
+        assert!(state.is_seeded());
+    }
+
+    #[tokio::test]
+    async fn a_failed_snapshot_never_reports_the_catalog_as_seeded() -> Result<()> {
+        // A control plane that answers every snapshot with 500. `sync_once`
+        // logs and returns Ok, so without the seeded check the broker would
+        // report ready having restored nothing.
+        let router = Router::new()
+            .route(
+                "/v1/tenants/snapshot",
+                axum::routing::get(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+            )
+            .route(
+                "/v1/namespaces/snapshot",
+                axum::routing::get(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+            )
+            .route(
+                "/v1/caches/snapshot",
+                axum::routing::get(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+            )
+            .route(
+                "/v1/streams/snapshot",
+                axum::routing::get(|| async { axum::http::StatusCode::INTERNAL_SERVER_ERROR }),
+            );
+        let (addr, shutdown_tx, handle) = serve_router(router).await?;
+        let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+        let client = build_test_client()?;
+
+        let state = sync_once(
+            &broker,
+            &client,
+            &format!("http://{addr}"),
+            SyncState::new(),
+        )
+        .await?;
+        assert!(
+            !state.is_seeded(),
+            "a sync where every snapshot failed must not count as seeded"
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
         Ok(())
     }
 

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -93,6 +93,9 @@ where
         Readiness::ready()
     };
     let accept_shutdown = CancellationToken::new();
+    // Cancelled the moment shutdown begins, so startup work in flight can tell
+    // "not ready yet" from "no longer ready".
+    let draining = CancellationToken::new();
     let sync_shutdown = CancellationToken::new();
     let metrics_shutdown = CancellationToken::new();
     let connections = TaskTracker::new();
@@ -227,28 +230,51 @@ where
         None
     };
 
-    // Block until the shutdown signal resolves so the process stays alive.
-    shutdown.await;
-
     // Flip to ready once the catalog has been applied and every durable stream
-    // it named has been recovered. Deliberately a task rather than an await:
-    // the listener is already accepting and `/ready` already reports false, so
-    // holding startup here would only delay the point at which an operator can
-    // see the broker's state.
+    // it named has been recovered.
+    //
+    // This has to be armed *before* the shutdown await, not after it: a task
+    // spawned below that point would only start listening for the seed signal
+    // once the broker was already draining, so it would never report ready
+    // while serving — and could flip back to ready in the middle of a drain.
+    //
+    // A task rather than an inline await: `/ready` already reports false, so
+    // blocking startup here would only delay the point at which an operator
+    // can observe that state.
+    //
+    // The task holds a `Readiness` clone and ends when the signal resolves or
+    // its sender is dropped, so nothing keeps it alive past shutdown.
     if gate_readiness_on_sync {
         let readiness = readiness.clone();
+        let draining = draining.clone();
         tokio::spawn(async move {
-            if seeded_rx.await.is_ok() {
-                readiness.mark_ready();
-                tracing::info!("initial control-plane sync applied; reporting ready");
+            // `Readiness` is a single flag, so it cannot distinguish "never
+            // ready yet" from "already drained" — both read false. The drain
+            // token is what makes the difference observable, so a seed that
+            // lands mid-drain cannot flip the broker back to ready.
+            tokio::select! {
+                biased;
+                _ = draining.cancelled() => {
+                    tracing::warn!("shutdown began before the initial sync; staying unready");
+                }
+                seeded = seeded_rx => {
+                    if seeded.is_ok() {
+                        readiness.mark_ready();
+                        tracing::info!("initial control-plane sync applied; reporting ready");
+                    }
+                }
             }
         });
     }
+
+    // Block until the shutdown signal resolves so the process stays alive.
+    shutdown.await;
 
     // Step 1: stop advertising readiness. Load balancers and the Kubernetes
     // endpoints controller drop this instance from rotation while it can still
     // serve, so new traffic is steered elsewhere rather than hitting a closing
     // listener. This must happen before anything stops working.
+    draining.cancel();
     readiness.begin_draining();
     tracing::info!("readiness set to draining");
 


### PR DESCRIPTION
Closes the three blockers from the fifth review. All three were verified in the code before being changed, and two have regression tests that fail on `main`.

Two of the three were defects I introduced while fixing earlier review findings, which is worth saying plainly.

## 1. Cancelled ranges let later publishes overtake an unfinished one

`CommitTurn::drop` advanced `state.next` straight to its own end offset. A range cancelled *while waiting* therefore handed its successors permission to proceed even though the range **ahead** of them was still in flight — so a later publish could reach the replay ring first, and disk order would disagree with cursor and delivery order.

That is exactly the defect the sequencer exists to prevent, reintroduced by the cancellation fix in #178.

Resolving a range is now distinct from being next. Out-of-order resolutions are parked in a `BTreeMap` keyed by first offset, and the sequence advances only through a **contiguous prefix** of resolved ranges — a gap stops the walk, and that gap is precisely the range still in flight. The map holds at most one entry per publish in flight.

```
reserve [0,3)  in flight
reserve [3,6)  cancelled while waiting  -> parked, not applied
reserve [6,9)  must still wait          <- was proceeding before this fix
drop   [0,3)   resolves                 -> prefix walks 0->3->6->9
```

## 2. Readiness was armed after the shutdown await

The task watching for the seed signal was spawned *below* `shutdown.await`, so it only began listening once the broker was already draining. A durable broker never reported ready while serving, and a late seed could flip it back to ready mid-drain.

My error, and the cause is worth recording: I placed that block by anchoring on a nearby comment without checking what preceded it.

It is armed before the await now, and races an explicit drain token. `Readiness` is a single flag and cannot distinguish "never ready yet" from "already drained" — both read false — so the token is what makes a mid-drain seed observable and refusable.

## 3. A failed cold start could still report ready

`sync_once` returns `Ok` when snapshot fetches fail: they are logged and retried, which is correct for a background refresh, but means "the iteration completed" says nothing about whether any tenant, namespace, cache or stream was restored.

The seed signal now requires `SyncState::is_seeded()` — every cold-start cursor non-zero, which is this module's own definition of seeded and what makes the snapshot blocks re-fetch. A new test drives a control plane that answers every snapshot with 500 and asserts the result is not seeded.

## Deliberately not changed

**QUIC acceptance still starts before the first sync.** Readiness is the signal orchestrators route on, and refusing connections outright would take the broker down for non-durable streams too whenever the control plane is slow. A client that connects early and asks for a stream that has not been applied yet gets `StreamNotFound` — a recoverable answer, not a durability violation.

Worth revisiting if the preference is to fail closed; it is a small change, but it trades availability for strictness in a way that should be a deliberate call rather than a side effect.

## Verification

Run against the checks CI actually runs, on this branch rebased onto merged `main`:

- `task lint` — pass
- `task test` (default features) — pass
- all-features workspace tests — 0 failures
- `task demo:check` (4 standalone crates) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
