### PR TITLE
M1: pin cursor identity to disk offsets, prove catalog seeding, gate accept on recovery

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -250,6 +250,7 @@ impl Broker {
         // below, not just the replay-ring append, because a subscriber's
         // delivery order is as much a part of the stream's order as its
         // cursors are.
+        let mut durable_first_offset = None;
         let _commit_turn = match &stream_state.durable {
             None => None,
             Some(durable) => {
@@ -263,6 +264,7 @@ impl Broker {
                 // publish abandoned its range, and every later publish waited
                 // on a turn that could never arrive.
                 let pending = durable.begin_append(payloads).await?;
+                durable_first_offset = Some(pending.first_offset());
                 let turn = stream_state
                     .commit_sequencer
                     .reserve(pending.first_offset(), pending.last_offset() + 1);
@@ -282,8 +284,10 @@ impl Broker {
 
         let append_start = t_now_if(sample);
         // Append to the in-memory log so cursors can replay without touching
-        // disk. For durable streams this mirrors what was just persisted.
-        stream_state.append_batch(payloads, self.log_capacity);
+        // disk. A durable stream pins the sequence numbers to the offsets the
+        // log assigned, so a cursor and a disk offset are the same value no
+        // matter what happened to any publish in between.
+        stream_state.append_batch_at(payloads, durable_first_offset, self.log_capacity);
 
         if let Some(start) = append_start {
             let append_ns = start.elapsed().as_nanos() as u64;
@@ -425,6 +429,13 @@ impl Broker {
     }
 
     // Return a cursor positioned at the tail of the stream log.
+    //
+    // For a durable stream the log is authoritative, not the replay ring. A
+    // publish can consume offsets without reaching the ring — a cancelled
+    // request does exactly that — so the ring's counter can sit behind the
+    // durable tail. Handing out a cursor from the ring would then name a
+    // position that is already in the past on disk, and replaying from it
+    // fails as too old rather than resuming where the caller actually was.
     pub async fn cursor_tail(
         &self,
         tenant_id: &str,
@@ -435,9 +446,11 @@ impl Broker {
             .resolve_stream_handle(tenant_id, namespace, stream)
             .await?;
 
-        Ok(Cursor {
-            next_seq: handle.state.tail_seq(),
-        })
+        let next_seq = match &handle.state.durable {
+            Some(log) => log.tail_offset().await?,
+            None => handle.state.tail_seq(),
+        };
+        Ok(Cursor { next_seq })
     }
 
     /// Allows us to subscribe from a previous point in time. If that point in time

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -209,7 +209,36 @@ impl StreamState {
         state.senders.len()
     }
 
+    /// Append with sequence numbers drawn from the ring's own counter.
+    ///
+    /// Only ephemeral streams use this; a durable stream pins its sequences to
+    /// disk offsets via [`StreamState::append_batch_at`]. Kept for tests, which
+    /// exercise the ring without a log behind it.
+    #[cfg(test)]
     pub(crate) fn append_batch(&self, payloads: &[Bytes], log_capacity: usize) {
+        self.append_batch_at(payloads, None, log_capacity);
+    }
+
+    /// Append to the replay ring, optionally pinning the sequence numbers.
+    ///
+    /// `first_seq` is `Some` for durable streams, carrying the offsets the log
+    /// already assigned. That pinning is what keeps a cursor's sequence number
+    /// and a record's disk offset the same value.
+    ///
+    /// Deriving the sequence from an independent counter instead let the two
+    /// drift the moment a publish did not reach the ring — a cancelled publish
+    /// consumes a disk offset, so the next record would take the *next* offset
+    /// on disk but the *cancelled* record's sequence in memory. The same record
+    /// then answered to one cursor before a restart and a different one after,
+    /// because hydration rebuilds sequences from disk offsets. Pinning removes
+    /// the possibility rather than relying on every path to keep two counters
+    /// in step.
+    pub(crate) fn append_batch_at(
+        &self,
+        payloads: &[Bytes],
+        first_seq: Option<u64>,
+        log_capacity: usize,
+    ) {
         if payloads.is_empty() {
             return;
         }
@@ -231,17 +260,18 @@ impl StreamState {
             }
         }
 
+        let mut seq = first_seq.unwrap_or(state.next_seq);
         for payload in payloads {
-            let seq = state.next_seq;
-            state.next_seq = state
-                .next_seq
-                .checked_add(1)
-                .expect("log sequence overflow");
             state.log.push_back(LogEntry {
                 seq,
                 payload: payload.clone(),
             });
+            seq = seq.checked_add(1).expect("log sequence overflow");
         }
+        // A pinned batch may start beyond `next_seq` when an earlier publish
+        // consumed offsets without reaching the ring; the tail is what the next
+        // cursor must point at either way.
+        state.next_seq = state.next_seq.max(seq);
 
         // Trim once after append to keep the newest `log_capacity` entries.
         let overflow = state.log.len().saturating_sub(log_capacity);

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -859,3 +859,68 @@ async fn hydration_never_leaves_a_gap_between_the_ring_and_the_tail() {
     assert_eq!(backlog[0], payload("v0550"));
     assert_eq!(backlog[49], payload("v0599"));
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_cancelled_publish_does_not_shift_cursor_identity() {
+    let dir = tempdir().expect("dir");
+    let saved_cursor;
+    let before_restart;
+    {
+        let (broker, storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+        register(&broker, "orders", true).await;
+
+        // Cancel publishes mid-fsync so their disk offsets are consumed without
+        // ever reaching the replay ring.
+        for _ in 0..12 {
+            let _ = tokio::time::timeout(
+                Duration::from_micros(200),
+                broker.publish("t1", "default", "orders", payload("cancelled")),
+            )
+            .await;
+        }
+
+        // A client takes its cursor after that, then reads five records.
+        saved_cursor = broker
+            .cursor_tail("t1", "default", "orders")
+            .await
+            .expect("cursor");
+        for i in 0..5 {
+            broker
+                .publish("t1", "default", "orders", payload(&format!("kept-{i}")))
+                .await
+                .expect("publish");
+        }
+
+        let (backlog, _) = broker
+            .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+            .await
+            .expect("replay");
+        before_restart = backlog
+            .into_iter()
+            .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
+            .collect::<Vec<_>>();
+        assert_eq!(before_restart.len(), 5, "the five kept records must replay");
+        storage.shutdown().await.expect("shutdown");
+    }
+
+    // The same cursor after a restart, where hydration rebuilds sequences from
+    // disk offsets. If the in-memory sequence had been assigned from its own
+    // counter, a consumed-but-unapplied offset would have shifted every later
+    // record's cursor by one, and this cursor would name different records
+    // either side of the restart.
+    let (broker, _storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
+    register(&broker, "orders", true).await;
+    let (backlog, _) = broker
+        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .await
+        .expect("replay after restart");
+    let after_restart: Vec<String> = backlog
+        .into_iter()
+        .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
+        .collect();
+
+    assert_eq!(
+        before_restart, after_restart,
+        "the same cursor named different records before and after a restart"
+    );
+}

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -50,24 +50,45 @@ struct SyncState {
     next_cache_seq: u64,
     /// Next sequence cursor for the streams change feed.
     next_stream_seq: u64,
+    /// Which cold-start snapshots have actually been fetched and applied.
+    ///
+    /// Deliberately separate from the cursors. A cursor cannot answer "was this
+    /// resource seeded?" for two independent reasons: a *successful* snapshot of
+    /// an empty catalog legitimately returns `next_seq == 0`, which reads as
+    /// "never seeded" and would leave such a deployment unready forever; and a
+    /// *failed* snapshot leaves the cursor at 0, after which the change feed in
+    /// the same iteration polls from zero and can advance the cursor straight
+    /// to the global tail — making a resource look seeded when nothing was
+    /// applied. Only an explicit flag set where the snapshot is applied says
+    /// what actually happened.
+    seeded: SeededSnapshots,
+}
+
+/// Per-resource record of a completed cold-start snapshot.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SeededSnapshots {
+    tenants: bool,
+    namespaces: bool,
+    caches: bool,
+    streams: bool,
+}
+
+impl SeededSnapshots {
+    fn all(&self) -> bool {
+        self.tenants && self.namespaces && self.caches && self.streams
+    }
 }
 
 impl SyncState {
     /// Whether every cold-start snapshot has been fetched and applied.
     ///
-    /// A cursor of 0 is this module's existing definition of "not yet seeded" —
-    /// it is what makes the snapshot blocks re-fetch — so the same test decides
-    /// whether the catalog is actually present. It matters because `sync_once`
-    /// returns `Ok` even when every snapshot fetch failed: the failures are
-    /// logged and retried, which is right for a background refresh, but means
-    /// "the iteration completed" says nothing about whether any tenant,
-    /// namespace, cache or stream was restored. Readiness needs the stronger
-    /// statement.
+    /// `sync_once` returns `Ok` even when every snapshot fetch failed — the
+    /// failures are logged and retried, which is right for a background
+    /// refresh, but means "the iteration completed" says nothing about whether
+    /// any tenant, namespace, cache or stream was restored. Readiness needs the
+    /// stronger statement.
     fn is_seeded(&self) -> bool {
-        self.next_tenant_seq != 0
-            && self.next_namespace_seq != 0
-            && self.next_cache_seq != 0
-            && self.next_stream_seq != 0
+        self.seeded.all()
     }
 
     fn new() -> Self {
@@ -76,6 +97,7 @@ impl SyncState {
             next_namespace_seq: 0,
             next_cache_seq: 0,
             next_stream_seq: 0,
+            seeded: SeededSnapshots::default(),
         }
     }
 }
@@ -377,13 +399,14 @@ async fn sync_once(
     let log_as_debug = cfg!(test) || std::env::var_os("RUST_TEST_THREADS").is_some();
     // === Cold start snapshot seeding ===
     // 1. Seed tenants first.
-    if state.next_tenant_seq == 0 {
+    if !state.seeded.tenants {
         match fetch_tenant_snapshot(client, base_url).await {
             Ok(snapshot) => {
                 for tenant in snapshot.items {
                     broker.register_tenant(tenant.tenant_id).await?;
                 }
                 state.next_tenant_seq = snapshot.next_seq;
+                state.seeded.tenants = true;
             }
             Err(err) => {
                 if log_as_debug {
@@ -396,7 +419,7 @@ async fn sync_once(
     }
 
     // 2. Seed namespaces after tenants.
-    if state.next_namespace_seq == 0 {
+    if !state.seeded.namespaces {
         match fetch_namespace_snapshot(client, base_url).await {
             Ok(snapshot) => {
                 for namespace in snapshot.items {
@@ -404,6 +427,7 @@ async fn sync_once(
                         .await?;
                 }
                 state.next_namespace_seq = snapshot.next_seq;
+                state.seeded.namespaces = true;
             }
             Err(err) => {
                 if log_as_debug {
@@ -416,7 +440,7 @@ async fn sync_once(
     }
 
     // 3. Seed caches after namespaces.
-    if state.next_cache_seq == 0 {
+    if !state.seeded.caches {
         match fetch_cache_snapshot(client, base_url).await {
             Ok(snapshot) => {
                 for cache in snapshot.items {
@@ -424,6 +448,7 @@ async fn sync_once(
                         .await?;
                 }
                 state.next_cache_seq = snapshot.next_seq;
+                state.seeded.caches = true;
             }
             Err(err) => {
                 if log_as_debug {
@@ -436,7 +461,7 @@ async fn sync_once(
     }
 
     // 4. Seed streams after caches.
-    if state.next_stream_seq == 0 {
+    if !state.seeded.streams {
         match fetch_snapshot(client, base_url).await {
             Ok(snapshot) => {
                 for stream in snapshot.items {
@@ -453,6 +478,7 @@ async fn sync_once(
                     .await?;
                 }
                 state.next_stream_seq = snapshot.next_seq;
+                state.seeded.streams = true;
             }
             Err(err) => {
                 if log_as_debug {
@@ -1505,13 +1531,77 @@ mod tests {
         let mut state = SyncState::new();
         assert!(!state.is_seeded(), "a fresh state is not seeded");
 
-        state.next_tenant_seq = 2;
-        state.next_namespace_seq = 2;
-        state.next_cache_seq = 2;
+        state.seeded.tenants = true;
+        state.seeded.namespaces = true;
+        state.seeded.caches = true;
         assert!(!state.is_seeded(), "streams never arrived");
 
-        state.next_stream_seq = 2;
+        state.seeded.streams = true;
         assert!(state.is_seeded());
+
+        // A cursor advancing on its own proves nothing: a failed snapshot
+        // leaves the cursor at 0 and the change feed in the same iteration
+        // polls from zero, which can carry it straight to the global tail.
+        let mut cursors_only = SyncState::new();
+        cursors_only.next_tenant_seq = 9_000;
+        cursors_only.next_namespace_seq = 9_000;
+        cursors_only.next_cache_seq = 9_000;
+        cursors_only.next_stream_seq = 9_000;
+        assert!(
+            !cursors_only.is_seeded(),
+            "advanced cursors must not stand in for an applied snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_catalog_still_becomes_seeded() -> Result<()> {
+        // A successful snapshot of an empty catalog returns next_seq == 0. That
+        // is a valid cursor, not a failure, and such a deployment has to be
+        // able to reach ready.
+        let router = Router::new()
+            .route(
+                "/v1/tenants/snapshot",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({ "items": [], "next_seq": 0 }))
+                }),
+            )
+            .route(
+                "/v1/namespaces/snapshot",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({ "items": [], "next_seq": 0 }))
+                }),
+            )
+            .route(
+                "/v1/caches/snapshot",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({ "items": [], "next_seq": 0 }))
+                }),
+            )
+            .route(
+                "/v1/streams/snapshot",
+                axum::routing::get(|| async {
+                    axum::Json(serde_json::json!({ "items": [], "next_seq": 0 }))
+                }),
+            );
+        let (addr, shutdown_tx, handle) = serve_router(router).await?;
+        let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+        let client = build_test_client()?;
+
+        let state = sync_once(
+            &broker,
+            &client,
+            &format!("http://{addr}"),
+            SyncState::new(),
+        )
+        .await?;
+        assert!(
+            state.is_seeded(),
+            "an empty catalog that fetched cleanly is seeded"
+        );
+
+        let _ = shutdown_tx.send(());
+        let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+        Ok(())
     }
 
     #[tokio::test]

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -96,6 +96,11 @@ where
     // Cancelled the moment shutdown begins, so startup work in flight can tell
     // "not ready yet" from "no longer ready".
     let draining = CancellationToken::new();
+    // Cancelled once the catalog is applied and every durable log recovered.
+    // Both readiness and the accept loop wait on it, so a durable broker
+    // neither advertises itself nor answers a direct client before its streams
+    // exist.
+    let seeded = CancellationToken::new();
     let sync_shutdown = CancellationToken::new();
     let metrics_shutdown = CancellationToken::new();
     let connections = TaskTracker::new();
@@ -180,7 +185,26 @@ where
         let auth = Arc::clone(&auth);
         let accept_shutdown = accept_shutdown.clone();
         let connections = connections.clone();
+        let seeded = seeded.clone();
         tokio::spawn(async move {
+            // A durable broker does not accept until its streams exist.
+            // Readiness alone only steers orchestrated traffic; a client with
+            // the address in hand would otherwise connect during recovery and
+            // be told its durable stream does not exist. Waiting is the honest
+            // answer, and shutdown still wins the race so a broker told to stop
+            // during recovery stops.
+            if gate_readiness_on_sync {
+                tokio::select! {
+                    biased;
+                    _ = accept_shutdown.cancelled() => {
+                        tracing::info!("shutdown before initial sync; not accepting");
+                        return;
+                    }
+                    _ = seeded.cancelled() => {
+                        tracing::info!("initial sync applied; accepting connections");
+                    }
+                }
+            }
             if let Err(err) = quic::serve_with_shutdown(
                 quic_server,
                 broker,
@@ -247,6 +271,7 @@ where
     if gate_readiness_on_sync {
         let readiness = readiness.clone();
         let draining = draining.clone();
+        let seeded = seeded.clone();
         tokio::spawn(async move {
             // `Readiness` is a single flag, so it cannot distinguish "never
             // ready yet" from "already drained" — both read false. The drain
@@ -257,8 +282,12 @@ where
                 _ = draining.cancelled() => {
                     tracing::warn!("shutdown began before the initial sync; staying unready");
                 }
-                seeded = seeded_rx => {
-                    if seeded.is_ok() {
+                result = seeded_rx => {
+                    if result.is_ok() {
+                        // Release the accept loop first, so a connection that
+                        // arrives the instant readiness flips is answered
+                        // rather than dropped.
+                        seeded.cancel();
                         readiness.mark_ready();
                         tracing::info!("initial control-plane sync applied; reporting ready");
                     }


### PR DESCRIPTION
Closes the four findings from the sixth review. Each was verified in the code before being changed.

Two of them are the same root cause: **a durable stream had two independent notions of "where am I", and they could drift.**

## 1. Cancellation could change cursor identity

The replay ring numbered its entries from its own counter. A publish that consumed disk offsets without reaching the ring — which a cancelled request does by construction — left the two sequences one apart. The next record then held one offset on disk and a different cursor number in memory. Because hydration rebuilds sequences *from* disk offsets, the same record answered to one cursor before a restart and a different one after.

A durable stream now **pins its ring sequences to the offsets the log assigned**. The invariant holds by construction rather than by two counters being kept in step along every code path.

The same drift reached `cursor_tail`, which read the ring's counter and could therefore hand out a cursor already in the past on disk — replaying from it then failed as `CursorTooOld`. For a durable stream the log is authoritative, and `cursor_tail` now says so.

That second half is worth noting because **my own regression test caught it**, not the review: pinning the sequences made the test fail with `CursorTooOld { oldest: 12, requested: 0 }`, which turned out to be a correct complaint about a stale cursor source.

## 2 & 3. Seeding was inferred from cursors, which cannot carry that meaning

Two independent failures with one cause:

- A **successful** snapshot of an empty catalog returns `next_seq == 0`. That read as "never seeded", so an empty deployment would never reach ready.
- A **failed** snapshot left the cursor at 0, after which the change feed *in the same iteration* polled from zero and could advance the cursor straight to the global tail — making a resource look seeded when nothing had been applied.

Seeding is now an explicit per-resource flag, set where the snapshot is applied. Tests cover the empty catalog reaching ready, and advanced cursors failing to stand in for an applied snapshot.

## 4. QUIC accepted before recovery

I had left this open in #179, arguing readiness was the signal that mattered. That was too narrow, and the review is right: readiness only steers *orchestrated* traffic. A client holding the address connects anyway and is told its durable stream does not exist.

A durable broker now waits for the same seed signal before accepting. Shutdown still wins the race, so a broker told to stop during recovery stops rather than hanging, and the accept gate is released *before* readiness flips so a connection arriving on that edge is answered rather than dropped.

## Still open, and unchanged by this PR

A cancelled publish's record is on disk but never reaches the replay ring or live subscribers pre-restart, while post-restart hydration reads it back from disk. Identity is now stable either side; **presence** still differs.

The fix is to detach the post-durability half of a publish — wait-turn, ring append, fanout — from the caller's future, so work whose bytes are already committed completes regardless of whether the caller is still waiting. That is a change to the publish hot path and deserves its own PR rather than being folded in here.

Also open: #177 (wire/client resumable replay), retention enforcement, #172 (tiered storage).

## Verification

- `task lint` — pass
- `task test` (default features) — pass
- all-features workspace tests — 0 failures
- `task demo:check` (4 standalone crates) — pass
- mermaid validator — 73/73

🤖 Generated with [Claude Code](https://claude.com/claude-code)
