### PR TITLE
fix(storage): make a failed rollover terminal before anything relaxes

### DIFF
--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -84,7 +84,23 @@ struct LogInner {
     /// retired segment that no sync of the active segment covers, and reporting
     /// them durable would be a lie under `FsyncMode::OnCommit`. So `flush`
     /// syncs this handle too for as long as it is set.
+    ///
+    /// Cleared only after a *successful* seal. A failed one leaves it in place
+    /// so every later flush keeps trying to cover those records rather than
+    /// quietly reporting them durable.
     pending_seal: Mutex<Option<Arc<std::fs::File>>>,
+    /// Why the log stopped accepting work, once a rollover has failed.
+    ///
+    /// Separate from `roll_state` because the two are read for different
+    /// reasons and, critically, are written in a specific order: this is set
+    /// *before* anything observable is relaxed, so there is no window in which
+    /// a durability wait can see a cleared `pending_seal` and a state that is
+    /// not yet `Failed`. `roll_state` remains the scheduler's view; this is the
+    /// durability view.
+    roll_failure: Mutex<Option<String>>,
+    /// Forces the next seal to fail, so the failure path can be tested.
+    #[cfg(test)]
+    fail_seal: std::sync::atomic::AtomicBool,
 }
 
 /// Lifecycle of the background rollover.
@@ -183,12 +199,24 @@ impl LogInner {
             // Flushed with no lock held. The segment is already listed as
             // sealed and readable — this only makes it durable.
             let mut retired = retired;
-            let sealed = retired.seal();
-            // Cleared either way: on success it is durable, and on failure the
-            // log is about to stop accepting appends anyway.
-            *inner.pending_seal.lock() = None;
-            sealed?;
-            Ok::<(), StorageError>(())
+            match inner.seal_retired(&mut retired) {
+                Ok(()) => {
+                    // Only now: these records are on the device, so a flush no
+                    // longer has to cover them.
+                    *inner.pending_seal.lock() = None;
+                    Ok::<(), StorageError>(())
+                }
+                Err(err) => {
+                    // Order matters. `pending_seal` stays set and the failure is
+                    // recorded before this task returns, so an `OnCommit` append
+                    // already in flight cannot find a cleared `pending_seal`
+                    // alongside a roll state that has not been marked failed
+                    // yet, sync only the new segment, and acknowledge records
+                    // that are still sitting in an unflushed retired one.
+                    inner.record_roll_failure(&err);
+                    Err(err)
+                }
+            }
         })
         .await
         .map_err(|err| StorageError::Io(std::io::Error::other(err)))?
@@ -202,8 +230,47 @@ impl LogInner {
         )
     }
 
