### PR TITLE
M1: make the backlog-to-live subscription handoff lossless

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -287,7 +287,8 @@ impl Broker {
         // disk. A durable stream pins the sequence numbers to the offsets the
         // log assigned, so a cursor and a disk offset are the same value no
         // matter what happened to any publish in between.
-        stream_state.append_batch_at(payloads, durable_first_offset, self.log_capacity);
+        let senders =
+            stream_state.append_batch_at(payloads, durable_first_offset, self.log_capacity);
 
         if let Some(start) = append_start {
             let append_ns = start.elapsed().as_nanos() as u64;
@@ -296,7 +297,6 @@ impl Broker {
         }
 
         let send_start = t_now_if(sample);
-        let senders = stream_state.subscriber_snapshot();
         let fanout = senders.len();
         #[cfg(feature = "telemetry")]
         let payload_bytes: usize = payloads.iter().map(Bytes::len).sum();
@@ -467,16 +467,16 @@ impl Broker {
             .await?;
         let stream_state = handle.state;
 
-        let (oldest, backlog) = stream_state.snapshot_from(cursor.next_seq);
-        // TODO: Should we really return an error? Would this not just be all entries?
-        if cursor.next_seq < oldest {
-            return Err(BrokerError::CursorTooOld {
+        // Backlog and registration are captured together. Taking the snapshot
+        // first and registering after left a window in which a publish landed
+        // in neither: appended after the snapshot, fanned out to a subscriber
+        // list that did not yet include this one.
+        let (backlog, subscriber_id, receiver) = stream_state
+            .register_with_backlog(cursor.next_seq)
+            .map_err(|oldest| BrokerError::CursorTooOld {
                 oldest,
                 requested: cursor.next_seq,
-            });
-        }
-        // Return backlog for replay plus a live subscription for new events.
-        let (subscriber_id, receiver) = stream_state.register_subscriber();
+            })?;
         Ok((
             backlog,
             Subscription {

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -187,6 +187,12 @@ impl StreamState {
         }
     }
 
+    /// The current fanout list.
+    ///
+    /// The publish path no longer calls this: it takes the list from
+    /// [`StreamState::append_batch_at`] under the log lock, which is what makes
+    /// a joining subscriber's handoff lossless. Retained for tests.
+    #[cfg(test)]
     #[inline]
     pub(crate) fn subscriber_snapshot(&self) -> Arc<Vec<SubscriberEntry>> {
         self.subscribers_snapshot.load_full()
@@ -233,14 +239,25 @@ impl StreamState {
     /// because hydration rebuilds sequences from disk offsets. Pinning removes
     /// the possibility rather than relying on every path to keep two counters
     /// in step.
+    /// Append and capture the subscriber list that must receive this batch.
+    ///
+    /// The two happen under one lock on purpose. A subscriber joining is only
+    /// well defined relative to a point in the log: it takes everything before
+    /// that point as backlog and everything after it live. If a publish could
+    /// append *after* a joining subscriber captured its backlog and then fan
+    /// out to a list captured *before* that subscriber registered, the record
+    /// would be in neither — silently dropped from a replay the caller believes
+    /// is contiguous. Pairing the append with the fanout list, and pairing
+    /// registration with the backlog snapshot (see
+    /// [`StreamState::register_with_backlog`]), removes the window.
     pub(crate) fn append_batch_at(
         &self,
         payloads: &[Bytes],
         first_seq: Option<u64>,
         log_capacity: usize,
-    ) {
+    ) -> Arc<Vec<SubscriberEntry>> {
         if payloads.is_empty() {
-            return;
+            return self.subscribers_snapshot.load_full();
         }
 
         // Hot path: one lock per publish batch (instead of per payload).
@@ -278,30 +295,44 @@ impl StreamState {
         if overflow > 0 {
             state.log.drain(..overflow);
         }
+
+        // Captured while the log lock is still held, so any subscriber that
+        // registers after this point takes these records as backlog instead.
+        self.subscribers_snapshot.load_full()
     }
 
-    pub(crate) fn snapshot_range(&self, from_seq: u64, to_seq: u64) -> (u64, Vec<Bytes>) {
+    /// Register a subscriber and capture its backlog atomically.
+    ///
+    /// Returns `(oldest, backlog, subscriber_id, receiver)`. Holding the log
+    /// lock across both halves is what makes the handoff lossless: a publish
+    /// either completes before this and appears in the backlog, or happens
+    /// after and is fanned out to a list that already contains this
+    /// subscriber. It cannot fall between.
+    pub(crate) fn register_with_backlog(
+        &self,
+        from_seq: u64,
+    ) -> std::result::Result<(Vec<Bytes>, u64, SubscriptionReceiver), u64> {
         let state = self.log_state.lock();
-
-        // We return this to let the caller know if they need to indicate
-        // they are requesting entries which are too far back in time.
         let oldest = state
             .log
             .front()
             .map(|entry| entry.seq)
             .unwrap_or(state.next_seq);
-
+        // Checked before registering, so a rejected subscribe leaves no slot
+        // behind for the publish path to discover and reap.
+        if from_seq < oldest {
+            return Err(oldest);
+        }
         let backlog = state
             .log
             .iter()
-            .filter(|entry| entry.seq >= from_seq && entry.seq <= to_seq)
+            .filter(|entry| entry.seq >= from_seq)
             .map(|entry| entry.payload.clone())
             .collect();
-        (oldest, backlog)
-    }
 
-    pub(crate) fn snapshot_from(&self, from_seq: u64) -> (u64, Vec<Bytes>) {
-        self.snapshot_range(from_seq, u64::MAX)
+        let (subscriber_id, receiver) = self.register_subscriber();
+        drop(state);
+        Ok((backlog, subscriber_id, receiver))
     }
 
     pub(crate) fn tail_seq(&self) -> u64 {

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -924,3 +924,58 @@ async fn a_cancelled_publish_does_not_shift_cursor_identity() {
         "the same cursor named different records before and after a restart"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn the_backlog_to_live_handoff_loses_nothing_under_concurrent_publishes() {
+    let dir = tempdir().expect("dir");
+    let (broker, _storage) = broker_with_storage(&dir, FsyncMode::None).await;
+    register(&broker, "orders", true).await;
+
+    // A publisher running flat out while a subscriber joins. The handoff is the
+    // moment a record can fall between a backlog captured too early and a
+    // subscriber registered too late.
+    const TOTAL: u32 = 400;
+    let publisher = {
+        let broker = Arc::clone(&broker);
+        tokio::spawn(async move {
+            for i in 0..TOTAL {
+                broker
+                    .publish("t1", "default", "orders", payload(&format!("v{i:04}")))
+                    .await
+                    .expect("publish");
+            }
+        })
+    };
+
+    // Join mid-flight.
+    tokio::time::sleep(Duration::from_millis(5)).await;
+    let cursor = broker
+        .cursor_tail("t1", "default", "orders")
+        .await
+        .expect("cursor");
+    let (backlog, mut sub) = broker
+        .subscribe_with_cursor("t1", "default", "orders", cursor)
+        .await
+        .expect("subscribe");
+    publisher.await.expect("join");
+
+    // Everything from the cursor onwards must arrive, once, in order, across
+    // the backlog/live seam.
+    let mut seen: Vec<String> = backlog
+        .into_iter()
+        .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
+        .collect();
+    let expected_from = cursor.next_seq() as u32;
+    while (seen.len() as u32) < TOTAL - expected_from {
+        match tokio::time::timeout(Duration::from_secs(5), sub.recv()).await {
+            Ok(Some(msg)) => seen.push(String::from_utf8(msg.to_vec()).expect("utf8")),
+            _ => break,
+        }
+    }
+
+    let expected: Vec<String> = (expected_from..TOTAL).map(|i| format!("v{i:04}")).collect();
+    assert_eq!(
+        seen, expected,
+        "a record fell between the backlog snapshot and the live subscription"
+    );
+}


### PR DESCRIPTION
Fixes the one data-loss defect from the seventh review. The rest of that review is triaged below rather than fixed here, with reasons.

## Fixed: the backlog-to-live handoff could lose a publish

`subscribe_with_cursor` captured the backlog and *then* registered the subscriber. A publish landing between the two was in neither — appended after the snapshot, fanned out to a subscriber list that did not yet include the joining subscriber. The caller saw a replay it believed was contiguous with a record silently missing from it.

A subscriber joining is only well defined relative to a point in the log: everything before it is backlog, everything after is live. So the two halves have to be decided together, and both sides now do that under the log lock:

- **`append_batch_at`** captures the fanout list while it still holds the lock, so a subscriber registering afterwards takes those records as backlog instead of missing them.
- **`register_with_backlog`** registers and snapshots together, so a publish either completes first and lands in the backlog, or happens after and is fanned out to a list that already contains the new subscriber.

The `CursorTooOld` check moved inside that lock too — rejecting *after* registering left a subscriber slot behind for the publish path to discover and reap.

Regression test runs a publisher flat out while a subscriber joins mid-flight, and asserts the union of backlog and live delivery is exactly the contiguous range from the cursor.

## Reported, not fixed: rollover lock contention (review item 5)

Real, and correctly described. The filesystem work moved to `spawn_blocking` in an earlier PR, but rollover still holds the *synchronous* segment lock across sealing and fsync — so a Tokio appender calling `segments.write()` blocks a reactor worker for the duration anyway. Moving the blocking call without moving the contention only solved half of it.

Two ways out, both publish-hot-path changes that deserve their own review rather than being folded into a correctness fix:

1. Make the segment lock async (`tokio::sync::RwLock`), so appenders yield instead of blocking. The roller would take it via `blocking_write()` inside `spawn_blocking`. Costs an async lock on every append.
2. Shorten the critical section so sealing and fsync happen outside the lock, with the segment marked as rolling.

## Out of scope here: control-plane API (review items 1, 2, 4)

Paginated change feeds returning the global tail rather than the sequence after the last item; snapshots not being point-in-time consistent; no typed stale-cursor rejection.

All three are real, and all three are in the **control-plane HTTP API** — a different component from the durable broker this milestone covers. They affect what a broker can trust from the catalog, so they matter, but bolting server-side API changes onto an M1 durability PR would make both harder to review. They belong in their own issue, most naturally alongside M7 (control-plane HA).

Happy to file that with the analysis if useful.

## Still open

#177 (wire/client resumable replay), retention enforcement, #172 (tiered storage), and the cancelled-publish *presence* gap documented in #180.

## Verification

`task lint`, `task test`, all-features workspace tests, `task demo:check`, mermaid validator — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
