### PR TITLE
perf(storage): cut an fsync from the rollover path; add background rollover (off by default)

### DIFF
--- a/crates/felix-storage/src/bin/log_tool/args.rs
+++ b/crates/felix-storage/src/bin/log_tool/args.rs
@@ -73,6 +73,10 @@ COMMON OPTIONS:
     --segment-bytes <N>           Segment rollover size [default: 67108864]
     --index-spacing-bytes <N>     Sparse index interval [default: 4096]
     --no-preallocate              Do not reserve segment blocks up front
+    --rollover-threshold-percent <N>  Start the background roll at this % of
+                                  --segment-bytes; 100 disables it [default: 80]
+    --max-overshoot-percent <N>   How far past --segment-bytes a segment may
+                                  grow while its replacement is prepared
 
 write OPTIONS:
     --records <N>                 Records to append; 0 means run until killed
@@ -237,6 +241,17 @@ impl Flags {
                 .unwrap_or(defaults.index_spacing_bytes),
             fsync_mode,
             preallocate_segments: !self.flag("--no-preallocate"),
+            // Exposed so a benchmark can A/B the background rollover in one
+            // binary: at 100% no roll is ever started early, which is exactly
+            // the behaviour that predates it.
+            rollover_threshold_percent: self
+                .number("--rollover-threshold-percent")?
+                .unwrap_or(defaults.rollover_threshold_percent as u64)
+                as u8,
+            max_overshoot_percent: self
+                .number("--max-overshoot-percent")?
+                .unwrap_or(defaults.max_overshoot_percent as u64)
+                as u8,
             ..defaults
         };
         config.validate().map_err(|err| err.to_string())?;

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -37,6 +37,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use std::sync::atomic::{AtomicU8, Ordering};
+
 use parking_lot::{Mutex, RwLock};
 
 use crate::log::{
@@ -53,7 +55,7 @@ use crate::{Result, StorageError, metrics_names};
 /// interleaving.
 const MAX_ROLL_ATTEMPTS: usize = 8;
 
-use segments::SegmentSet;
+use segments::{RollOutcome, SegmentSet};
 use sync::{Durability, PeriodicSyncer};
 
 /// Shared state behind every clone of a [`DiskLog`].
@@ -67,6 +69,61 @@ struct LogInner {
     durability: Durability,
     /// `None` unless the fsync policy is `Periodic`. Taken on shutdown.
     syncer: Mutex<Option<PeriodicSyncer>>,
+    /// Where the background rollover is in its lifecycle. At most one runs at
+    /// a time, and a failure is terminal for the log.
+    roll_state: AtomicU8,
+    /// The in-flight rollover, so shutdown can wait for it to finish rather
+    /// than dropping the runtime out from under a half-installed segment.
+    roll_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    /// A retired segment that has been swapped out but not yet flushed.
+    ///
+    /// `flush` reports durability for the whole log, but it only ever syncs the
+    /// *active* segment. With an inline rollover that was sound, because
+    /// sealing happened before the replacement existed. A background rollover
+    /// breaks it: between the swap and the seal there are records in the
+    /// retired segment that no sync of the active segment covers, and reporting
+    /// them durable would be a lie under `FsyncMode::OnCommit`. So `flush`
+    /// syncs this handle too for as long as it is set.
+    pending_seal: Mutex<Option<Arc<std::fs::File>>>,
+}
+
+/// Lifecycle of the background rollover.
+///
+/// Explicit rather than a boolean because the states are not symmetric: the
+/// first two are recoverable and self-clearing, the last is terminal.
+///
+/// ```text
+///   Idle ──► Preparing ──► Sealing ──► Idle
+///              │              │
+///              └──────────────┴──────► Failed  (terminal)
+/// ```
+///
+/// * `Preparing` — building the replacement segment. Nothing is installed yet;
+///   a crash here leaves an uninstalled segment that recovery discards.
+/// * `Sealing` — the replacement is live and the retired segment is being
+///   flushed. Reads already route across it, so a crash here loses nothing that
+///   the fsync policy had promised.
+/// * `Failed` — the retired segment could not be flushed. The log stops
+///   accepting appends: a failed fsync means bytes that were reported durable
+///   may not be, and continuing to append over that is worse than stopping.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[repr(u8)]
+enum RollState {
+    Idle = 0,
+    Preparing = 1,
+    Sealing = 2,
+    Failed = 3,
+}
+
+impl RollState {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Preparing,
+            2 => Self::Sealing,
+            3 => Self::Failed,
+            _ => Self::Idle,
+        }
+    }
 }
 
 impl std::fmt::Debug for LogInner {
@@ -79,6 +136,83 @@ impl std::fmt::Debug for LogInner {
 }
 
 impl LogInner {
+    /// Build the next segment and swap it in, with every fsync off the lock.
+    ///
+    /// Runs on a blocking thread. The segment lock is taken twice and held only
+    /// for pointer work: once to install the replacement, once to record the
+    /// retired segment as sealed. The two expensive halves — creating the new
+    /// file and flushing the old one — happen with no lock held, so an append
+    /// never queues behind a rollover's flushes.
+    async fn roll_in_background(self: Arc<Self>) -> Result<()> {
+        let inner = Arc::clone(&self);
+        tokio::task::spawn_blocking(move || {
+            // The plan is copied out under a read lock; the segment is built
+            // with no lock at all. Creating it fsyncs its header and its parent
+            // directory, so by the time anything can be appended here it is
+            // durable -- and holding a lock across those two flushes would stall
+            // every append waiting on the write lock, which is the entire cost
+            // this design exists to remove.
+            let plan = { inner.segments.read().roll_plan() };
+            let prepared = plan.build()?;
+
+            let retired = {
+                let mut segments = inner.segments.write();
+                match segments.commit_roll(prepared)? {
+                    RollOutcome::Installed(retired) => {
+                        // Published before the lock is released, so no flush can
+                        // observe the new active segment without also seeing the
+                        // retired one it has to cover.
+                        *inner.pending_seal.lock() = Some(retired.sync_handle());
+                        retired
+                    }
+                    // The tail moved past the offset this segment was built
+                    // for. Delete it here — leaving it for recovery to clean up
+                    // works, but only because recovery knows the rule.
+                    RollOutcome::Stale(prepared) => {
+                        drop(segments);
+                        metrics::counter!(metrics_names::SEGMENT_ROLL_DISCARDED_TOTAL).increment(1);
+                        return prepared.discard();
+                    }
+                }
+            };
+
+            inner
+                .roll_state
+                .store(RollState::Sealing as u8, Ordering::Release);
+
+            // Flushed with no lock held. The segment is already listed as
+            // sealed and readable — this only makes it durable.
+            let mut retired = retired;
+            let sealed = retired.seal();
+            // Cleared either way: on success it is durable, and on failure the
+            // log is about to stop accepting appends anyway.
+            *inner.pending_seal.lock() = None;
+            sealed?;
+            Ok::<(), StorageError>(())
+        })
+        .await
+        .map_err(|err| StorageError::Io(std::io::Error::other(err)))?
+    }
+
+    /// Whether a background rollover is between its start and its completion.
+    fn roll_pending(&self) -> bool {
+        matches!(
+            RollState::from_u8(self.roll_state.load(Ordering::Acquire)),
+            RollState::Preparing | RollState::Sealing
+        )
+    }
+
+    /// Refuse further appends once a rollover has failed.
+    fn check_roll_state(&self) -> Result<()> {
+        if RollState::from_u8(self.roll_state.load(Ordering::Acquire)) == RollState::Failed {
+            return Err(StorageError::SyncFailed(format!(
+                "{}: a background segment rollover failed; the log is no longer accepting appends",
+                self.label
+            )));
+        }
+        Ok(())
+    }
+
     /// Flush the active segment and report the exclusive offset bound now
     /// durable.
     ///
@@ -96,11 +230,22 @@ impl LogInner {
                 segments.tail_offset(),
             )
         };
+        // Taken after the active handle, so a rollover that lands in between is
+        // seen here rather than missed: `commit_roll` sets it before releasing
+        // the lock this read just took.
+        let retired = self.pending_seal.lock().clone();
 
         let started = std::time::Instant::now();
-        let outcome = tokio::task::spawn_blocking(move || sync_data(&handle))
-            .await
-            .map_err(|err| StorageError::SyncFailed(format!("flush task failed: {err}")))?;
+        let outcome = tokio::task::spawn_blocking(move || {
+            // The retired segment first. `durable_upto` covers records in both,
+            // and it may not be reported until every one of them is on disk.
+            if let Some(retired) = retired {
+                sync_data(&retired)?;
+            }
+            sync_data(&handle)
+        })
+        .await
+        .map_err(|err| StorageError::SyncFailed(format!("flush task failed: {err}")))?;
         outcome.map_err(|err| StorageError::SyncFailed(err.to_string()))?;
 
         metrics::counter!(metrics_names::SYNC_TOTAL).increment(1);
@@ -110,8 +255,9 @@ impl LogInner {
         {
             let mut segments = self.segments.write();
             // A rollover may have swapped the active segment while the flush was
-            // in flight. The old segment was sealed (and therefore synced) as
-            // part of that roll, so there is nothing to record against it.
+            // in flight. Its records were covered by the `pending_seal` sync
+            // above, and the retired writer is owned by the rollover task, so
+            // there is nothing to record against it here.
             if segments.active().id() == segment_id {
                 segments.active_mut().mark_synced(synced_bytes);
             }
@@ -182,6 +328,9 @@ impl DiskLog {
             segments: RwLock::new(segments),
             durability: Durability::new(config.fsync_mode, durable_upto),
             syncer: Mutex::new(None),
+            roll_state: AtomicU8::new(RollState::Idle as u8),
+            roll_task: Mutex::new(None),
+            pending_seal: Mutex::new(None),
         });
 
         if let FsyncMode::Periodic { interval } = config.fsync_mode {
@@ -277,6 +426,16 @@ impl DiskLog {
         if let Some(syncer) = syncer {
             syncer.shutdown().await;
         }
+        // A rollover in flight owns the retired segment and is the only thing
+        // that will ever flush it. Dropping the runtime here would abandon it
+        // half-installed, so wait it out first — it is bounded by two fsyncs.
+        let roll = self.inner.roll_task.lock().take();
+        if let Some(roll) = roll {
+            // A panicked rollover has already recorded itself as `Failed`; the
+            // `sync` below is what reports the problem.
+            let _ = roll.await;
+        }
+        self.inner.check_roll_state()?;
         self.sync().await
     }
 }
@@ -308,23 +467,22 @@ impl DiskLog {
         if records.is_empty() {
             return Err(StorageError::InvalidRange);
         }
+        inner.check_roll_state()?;
 
-        // Rolling a segment seals one file, creates another, and fsyncs both
-        // plus the directory entry. That is real blocking work, so it must not
-        // run on a reactor worker.
-        //
-        // Detect-and-retry rather than detect-then-append: a concurrent append
-        // can fill the segment between the check and the write lock, and if
-        // this path then let `SegmentSet::append` roll inline, the flushes
-        // would land on a Tokio worker after all — exactly what moving the roll
-        // off-thread was meant to prevent. So the write lock is released and
-        // the roll retried on a blocking thread instead.
-        //
-        // `would_roll` is false for an empty active segment, so an oversized
-        // record terminates the loop rather than spinning: it gets a segment to
-        // itself, which is the documented policy.
+        // The hard-limit fallback. A background roll normally replaces the
+        // segment well before this, so reaching here means the log filled
+        // faster than a replacement could be built — rare, and still correct.
         for attempt in 0..MAX_ROLL_ATTEMPTS {
-            if inner.segments.read().would_roll(&records) {
+            // While a background rollover is building the replacement, the
+            // segment is allowed to grow past its configured size rather than
+            // blocking here. That headroom is what gives the preparation time
+            // to finish; without it the inline path below wins every race.
+            let roll_pending = inner.roll_pending();
+            if inner
+                .segments
+                .read()
+                .would_roll_within(&records, roll_pending)
+            {
                 let roller = Arc::clone(&inner);
                 let batch = records.clone();
                 tokio::task::spawn_blocking(move || {
@@ -332,7 +490,7 @@ impl DiskLog {
                     // Re-checked under the write lock: another publisher may
                     // have rolled already, and rolling twice leaves an empty
                     // segment behind.
-                    if segments.would_roll(&batch) {
+                    if segments.would_roll_within(&batch, roller.roll_pending()) {
                         segments.roll()?;
                     }
                     Ok::<(), StorageError>(())
@@ -342,7 +500,7 @@ impl DiskLog {
             }
 
             let mut segments = inner.segments.write();
-            if segments.would_roll(&records) {
+            if segments.would_roll_within(&records, inner.roll_pending()) {
                 // Filled again in the gap. Drop the lock and roll off-thread.
                 drop(segments);
                 debug_assert!(attempt + 1 < MAX_ROLL_ATTEMPTS, "rollover retry starved");
@@ -350,6 +508,54 @@ impl DiskLog {
             }
             let (first_offset, last_offset) = segments.append(&records)?;
             let durable_target = segments.tail_offset();
+            let prepare_roll = segments.should_prepare_roll();
+            drop(segments);
+
+            // Start the replacement while the current segment still has room,
+            // so the flushes it costs never land on an append. `Idle ->
+            // Preparing` is a compare-exchange, which is what keeps exactly one
+            // rollover in flight and leaves `Failed` terminal.
+            if prepare_roll
+                && inner
+                    .roll_state
+                    .compare_exchange(
+                        RollState::Idle as u8,
+                        RollState::Preparing as u8,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    )
+                    .is_ok()
+            {
+                let roller = Arc::clone(&inner);
+                metrics::counter!(metrics_names::SEGMENT_ROLL_BACKGROUND_TOTAL).increment(1);
+                let handle = tokio::spawn(async move {
+                    match Arc::clone(&roller).roll_in_background().await {
+                        Ok(()) => roller
+                            .roll_state
+                            .store(RollState::Idle as u8, Ordering::Release),
+                        Err(err) => {
+                            // Terminal. A rollover fails on a failed fsync or a
+                            // failed file creation, and both mean the log can no
+                            // longer honour what it has already acknowledged.
+                            // Retrying would just fail again, quietly, forever.
+                            tracing::error!(
+                                shard = %roller.label,
+                                error = %err,
+                                "background segment rollover failed; the log will reject further appends",
+                            );
+                            metrics::counter!(metrics_names::SEGMENT_ROLL_FAILED_TOTAL)
+                                .increment(1);
+                            roller
+                                .roll_state
+                                .store(RollState::Failed as u8, Ordering::Release);
+                        }
+                    }
+                });
+                // Replaces a handle only when the previous roll has finished,
+                // because the compare-exchange above admits one at a time.
+                *inner.roll_task.lock() = Some(handle);
+            }
+
             return Ok(PendingAppend {
                 result: AppendResult {
                     first_offset,

--- a/crates/felix-storage/src/disk_log/recovery.rs
+++ b/crates/felix-storage/src/disk_log/recovery.rs
@@ -34,6 +34,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::log::{LogConfig, Offset, SegmentDescriptor, SegmentId};
+use crate::segment::format::SEGMENT_HEADER_LEN;
 use crate::segment::io::sync_dir;
 use crate::segment::writer::ResumeState;
 use crate::segment::{
@@ -92,7 +93,12 @@ pub fn recover_shard(dir: &Path, label: &str, config: &LogConfig) -> Result<Reco
         sync_dir(parent)?;
     }
 
-    let ids = discover_segment_ids(dir)?;
+    let mut ids = discover_segment_ids(dir)?;
+    // Rollover prepares the replacement segment ahead of the swap that installs
+    // it, so a crash — or a truncation — can leave one behind that was never
+    // used. Drop them before recovery proper, or their base offset reads as a
+    // break in the offset chain. See `discard_abandoned_preparations`.
+    let abandoned = discard_abandoned_preparations(dir, label, config, &mut ids)?;
     let recovered = match ids.split_last() {
         None => Recovered {
             sealed: Vec::new(),
@@ -118,11 +124,121 @@ pub fn recover_shard(dir: &Path, label: &str, config: &LogConfig) -> Result<Reco
         metrics::counter!(metrics_names::RECOVERY_TRUNCATED_BYTES)
             .increment(recovered.truncated_bytes);
     }
+    if abandoned > 0 {
+        metrics::counter!(metrics_names::RECOVERY_ABANDONED_ROLLS_TOTAL)
+            .increment(abandoned as u64);
+    }
     if recovered.index_rebuilds > 0 {
         metrics::counter!(metrics_names::RECOVERY_INDEX_REBUILDS_TOTAL)
             .increment(recovered.index_rebuilds as u64);
     }
     Ok(recovered)
+}
+
+/// Remove trailing segments that a rollover created but never installed.
+///
+/// A background rollover builds its replacement segment — file, header,
+/// directory entry, all fsynced — before taking the lock that swaps it in, so
+/// that the flushes never land on an append. The consequence is a window in
+/// which a replacement exists on disk but is not yet part of the log, and two
+/// things can end that window without installing it: a crash, or a truncation
+/// that rewinds the tail past the offset the replacement was built for.
+///
+/// Such a segment is recognisable without any durable roll-intent record,
+/// because it is self-describing: it is the newest segment, it holds **zero
+/// records**, and its base offset is not where the log actually ends. A segment
+/// that holds no records has nothing to lose, so deleting it cannot discard an
+/// acknowledged write — which is what makes this rule safe to apply blindly.
+///
+/// Both directions occur and both are handled:
+///
+/// * base offset *below* the tail — appends kept landing in the old segment
+///   after the replacement was built, which is the normal design of the
+///   background roll;
+/// * base offset *above* the tail — a truncation rewound the log underneath a
+///   replacement that had already been built.
+///
+/// An empty newest segment whose base offset *does* match the tail is the
+/// ordinary state right after a successful roll, and is kept.
+fn discard_abandoned_preparations(
+    dir: &Path,
+    label: &str,
+    config: &LogConfig,
+    ids: &mut Vec<SegmentId>,
+) -> Result<usize> {
+    let mut discarded = 0;
+    // More than one can accumulate: each crash during a roll can leave its own.
+    while ids.len() > 1 {
+        let id = *ids.last().expect("non-empty");
+        let path = dir.join(segment_file_name(id));
+
+        // A file too short to hold a header is a rollover that was interrupted
+        // between creating the segment and writing its header. It has no base
+        // offset to compare and, having no header, cannot hold a record either.
+        let headerless = std::fs::metadata(&path)?.len() < SEGMENT_HEADER_LEN;
+        let base_offset = if headerless {
+            None
+        } else {
+            let outcome = scan_segment(
+                &path,
+                id,
+                label,
+                config.index_spacing_bytes,
+                ScanStart::Full,
+                config.repair_checksum_tail,
+            )?;
+            if outcome.record_count > 0 {
+                break;
+            }
+
+            // Empty. Compare its base against where the previous segment ends.
+            let previous = *ids.get(ids.len() - 2).expect("len > 1");
+            let previous_end = scan_segment(
+                &dir.join(segment_file_name(previous)),
+                previous,
+                label,
+                config.index_spacing_bytes,
+                ScanStart::Full,
+                config.repair_checksum_tail,
+            )?
+            .next_offset;
+            if outcome.header.base_offset == previous_end {
+                break;
+            }
+            Some((outcome.header.base_offset, previous_end))
+        };
+
+        match base_offset {
+            None => tracing::warn!(
+                shard = label,
+                segment = id,
+                "discarding a headerless segment left behind by an uninstalled rollover"
+            ),
+            Some((base_offset, log_tail)) => tracing::warn!(
+                shard = label,
+                segment = id,
+                base_offset,
+                log_tail,
+                "discarding an empty segment left behind by an uninstalled rollover"
+            ),
+        }
+        for path in [
+            dir.join(segment_file_name(id)),
+            dir.join(index_file_name(id)),
+        ] {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(StorageError::Io(err)),
+            }
+        }
+        ids.pop();
+        discarded += 1;
+    }
+    if discarded > 0 {
+        sync_dir(dir)?;
+    }
+    Ok(discarded)
 }
 
 fn preallocate_bytes(config: &LogConfig) -> u64 {
@@ -384,6 +500,144 @@ mod tests {
 
     fn reopen(dir: &TempDir) -> Result<Recovered> {
         recover_shard(dir.path(), "t/ns/s/0", &config())
+    }
+
+    /// Reproduce the on-disk state left by a crash while a rollover was
+    /// *preparing*: a replacement segment exists, fsynced, but was never
+    /// installed. `base_offset` is whatever the tail was when it was built.
+    fn plant_uninstalled_preparation(dir: &TempDir, base_offset: Offset) -> SegmentId {
+        let id = discover_segment_ids(dir.path())
+            .expect("ids")
+            .last()
+            .copied()
+            .expect("ids")
+            + 1;
+        SegmentWriter::create(
+            dir.path(),
+            id,
+            base_offset,
+            now_micros(),
+            0,
+            config().index_spacing_bytes,
+        )
+        .expect("create");
+        id
+    }
+
+    #[test]
+    fn a_crash_before_the_header_is_written_leaves_the_log_openable() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        // A rollover interrupted between creating the segment and activating
+        // it: the file exists, preallocated and directory-synced, but carries
+        // no header and so claims no base offset at all.
+        let id = discover_segment_ids(dir.path())
+            .expect("ids")
+            .last()
+            .copied()
+            .expect("ids")
+            + 1;
+        let path = dir.path().join(segment_file_name(id));
+        std::fs::write(&path, b"").expect("create");
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn a_partially_written_header_is_also_an_uninstalled_rollover() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        let id = discover_segment_ids(dir.path())
+            .expect("ids")
+            .last()
+            .copied()
+            .expect("ids")
+            + 1;
+        let path = dir.path().join(segment_file_name(id));
+        // Torn mid-header. Nothing can have been acknowledged here.
+        std::fs::write(&path, vec![0u8; (SEGMENT_HEADER_LEN - 1) as usize]).expect("create");
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn a_crash_while_preparing_a_rollover_leaves_the_log_openable() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        // Built when the tail was 3 records back; appends kept going after.
+        // This is the ordinary shape of the background roll, interrupted.
+        let planted = plant_uninstalled_preparation(&dir, tail - 3);
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail, "no record was lost");
+        assert!(
+            !dir.path().join(segment_file_name(planted)).exists(),
+            "the uninstalled preparation should have been removed",
+        );
+    }
+
+    #[test]
+    fn a_preparation_stranded_ahead_of_the_tail_is_also_discarded() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        // The mirror image: a truncation rewound the log underneath a
+        // replacement that had already been built for a higher offset.
+        let planted = plant_uninstalled_preparation(&dir, tail + 50);
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail);
+        assert!(!dir.path().join(segment_file_name(planted)).exists());
+    }
+
+    #[test]
+    fn an_empty_newest_segment_at_the_tail_is_a_completed_roll_and_is_kept() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        // Same shape as an abandoned preparation except for the one thing that
+        // distinguishes them: its base offset *is* the tail. That is simply a
+        // roll that finished with nothing appended yet.
+        let planted = plant_uninstalled_preparation(&dir, tail);
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.id(), planted, "it is the active segment");
+        assert_eq!(recovered.active.next_offset(), tail);
+        assert!(dir.path().join(segment_file_name(planted)).exists());
+    }
+
+    #[test]
+    fn successive_crashes_can_strand_more_than_one_preparation() {
+        let dir = tempdir().expect("dir");
+        let tail = populate(&dir, 12);
+        let first = plant_uninstalled_preparation(&dir, tail - 3);
+        let second = plant_uninstalled_preparation(&dir, tail - 1);
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail);
+        for id in [first, second] {
+            assert!(!dir.path().join(segment_file_name(id)).exists());
+        }
+    }
+
+    #[test]
+    fn a_crash_while_sealing_a_retired_segment_loses_nothing() {
+        let dir = tempdir().expect("dir");
+        // A retired segment that was never sealed is byte-identical to one that
+        // was: sealing only syncs and trims to `size_bytes`, and preallocation
+        // never extends the logical length. So the crash window between
+        // installing the replacement and flushing the retired segment leaves a
+        // chain recovery reads normally -- which is what makes the background
+        // roll safe without a durable roll-intent record.
+        let tail = populate(&dir, 12);
+        let ids = discover_segment_ids(dir.path()).expect("ids");
+        assert!(ids.len() > 1, "the test needs a retired segment");
+
+        let recovered = reopen(&dir).expect("recover");
+        assert_eq!(recovered.active.next_offset(), tail);
+        assert_eq!(recovered.sealed.len(), ids.len() - 1);
     }
 
     #[test]

--- a/crates/felix-storage/src/disk_log/segments.rs
+++ b/crates/felix-storage/src/disk_log/segments.rs
@@ -6,16 +6,78 @@
 // lock and calls in.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::log::{AppendRecord, LogConfig, LogRecord, Offset, SegmentDescriptor, SegmentId};
 use crate::segment::format::SEGMENT_HEADER_LEN;
 use crate::segment::io::read_at;
-use crate::segment::writer::ResumeState;
+use crate::segment::writer::{BlankSegment, ResumeState};
 use crate::segment::{
     ReadBudget, ScanStart, SegmentReader, SegmentWriter, SparseIndex, index_file_name,
     scan_segment, segment_file_name,
 };
 use crate::{Result, StorageError, metrics_names};
+
+/// Everything needed to build a replacement segment, captured under the lock so
+/// that the building itself can happen without one.
+#[derive(Debug, Clone)]
+pub struct RollPlan {
+    dir: PathBuf,
+    id: SegmentId,
+    previous_active_id: SegmentId,
+    preallocate_bytes: u64,
+    index_spacing_bytes: u64,
+}
+
+impl RollPlan {
+    /// Create the replacement segment. Blocking, and safe to call with no lock.
+    ///
+    /// The segment is left *headerless*: it claims no base offset yet, because
+    /// the correct one is not known until the swap. See [`BlankSegment`].
+    pub fn build(self) -> Result<PreparedSegment> {
+        let blank = BlankSegment::create(
+            &self.dir,
+            self.id,
+            self.preallocate_bytes,
+            self.index_spacing_bytes,
+        )?;
+        Ok(PreparedSegment {
+            blank,
+            previous_active_id: self.previous_active_id,
+        })
+    }
+}
+
+/// A replacement segment built ahead of the swap that installs it.
+#[derive(Debug)]
+pub struct PreparedSegment {
+    blank: BlankSegment,
+    /// The segment this replacement was built to retire.
+    ///
+    /// The only thing that can invalidate a prepared segment now that it takes
+    /// its base offset at the swap: another roll got there first, so the
+    /// segment this one was built to retire is no longer the active one.
+    /// Installing anyway would abandon that segment's file with no owner.
+    previous_active_id: SegmentId,
+}
+
+impl PreparedSegment {
+    /// Remove the files backing a replacement that was never installed.
+    pub fn discard(self) -> Result<()> {
+        self.blank.discard()
+    }
+}
+
+/// What happened to a prepared segment offered to [`SegmentSet::commit_roll`].
+#[derive(Debug)]
+pub enum RollOutcome {
+    /// Installed as the active segment. Carries the retired writer to be sealed.
+    Installed(SegmentWriter),
+    /// Rejected: the tail moved past the offset it was built for. Handed back
+    /// so the caller can delete its files — dropping it would leave them on
+    /// disk for recovery to clean up instead.
+    Stale(PreparedSegment),
+}
 
 /// A finished segment: immutable bytes plus the index needed to seek into them.
 #[derive(Debug)]
@@ -45,7 +107,13 @@ pub struct SegmentSet {
     active: SegmentWriter,
     /// Read handle on the active segment. Recreated on every roll.
     active_reader: SegmentReader,
-    next_segment_id: SegmentId,
+    /// Next free segment id.
+    ///
+    /// Atomic because `roll_plan` runs under a *read* lock — it has to, so
+    /// appends continue while a replacement is built — and two plans racing on
+    /// the same id would both try to create the same file, with the loser
+    /// failing on `create_new`.
+    next_segment_id: AtomicU64,
 }
 
 impl SegmentSet {
@@ -58,7 +126,7 @@ impl SegmentSet {
         active: SegmentWriter,
     ) -> Result<Self> {
         let active_reader = SegmentReader::open(active.path(), active.id(), active.base_offset())?;
-        let next_segment_id = active.id() + 1;
+        let next_segment_id = AtomicU64::new(active.id() + 1);
         metrics::gauge!(metrics_names::SEGMENT_COUNT).set((sealed.len() + 1) as f64);
         Ok(Self {
             dir,
@@ -111,8 +179,46 @@ impl SegmentSet {
     /// creates another, and fsyncs both plus the directory — on a blocking
     /// thread instead of inline on a reactor worker.
     pub fn would_roll(&self, records: &[AppendRecord]) -> bool {
-        self.active.projected_size(records) > self.config.segment_size_bytes
+        self.would_roll_within(records, false)
+    }
+
+    /// Whether appending `records` requires an *inline* rollover — the blocking
+    /// kind, which seals and fsyncs while holding the caller's lock.
+    ///
+    /// `roll_pending` says a background rollover is already building the
+    /// replacement. When it is, the ceiling rises to `max_overshoot_percent`
+    /// above the configured size, and this is the crux of why the background
+    /// roll works at all:
+    ///
+    /// The gap between the soft threshold and the hard limit is spent in
+    /// *appends*, which cost microseconds. Building a replacement segment costs
+    /// two *fsyncs*, which cost milliseconds. Hold the configured size as a hard
+    /// ceiling and the inline path always wins that race, so every roll blocks
+    /// exactly as it did before and the preparation is discarded unused —
+    /// measurably worse than not trying. Letting the segment overshoot while its
+    /// replacement is built is what buys the preparation enough time to finish.
+    ///
+    /// The overshoot is bounded rather than open-ended, because
+    /// `segment_size_bytes` is also what bounds recovery time: the active
+    /// segment is the one scanned in full at startup. Past the bound, appends
+    /// roll inline and take the latency hit, which is the correct trade when the
+    /// alternative is an unboundedly large segment to re-scan after a crash.
+    pub fn would_roll_within(&self, records: &[AppendRecord], roll_pending: bool) -> bool {
+        self.active.projected_size(records) > self.size_ceiling(roll_pending)
             && self.active.record_count() > 0
+    }
+
+    /// Largest the active segment may grow before an inline roll is forced.
+    fn size_ceiling(&self, roll_pending: bool) -> u64 {
+        if !roll_pending {
+            return self.config.segment_size_bytes;
+        }
+        let overshoot = 100u64.saturating_add(self.config.max_overshoot_percent as u64);
+        self.config
+            .segment_size_bytes
+            .saturating_mul(overshoot)
+            .max(self.config.segment_size_bytes)
+            / 100
     }
 
     /// Append a batch, rolling to a new segment first if it would not fit.
@@ -136,11 +242,108 @@ impl SegmentSet {
         self.active.append(records)
     }
 
+    /// Build a replacement segment for the current tail, touching no shared
+    /// state.
+    ///
+    /// This is the expensive half of a rollover — creating the file, writing
+    /// and syncing its header, syncing the directory entry — and it runs with
+    /// no lock held. `commit_roll` then swaps it in under a lock held only long
+    /// enough to move a pointer.
+    ///
+    /// This half is deliberately trivial: it copies a path and bumps a counter.
+    /// Everything expensive belongs to [`RollPlan::build`], which must run with
+    /// no lock held — creating a segment fsyncs its header *and* its parent
+    /// directory, and holding even a read lock across that blocks every append
+    /// waiting for the write lock, which is the stall this whole design exists
+    /// to remove.
+    pub fn roll_plan(&self) -> RollPlan {
+        RollPlan {
+            dir: self.dir.clone(),
+            id: self.next_segment_id.fetch_add(1, Ordering::AcqRel),
+            previous_active_id: self.active.id(),
+            preallocate_bytes: self.preallocate_bytes(),
+            index_spacing_bytes: self.config.index_spacing_bytes,
+        }
+    }
+
+    /// Swap a prepared segment in, returning the retired writer to be sealed.
+    ///
+    /// Fast by construction: a pointer swap plus a descriptor built from
+    /// in-memory state. The retired segment joins the sealed list immediately,
+    /// so reads never see a gap while it is still being flushed — its
+    /// descriptor already describes every record it holds, because
+    /// preallocation reserves blocks without extending the file, so a segment's
+    /// length always equals the bytes actually written to it.
+    ///
+    /// The replacement takes its base offset *here*, from the tail as it stands
+    /// at the swap. That is what lets appends keep landing in the old segment
+    /// for as long as the preparation takes: however far the tail has moved,
+    /// the replacement still continues it exactly, so no gap is possible and no
+    /// preparation is wasted for having been built a moment too early.
+    ///
+    /// Returns [`RollOutcome::Stale`] only when another roll already replaced
+    /// the segment this one was built to retire.
+    pub fn commit_roll(&mut self, prepared: PreparedSegment) -> Result<RollOutcome> {
+        // Rolling an empty segment would push a `SealedEntry` with no
+        // `last_offset` to describe, and gains nothing.
+        if prepared.previous_active_id != self.active.id() || self.active.record_count() == 0 {
+            return Ok(RollOutcome::Stale(prepared));
+        }
+        let descriptor = self.active.descriptor();
+        // One page-cache write, no flush: see `BlankSegment::activate`.
+        let replacement = prepared
+            .blank
+            .activate(self.active.next_offset(), now_micros())?;
+        self.bump_next_segment_id(replacement.id() + 1);
+        let retired = std::mem::replace(&mut self.active, replacement);
+        self.active_reader = SegmentReader::open(
+            self.active.path(),
+            self.active.id(),
+            self.active.base_offset(),
+        )?;
+
+        // Guaranteed non-empty by the check above, so `last_offset` is real.
+        self.sealed.push(SealedEntry {
+            descriptor,
+            index: retired.index().clone(),
+            reader: SegmentReader::open(retired.path(), retired.id(), retired.base_offset())?,
+        });
+
+        metrics::counter!(metrics_names::SEGMENT_ROLL_TOTAL).increment(1);
+        metrics::gauge!(metrics_names::SEGMENT_COUNT).set((self.sealed.len() + 1) as f64);
+        Ok(RollOutcome::Installed(retired))
+    }
+
+    /// Whether the active segment has crossed the point where a rollover should
+    /// be started in the background.
+    ///
+    /// Deliberately below `segment_size_bytes`: the roll is prepared while
+    /// there is still room, so appends keep landing in the current segment
+    /// instead of waiting for one to be built. That makes the configured size a
+    /// target rather than a hard ceiling — a segment can overshoot slightly
+    /// while its replacement is being created.
+    pub fn should_prepare_roll(&self) -> bool {
+        if self.active.record_count() == 0 {
+            return false;
+        }
+        let threshold = self
+            .config
+            .segment_size_bytes
+            .saturating_mul(self.config.rollover_threshold_percent.min(100) as u64)
+            / 100;
+        self.active.size_bytes() >= threshold.max(1)
+    }
+
     /// Seal the active segment and start a new one at the current tail.
+    ///
+    /// The all-in-one path, kept for the hard-limit fallback and for callers
+    /// that drive `SegmentSet` directly. It holds the caller's lock across
+    /// several fsyncs; the split `roll_plan`/`commit_roll` pair is what the
+    /// async log uses to keep that off the append path.
     pub fn roll(&mut self) -> Result<()> {
         let descriptor = self.active.seal()?;
         let base_offset = self.active.next_offset();
-        let id = self.next_segment_id;
+        let id = self.next_segment_id.fetch_add(1, Ordering::AcqRel);
 
         let replacement = SegmentWriter::create(
             &self.dir,
@@ -153,21 +356,38 @@ impl SegmentSet {
         let retired = std::mem::replace(&mut self.active, replacement);
         self.active_reader =
             SegmentReader::open(self.active.path(), self.active.id(), base_offset)?;
-        self.next_segment_id = id + 1;
+        self.bump_next_segment_id(id + 1);
 
         // A sealed segment holding no records would break the `last_offset`
-        // invariant `SealedEntry` relies on; drop it instead of listing it.
+        // invariant `SealedEntry` relies on. Rather than list it, delete it:
+        // leaving the file behind would put an empty segment in the middle of
+        // the chain, where recovery reads its base offset as a break.
         if retired.record_count() > 0 {
             self.sealed.push(SealedEntry {
                 descriptor,
                 index: retired.index().clone(),
                 reader: SegmentReader::open(retired.path(), retired.id(), retired.base_offset())?,
             });
+        } else {
+            let path = retired.path().to_path_buf();
+            let index = self.dir.join(index_file_name(retired.id()));
+            drop(retired);
+            for path in [path, index] {
+                match std::fs::remove_file(&path) {
+                    Ok(()) => {}
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(err) => return Err(StorageError::Io(err)),
+                }
+            }
         }
 
         metrics::counter!(metrics_names::SEGMENT_ROLL_TOTAL).increment(1);
         metrics::gauge!(metrics_names::SEGMENT_COUNT).set((self.sealed.len() + 1) as f64);
         Ok(())
+    }
+
+    fn bump_next_segment_id(&self, at_least: SegmentId) {
+        self.next_segment_id.fetch_max(at_least, Ordering::AcqRel);
     }
 
     fn preallocate_bytes(&self) -> u64 {
@@ -369,7 +589,7 @@ impl SegmentSet {
             self.active.id(),
             self.active.base_offset(),
         )?;
-        self.next_segment_id = self.next_segment_id.max(id + 1);
+        self.bump_next_segment_id(id + 1);
         metrics::gauge!(metrics_names::SEGMENT_COUNT).set((self.sealed.len() + 1) as f64);
         Ok(())
     }
@@ -467,6 +687,75 @@ mod tests {
             active,
         )
         .expect("set")
+    }
+
+    #[test]
+    fn a_preparation_still_installs_after_the_tail_has_moved() {
+        let dir = tempdir().expect("dir");
+        let mut set = new_set(&dir, 4096);
+        set.append(&[record("a")]).expect("append");
+
+        let prepared = set.roll_plan().build().expect("prepare");
+        // The whole point of preparing off the lock: appends keep landing while
+        // the replacement is built, and they must not invalidate it. The
+        // replacement takes its base offset at the swap, so it continues from
+        // wherever the tail ended up.
+        set.append(&[record("b")]).expect("append");
+        set.append(&[record("c")]).expect("append");
+        let tail = set.tail_offset();
+
+        match set.commit_roll(prepared).expect("commit") {
+            RollOutcome::Installed(mut retired) => retired.seal().expect("seal"),
+            RollOutcome::Stale(_) => panic!("a moving tail must not waste a preparation"),
+        };
+        assert_eq!(set.active().base_offset(), tail);
+        assert_eq!(set.tail_offset(), tail, "no gap and no rewind");
+
+        set.append(&[record("d")]).expect("append");
+        assert_eq!(read_all(&set, 0), ["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn a_preparation_is_rejected_once_another_roll_has_replaced_the_active_segment() {
+        let dir = tempdir().expect("dir");
+        let mut set = new_set(&dir, 4096);
+        set.append(&[record("a")]).expect("append");
+
+        let prepared = set.roll_plan().build().expect("prepare");
+        let path = prepared.blank.path().to_path_buf();
+        // The inline hard-limit path rolls while the preparation is in flight.
+        // The segment this preparation was built to retire is gone, so
+        // installing it now would strand the segment that replaced it.
+        set.roll().expect("roll");
+
+        match set.commit_roll(prepared).expect("commit") {
+            RollOutcome::Stale(prepared) => prepared.discard().expect("discard"),
+            RollOutcome::Installed(_) => panic!("the active segment is not the one it retires"),
+        }
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn a_completed_background_roll_keeps_every_record_readable() {
+        let dir = tempdir().expect("dir");
+        let mut set = new_set(&dir, 4096);
+        for i in 0..4 {
+            set.append(&[record(&format!("v{i}"))]).expect("append");
+        }
+
+        let prepared = set.roll_plan().build().expect("prepare");
+        let mut retired = match set.commit_roll(prepared).expect("commit") {
+            RollOutcome::Installed(retired) => retired,
+            RollOutcome::Stale(_) => panic!("nothing moved the tail"),
+        };
+        // Reads route across the retired segment before it is sealed: it joins
+        // the sealed list at swap time, not at flush time.
+        assert_eq!(read_all(&set, 0).len(), 4);
+        retired.seal().expect("seal");
+
+        set.append(&[record("v4")]).expect("append");
+        assert_eq!(read_all(&set, 0).len(), 5);
+        assert_eq!(set.descriptors().len(), 2);
     }
 
     fn read_all(set: &SegmentSet, start: Offset) -> Vec<String> {

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -228,6 +228,38 @@ async fn records_survive_reopening_the_log() {
 }
 
 #[tokio::test]
+async fn background_rollover_keeps_the_log_contiguous_and_reopenable() {
+    // `rollover_threshold_percent` is 100 by default -- the background roll is
+    // measured to hurt tail latency on a device-level flush, so it ships off.
+    // This exercises it explicitly so the path stays covered.
+    let dir = tempdir().expect("dir");
+    let config = LogConfig {
+        rollover_threshold_percent: 60,
+        max_overshoot_percent: 200,
+        ..config(FsyncMode::OnCommit)
+    };
+    {
+        let log = DiskLog::open(dir.path(), "t/ns/s/0", config.clone()).expect("open");
+        for i in 0..60 {
+            log.append(&records(&[&format!("value-{i:03}")]))
+                .await
+                .expect("append");
+        }
+        assert!(log.segments().len() > 1, "expected rollovers");
+        log.shutdown().await.expect("shutdown");
+    }
+
+    // Reopening is the real assertion: a background roll that left an
+    // uninstalled segment, a gap, or a duplicated offset shows up here.
+    let log = DiskLog::open(dir.path(), "t/ns/s/0", config).expect("reopen");
+    assert_eq!(log.tail_offset().await.expect("tail"), 60);
+    let values = read_all(&log, 0).await;
+    assert_eq!(values.len(), 60);
+    assert_eq!(values[0], "value-000");
+    assert_eq!(values[59], "value-059");
+}
+
+#[tokio::test]
 async fn on_commit_acknowledges_only_durable_records() {
     let dir = tempdir().expect("dir");
     let log = open(&dir, FsyncMode::OnCommit);
@@ -244,7 +276,17 @@ async fn on_commit_acknowledges_only_durable_records() {
             "offset {} not durable at ack",
             result.last_offset
         );
-        assert_eq!(log.unsynced_bytes(), 0);
+        // Zero, or one segment header. A background rollover installs its
+        // replacement by writing the header into the page cache and leaving the
+        // flush to the next sync, so an ack can land in the window where those
+        // 32 bytes are the only thing outstanding. No *record* is ever
+        // unsynced at an ack, which is what the assertion above checks
+        // directly.
+        assert!(
+            log.unsynced_bytes() <= crate::segment::SEGMENT_HEADER_LEN,
+            "unsynced record bytes at ack: {}",
+            log.unsynced_bytes(),
+        );
     }
 }
 

--- a/crates/felix-storage/src/log.rs
+++ b/crates/felix-storage/src/log.rs
@@ -66,6 +66,57 @@ pub struct LogConfig {
     /// that will not start, which is a defensible trade under `FsyncMode::None`
     /// and is not one under `OnCommit`.
     pub repair_checksum_tail: bool,
+    /// Percentage of `segment_size_bytes` at which a rollover is started in the
+    /// background. **100 disables it, which is the default.**
+    ///
+    /// Rolling a segment costs several fsyncs, and doing that work when an
+    /// append discovers the segment is full puts those flushes on the publish
+    /// path. Starting the roll early — building the replacement off the lock
+    /// while the current segment still has room — is the obvious way to keep
+    /// appends off them, and it is implemented here in full.
+    ///
+    /// It is off by default because it was measured, and it does not help.
+    /// Over five 200k-record runs at 16 MiB segments and 16 publishers, median
+    /// p999 was 3.98ms with it disabled and 7.97ms with it enabled, with a much
+    /// heavier upper tail (worst run 19.0ms against 5.0ms). At 256 MiB and at
+    /// 1 MiB it was neutral. It was never better anywhere.
+    ///
+    /// The reason is `F_FULLFSYNC`, which is what durability on macOS actually
+    /// requires: it flushes the whole device write cache, so it does not
+    /// overlap with concurrent writes. Moving a rollover's flushes off the
+    /// append lock does not hide them; it just stops confining them, so instead
+    /// of blocking behind one lock they land on whichever appends happen to be
+    /// in flight. The cost is the same and the tail is worse.
+    ///
+    /// It is kept, and kept configurable, because that reasoning is specific to
+    /// a flush that reaches the device. On a platform where `fdatasync` returns
+    /// once the write is in the kernel, the overlap is real and the trade may
+    /// invert — but that has not been measured here, so it is not the default.
+    ///
+    /// Enabling it makes `segment_size_bytes` a target rather than a ceiling;
+    /// see `max_overshoot_percent`.
+    pub rollover_threshold_percent: u8,
+    /// How far past `segment_size_bytes` a segment may grow while its
+    /// replacement is being prepared, as a percentage.
+    ///
+    /// This is the price of keeping rollover off the append path, and it is not
+    /// optional slack: preparing a replacement costs two fsyncs — milliseconds —
+    /// while the appends that fill the remaining space cost microseconds. With
+    /// no room to overshoot, the inline roll always wins that race, every roll
+    /// blocks exactly as it did before, and the prepared segment is discarded
+    /// unused. Measured, that combination is *slower* than not preparing at all.
+    ///
+    /// It is bounded rather than open-ended because `segment_size_bytes` also
+    /// bounds recovery time: the newest segment is the one scanned in full at
+    /// startup. Once a segment reaches this bound its appends roll inline and
+    /// pay the latency, which is the right trade against an unboundedly large
+    /// segment to re-scan after a crash.
+    ///
+    /// The overshoot a segment actually takes is roughly `write_rate x
+    /// prepare_time`, so it shrinks as segments grow: at 256 MiB and 300 MB/s
+    /// an 8ms preparation overshoots by about 1%. Small segments are the case
+    /// this cannot rescue — see the note on `segment_size_bytes`.
+    pub max_overshoot_percent: u8,
     /// Checksum every record of every segment at open time.
     ///
     /// Off by default: startup would otherwise cost one full pass over all data
@@ -86,6 +137,8 @@ impl Default for LogConfig {
             },
             max_records_per_read: 10_000,
             preallocate_segments: true,
+            rollover_threshold_percent: 100,
+            max_overshoot_percent: 100,
             repair_checksum_tail: false,
             verify_all_on_open: false,
         }

--- a/crates/felix-storage/src/metrics_names.rs
+++ b/crates/felix-storage/src/metrics_names.rs
@@ -44,6 +44,12 @@ pub const INDEX_WRITE_FAILURES_TOTAL: &str = "felix_storage_index_write_failures
 
 /// Segment rollovers.
 pub const SEGMENT_ROLL_TOTAL: &str = "felix_storage_segment_roll_total";
+/// Rollovers started in the background, off the append path.
+pub const SEGMENT_ROLL_BACKGROUND_TOTAL: &str = "felix_storage_segment_roll_background_total";
+/// Background rollovers that failed and degraded the log.
+pub const SEGMENT_ROLL_FAILED_TOTAL: &str = "felix_storage_segment_roll_failed_total";
+/// Prepared segments discarded because the tail moved on before the swap.
+pub const SEGMENT_ROLL_DISCARDED_TOTAL: &str = "felix_storage_segment_roll_discarded_total";
 /// Segments currently on disk for a shard.
 pub const SEGMENT_COUNT: &str = "felix_storage_segment_count";
 
@@ -58,5 +64,7 @@ pub const READ_DURATION_SECONDS: &str = "felix_storage_read_duration_seconds";
 pub const RECOVERY_DURATION_SECONDS: &str = "felix_storage_recovery_duration_seconds";
 /// Bytes discarded from a torn tail during recovery.
 pub const RECOVERY_TRUNCATED_BYTES: &str = "felix_storage_recovery_truncated_bytes";
+/// Empty segments removed at startup because a rollover never installed them.
+pub const RECOVERY_ABANDONED_ROLLS_TOTAL: &str = "felix_storage_recovery_abandoned_rolls_total";
 /// Indexes rebuilt because they were missing or stale.
 pub const RECOVERY_INDEX_REBUILDS_TOTAL: &str = "felix_storage_recovery_index_rebuilds_total";

--- a/crates/felix-storage/src/segment/index.rs
+++ b/crates/felix-storage/src/segment/index.rs
@@ -149,6 +149,39 @@ pub struct IndexWriter {
 
 impl IndexWriter {
     /// Open `path` for appending, seeding in-memory state from `index`.
+    /// Open an index for a segment that has just been created.
+    ///
+    /// Skips the fsync that [`Self::open`] performs, because there is nothing
+    /// yet to make durable: the file holds a header and no entries. That
+    /// matters because this runs while installing a rollover, under the lock
+    /// appends contend on, where an fsync costs milliseconds and would put back
+    /// exactly the stall that preparing the segment ahead of time removes.
+    ///
+    /// Safe for the same reason a stale index is safe anywhere: indexes are
+    /// derived data, rebuilt from the segment whenever they are missing, short
+    /// or inconsistent. Losing this write costs a rebuild, never a record.
+    pub fn create(path: &Path, index: SparseIndex, spacing_bytes: u64) -> Result<Self> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)?;
+        file.write_all(
+            &IndexHeader {
+                base_offset: index.base_offset(),
+            }
+            .encode(),
+        )?;
+        drop(file);
+        let file = OpenOptions::new().append(true).open(path)?;
+        Ok(Self {
+            file,
+            index,
+            spacing_bytes: spacing_bytes.max(1),
+            bytes_since_entry: 0,
+        })
+    }
+
     pub fn open(path: &Path, index: SparseIndex) -> Result<Self> {
         // The index was just rebuilt or loaded, so rewrite it whole and append
         // from there. This is what makes a stale index self-correcting.

--- a/crates/felix-storage/src/segment/writer.rs
+++ b/crates/felix-storage/src/segment/writer.rs
@@ -74,6 +74,127 @@ pub struct SegmentWriter {
     index_degraded: bool,
 }
 
+/// A segment file that exists on disk but has no header yet, and so does not
+/// yet claim a base offset.
+///
+/// This split is what lets a rollover be prepared without blocking appends.
+/// Everything expensive about creating a segment — the file, its preallocated
+/// blocks, its index, and the *directory* fsync that makes the entry durable —
+/// happens here, with no lock held. What is left for [`Self::activate`] is a
+/// 32-byte write into the page cache.
+///
+/// The reason the header cannot be written up front is that its `base_offset`
+/// must be the log's tail *at the moment of the swap*, and the whole point of
+/// preparing ahead is that appends keep advancing that tail meanwhile. Writing
+/// the header early would pin the segment to an offset the log has already
+/// passed, and the swap would have to be abandoned — which is exactly what
+/// makes a prepare-ahead scheme with an early header no faster than rolling
+/// inline.
+///
+/// A crash between `create` and `activate` leaves a headerless file. Recovery
+/// treats one as an uninstalled rollover and deletes it; it can hold no
+/// records, so nothing acknowledged is at stake.
+#[derive(Debug)]
+pub struct BlankSegment {
+    id: SegmentId,
+    path: PathBuf,
+    file: File,
+    index_path: PathBuf,
+    index_spacing_bytes: u64,
+}
+
+impl BlankSegment {
+    /// Create the file and its index, and make the directory entry durable.
+    pub fn create(
+        dir: &Path,
+        id: SegmentId,
+        preallocate_bytes: u64,
+        index_spacing_bytes: u64,
+    ) -> Result<Self> {
+        let path = dir.join(segment_file_name(id));
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)?;
+        preallocate(&file, preallocate_bytes)?;
+        sync_dir(dir)?;
+        Ok(Self {
+            id,
+            path,
+            file,
+            index_path: dir.join(index_file_name(id)),
+            index_spacing_bytes,
+        })
+    }
+
+    pub fn id(&self) -> SegmentId {
+        self.id
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn index_path(&self) -> &Path {
+        &self.index_path
+    }
+
+    /// Write the header and become a writable segment based at `base_offset`.
+    ///
+    /// One page-cache write and no flush, so this is safe to call under the
+    /// lock that appends contend on. The header reaches disk with the first
+    /// sync of this segment, which under every fsync policy happens no later
+    /// than the acknowledgement of the first record written to it.
+    pub fn activate(
+        mut self,
+        base_offset: Offset,
+        created_at_micros: u64,
+    ) -> Result<SegmentWriter> {
+        self.file
+            .write_all(&SegmentHeader::new(base_offset, created_at_micros).encode())?;
+        let index = IndexWriter::create(
+            &self.index_path,
+            SparseIndex::new(base_offset),
+            self.index_spacing_bytes,
+        )?;
+        let sync_handle = Arc::new(self.file.try_clone()?);
+        Ok(SegmentWriter {
+            id: self.id,
+            base_offset,
+            path: self.path,
+            file: self.file,
+            index,
+            size_bytes: SEGMENT_HEADER_LEN,
+            synced_bytes: 0,
+            next_offset: base_offset,
+            record_count: 0,
+            staging: Vec::new(),
+            sync_handle,
+            poisoned: false,
+            index_degraded: false,
+        })
+    }
+
+    /// Delete a blank segment that will never be activated.
+    pub fn discard(self) -> Result<()> {
+        let Self {
+            path,
+            file,
+            index_path,
+            ..
+        } = self;
+        drop(file);
+        for path in [path, index_path] {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(StorageError::Io(err)),
+            }
+        }
+        Ok(())
+    }
+}
+
 impl SegmentWriter {
     /// Create a brand new segment starting at `base_offset`.
     pub fn create(
@@ -84,41 +205,13 @@ impl SegmentWriter {
         preallocate_bytes: u64,
         index_spacing_bytes: u64,
     ) -> Result<Self> {
-        let path = dir.join(segment_file_name(id));
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&path)?;
-
-        preallocate(&file, preallocate_bytes)?;
-        file.write_all(&SegmentHeader::new(base_offset, created_at_micros).encode())?;
-        // The header must be durable, and the directory entry must be durable
-        // too, before any record claims to live in this segment.
-        sync_data(&file)?;
-        sync_dir(dir)?;
-
-        let index = IndexWriter::open(
-            &dir.join(index_file_name(id)),
-            SparseIndex::new(base_offset),
-        )?
-        .with_spacing(index_spacing_bytes);
-        let sync_handle = Arc::new(file.try_clone()?);
-
-        Ok(Self {
-            id,
-            base_offset,
-            path,
-            file,
-            index,
-            size_bytes: SEGMENT_HEADER_LEN,
-            synced_bytes: SEGMENT_HEADER_LEN,
-            next_offset: base_offset,
-            record_count: 0,
-            staging: Vec::new(),
-            sync_handle,
-            poisoned: false,
-            index_degraded: false,
-        })
+        let mut writer = BlankSegment::create(dir, id, preallocate_bytes, index_spacing_bytes)?
+            .activate(base_offset, created_at_micros)?;
+        // The header must be durable before any record claims to live here. The
+        // directory entry already is: `BlankSegment::create` synced it.
+        sync_data(&writer.file)?;
+        writer.mark_synced(SEGMENT_HEADER_LEN);
+        Ok(writer)
     }
 
     /// Reopen an existing, already validated segment for further appends.

--- a/docs/storage-performance.md
+++ b/docs/storage-performance.md
@@ -174,6 +174,63 @@ against, and a breach is a design conversation rather than an automatic failure.
 | Batch-16 throughput vs batch-1 | ≥ 4× | Confirms one `write` per batch, not per record |
 | Recovery time | ≤ 1s per GiB of active segment | Measured at 0.32s for a 1.01 GiB segment (~3.2 GiB/s), so the budget carries about 3× headroom. Only the active segment is fully scanned |
 
+### Segment size is a latency knob, not only a recovery knob
+
+`segment_size_bytes` is usually presented as a recovery-time dial: only the
+active segment is scanned in full at startup, so a smaller segment restarts
+faster. That is true, and it is not the whole trade.
+
+Every rollover costs several device flushes — sealing the retired segment, and
+creating and directory-syncing its replacement — and those flushes land on
+whichever appends are in flight. Smaller segments roll more often, so the cost
+appears more often, and it appears in the tail:
+
+| Segment size | p999, 16 publishers | Rollovers per 20k records |
+| --- | --- | --- |
+| 256 MiB (default) | ~0.9ms | 0 |
+| 16 MiB | ~1.3ms | ~1 |
+| 1 MiB | ~30ms | ~20 |
+| 128 KiB | ~112ms | ~160 |
+
+Trading a 256 MiB segment for a 1 MiB one buys about 0.25s of restart time and
+costs roughly 30× on p999. Below a few MiB the log is rolling often enough that
+tail latency is dominated by rollover flushes rather than by appends. Prefer the
+default unless restart time is genuinely the binding constraint, and if it is,
+measure the tail rather than assuming recovery is the only thing that moved.
+
+### Rolling segments in the background does not help
+
+The obvious fix for the table above is to stop doing rollover work on the append
+path: build the replacement segment ahead of time, off the lock, and swap it in
+with a pointer write. `rollover_threshold_percent` implements exactly that. It
+is disabled by default, because it was measured and it is worse.
+
+Five 200k-record runs, 16 MiB segments, 16 publishers, median across runs:
+
+| | p99 | p999 | max | throughput |
+| --- | --- | --- | --- | --- |
+| Inline roll (default) | 669µs | **3.98ms** | 47.0ms | 99.1k rec/s |
+| Background roll | 667µs | **7.97ms** | 50.8ms | 98.0k rec/s |
+
+The upper tail is where it shows: the worst background-roll run reached 19.0ms
+p999 against 5.0ms for the inline path. At 256 MiB and at 1 MiB the two were
+within noise. The background roll was not faster in any configuration tested.
+
+The reason is `F_FULLFSYNC`. Durability on macOS means flushing the device write
+cache, and that flush does not overlap with concurrent writes — so moving a
+rollover's flushes off the append lock does not hide them, it only stops
+confining them. Instead of a queue behind one lock, the same cost lands on
+whichever appends happen to be in flight, which is strictly worse for the tail.
+
+Two things are worth keeping from the exercise. The first is that reasoning is
+specific to a flush that reaches the device; where `fdatasync` returns once the
+write is in the kernel, overlap is real and the trade may invert, which is why
+the code is kept and configurable rather than deleted. The second is what the
+work actually did buy: measuring it exposed an `fsync` of a freshly created
+(and therefore empty) index file sitting inside the rollover path. Removing it
+improved the **default** inline path from 5.12ms to 3.98ms median p999 (-22%)
+and 61.8ms to 47.0ms max (-24%).
+
 ### Operating envelope
 
 | If you need | Choose | Expect |

--- a/services/broker/src/durable_config.rs
+++ b/services/broker/src/durable_config.rs
@@ -48,6 +48,14 @@ impl DurableStorageConfig {
                 .unwrap_or(LogConfig::default().verify_all_on_open),
             repair_checksum_tail: parse_bool_env("FELIX_DURABLE_REPAIR_CHECKSUM_TAIL")?
                 .unwrap_or(LogConfig::default().repair_checksum_tail),
+            // Off by default: rolling segments in the background measured worse
+            // than rolling them inline, because a device-level flush does not
+            // overlap with concurrent writes. Exposed anyway, since that is a
+            // property of the platform's fsync rather than of the design.
+            rollover_threshold_percent: parse_env("FELIX_DURABLE_ROLLOVER_THRESHOLD_PERCENT")?
+                .unwrap_or(LogConfig::default().rollover_threshold_percent),
+            max_overshoot_percent: parse_env("FELIX_DURABLE_MAX_OVERSHOOT_PERCENT")?
+                .unwrap_or(LogConfig::default().max_overshoot_percent),
         };
         // Fail at startup rather than at the first durable publish.
         log.validate()


### PR DESCRIPTION
Follow-up to the M1 review item *"rollover contention is a latency/reactor-utilization risk... it deserves a focused design change and benchmark."*

This is largely a **negative result**, plus the real win the investigation turned up along the way.

## The measurement that started it was bad methodology

The earlier "rollover contention is a 2,265x p999 regression" number compared 256 MiB segments (zero rollovers in the run) against 128 KiB segments (many), which conflates *segment size* with *per-rollover cost*. The real per-rollover cost is ~4-5ms, and it is **fsync-bound, not lock-bound**.

## Background rollover: implemented, measured, shipped disabled

Design B — build the replacement segment off the append lock, swap it in with a pointer write — is implemented in full. It ships disabled because it does not help.

Five 200k-record runs, 16 MiB segments, 16 publishers, median across runs:

| | p99 | p999 | max | throughput |
| --- | --- | --- | --- | --- |
| Inline roll (default) | 669µs | **3.98ms** | 47.0ms | 99.1k rec/s |
| Background roll | 667µs | **7.97ms** | 50.8ms | 98.0k rec/s |

The upper tail is where it shows: worst background run 19.0ms p999 against 5.0ms inline. At 256 MiB and 1 MiB the two are within noise. It was not faster in any configuration tested.

`F_FULLFSYNC` flushes the device write cache, so it does not overlap with concurrent writes. Moving rollover flushes off the append lock does not hide them, it stops *confining* them — the same cost lands on whichever appends are in flight instead of queueing behind one lock. That is a property of a flush that reaches the device rather than of the design, so the code is kept and configurable: where `fdatasync` returns once the write is in the kernel, the trade may invert. Not measured here, so not the default.

## The actual win

Measuring it exposed an `fsync` of a freshly created — and therefore empty — index file sitting inside the rollover path. An empty index makes nothing durable that a rebuild would not reproduce; indexes are derived data, rewritten from the segment whenever they are missing, short or inconsistent.

Removing it improves the **default** inline path: median p999 5.12ms -> 3.98ms (**-22%**), max 61.8ms -> 47.0ms (**-24%**).

## Correctness defects found and fixed

Working through the invariants for a non-blocking handoff surfaced four real problems:

1. **`flush` reported durability it did not have.** It reports `durable_upto` for the whole log but only ever synced the *active* segment. Sound with an inline roll, because sealing preceded the replacement existing. With a background roll there are records in the retired segment that no sync of the active segment covers. Now tracked and synced first.
2. **Uninstalled preparations were orphaned** — reproducible *without* a crash, in both directions (base offset below the tail after appends continued; above it after a truncation). Recovery now discards them. No durable roll-intent record is needed: they are self-describing (newest, zero records, base offset not at the tail, or no header at all), and a segment holding no records cannot cost an acknowledged write.
3. **A failed seal was a `tracing::warn!`.** Now an explicit `Idle -> Preparing -> Sealing -> Idle` state machine with `Failed` terminal. A rollover fails on a failed fsync or a failed file creation, both of which mean the log can no longer honour what it acknowledged, so it stops accepting appends rather than retrying quietly forever.
4. **Shutdown abandoned a rollover in flight**, leaving a half-installed segment. Now awaited.

## Design notes, for whoever revisits this

- The replacement takes its base offset **at the swap**, not when it is built. Appends keep advancing the tail while a segment is prepared, so an offset chosen up front is stale by the time it is installed — and discarding the preparation for that reason makes the whole scheme no faster than rolling inline. This is why segment creation had to be split into `BlankSegment::create` / `activate`.
- Under the lock: one page-cache write and two file opens. No fsync.
- `max_overshoot_percent` bounds how far a segment may grow while its replacement is built. Unbounded overshoot would undo the recovery-time sizing that `segment_size_bytes` exists to provide. Keeping the configured size a *hard* ceiling does not work: the runway to it is spent in appends (µs) while preparation costs two fsyncs (ms), so the inline path wins every race and each preparation is discarded unused — measurably worse than not preparing at all.

## Docs

`segment_size_bytes` was documented purely as a recovery-time dial. It is also a latency knob: trading 256 MiB for 1 MiB buys about 0.25s of restart time and costs roughly 30x on p999. Now disclosed, with the measurements and the negative result recorded.

## Testing

`task lint`, `task test`, and `task demo:check` all pass. New coverage for a crash at each rollover transition, both directions of stranded preparation, headerless and torn-header files, and an explicit background-rollover test so the path stays covered now that it is off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)