-    /// Refuse further appends once a rollover has failed.
+    /// Seal the retired segment, with a hook tests use to force a failure.
+    fn seal_retired(&self, retired: &mut crate::segment::SegmentWriter) -> Result<()> {
+        #[cfg(test)]
+        if self.fail_seal.load(Ordering::Acquire) {
+            return Err(StorageError::SyncFailed(
+                "injected seal failure".to_string(),
+            ));
+        }
+        retired.seal().map(|_| ())
+    }
+
+    /// Record a failed rollover as terminal, and say why.
+    ///
+    /// Idempotent and first-writer-wins: the first failure is the interesting
+    /// one, and a later flush failing for the same underlying reason should not
+    /// overwrite it.
+    fn record_roll_failure(&self, err: &StorageError) {
+        let mut failure = self.roll_failure.lock();
+        if failure.is_none() {
+            *failure = Some(err.to_string());
+        }
+        self.roll_state
+            .store(RollState::Failed as u8, Ordering::Release);
+    }
+
+    /// The terminal rollover error, if one has been recorded.
+    ///
+    /// Checked on every path that either accepts new work or reports
+    /// durability — not just at the entry to an append. A rollover can fail
+    /// while an append is already in flight, and that append must not be
+    /// acknowledged on the strength of a flush that did not cover it.
     fn check_roll_state(&self) -> Result<()> {
+        if let Some(reason) = self.roll_failure.lock().as_deref() {
+            return Err(StorageError::SyncFailed(format!(
+                "{}: a background segment rollover failed ({reason}); the log is no longer \
+                 accepting appends",
+                self.label
+            )));
+        }
+        // A `Failed` state with no recorded reason means the rollover task
+        // itself panicked or was cancelled. Still terminal.
         if RollState::from_u8(self.roll_state.load(Ordering::Acquire)) == RollState::Failed {
             return Err(StorageError::SyncFailed(format!(
                 "{}: a background segment rollover failed; the log is no longer accepting appends",
@@ -234,6 +301,7 @@ impl LogInner {
         // seen here rather than missed: `commit_roll` sets it before releasing
         // the lock this read just took.
         let retired = self.pending_seal.lock().clone();
+        let had_pending_seal = retired.is_some();
 
         let started = std::time::Instant::now();
         let outcome = tokio::task::spawn_blocking(move || {
@@ -246,7 +314,15 @@ impl LogInner {
         })
         .await
         .map_err(|err| StorageError::SyncFailed(format!("flush task failed: {err}")))?;
-        outcome.map_err(|err| StorageError::SyncFailed(err.to_string()))?;
+        if let Err(err) = outcome {
+            let err = StorageError::SyncFailed(err.to_string());
+            // A flush that could not cover the retired segment is the same
+            // failure as a seal that could not, and is equally terminal.
+            if had_pending_seal {
+                self.record_roll_failure(&err);
+            }
+            return Err(err);
+        }
 
         metrics::counter!(metrics_names::SYNC_TOTAL).increment(1);
         metrics::histogram!(metrics_names::SYNC_DURATION_SECONDS)
@@ -264,6 +340,12 @@ impl LogInner {
             metrics::gauge!(metrics_names::UNSYNCED_BYTES)
                 .set(segments.active().unsynced_bytes() as f64);
         }
+
+        // Rechecked after the flush, not only before it. A rollover can fail
+        // while this flush is in flight, and `durable_upto` spans the retired
+        // segment as well as the active one -- reporting it would acknowledge
+        // records that the failed seal left unflushed.
+        self.check_roll_state()?;
 
         Ok(durable_upto)
     }
@@ -329,6 +411,9 @@ impl DiskLog {
             durability: Durability::new(config.fsync_mode, durable_upto),
             syncer: Mutex::new(None),
             roll_state: AtomicU8::new(RollState::Idle as u8),
+            roll_failure: Mutex::new(None),
+            #[cfg(test)]
+            fail_seal: std::sync::atomic::AtomicBool::new(false),
             roll_task: Mutex::new(None),
             pending_seal: Mutex::new(None),
         });
@@ -404,7 +489,11 @@ impl DiskLog {
         if self.inner.durability.acknowledges_before_sync() {
             return Ok(());
         }
-        self.inner.ensure_durable(pending.durable_target).await
+        self.inner.ensure_durable(pending.durable_target).await?;
+        // `ensure_durable` returns immediately when the target is already
+        // covered, which skips the check inside `flush`. A rollover that failed
+        // since then still has to be reported rather than acknowledged.
+        self.inner.check_roll_state()
     }
 
     /// Force a flush regardless of the configured policy.
@@ -413,7 +502,7 @@ impl DiskLog {
             .durability
             .force_flush(|| Arc::clone(&self.inner).flush())
             .await?;
-        Ok(())
+        self.inner.check_roll_state()
     }
 
     /// Stop background work and flush everything one last time.
@@ -545,9 +634,10 @@ impl DiskLog {
                             );
                             metrics::counter!(metrics_names::SEGMENT_ROLL_FAILED_TOTAL)
                                 .increment(1);
-                            roller
-                                .roll_state
-                                .store(RollState::Failed as u8, Ordering::Release);
+                            // Usually already recorded, by the seal that failed.
+                            // This covers a failure earlier in the rollover --
+                            // building the replacement, or installing it.
+                            roller.record_roll_failure(&err);
                         }
                     }
                 });
@@ -586,6 +676,11 @@ impl AppendOnlyLog for DiskLog {
             // on the periodic flush (or the operating system) from there.
             if !inner.durability.acknowledges_before_sync() {
                 inner.ensure_durable(pending.durable_target).await?;
+                // Checked again after the wait: `check_roll_state` at the top of
+                // `write_batch` only covers rollovers that had already failed
+                // when this append started, and this one may have been in flight
+                // across the failure.
+                inner.check_roll_state()?;
             }
 
             metrics::histogram!(metrics_names::APPEND_DURATION_SECONDS)

--- a/crates/felix-storage/src/disk_log/segments.rs
+++ b/crates/felix-storage/src/disk_log/segments.rs
@@ -323,6 +323,14 @@ impl SegmentSet {
     /// target rather than a hard ceiling — a segment can overshoot slightly
     /// while its replacement is being created.
     pub fn should_prepare_roll(&self) -> bool {
+        // 100 means "never roll early", and it is the default. Without this the
+        // comparison below still fires whenever the segment has *reached* its
+        // configured size -- which an exactly fitting batch or a single
+        // oversized record does -- so the documented way to disable the
+        // background roll would quietly enter it anyway.
+        if self.config.rollover_threshold_percent >= 100 {
+            return false;
+        }
         if self.active.record_count() == 0 {
             return false;
         }
@@ -756,6 +764,37 @@ mod tests {
         set.append(&[record("v4")]).expect("append");
         assert_eq!(read_all(&set, 0).len(), 5);
         assert_eq!(set.descriptors().len(), 2);
+    }
+
+    #[test]
+    fn the_default_threshold_never_starts_a_background_roll() {
+        let dir = tempdir().expect("dir");
+        // 100 is the default and is documented as disabling the background
+        // roll. An exactly-full segment is the case that used to slip through.
+        let mut set = new_set(&dir, 4096);
+        assert_eq!(set.config.rollover_threshold_percent, 100);
+        // Enough appends to fill the segment several times over, so the check
+        // covers a segment that is nearly full, exactly full, and freshly
+        // rolled. `append` rolls on its own, so this cannot run forever.
+        for _ in 0..400 {
+            set.append(&[record("padding")]).expect("append");
+            assert!(
+                !set.should_prepare_roll(),
+                "a threshold of 100 must never ask for an early roll",
+            );
+        }
+        assert!(set.descriptors().len() > 1, "expected inline rollovers");
+    }
+
+    #[test]
+    fn an_oversized_first_record_does_not_trigger_a_disabled_roll() {
+        let dir = tempdir().expect("dir");
+        let mut set = new_set(&dir, 128);
+        // One record larger than the whole segment: `size_bytes` lands far past
+        // the threshold in a single step.
+        set.append(&[record(&"x".repeat(512))]).expect("append");
+        assert!(set.active().size_bytes() > 128);
+        assert!(!set.should_prepare_roll());
     }
 
     fn read_all(set: &SegmentSet, start: Offset) -> Vec<String> {

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -259,6 +259,56 @@ async fn background_rollover_keeps_the_log_contiguous_and_reopenable() {
     assert_eq!(values[59], "value-059");
 }
 
+/// A rollover whose seal fails must never let an `OnCommit` append be
+/// acknowledged on the strength of a flush that did not cover it.
+///
+/// The window this guards: the seal fails, `pending_seal` is cleared, and an
+/// append already in flight captures only the new active segment, syncs that,
+/// and reports a durable bound spanning both. The retired segment's records
+/// were never flushed.
+#[tokio::test]
+async fn a_failed_seal_stops_the_log_instead_of_acknowledging() {
+    let dir = tempdir().expect("dir");
+    let config = LogConfig {
+        rollover_threshold_percent: 60,
+        max_overshoot_percent: 200,
+        ..config(FsyncMode::OnCommit)
+    };
+    let log = DiskLog::open(dir.path(), "t/ns/s/0", config).expect("open");
+
+    log.inner
+        .fail_seal
+        .store(true, std::sync::atomic::Ordering::Release);
+
+    // Append until the background rollover has run and failed. Every append
+    // either succeeds durably or fails -- what must never happen is an
+    // acknowledgement after the seal failed.
+    let mut rejected = None;
+    for i in 0..200 {
+        if let Err(err) = log.append(&records(&[&format!("value-{i:03}")])).await {
+            rejected = Some(err);
+            break;
+        }
+    }
+    let rejected = rejected.expect("the failed seal should have stopped the log");
+    assert!(
+        rejected.to_string().contains("rollover failed"),
+        "unexpected error: {rejected}",
+    );
+
+    // Terminal, on every path that accepts work or reports durability.
+    assert!(log.append(&records(&["after"])).await.is_err());
+    assert!(log.sync().await.is_err());
+    assert!(log.shutdown().await.is_err());
+
+    // And the retired segment is still owed a flush, so no later flush can
+    // silently skip it.
+    assert!(
+        log.inner.pending_seal.lock().is_some(),
+        "a failed seal must keep the retired segment on the flush path",
+    );
+}
+
 #[tokio::test]
 async fn on_commit_acknowledges_only_durable_records() {
     let dir = tempdir().expect("dir");


### PR DESCRIPTION
**This is the last commit of #192, which missed the squash-merge.** #192 landed at 19:39:39Z; this commit was pushed to the branch shortly after and so was never merged. `main` currently has the background rollover *without* it.

That combination is worse than either half alone, because the two missing pieces compound: the absent threshold guard lets the **default** configuration enter the background-rollover path, and that path still carries the durability race.

## The durability race

`roll_in_background` cleared `pending_seal` whether or not `retired.seal()` succeeded, and the roll state only became `Failed` afterwards, in the spawning task. In between, an `OnCommit` append already in flight could:

1. capture the new active segment,
2. observe `pending_seal == None`,
3. sync only that segment,
4. report a durable bound covering **both** segments,
5. return success — while the retired segment's records sat unflushed behind a seal that had just failed.

`check_roll_state` also ran only at the entry to `write_batch`, so an append that started before the failure was never rechecked.

### Fix

- `pending_seal` is cleared **only after a successful seal**. A failed one leaves it set, so every later flush keeps trying to cover those records instead of skipping them.
- The failure is recorded in a new `roll_failure` from inside the rollover's blocking closure, *before it returns* — closing the window where a durability wait could see a cleared `pending_seal` next to a not-yet-`Failed` state. `roll_state` stays the scheduler's view; `roll_failure` is the durability view.
- Every path that accepts work or reports durability rechecks it: after the await in `append`, in `commit` (`ensure_durable` returns early when the target is already covered, skipping `flush` entirely), in `sync`, and in `flush` **after** the sync rather than only before — `durable_upto` spans the retired segment as well as the active one.
- A flush that fails while `pending_seal` was set records the roll failure itself, so the terminal state is reached whether the seal or a later flush discovers the bad device.

## The configuration defect

`rollover_threshold_percent = 100` is documented as disabling the background roll, and is the default — but `should_prepare_roll` still returned true once a segment had *reached* its configured size, which an exactly fitting batch or a single oversized record does. The default could therefore quietly enter the path it claims to disable.

## Verification

- **Inversion**: restoring the two original lines makes the new test fail on `a failed seal must keep the retired segment on the flush path`; with the fix it passes. A regression test that passes either way would prove nothing.
- The test also asserts `append`, `sync`, and `shutdown` all reject after the failure.
- Threshold tests cover both the exact-boundary case (400 appends across several inline rollovers) and an oversized first record.
- Rebased onto current `main` and re-verified there: `task lint` clean, 172 storage tests passing, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)