### PR TITLE
ci: stop failing the perf check when its comment cannot be posted

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -23,6 +23,15 @@ concurrency:
   group: perf-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Stated rather than inherited, so it is clear what the comment step needs.
+# `issues: write` is what posting the report costs; GitHub withholds it on
+# Dependabot and fork pull requests regardless of what is asked for here, which
+# is why the step treats it as optional.
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   # NOTE: core shards are intentionally left disabled here. `FELIX_CORE_SHARDS=N`
@@ -156,27 +165,44 @@ jobs:
             }
             const fullBody = `${marker}\n## Performance comparison (fast subset)\n\n${body}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            // The report goes to the job summary unconditionally. Posting it as
+            // a comment is a convenience on top of that, and is allowed to fail:
+            // Dependabot pull requests run with a read-only GITHUB_TOKEN, as do
+            // pull requests from forks, so `issues: write` is simply not
+            // available there. This workflow is advisory and must never fail a
+            // check -- losing the comment costs nothing when the same content is
+            // one click away in the summary.
+            await core.summary.addRaw(fullBody).write();
 
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body: fullBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: fullBody,
               });
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body: fullBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: fullBody,
+                });
+              }
+            } catch (error) {
+              core.warning(
+                `Could not post the performance comment (${error.message}). ` +
+                'The report is in this job\'s summary. This is expected on ' +
+                'Dependabot and fork pull requests, which get a read-only token.'
+              );
             }
 
       - name: Upload raw results


### PR DESCRIPTION
Every open Dependabot pull request — all ten (#181–#190) — is currently un-mergeable because `perf-compare` fails on it. This fixes that.

## What was happening

The benchmarks ran fine. Posting the summary comment did not:

```
RequestError [HttpError]: Resource not accessible by integration
  'x-accepted-github-permissions': 'issues=write; pull_requests=write'
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

Dependabot pull requests — like those from forks — run with a read-only `GITHUB_TOKEN`, so `issues: write` is withheld no matter what the workflow asks for. The unhandled 403 failed the whole job.

That directly contradicts the workflow's own design. Its header says:

> This does NOT fail the check on a regression: it's advisory only.

Every benchmark step from "Run baseline" through "Compare" is already `continue-on-error: true`. The comment step was the one place that could still fail the check, and it did so for a reason unrelated to performance.

## The fix

- The report is written to the **job summary** unconditionally, so the content is never lost.
- Posting it as a comment is treated as a convenience: wrapped in `try`/`catch`, downgraded to `core.warning` on failure.
- The workflow's `permissions` are now stated rather than inherited, so what the comment step needs is visible at the top of the file.

## Note on the two OpenTelemetry PRs

#183 and #187 fail `test` and `coverage` as well, which this does not address — that is a real diamond-dependency break (two copies of `opentelemetry` in the tree) and needs the four OTel crates bumped together, which Dependabot cannot do one pull request at a time. Handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)