### PR TITLE
M1: resumable subscriptions and event offsets over the wire (#177)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs-site/.astro/
 .cache/
 data/soak/
 /crates/felix-storage/fuzz/target
+.venv-perf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+Rust 1.97, edition 2024. The `Taskfile.yml` shortcuts are the source of truth — CI runs the same ones.
+
+```bash
+task lint          # cargo fmt --check + clippy --workspace --all-targets --all-features -D warnings
+task test          # cargo test --workspace, then cargo test -p felix-client --features in-process
+task demo:check    # build/clippy/test the demo crates that are OUTSIDE the workspace
+task coverage      # llvm-cov; spins up a Postgres container unless CI or FELIX_TEST_DATABASE_URL is set
+task conformance   # wire-protocol conformance runner
+```
+
+Single test / narrower runs:
+
+```bash
+cargo test -p felix-storage --lib disk_log::                    # one module
+cargo test -p felix-broker --test durable_streams <name>        # one integration test
+cargo test -p broker quic_subscribe                             # QUIC integration tests
+```
+
+Docs and perf:
+
+```bash
+cd docs-site && npm run build          # runs check:mermaid first, then astro build
+node scripts/check-mermaid.mjs         # validate every mermaid diagram in docs/ and docs-site/
+task perf:latency-matrix               # run matrix -> aggregate -> charts -> markdown snippets
+```
+
+`scripts/perf/` needs `matplotlib` (see `scripts/perf/requirements.txt`); the aggregate step
+degrades gracefully without `pandas`.
+
+### Two traps worth knowing
+
+- **`demos/slow-consumer`, `demos/state-divergence`, `demos/rbac-live`, and
+  `demos/cross_tenant_isolation` are separate crates, not workspace members.** `task lint`
+  and `task test` cannot see them, so a workspace-scoped "this is unused, delete it" signal
+  is unreliable — deleting a public item that only a demo uses passes lint and breaks the
+  build. Run `task demo:check` after changing public APIs.
+- **`task test` deliberately does not use `--all-features` on the whole workspace.**
+  `felix-client`'s `in-process` feature is run separately so its tests do not add concurrent
+  load to timing-sensitive tests elsewhere.
+
+## Architecture
+
+### The publish path is where most invariants live
+
+A publish crosses four components in a fixed order, and the order is the design:
+
+1. **`services/broker/src/transport/quic/`** decodes the frame. `handlers/publish.rs` and
+   `handlers/subscribe.rs` own the per-message work; `streams/control.rs` is the control-stream
+   loop that owns auth state and dispatches every `Message` variant.
+2. **`crates/felix-broker/src/broker.rs`** takes offsets from storage *before* waiting on
+   durability (`begin_append` → `commit`), so the batch claims its place in the stream's order
+   the instant its offsets are consumed. `commit_order.rs` (`CommitSequencer`) then makes
+   later publishes wait behind earlier ones regardless of whether those succeed, fail, or are
+   cancelled.
+3. **`crates/felix-storage/src/disk_log/`** persists it. See below.
+4. **Fanout** happens after durability, via `delivery.rs`. One `DeliveryEnvelope` is shared by
+   every subscriber and caches its encoded frame, so a publish is encoded once regardless of
+   fanout — with a second cached encoding when some subscribers negotiated event offsets and
+   others did not.
+
+Reordering these is almost always a bug. Several past defects were "the natural order" —
+e.g. reading history before registering a subscriber loses any publish landing in between.
+
+### Storage: a log-structured segment store, not a WAL
+
+`crates/felix-storage/src/`:
+
+- `segment/` — the byte format (`format.rs`), platform I/O (`io.rs`: `pread`, preallocation,
+  `F_FULLFSYNC` on macOS), writer, reader, sparse index.
+- `disk_log/` — `segments.rs` (rollover, offset routing, truncation), `recovery.rs` (startup
+  validation and torn-tail repair), `sync.rs` (fsync policy and group commit), `mod.rs` (the
+  async `AppendOnlyLog` seam).
+
+Load-bearing properties, all documented in `docs/durable-storage.md` and
+`docs/storage-format.md`:
+
+- **Records are never rewritten**, so recovery can trust "valid bytes end at EOF". Preallocation
+  reserves blocks *without* changing `st_size` for exactly this reason.
+- **A torn tail is repaired; interior corruption is fatal.** Refusing to start beats silently
+  losing acknowledged records.
+- **Indexes are derived, never trusted** — a missing, short, or stale index is rebuilt from the
+  segment it describes. This is why it is safe to skip fsyncing a freshly created index.
+- **Group commit** is the single biggest throughput lever under `FsyncMode::OnCommit`; one
+  blocking flush serves many waiters.
+
+### Subscribers are isolated by construction
+
+Per-subscriber bounded queues with an explicit overflow policy (`SubQueuePolicy`, default
+`DropNew`). A publisher never blocks on a slow subscriber. `handlers/subscribe/feeder.rs`
+and `event_writer.rs` do per-subscriber batching and writing behind a lane manager.
+
+Because dropping is the default, **a subscriber can silently miss records** — which is why
+delivered events carry log offsets for durable streams: a jump in offsets is exactly a drop.
+
+### Wire protocol: capability negotiation, not versioning
+
+`crates/felix-wire/`. Frame flags (`frame.rs`) select the *payload layout*, so an unknown flag
+bit is rejected rather than masked off — masking one means confidently misparsing the body.
+
+New features are added as negotiated flag bits, not version bumps: a client offers
+`Auth.client_flags`, the broker answers `AuthOk.server_flags`. A peer that predates negotiation
+sends/receives a plain `Ok`, and the only safe reading of that silence is `ORIGINAL_V1_FLAGS`.
+`ORIGINAL_V1_FLAGS` is frozen — never add to it.
+
+Optional JSON fields must default to the pre-existing behaviour so an old peer and a new peer
+exchange byte-identical frames.
+
+### Control plane and startup ordering
+
+`services/controlplane/` serves metadata over REST; the broker seeds from it at startup.
+`services/broker/src/main.rs` gates readiness and the accept loop on that seeding, so the
+broker does not accept traffic for streams it does not yet know about.
+
+## Conventions
+
+- **Comments explain *why*, and are load-bearing.** Much of this codebase's reasoning about
+  ordering, durability, and failure modes lives in comments next to the code that depends on
+  it. Match that density; do not strip it.
+- **Docs are treated as part of the change.** `docs/protocol.md`, `docs/durable-storage.md`,
+  `docs/storage-format.md`, `docs/storage-performance.md`, and the status tables in
+  `docs-site/src/content/docs/getting-started/what-felix-is-for.md` make specific claims about
+  what is implemented. That page states outright that stale status markers are worse than none.
+  If you ship a capability, move its row; if you find a claim the code cannot back, fix the claim.
+- **A regression test that passes without the fix proves nothing.** For concurrency and
+  durability fixes, revert the fix, watch the new test fail, then restore it.
+- Benchmarks: `throughput` is what publishers sent, `delivered_throughput` counts subscriber
+  deliveries — they differ by the fanout factor. Batched runs (`batch > 1`) measure a
+  throughput profile, not request latency.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,7 @@ dependencies = [
  "serde_yaml_ng",
  "serial_test",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -169,6 +169,15 @@ tasks:
       - "task pg:up"
       - "cargo run --manifest-path demos/cross_tenant_isolation/Cargo.toml -- {{.CLI_ARGS}}"
       - "task pg:down"
+  perf:deps:
+    desc: "Install the Python dependencies the perf charting pipeline needs"
+    cmds:
+      - "python3 -m pip install -r scripts/perf/requirements.txt"
+  perf:charts:
+    desc: "Re-render charts from data already in data/derived (no benchmark run)"
+    cmds:
+      - "python3 scripts/perf/make_charts.py"
+      - "python3 scripts/perf/render_markdown_snippets.py"
   perf:latency-matrix:
     cmds:
       - "python3 scripts/perf/run_latency_matrix.py"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,19 +170,31 @@ tasks:
       - "cargo run --manifest-path demos/cross_tenant_isolation/Cargo.toml -- {{.CLI_ARGS}}"
       - "task pg:down"
   perf:deps:
-    desc: "Install the Python dependencies the perf charting pipeline needs"
+    desc: "Create .venv-perf and install the Python deps the charting pipeline needs"
     cmds:
-      - "python3 -m pip install -r scripts/perf/requirements.txt"
+      # A virtualenv rather than a bare `pip install`: Homebrew and most distro
+      # Pythons are marked externally managed (PEP 668), so installing into them
+      # fails outright. Everything below prefers this venv when it exists and
+      # falls back to system python3 otherwise, so nothing is required of a
+      # machine where the deps happen to be installed already.
+      - "python3 -m venv .venv-perf"
+      - ".venv-perf/bin/python -m pip install --quiet --upgrade pip"
+      - ".venv-perf/bin/python -m pip install --quiet -r scripts/perf/requirements.txt"
+      - '.venv-perf/bin/python -c "import matplotlib; print(f\"matplotlib {matplotlib.__version__} ready in .venv-perf\")"'
   perf:charts:
     desc: "Re-render charts from data already in data/derived (no benchmark run)"
     cmds:
-      - "python3 scripts/perf/make_charts.py"
-      - "python3 scripts/perf/render_markdown_snippets.py"
+      - |
+        PY=$([ -x .venv-perf/bin/python ] && echo .venv-perf/bin/python || echo python3)
+        "$PY" scripts/perf/make_charts.py
+        "$PY" scripts/perf/render_markdown_snippets.py
   perf:latency-matrix:
     cmds:
-      - "python3 scripts/perf/run_latency_matrix.py"
-      - "python3 scripts/perf/normalize_and_aggregate.py"
-      - "python3 scripts/perf/make_charts.py"
-      - "python3 scripts/perf/render_markdown_snippets.py"
+      - |
+        PY=$([ -x .venv-perf/bin/python ] && echo .venv-perf/bin/python || echo python3)
+        "$PY" scripts/perf/run_latency_matrix.py
+        "$PY" scripts/perf/normalize_and_aggregate.py
+        "$PY" scripts/perf/make_charts.py
+        "$PY" scripts/perf/render_markdown_snippets.py
   conformance:
     cmds: ["cargo run -p felix-conformance"]

--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -21,6 +21,7 @@ use crate::stream_state::{Cursor, StreamState};
 use crate::subscription::{Subscription, SubscriptionGuard};
 use crate::telemetry::{t_now_if, t_should_sample};
 use crate::timings;
+pub use felix_wire::StartPosition;
 
 /// In-process broker for pub/sub messaging.
 ///
@@ -128,6 +129,40 @@ impl Default for StreamMetadata {
             shards: 1,
         }
     }
+}
+
+/// The disk-backed range a resumed subscription must replay before its backlog.
+///
+/// Half-open: `[from_offset, until_offset)`. Closed at the moment it is
+/// produced, because the live subscription is already registered at
+/// `until_offset`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HistoryRange {
+    pub from_offset: u64,
+    pub until_offset: u64,
+}
+
+/// A subscription resumed from a position, with the history needed to reach it.
+///
+/// Deliver in order: `history` (paged from disk by the caller, so an arbitrarily
+/// long backlog is never buffered here), then `backlog`, then the live
+/// subscription. The three are contiguous by construction.
+#[derive(Debug)]
+pub struct ResumedSubscription {
+    /// Older records to page off disk, or `None` when the ring covered the
+    /// whole request.
+    pub history: Option<HistoryRange>,
+    /// Records already in the replay ring, each with its own offset.
+    ///
+    /// Offsets are carried rather than derived because the ring can contain
+    /// holes -- a publish that took disk offsets and was cancelled before
+    /// reaching the ring leaves one. A caller that numbered these sequentially
+    /// from `backlog_start` would mislabel everything after a hole.
+    pub backlog: Vec<(u64, Bytes)>,
+    /// Offset of the first backlog entry, and of the live edge when the backlog
+    /// is empty.
+    pub backlog_start: u64,
+    pub subscription: Subscription,
 }
 
 impl Broker {
@@ -310,7 +345,12 @@ impl Broker {
         let fanout_start = t_now_if(sample);
         let mut closed_subscribers = Vec::new();
         let mut sent = 0usize;
-        let envelope = DeliveryEnvelope::new(payloads);
+        // The offsets the log just assigned travel with the batch, so live
+        // delivery can report them exactly as replay does. Without this a
+        // resumed subscriber gets offsets for its history and then nothing once
+        // it reaches the live edge, which is precisely where it needs to start
+        // checkpointing.
+        let envelope = DeliveryEnvelope::with_base_offset(payloads, durable_first_offset);
         let item_count = envelope.len();
         let enqueue_start = t_now_if(sample);
         for subscriber in senders.iter() {
@@ -528,6 +568,135 @@ impl Broker {
             });
         };
         log.read_from(from_offset, max_bytes).await
+    }
+
+    /// Subscribe from a chosen position, joining stored history to live
+    /// delivery without a gap or a duplicate.
+    ///
+    /// The ordering is what makes this correct, and it is not the obvious one.
+    /// The live subscription is registered **first**, clamped to the oldest
+    /// entry the replay ring still holds, and only then is the older history
+    /// read from disk. Registering first pins the live edge: every record from
+    /// `backlog_start` onward is already captured, either in the returned
+    /// backlog or on the subscription's receiver. The disk range left to serve,
+    /// `[requested, backlog_start)`, is therefore closed -- it cannot grow, and
+    /// nothing can be evicted out of it into a gap while it is being read.
+    ///
+    /// Reading history first and subscribing after is the version that looks
+    /// natural and loses records: publishes landing between the read and the
+    /// registration reach neither.
+    ///
+    /// The caller delivers in three phases: `history` (paged from disk),
+    /// then `backlog`, then whatever arrives on the subscription.
+    pub async fn subscribe_from(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        start: StartPosition,
+    ) -> Result<ResumedSubscription> {
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
+            .await?;
+        let stream_state = handle.state;
+        let durable = stream_state.durable.clone();
+
+        // Resolve the requested position to an offset before touching the ring.
+        let requested = match start {
+            StartPosition::Latest => match &durable {
+                Some(log) => log.tail_offset().await?,
+                None => stream_state.tail_seq(),
+            },
+            StartPosition::Earliest => match &durable {
+                // The oldest offset still on disk, which retention raises as it
+                // trims. Never 0 for a trimmed stream.
+                Some(log) => log.base_offset(),
+                None => stream_state.oldest_seq(),
+            },
+            StartPosition::Offset(offset) => offset,
+        };
+
+        // Resuming past the tail would register for live delivery and then hand
+        // over records *below* the requested offset -- the opposite of what was
+        // asked for. Rejected rather than silently reinterpreted; a client that
+        // wants to wait for an offset that does not exist yet should ask for
+        // `Latest` and track its own position.
+        let tail = match &durable {
+            Some(log) => log.tail_offset().await?,
+            None => stream_state.tail_seq(),
+        };
+        if requested > tail {
+            return Err(BrokerError::CursorInFuture { requested, tail });
+        }
+
+        let (backlog, backlog_start, subscriber_id, receiver) =
+            stream_state.register_clamped(requested);
+        // Built the moment the subscriber exists, so every error path below
+        // releases the registration by `Drop` instead of stranding a closed
+        // sender in the registry for the publish path to reap later. Repeated
+        // rejected subscribes would otherwise grow the slab without ever
+        // touching the per-connection subscription cap.
+        let guard = SubscriptionGuard {
+            stream_state: Arc::downgrade(&stream_state),
+            subscriber_id,
+        };
+
+        // Anything older than the ring has to come from disk, and only a
+        // durable stream has any. For an in-memory stream this is the same
+        // "your cursor is too old" condition `subscribe_with_cursor` reports.
+        let history = if requested < backlog_start {
+            if durable.is_none() {
+                return Err(BrokerError::CursorTooOld {
+                    oldest: backlog_start,
+                    requested,
+                });
+            }
+            Some(HistoryRange {
+                from_offset: requested,
+                until_offset: backlog_start,
+            })
+        } else {
+            None
+        };
+
+        // A durable stream can also have been trimmed past the request, which
+        // the ring cannot tell us about -- it only knows its own oldest entry.
+        if let (Some(range), Some(log)) = (&history, &durable)
+            && range.from_offset < log.base_offset()
+        {
+            return Err(BrokerError::CursorTooOld {
+                oldest: log.base_offset(),
+                requested,
+            });
+        }
+
+        Ok(ResumedSubscription {
+            history,
+            backlog,
+            backlog_start,
+            subscription: Subscription {
+                receiver,
+                guard,
+                pending: VecDeque::new(),
+            },
+        })
+    }
+
+    /// Number of subscriber slots currently registered for a stream.
+    ///
+    /// Exposed for tests that need to prove a failed subscribe left nothing
+    /// behind: a stranded registration is invisible from the outside until some
+    /// later publish happens to reap it.
+    pub async fn registered_subscribers(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+    ) -> Result<usize> {
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
+            .await?;
+        Ok(handle.state.subscriber_count())
     }
 
     pub fn cache(&self) -> &(dyn StorageApi + Send) {

--- a/crates/felix-broker/src/delivery.rs
+++ b/crates/felix-broker/src/delivery.rs
@@ -47,17 +47,33 @@ impl Drop for QueuedDelivery {
 #[derive(Debug)]
 struct DeliveryBatch {
     payloads: Arc<[Bytes]>,
+    /// Offset of `payloads[0]` for a durable stream; `None` for an in-memory
+    /// one, which has no durable position to report.
+    ///
+    /// One value per batch is enough because a publish batch takes a contiguous
+    /// run of offsets. That is what keeps offsets off the per-event cost model
+    /// and lets them ride the shared encode-once frame: the offsets belong to
+    /// the stream, not to any subscriber.
+    base_offset: Option<u64>,
     enqueued_at: Instant,
     encoded_frame: Mutex<Option<Bytes>>,
+    /// The same batch encoded *with* offsets, for subscribers that negotiated
+    /// them. Cached separately rather than replacing the plain encoding,
+    /// because a stream can have subscribers of both kinds and each must get
+    /// the frame shape it agreed to. At most two encodings per batch, however
+    /// many subscribers there are.
+    encoded_frame_with_offsets: Mutex<Option<Bytes>>,
 }
 
 impl DeliveryEnvelope {
-    pub(crate) fn new(payloads: &[Bytes]) -> Self {
+    pub(crate) fn with_base_offset(payloads: &[Bytes], base_offset: Option<u64>) -> Self {
         Self {
             inner: Arc::new(DeliveryBatch {
                 payloads: Arc::from(payloads),
+                base_offset,
                 enqueued_at: Instant::now(),
                 encoded_frame: Mutex::new(None),
+                encoded_frame_with_offsets: Mutex::new(None),
             }),
         }
     }
@@ -74,12 +90,39 @@ impl DeliveryEnvelope {
         self.inner.payloads.is_empty()
     }
 
+    /// Offset of the first payload, when this batch came from a durable stream.
+    pub fn base_offset(&self) -> Option<u64> {
+        self.inner.base_offset
+    }
+
     pub fn shared_event_frame(&self) -> felix_wire::Result<Bytes> {
         let mut cached = self.inner.encoded_frame.lock();
         if let Some(frame) = cached.as_ref() {
             return Ok(frame.clone());
         }
         let frame = felix_wire::binary::encode_shared_event_batch_bytes(&self.inner.payloads)?;
+        *cached = Some(frame.clone());
+        Ok(frame)
+    }
+
+    /// The shared frame carrying offsets, for subscribers that negotiated them.
+    ///
+    /// Falls back to the plain frame when this batch has no offset to report,
+    /// so an in-memory stream costs nothing extra and an offset-capable
+    /// subscriber on one simply sees no offsets -- which is what the protocol
+    /// says an ephemeral event carries.
+    pub fn shared_event_frame_with_offsets(&self) -> felix_wire::Result<Bytes> {
+        let Some(base_offset) = self.inner.base_offset else {
+            return self.shared_event_frame();
+        };
+        let mut cached = self.inner.encoded_frame_with_offsets.lock();
+        if let Some(frame) = cached.as_ref() {
+            return Ok(frame.clone());
+        }
+        let frame = felix_wire::binary::encode_shared_event_batch_bytes_with_offset(
+            &self.inner.payloads,
+            base_offset,
+        )?;
         *cached = Some(frame.clone());
         Ok(frame)
     }

--- a/crates/felix-broker/src/durable.rs
+++ b/crates/felix-broker/src/durable.rs
@@ -165,6 +165,15 @@ impl StreamLog {
         self.log.tail_offset().await.map_err(storage_error)
     }
 
+    /// Oldest offset still on disk.
+    ///
+    /// Rises as retention trims the head, so this is the floor a resuming
+    /// subscriber can ask for: anything below it has been discarded and must be
+    /// reported rather than silently skipped.
+    pub fn base_offset(&self) -> Offset {
+        self.log.base_offset()
+    }
+
     /// Exclusive bound on offsets that survive a crash right now.
     pub fn durable_offset(&self) -> Offset {
         self.log.durable_offset()

--- a/crates/felix-broker/src/error.rs
+++ b/crates/felix-broker/src/error.rs
@@ -8,6 +8,13 @@ pub enum BrokerError {
     CapacityTooLarge,
     #[error("cursor too old (oldest {oldest}, requested {requested})")]
     CursorTooOld { oldest: u64, requested: u64 },
+    /// A resume asked to start past the end of the stream.
+    ///
+    /// Distinct from `CursorTooOld` because the remedy is the opposite: the
+    /// client is ahead of the log, not behind it, and silently starting at the
+    /// tail would deliver records it explicitly skipped past.
+    #[error("cursor is past the tail (tail {tail}, requested {requested})")]
+    CursorInFuture { requested: u64, tail: u64 },
     #[error("stream not found: tenant={tenant_id} namespace={namespace} stream={stream}")]
     StreamNotFound {
         tenant_id: String,

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -33,7 +33,10 @@ mod subscription;
 
 pub mod timings;
 
-pub use broker::{Broker, CacheMetadata, StreamHandle, StreamMetadata};
+pub use broker::{
+    Broker, CacheMetadata, HistoryRange, ResumedSubscription, StartPosition, StreamHandle,
+    StreamMetadata,
+};
 pub use config::SubQueuePolicy;
 pub use delivery::DeliveryEnvelope;
 pub use durable::{DurableStorage, StreamLog};

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -209,7 +209,11 @@ impl StreamState {
         self.subscribers_snapshot.store(Arc::new(snapshot));
     }
 
-    #[cfg(test)]
+    /// How many subscriber slots are registered right now.
+    ///
+    /// No longer test-only: `Broker::registered_subscribers` exposes it so a
+    /// test can prove a *failed* subscribe left nothing behind. A stranded
+    /// registration is otherwise invisible until some later publish reaps it.
     pub(crate) fn subscriber_count(&self) -> usize {
         let state = self.subscribers.lock();
         state.senders.len()
@@ -333,6 +337,71 @@ impl StreamState {
         let (subscriber_id, receiver) = self.register_subscriber();
         drop(state);
         Ok((backlog, subscriber_id, receiver))
+    }
+
+    /// Register a subscriber starting as far back as the replay ring allows,
+    /// reporting where that turned out to be.
+    ///
+    /// This is [`Self::register_with_backlog`] without the rejection. It cannot
+    /// fail on a too-old cursor: it clamps to the oldest entry the ring still
+    /// holds and returns that offset, so the caller learns exactly which range
+    /// it must serve from disk to close the gap.
+    ///
+    /// The clamp has to happen *here*, under the one lock acquisition that also
+    /// takes the backlog and registers the subscriber. Discovering `oldest` from
+    /// a failed call and registering again would leave a window in which the
+    /// ring evicts further, and the second registration would start later than
+    /// the offset the caller was told to read up to -- which is precisely the
+    /// gap this whole path exists to prevent.
+    ///
+    /// Returns `(backlog, backlog_start, subscriber_id, receiver)`, where
+    /// `backlog_start` is the offset of the first backlog entry. Everything from
+    /// `backlog_start` onward is either in `backlog` or will arrive on
+    /// `receiver`; nothing can fall between them.
+    pub(crate) fn register_clamped(
+        &self,
+        from_seq: u64,
+    ) -> (Vec<(u64, Bytes)>, u64, u64, SubscriptionReceiver) {
+        let state = self.log_state.lock();
+        let oldest = state
+            .log
+            .front()
+            .map(|entry| entry.seq)
+            .unwrap_or(state.next_seq);
+        let start = from_seq.max(oldest);
+        // Each payload keeps its sequence number. The ring is *not* guaranteed
+        // contiguous: a publish that consumed disk offsets and was cancelled
+        // before reaching the ring leaves a hole. Returning bare payloads made
+        // the caller assume `start, start+1, start+2, ...`, which both mislabels
+        // every offset after a hole and hides the missing record entirely.
+        let backlog: Vec<(u64, Bytes)> = state
+            .log
+            .iter()
+            .filter(|entry| entry.seq >= start)
+            .map(|entry| (entry.seq, entry.payload.clone()))
+            .collect();
+        // Where the backlog *actually* begins, which is not `start` when the
+        // first surviving entry sits above it.
+        let backlog_start = match backlog.first() {
+            Some((seq, _)) => *seq,
+            // An empty ring means the live edge is `next_seq`, and that is where
+            // the backlog would have started had there been one.
+            None => state.next_seq.max(start),
+        };
+
+        let (subscriber_id, receiver) = self.register_subscriber();
+        drop(state);
+        (backlog, backlog_start, subscriber_id, receiver)
+    }
+
+    /// Oldest sequence the in-memory replay ring can still serve.
+    pub(crate) fn oldest_seq(&self) -> u64 {
+        let state = self.log_state.lock();
+        state
+            .log
+            .front()
+            .map(|entry| entry.seq)
+            .unwrap_or(state.next_seq)
     }
 
     pub(crate) fn tail_seq(&self) -> u64 {

--- a/crates/felix-broker/src/subscription.rs
+++ b/crates/felix-broker/src/subscription.rs
@@ -77,6 +77,21 @@ impl SubscriptionReceiver {
     }
 }
 
+impl Subscription {
+    /// Take whatever is already queued, without waiting.
+    ///
+    /// Used by resume to drain what accumulated while history was being read,
+    /// so the handler can spot a queue drop -- a jump in offsets -- and fill it
+    /// from disk before live delivery starts.
+    pub fn drain_ready(&mut self) -> Vec<DeliveryEnvelope> {
+        let mut drained = Vec::new();
+        while let Ok(envelope) = self.receiver.try_recv() {
+            drained.push(envelope);
+        }
+        drained
+    }
+}
+
 impl Drop for SubscriptionReceiver {
     fn drop(&mut self) {
         self.receiver.close();

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use felix_broker::{Broker, BrokerError, DurableStorage, StreamMetadata};
+use felix_broker::{
+    Broker, BrokerError, DurableStorage, ResumedSubscription, StartPosition, StreamMetadata,
+};
 use felix_storage::EphemeralCache;
 use felix_storage::log::{FsyncMode, LogConfig};
 use tempfile::{TempDir, tempdir};
@@ -966,16 +968,340 @@ async fn the_backlog_to_live_handoff_loses_nothing_under_concurrent_publishes() 
         .map(|b| String::from_utf8(b.to_vec()).expect("utf8"))
         .collect();
     let expected_from = cursor.next_seq() as u32;
+    // A timeout used to `break` and let the length assertion below report it as
+    // a lost record, which sends anyone reading the failure after the handoff
+    // logic instead of at the clock. On a machine busy enough -- a full test
+    // suite, or a benchmark run alongside it -- waiting is not the same fact as
+    // losing, so the two now fail differently.
+    let mut timed_out = false;
     while (seen.len() as u32) < TOTAL - expected_from {
-        match tokio::time::timeout(Duration::from_secs(5), sub.recv()).await {
+        match tokio::time::timeout(Duration::from_secs(30), sub.recv()).await {
             Ok(Some(msg)) => seen.push(String::from_utf8(msg.to_vec()).expect("utf8")),
-            _ => break,
+            Ok(None) => break,
+            Err(_) => {
+                timed_out = true;
+                break;
+            }
         }
     }
+    assert!(
+        !timed_out,
+        "timed out after {} of {} records -- the machine was too slow to \
+         conclude anything about the handoff",
+        seen.len(),
+        TOTAL - expected_from,
+    );
 
     let expected: Vec<String> = (expected_from..TOTAL).map(|i| format!("v{i:04}")).collect();
     assert_eq!(
         seen, expected,
         "a record fell between the backlog snapshot and the live subscription"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Resuming from a position: the seam between stored history and live delivery.
+// ---------------------------------------------------------------------------
+
+/// A broker whose replay ring is deliberately tiny, so history has to come off
+/// disk rather than out of memory.
+async fn broker_with_small_ring(dir: &TempDir, ring: usize) -> Arc<Broker> {
+    let storage = DurableStorage::open(dir.path(), log_config(FsyncMode::None)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into())
+        .with_durable_storage(storage)
+        .with_log_capacity(ring)
+        .expect("capacity");
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+    Arc::new(broker)
+}
+
+/// Drain everything a resume produced: disk history, then ring backlog, then
+/// whatever is already sitting on the live receiver.
+async fn drain_resume(
+    broker: &Broker,
+    stream: &str,
+    resumed: &mut ResumedSubscription,
+) -> Vec<String> {
+    let mut seen = Vec::new();
+    if let Some(range) = resumed.history {
+        let mut at = range.from_offset;
+        while at < range.until_offset {
+            let records = broker
+                .read_durable("t1", "default", stream, at, 64 * 1024)
+                .await
+                .expect("history");
+            if records.is_empty() {
+                break;
+            }
+            for record in records {
+                if record.offset >= range.until_offset {
+                    break;
+                }
+                seen.push(String::from_utf8(record.payload.to_vec()).expect("utf8"));
+                at = record.offset + 1;
+            }
+        }
+    }
+    for (_, payload) in &resumed.backlog {
+        seen.push(String::from_utf8(payload.to_vec()).expect("utf8"));
+    }
+    seen
+}
+
+#[tokio::test]
+async fn resuming_at_an_offset_older_than_the_ring_replays_from_disk() {
+    let dir = tempdir().expect("dir");
+    // Ring holds 4; publish 20. Everything below offset 16 exists only on disk.
+    let broker = broker_with_small_ring(&dir, 4).await;
+    register(&broker, "orders", true).await;
+    for i in 0..20 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i:02}")))
+            .await
+            .expect("publish");
+    }
+
+    let mut resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(3))
+        .await
+        .expect("resume");
+
+    // The request is older than the ring, so a disk range must have been
+    // produced -- and it must stop exactly where the backlog starts.
+    let range = resumed.history.expect("history below the ring");
+    assert_eq!(range.from_offset, 3);
+    assert_eq!(range.until_offset, resumed.backlog_start);
+
+    let seen = drain_resume(&broker, "orders", &mut resumed).await;
+    let expected: Vec<String> = (3..20).map(|i| format!("v{i:02}")).collect();
+    assert_eq!(seen, expected, "history and backlog must join with no gap");
+}
+
+#[tokio::test]
+async fn a_publish_during_the_resume_arrives_live_exactly_once() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 4).await;
+    register(&broker, "orders", true).await;
+    for i in 0..20 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i:02}")))
+            .await
+            .expect("publish");
+    }
+
+    let mut resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(3))
+        .await
+        .expect("resume");
+
+    // Published *after* registration but *before* the history is read. This is
+    // the record that a read-then-subscribe ordering loses: it is too new for
+    // the disk range and would have missed a later registration.
+    broker
+        .publish("t1", "default", "orders", payload("during"))
+        .await
+        .expect("publish");
+
+    let mut seen = drain_resume(&broker, "orders", &mut resumed).await;
+    while let Ok(Some(delivery)) =
+        tokio::time::timeout(Duration::from_millis(200), resumed.subscription.recv()).await
+    {
+        seen.push(String::from_utf8(delivery.to_vec()).expect("utf8"));
+    }
+
+    let mut expected: Vec<String> = (3..20).map(|i| format!("v{i:02}")).collect();
+    expected.push("during".to_string());
+    assert_eq!(seen, expected);
+}
+
+#[tokio::test]
+async fn resuming_within_the_ring_needs_no_disk_history() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 16).await;
+    register(&broker, "orders", true).await;
+    for i in 0..8 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i}")))
+            .await
+            .expect("publish");
+    }
+
+    let mut resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(5))
+        .await
+        .expect("resume");
+    assert!(resumed.history.is_none(), "the ring covered the request");
+    assert_eq!(resumed.backlog_start, 5);
+    assert_eq!(
+        drain_resume(&broker, "orders", &mut resumed).await,
+        ["v5", "v6", "v7"]
+    );
+}
+
+#[tokio::test]
+async fn latest_delivers_nothing_already_published() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 16).await;
+    register(&broker, "orders", true).await;
+    for i in 0..5 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i}")))
+            .await
+            .expect("publish");
+    }
+
+    let mut resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Latest)
+        .await
+        .expect("resume");
+    assert!(resumed.history.is_none());
+    assert!(
+        drain_resume(&broker, "orders", &mut resumed)
+            .await
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn earliest_replays_the_whole_retained_stream() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 4).await;
+    register(&broker, "orders", true).await;
+    for i in 0..12 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i:02}")))
+            .await
+            .expect("publish");
+    }
+
+    let mut resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Earliest)
+        .await
+        .expect("resume");
+    let seen = drain_resume(&broker, "orders", &mut resumed).await;
+    let expected: Vec<String> = (0..12).map(|i| format!("v{i:02}")).collect();
+    assert_eq!(seen, expected);
+}
+
+#[tokio::test]
+async fn an_in_memory_stream_reports_a_cursor_older_than_its_ring() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 4).await;
+    // Not durable: there is no disk to fall back to, so a request below the
+    // ring is unservable rather than slow.
+    register(&broker, "ephemeral", false).await;
+    for i in 0..20 {
+        broker
+            .publish("t1", "default", "ephemeral", payload(&format!("v{i:02}")))
+            .await
+            .expect("publish");
+    }
+
+    let err = broker
+        .subscribe_from("t1", "default", "ephemeral", StartPosition::Offset(2))
+        .await
+        .expect_err("cursor is below the ring and there is no disk");
+    assert!(
+        matches!(err, BrokerError::CursorTooOld { requested: 2, .. }),
+        "unexpected error: {err}",
+    );
+}
+
+#[tokio::test]
+async fn a_resume_past_the_tail_is_rejected_not_reinterpreted() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 16).await;
+    register(&broker, "orders", true).await;
+    for i in 0..5 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i}")))
+            .await
+            .expect("publish");
+    }
+
+    // Tail is 5. Asking for 99 previously registered for live delivery and then
+    // handed over records at offsets 5, 6, 7... -- below the requested position,
+    // which is the opposite of what was asked for.
+    let err = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(99))
+        .await
+        .expect_err("99 is past the tail");
+    assert!(
+        matches!(
+            err,
+            BrokerError::CursorInFuture {
+                requested: 99,
+                tail: 5
+            }
+        ),
+        "unexpected error: {err}",
+    );
+}
+
+#[tokio::test]
+async fn a_rejected_resume_leaves_no_subscriber_behind() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 4).await;
+    register(&broker, "ephemeral", false).await;
+    for i in 0..20 {
+        broker
+            .publish("t1", "default", "ephemeral", payload(&format!("v{i:02}")))
+            .await
+            .expect("publish");
+    }
+
+    // Registration happens before the too-old check can run, so each rejection
+    // used to strand a closed sender in the registry -- reaped only when some
+    // later publish happened to notice. Repeated rejected subscribes could grow
+    // the slab without ever touching the per-connection subscription cap.
+    for _ in 0..50 {
+        let err = broker
+            .subscribe_from("t1", "default", "ephemeral", StartPosition::Offset(1))
+            .await
+            .expect_err("below the ring, and no disk to fall back to");
+        assert!(matches!(err, BrokerError::CursorTooOld { .. }));
+    }
+
+    assert_eq!(
+        broker
+            .registered_subscribers("t1", "default", "ephemeral")
+            .await
+            .expect("count"),
+        0,
+        "the 50 rejected subscribes must not have left registrations behind",
+    );
+}
+
+#[tokio::test]
+async fn backlog_entries_carry_their_own_offsets() {
+    let dir = tempdir().expect("dir");
+    let broker = broker_with_small_ring(&dir, 16).await;
+    register(&broker, "orders", true).await;
+    for i in 0..6 {
+        broker
+            .publish("t1", "default", "orders", payload(&format!("v{i}")))
+            .await
+            .expect("publish");
+    }
+
+    let resumed = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(2))
+        .await
+        .expect("resume");
+
+    // Offsets travel with the payloads rather than being derived by index from
+    // `backlog_start`. The ring is not guaranteed contiguous -- a publish that
+    // consumed disk offsets and was cancelled before reaching the ring leaves a
+    // hole -- and numbering by position mislabels everything after one.
+    let offsets: Vec<u64> = resumed.backlog.iter().map(|(offset, _)| *offset).collect();
+    assert_eq!(offsets, vec![2, 3, 4, 5]);
+    assert_eq!(resumed.backlog_start, 2);
+    for (offset, payload) in &resumed.backlog {
+        let expected = format!("v{offset}");
+        assert_eq!(String::from_utf8(payload.to_vec()).expect("utf8"), expected);
+    }
 }

--- a/crates/felix-client/Cargo.toml
+++ b/crates/felix-client/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["felix", "client", "pubsub", "messaging", "quic"]
 categories = ["network-programming", "api-bindings"]
 
 [dependencies]
+thiserror = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 ahash = "0.8"

--- a/crates/felix-client/src/client/client.rs
+++ b/crates/felix-client/src/client/client.rs
@@ -11,7 +11,7 @@
 use anyhow::{Context, Result};
 use bytes::{Bytes, BytesMut};
 use felix_transport::{QuicClient, QuicConnection, TransportConfig};
-use felix_wire::Message;
+use felix_wire::{CursorErrorReason, Message, StartPosition};
 use quinn::{RecvStream, SendStream};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -254,11 +254,33 @@ impl Client {
         })
     }
 
+    /// Subscribe from the live tail, delivering only what is published from now.
     pub async fn subscribe(
         &self,
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+    ) -> Result<Subscription> {
+        self.subscribe_from(tenant_id, namespace, stream, None)
+            .await
+    }
+
+    /// Subscribe from a chosen position, resuming a durable stream.
+    ///
+    /// `start: None` is exactly [`Client::subscribe`]. Pass
+    /// `Some(StartPosition::Offset(n))` to resume at the first record not yet
+    /// seen -- an application that checkpoints the offset of the last event it
+    /// handled resumes at that offset plus one.
+    ///
+    /// Fails with a `CursorTooOld` error if retention has already discarded the
+    /// requested offset, rather than silently restarting at the tail: a resume
+    /// that quietly skips records is the failure mode this exists to remove.
+    pub async fn subscribe_from(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        start: Option<StartPosition>,
     ) -> Result<Subscription> {
         if tenant_id != self.auth_tenant_id {
             return Err(anyhow::anyhow!(
@@ -280,7 +302,7 @@ impl Client {
         let connection_index = rr as usize % self.event_pool_size;
         let connection = &self.event_connections[connection_index];
         let (mut send, mut recv) = connection.open_bi().await?;
-        authenticate_stream(
+        let server_flags = authenticate_stream(
             &mut send,
             &mut recv,
             &self.auth_tenant_id,
@@ -288,6 +310,24 @@ impl Client {
             self.runtime_config.max_frame_bytes,
         )
         .await?;
+
+        // A broker that predates resume ignores the unknown `start` field and
+        // subscribes at the tail, then answers `Subscribed` -- so the client
+        // would report success while silently losing everything published
+        // during the disconnect. That is worse than an error, because the
+        // application has no way to notice. `Latest` is safe to send either
+        // way: it is what an old broker does anyway.
+        let needs_replay = matches!(
+            start,
+            Some(StartPosition::Earliest) | Some(StartPosition::Offset(_))
+        );
+        if needs_replay && !felix_wire::supports(server_flags, felix_wire::FLAG_EVENT_BATCH_OFFSETS)
+        {
+            return Err(anyhow::anyhow!(
+                "broker does not support resumable subscriptions (negotiated flags {server_flags:#06x}); \
+                 resuming from a position would silently start at the tail instead"
+            ));
+        }
         let mut frame_scratch = BytesMut::with_capacity(64 * 1024);
         write_message(
             &mut send,
@@ -296,6 +336,7 @@ impl Client {
                 namespace: namespace.to_string(),
                 stream: stream.to_string(),
                 subscription_id: None,
+                start,
             },
         )
         .await?;
@@ -312,6 +353,21 @@ impl Client {
                 return Err(anyhow::anyhow!(
                     "subscribe response missing subscription id"
                 ));
+            }
+            Some(Message::SubscribeCursorError {
+                reason,
+                requested,
+                available,
+            }) => {
+                // Surfaced as a typed error rather than a debug-formatted
+                // message, because the two reasons have opposite remedies and an
+                // application has to be able to tell them apart in code.
+                return Err(SubscribeCursorError {
+                    reason,
+                    requested,
+                    available,
+                }
+                .into());
             }
             other => return Err(anyhow::anyhow!("subscribe failed: {other:?}")),
         };
@@ -496,5 +552,39 @@ async fn authenticate_stream(
         Some(Message::Error { message }) => Err(anyhow::anyhow!("auth rejected: {message}")),
         Some(other) => Err(anyhow::anyhow!("unexpected auth response: {other:?}")),
         None => Err(anyhow::anyhow!("auth response missing")),
+    }
+}
+
+/// A resume could not start where it asked to.
+///
+/// Typed rather than a formatted string so callers can branch: `TooOld` means
+/// retention has passed the requested offset and the application must decide
+/// whether to accept the gap or start from `earliest`; `InFuture` means the
+/// offset does not exist yet, which usually means a checkpoint was written from
+/// a different stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub struct SubscribeCursorError {
+    pub reason: CursorErrorReason,
+    /// The offset that was asked for.
+    pub requested: u64,
+    /// The nearest offset that would have worked: the oldest retained for
+    /// `TooOld`, the current tail for `InFuture`.
+    pub available: u64,
+}
+
+impl std::fmt::Display for SubscribeCursorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.reason {
+            CursorErrorReason::TooOld => write!(
+                f,
+                "offset {} is no longer retained; oldest available is {}",
+                self.requested, self.available
+            ),
+            CursorErrorReason::InFuture => write!(
+                f,
+                "offset {} is past the end of the stream; tail is {}",
+                self.requested, self.available
+            ),
+        }
     }
 }

--- a/crates/felix-client/src/client/subscription.rs
+++ b/crates/felix-client/src/client/subscription.rs
@@ -21,7 +21,8 @@ struct QueuedFrame {
 }
 
 enum QueuedEvent {
-    Payload(Bytes),
+    /// A payload and, for a durable stream, the log offset it sits at.
+    Payload(Bytes, Option<u64>),
     Error(anyhow::Error),
 }
 
@@ -43,6 +44,14 @@ pub struct Event {
     pub namespace: Arc<str>,
     pub stream: Arc<str>,
     pub payload: Bytes,
+    /// Log offset of this event on a durable stream, or `None` for an in-memory
+    /// one and for any broker that did not negotiate offsets.
+    ///
+    /// Two uses. Record it to resume from `offset + 1` after a reconnect. And
+    /// because offsets are contiguous, a jump between consecutive events is a
+    /// gap -- the subscriber queue dropped something, which is otherwise
+    /// invisible.
+    pub offset: Option<u64>,
 }
 
 pub(crate) struct SubscriptionPipelineConfig {
@@ -111,7 +120,7 @@ impl Subscription {
             return Ok(None);
         };
         match queued {
-            QueuedEvent::Payload(payload) => {
+            QueuedEvent::Payload(payload, offset) => {
                 record_e2e_latency(
                     &payload,
                     #[cfg(feature = "telemetry")]
@@ -122,6 +131,7 @@ impl Subscription {
                     namespace: Arc::clone(&self.namespace),
                     stream: Arc::clone(&self.stream),
                     payload,
+                    offset,
                 }))
             }
             QueuedEvent::Error(err) => Err(err),
@@ -203,7 +213,7 @@ async fn run_subscription_dispatch_task(
         #[cfg(feature = "telemetry")]
         let decode_start = crate::t_now_if(sample);
 
-        let payloads =
+        let (payloads, base_offset) =
             if queued_frame.frame.header.flags & felix_wire::FLAG_BINARY_EVENT_BATCH_SHARED != 0 {
                 match felix_wire::binary::decode_shared_event_batch(&queued_frame.frame)
                     .context("decode shared binary event batch")
@@ -218,7 +228,7 @@ async fn run_subscription_dispatch_task(
                                 .sub_items_in_ok
                                 .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
                         }
-                        batch.payloads
+                        (batch.payloads, batch.base_offset)
                     }
                     Err(err) => {
                         #[cfg(feature = "telemetry")]
@@ -270,7 +280,7 @@ async fn run_subscription_dispatch_task(
                                 .sub_items_in_ok
                                 .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
                         }
-                        batch.payloads
+                        (batch.payloads, batch.base_offset)
                     }
                     Err(err) => {
                         #[cfg(feature = "telemetry")]
@@ -316,16 +326,22 @@ async fn run_subscription_dispatch_task(
                     counters.sub_frames_in_ok.fetch_add(1, Ordering::Relaxed);
                 }
                 match message {
-                    Message::Event { payload, .. } => {
+                    Message::Event {
+                        payload, offset, ..
+                    } => {
                         #[cfg(feature = "telemetry")]
                         {
                             let counters = frame_counters();
                             counters.sub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
                             counters.sub_items_in_ok.fetch_add(1, Ordering::Relaxed);
                         }
-                        vec![Bytes::from(payload)]
+                        (vec![Bytes::from(payload)], offset)
                     }
-                    Message::EventBatch { payloads, .. } => {
+                    Message::EventBatch {
+                        payloads,
+                        base_offset,
+                        ..
+                    } => {
                         #[cfg(feature = "telemetry")]
                         {
                             let counters = frame_counters();
@@ -334,7 +350,7 @@ async fn run_subscription_dispatch_task(
                                 .sub_items_in_ok
                                 .fetch_add(payloads.len() as u64, Ordering::Relaxed);
                         }
-                        payloads.into_iter().map(Bytes::from).collect()
+                        (payloads.into_iter().map(Bytes::from).collect(), base_offset)
                     }
                     _ => {
                         let _ = enqueue_event(
@@ -360,10 +376,13 @@ async fn run_subscription_dispatch_task(
 
         #[cfg(feature = "telemetry")]
         let dispatch_start = crate::t_now_if(sample);
-        for payload in payloads {
+        for (index, payload) in payloads.into_iter().enumerate() {
+            // Offsets in a batch are contiguous by construction, so each event's
+            // offset is the batch base plus its position.
+            let offset = base_offset.map(|base| base + index as u64);
             if !enqueue_event(
                 &event_tx,
-                QueuedEvent::Payload(payload),
+                QueuedEvent::Payload(payload, offset),
                 queue_policy,
                 queue_capacity,
             )

--- a/crates/felix-client/src/lib.rs
+++ b/crates/felix-client/src/lib.rs
@@ -77,6 +77,7 @@ mod wire;
 pub mod timings;
 
 pub use client::client::Client;
+pub use client::client::SubscribeCursorError;
 #[cfg(feature = "in-process")]
 pub use client::inprocess::InProcessClient;
 pub use client::publisher::Publisher;
@@ -84,6 +85,7 @@ pub use client::sharding::PublishSharding;
 pub use client::subscription::{Event, Subscription};
 pub use config::{ClientConfig, ClientSubQueuePolicy};
 pub use counters::{FrameCountersSnapshot, frame_counters_snapshot, reset_frame_counters};
+pub use felix_wire::{CursorErrorReason, StartPosition};
 
 pub(crate) use macros::{t_now_if, t_should_sample};
 

--- a/crates/felix-client/src/tests.rs
+++ b/crates/felix-client/src/tests.rs
@@ -350,6 +350,7 @@ async fn quic_publish_subscribe_cache_success() -> Result<()> {
                             write_message(
                                 &mut uni,
                                 Message::EventBatch {
+                                    base_offset: None,
                                     tenant_id: "t1".to_string(),
                                     namespace: "default".to_string(),
                                     stream: "updates".to_string(),
@@ -934,6 +935,7 @@ async fn subscription_legacy_event_paths_and_unexpected_message_error() -> Resul
                         write_message(
                             &mut uni,
                             Message::Event {
+                                offset: None,
                                 tenant_id: "t1".to_string(),
                                 namespace: "default".to_string(),
                                 stream: "updates".to_string(),
@@ -944,6 +946,7 @@ async fn subscription_legacy_event_paths_and_unexpected_message_error() -> Resul
                         write_message(
                             &mut uni,
                             Message::EventBatch {
+                                base_offset: None,
                                 tenant_id: "t1".to_string(),
                                 namespace: "default".to_string(),
                                 stream: "updates".to_string(),
@@ -1067,6 +1070,7 @@ async fn subscription_empty_event_batch_returns_none() -> Result<()> {
                         write_message(
                             &mut uni,
                             Message::EventBatch {
+                                base_offset: None,
                                 tenant_id: "t1".to_string(),
                                 namespace: "default".to_string(),
                                 stream: "updates".to_string(),

--- a/crates/felix-conformance/src/main.rs
+++ b/crates/felix-conformance/src/main.rs
@@ -169,6 +169,7 @@ async fn run_pubsub(
     quic::write_message(
         &mut sub_send,
         Message::Subscribe {
+            start: None,
             tenant_id: "t1".to_string(),
             namespace: "default".to_string(),
             stream: "conformance".to_string(),

--- a/crates/felix-wire/src/binary.rs
+++ b/crates/felix-wire/src/binary.rs
@@ -6,7 +6,8 @@
 use crate::error::{Error, Result};
 use crate::frame::{
     FLAG_BINARY_EVENT_BATCH, FLAG_BINARY_EVENT_BATCH_SHARED, FLAG_BINARY_PUBLISH_ACK,
-    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, Frame, FrameHeader,
+    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, FLAG_EVENT_BATCH_OFFSETS, Frame,
+    FrameHeader,
 };
 use crate::message::AckMode;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -435,11 +436,16 @@ pub fn decode_publish_ack(frame: &Frame) -> Result<PublishAck> {
 pub struct EventBatch {
     pub subscription_id: u64,
     pub payloads: Vec<Bytes>,
+    /// Offset of `payloads[0]`, when the sender negotiated
+    /// `FLAG_EVENT_BATCH_OFFSETS`. Payload `i` is at `base_offset + i`.
+    pub base_offset: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SharedEventBatch {
     pub payloads: Vec<Bytes>,
+    /// Offset of `payloads[0]`, when negotiated. See [`EventBatch::base_offset`].
+    pub base_offset: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -468,6 +474,82 @@ pub fn encode_event_batch_bytes(subscription_id: u64, payloads: &[Bytes]) -> Res
     let mut buf = BytesMut::with_capacity(parts.frame_len());
     for segment in parts.segments() {
         buf.extend_from_slice(segment.as_ref());
+    }
+    Ok(buf.freeze())
+}
+
+/// Encode an event batch carrying the offset of its first payload.
+///
+/// Layout is the plain batch with a `u64 base_offset` inserted after the
+/// subscription id, and the frame flagged `FLAG_EVENT_BATCH_OFFSETS` so a
+/// decoder knows to expect it. Only sent to a peer that negotiated the bit; a
+/// peer that did not gets [`encode_event_batch_bytes`] and is unable to tell
+/// the difference.
+pub fn encode_event_batch_bytes_with_offset(
+    subscription_id: u64,
+    payloads: &[Bytes],
+    base_offset: u64,
+) -> Result<Bytes> {
+    let mut payload_len = 8usize + 8 + 4;
+    for payload in payloads {
+        let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+        payload_len = payload_len
+            .checked_add(4 + len as usize)
+            .ok_or(Error::FrameTooLarge)?;
+    }
+    if payload_len > u32::MAX as usize {
+        return Err(Error::FrameTooLarge);
+    }
+
+    let mut buf = BytesMut::with_capacity(FrameHeader::LEN + payload_len);
+    FrameHeader::new(
+        FLAG_BINARY_EVENT_BATCH | FLAG_EVENT_BATCH_OFFSETS,
+        payload_len as u32,
+    )
+    .encode(&mut buf);
+    buf.extend_from_slice(&subscription_id.to_be_bytes());
+    buf.extend_from_slice(&base_offset.to_be_bytes());
+    buf.extend_from_slice(&(payloads.len() as u32).to_be_bytes());
+    for payload in payloads {
+        let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+        buf.extend_from_slice(&len.to_be_bytes());
+        buf.extend_from_slice(payload);
+    }
+    Ok(buf.freeze())
+}
+
+/// Encode a shared (encode-once, fan-out-to-many) batch carrying its base offset.
+///
+/// Offsets belong to the stream rather than the subscriber, so one encoding
+/// still serves every subscriber that negotiated the bit -- which is what keeps
+/// this off the per-subscriber cost model.
+pub fn encode_shared_event_batch_bytes_with_offset(
+    payloads: &[Bytes],
+    base_offset: u64,
+) -> Result<Bytes> {
+    let mut payload_len = 8usize + 4;
+    for payload in payloads {
+        let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+        payload_len = payload_len
+            .checked_add(4 + len as usize)
+            .ok_or(Error::FrameTooLarge)?;
+    }
+    if payload_len > u32::MAX as usize {
+        return Err(Error::FrameTooLarge);
+    }
+
+    let mut buf = BytesMut::with_capacity(FrameHeader::LEN + payload_len);
+    FrameHeader::new(
+        FLAG_BINARY_EVENT_BATCH_SHARED | FLAG_EVENT_BATCH_OFFSETS,
+        payload_len as u32,
+    )
+    .encode(&mut buf);
+    buf.extend_from_slice(&base_offset.to_be_bytes());
+    buf.extend_from_slice(&(payloads.len() as u32).to_be_bytes());
+    for payload in payloads {
+        let len = u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?;
+        buf.extend_from_slice(&len.to_be_bytes());
+        buf.extend_from_slice(payload);
     }
     Ok(buf.freeze())
 }
@@ -540,10 +622,13 @@ pub fn encode_shared_event_batch_bytes(payloads: &[Bytes]) -> Result<Bytes> {
 // Decode binary event batch frame into its structured form.
 pub fn decode_event_batch(frame: &Frame) -> Result<EventBatch> {
     let mut buf = frame.payload.clone();
-    if buf.remaining() < 12 {
+    let has_offsets = frame.header.flags & FLAG_EVENT_BATCH_OFFSETS != 0;
+    let fixed = if has_offsets { 20 } else { 12 };
+    if buf.remaining() < fixed {
         return Err(Error::Incomplete);
     }
     let subscription_id = buf.get_u64();
+    let base_offset = has_offsets.then(|| buf.get_u64());
     let count = checked_payload_count(buf.get_u32() as usize, buf.remaining())?;
     let mut payloads = Vec::with_capacity(count);
     for _ in 0..count {
@@ -560,14 +645,18 @@ pub fn decode_event_batch(frame: &Frame) -> Result<EventBatch> {
     Ok(EventBatch {
         subscription_id,
         payloads,
+        base_offset,
     })
 }
 
 pub fn decode_shared_event_batch(frame: &Frame) -> Result<SharedEventBatch> {
     let mut buf = frame.payload.clone();
-    if buf.remaining() < 4 {
+    let has_offsets = frame.header.flags & FLAG_EVENT_BATCH_OFFSETS != 0;
+    let fixed = if has_offsets { 12 } else { 4 };
+    if buf.remaining() < fixed {
         return Err(Error::Incomplete);
     }
+    let base_offset = has_offsets.then(|| buf.get_u64());
     let count = checked_payload_count(buf.get_u32() as usize, buf.remaining())?;
     let mut payloads = Vec::with_capacity(count);
     for _ in 0..count {
@@ -580,5 +669,8 @@ pub fn decode_shared_event_batch(frame: &Frame) -> Result<SharedEventBatch> {
         }
         payloads.push(buf.copy_to_bytes(len));
     }
-    Ok(SharedEventBatch { payloads })
+    Ok(SharedEventBatch {
+        payloads,
+        base_offset,
+    })
 }

--- a/crates/felix-wire/src/frame.rs
+++ b/crates/felix-wire/src/frame.rs
@@ -16,6 +16,16 @@ pub const FLAG_BINARY_PUBLISH_ACKED: u16 = 0x0008;
 /// Broker → client acknowledgement of an acked publish, replacing the JSON
 /// `PublishOk`/`PublishError` messages on the binary path.
 pub const FLAG_BINARY_PUBLISH_ACK: u16 = 0x0010;
+/// Modifier on either event-batch flag: the payload carries a `base_offset`
+/// before its payload count, giving the log offset of the batch's first event.
+///
+/// A batch's offsets are contiguous, so one `u64` per *batch* is enough — a
+/// client derives each event's offset by adding its index. That is what keeps
+/// this off the per-event cost model, and it is why offsets can ride the shared
+/// encode-once batch at all: the offsets belong to the stream, not to the
+/// subscriber, so one encoding still serves every subscriber that negotiated
+/// the bit.
+pub const FLAG_EVENT_BATCH_OFFSETS: u16 = 0x0020;
 
 /// Every flag bit this version understands.
 ///
@@ -31,7 +41,8 @@ pub const KNOWN_FLAGS: u16 = FLAG_BINARY_PUBLISH_BATCH
     | FLAG_BINARY_EVENT_BATCH
     | FLAG_BINARY_EVENT_BATCH_SHARED
     | FLAG_BINARY_PUBLISH_ACKED
-    | FLAG_BINARY_PUBLISH_ACK;
+    | FLAG_BINARY_PUBLISH_ACK
+    | FLAG_EVENT_BATCH_OFFSETS;
 
 /// The flag bits that existed before capability negotiation.
 ///

--- a/crates/felix-wire/src/lib.rs
+++ b/crates/felix-wire/src/lib.rs
@@ -27,10 +27,10 @@ pub mod text;
 pub use error::{Error, Result};
 pub use frame::{
     FLAG_BINARY_EVENT_BATCH, FLAG_BINARY_EVENT_BATCH_SHARED, FLAG_BINARY_PUBLISH_ACK,
-    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, Frame, FrameHeader, KNOWN_FLAGS, MAGIC,
-    ORIGINAL_V1_FLAGS, VERSION, has_unknown_flags, supports,
+    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, FLAG_EVENT_BATCH_OFFSETS, Frame,
+    FrameHeader, KNOWN_FLAGS, MAGIC, ORIGINAL_V1_FLAGS, VERSION, has_unknown_flags, supports,
 };
-pub use message::{AckMode, Message};
+pub use message::{AckMode, CursorErrorReason, Message, StartPosition};
 
 #[cfg(test)]
 mod tests;

--- a/crates/felix-wire/src/message.rs
+++ b/crates/felix-wire/src/message.rs
@@ -78,6 +78,14 @@ pub enum Message {
         stream: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         subscription_id: Option<u64>,
+        /// Where to begin delivering from.
+        ///
+        /// Absent means the tail, which is what every client sent before this
+        /// field existed — so an old client and a new broker still produce
+        /// byte-for-byte the frames they always did, and a new client talking
+        /// to an old broker has its position ignored rather than misread.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start: Option<StartPosition>,
     },
     // Subscription confirmation with server-assigned ID.
     Subscribed {
@@ -94,6 +102,13 @@ pub enum Message {
         stream: String,
         #[serde(with = "crate::base64_serde::base64_bytes")]
         payload: Vec<u8>,
+        /// Log offset of this event, for durable streams.
+        ///
+        /// Absent for in-memory streams, which have no durable position to
+        /// checkpoint against, and absent from every frame a pre-offsets broker
+        /// sends.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        offset: Option<u64>,
     },
     // JSON event batch (binary batch uses FLAG_BINARY_EVENT_BATCH).
     EventBatch {
@@ -102,6 +117,10 @@ pub enum Message {
         stream: String,
         #[serde(with = "crate::base64_serde::base64_vec")]
         payloads: Vec<Vec<u8>>,
+        /// Offset of the first payload. The rest are contiguous from there, so
+        /// payload `i` sits at `base_offset + i`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        base_offset: Option<u64>,
     },
     // Cache set operation; may include TTL and request id.
     CachePut {
@@ -154,6 +173,55 @@ pub enum Message {
     Error {
         message: String,
     },
+    /// A subscribe could not start where it was asked to.
+    ///
+    /// Distinct from `Error` because the client must be able to *act* on it:
+    /// `too_old` means pick a newer offset (or `earliest`), `in_future` means
+    /// the log has not reached that offset yet. A generic string forces every
+    /// client to parse prose to tell those apart, and a client that guesses
+    /// wrong silently restarts at the tail -- the failure resume exists to
+    /// remove.
+    SubscribeCursorError {
+        reason: CursorErrorReason,
+        /// The offset that was asked for.
+        requested: u64,
+        /// For `too_old`, the oldest offset still retained. For `in_future`,
+        /// the current tail. Either way: the nearest offset that would work.
+        available: u64,
+    },
+}
+
+/// Why a subscribe could not start at the requested position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorErrorReason {
+    /// The offset has been discarded by retention, or has fallen out of an
+    /// in-memory stream's replay ring.
+    TooOld,
+    /// The offset is past the end of the stream.
+    InFuture,
+}
+
+/// Where a subscription should begin.
+///
+/// Untagged on the wire so `"latest"` and `{"offset": 42}` are both accepted,
+/// and so the common cases stay short in a JSON control message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StartPosition {
+    /// The live tail: deliver only what is published from now on. Identical to
+    /// omitting the field, and spelled out for clients that prefer to be
+    /// explicit.
+    Latest,
+    /// The oldest record the broker still retains.
+    ///
+    /// Deliberately not "offset 0": for a stream whose head has been trimmed,
+    /// offset 0 is gone and asking for it is an error, whereas `earliest` means
+    /// "as far back as you can" and always succeeds.
+    Earliest,
+    /// Resume at an exact log offset — the first record the client has *not*
+    /// seen, so a client checkpoints the offset it last handled plus one.
+    Offset(u64),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/felix-wire/src/tests.rs
+++ b/crates/felix-wire/src/tests.rs
@@ -5,8 +5,8 @@ use crate::binary;
 use crate::error::Error;
 use crate::frame::{
     FLAG_BINARY_EVENT_BATCH, FLAG_BINARY_EVENT_BATCH_SHARED, FLAG_BINARY_PUBLISH_ACK,
-    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, Frame, FrameHeader, MAGIC, VERSION,
-    has_unknown_flags,
+    FLAG_BINARY_PUBLISH_ACKED, FLAG_BINARY_PUBLISH_BATCH, FLAG_EVENT_BATCH_OFFSETS, Frame,
+    FrameHeader, KNOWN_FLAGS, MAGIC, VERSION, has_unknown_flags,
 };
 use crate::message::{AckMode, Message};
 use bytes::{BufMut, Bytes, BytesMut};
@@ -320,8 +320,18 @@ fn unknown_flags_are_detected() {
         FLAG_BINARY_PUBLISH_BATCH | FLAG_BINARY_PUBLISH_ACKED
     ));
     assert!(!has_unknown_flags(0));
-    // The first undefined bit must be rejected rather than masked off.
-    assert!(has_unknown_flags(0x0020));
+    assert!(!has_unknown_flags(FLAG_EVENT_BATCH_OFFSETS));
+
+    // The lowest undefined bit must be rejected rather than masked off.
+    // Derived from `KNOWN_FLAGS` rather than written as a literal: this
+    // assertion was `0x0020` until that bit was defined, at which point it
+    // quietly became a claim about a *known* flag and failed. Computing it
+    // keeps the test about the property instead of about one bit.
+    let first_undefined = (0..16u16)
+        .map(|bit| 1u16 << bit)
+        .find(|bit| KNOWN_FLAGS & bit == 0)
+        .expect("a free flag bit");
+    assert!(has_unknown_flags(first_undefined));
     assert!(has_unknown_flags(FLAG_BINARY_PUBLISH_BATCH | 0x8000));
 }
 
@@ -525,6 +535,7 @@ fn text_publish_batch_json_with_special_chars() {
 fn message_all_variants_encode_decode() {
     // Test Subscribe message
     let message = Message::Subscribe {
+        start: None,
         subscription_id: Some(42),
         tenant_id: "t1".to_string(),
         namespace: "ns".to_string(),
@@ -667,6 +678,7 @@ fn message_cache_operations() {
 fn message_event_variants() {
     // Test Event message
     let message = Message::Event {
+        offset: None,
         tenant_id: "t1".to_string(),
         namespace: "ns".to_string(),
         stream: "stream1".to_string(),
@@ -678,6 +690,7 @@ fn message_event_variants() {
 
     // Test EventBatch message
     let message = Message::EventBatch {
+        base_offset: None,
         tenant_id: "t1".to_string(),
         namespace: "ns".to_string(),
         stream: "stream1".to_string(),

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "opentelemetry_sdk",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -465,7 +465,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.10.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -474,7 +474,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -653,7 +653,7 @@ dependencies = [
  "jsonwebtoken",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -894,6 +894,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_yaml_ng",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2018,9 +2019,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2032,22 +2033,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2055,18 +2056,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2077,15 +2078,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -2275,6 +2277,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2542,9 +2553,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2565,13 +2574,44 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3626,6 +3666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3709,22 @@ dependencies = [
  "iri-string",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3721,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "opentelemetry_sdk",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -465,7 +465,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.10.2",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -474,7 +474,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "tower-http",
+ "tower-http 0.7.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -653,7 +653,7 @@ dependencies = [
  "jsonwebtoken",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -894,6 +894,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_yaml_ng",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -2018,9 +2019,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2032,22 +2033,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2055,18 +2056,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2077,15 +2078,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.2",
  "thiserror 2.0.18",
  "tokio",
@@ -2275,6 +2277,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2542,9 +2553,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2565,13 +2574,44 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3626,6 +3666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,6 +3709,22 @@ dependencies = [
  "iri-string",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "percent-encoding",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3721,9 +3788,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "opentelemetry_sdk",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -959,6 +959,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_yaml_ng",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -2086,9 +2087,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2100,22 +2101,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2123,18 +2124,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.20",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2145,15 +2146,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.20",
  "tokio",
@@ -2447,6 +2449,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2804,9 +2815,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2834,6 +2843,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3756,6 +3796,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "opentelemetry_sdk",
  "quinn",
  "rcgen",
- "reqwest",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",
@@ -959,6 +959,7 @@ dependencies = [
  "quinn",
  "serde",
  "serde_yaml_ng",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -2086,9 +2087,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2100,22 +2101,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -2123,18 +2124,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.13.4",
  "thiserror 2.0.20",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -2145,15 +2146,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.20",
  "tokio",
@@ -2447,6 +2449,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -2804,9 +2815,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2834,6 +2843,37 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3756,6 +3796,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",

--- a/docs-site/src/content/docs/demos/notifications.md
+++ b/docs-site/src/content/docs/demos/notifications.md
@@ -73,7 +73,10 @@ Demo complete.
 
 - `--drop-subscriber`: drops one subscriber mid-run and restarts it.
 - This demonstrates that other subscribers continue receiving events and that
-  the restarted subscriber resumes from new events (no historical replay).
+  the restarted subscriber resumes from new events only. That is a property of
+  *this* demo's streams, which are not durable — a durable stream can be resumed
+  from a checkpointed offset instead. See
+  [durable storage](/felix/architecture/durable-storage/).
 
 ## How to extend
 

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -149,8 +149,15 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 
 Single host, loopback, release build, TLS 1.3 on, defaults, zero delivery drops:
 
-- **Latency (batch = 1, per-message ack):** p50 82–128 µs, p999 175–329 µs at
-  fanout 1 across 0 B–1 KiB payloads.
+- **Latency (batch = 1, per-message ack, JSON framing):** p50 82–128 µs,
+  p999 175–329 µs at fanout 1 across 0 B–1 KiB payloads.
+
+  The framing matters and is easy to get wrong. `latency-demo` enables
+  per-message acks only when `batch <= 1 && !binary`, so passing `--binary`
+  silently measures a different thing — fire-and-forget delivery rather than a
+  request round trip. On the same machine that produced the figures above, the
+  binary path measures ~256 µs p50. That is not a regression against them; it
+  is a different configuration, and the two are not comparable.
 - **Throughput (batch = 64, lossless):** up to 2.92 M deliveries/s for 0 B at
   fanout 10; ~1.57 M/s at 1 KiB × fanout 10; ~2.3 GB/s of payload at 4 KiB ×
   fanout 10 on Linux.

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -13,7 +13,7 @@ around as if it exists, or claimed externally.
 - 🎯 **Target** — intended design. Not implemented. May change.
 :::
 :::note[Maintenance]
-**Status markers last verified against the code on 2026-08-09.** This page
+**Status markers last verified against the code on 2026-08-15.** This page
 goes stale the moment a 🎯 row lands, and stale status markers are worse than
 no status markers — a reader who catches one wrong row stops trusting the
 other twenty. Treat updating it as part of shipping any capability listed
@@ -140,6 +140,8 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Token-based authorization | ✅ Today | OIDC token exchange, tenant-scoped JWTs, broker-side permission checks on publish/subscribe/cache |
 | Control plane metadata service | ✅ Today | REST + OpenAPI, tenant/namespace/stream/cache CRUD, snapshot and changes feeds, in-memory or Postgres backing |
 | Prometheus metrics, health endpoints | ✅ Today | Plus opt-in `telemetry` feature for per-stage timings |
+| Durable streams | ✅ Today | Opt-in per stream via `durable: true`, and only when the broker runs with `FELIX_DURABLE_STORAGE_DIR`. Segmented crash-safe log: CRC-verified records, torn-tail recovery, group commit, three fsync policies. Single node, and nothing trims it |
+| Resumable subscriptions | ✅ Today | `Subscribe` takes `latest` / `earliest` / an offset; every delivered event carries its offset (`Event.offset`) so an application can checkpoint and resume at `offset + 1`. Stored history joins live delivery with no gap, backfilling from disk if the live queue overflowed. Durable streams only; unbounded until retention exists |
 | Graceful shutdown | 🚧 Partial | Readiness flip, bounded drain, and accept-loop cancellation done; per-subsystem cancellation still open |
 | Sharding | 🚧 Partial | Streams carry a shard count; ops are not yet directed to a shard leader |
 
@@ -162,11 +164,14 @@ for behavior at thousands of subscribers or across a network.
 - **At-most-once.** No redelivery, no publisher-visible confirmation that a
   subscriber received anything.
 - **Per-stream ordering** preserved for a given subscriber. No ordering across streams.
-- **Tail-only subscriptions over the wire.** A subscriber receives events
-  published after it subscribes; `Subscribe` still carries no offset or replay
-  parameter. Cursor replay and paged historical reads exist on the in-process
-  broker API for durable streams, but are not yet exposed through the wire
-  protocol.
+- **Resumable subscriptions over the wire, for durable streams.** `Subscribe`
+  carries an optional `start` — `latest` (the default, and what every older
+  client sends), `earliest`, or an exact offset — and every delivered event
+  carries its offset, so an application checkpoints what it handled and resumes
+  at the next one. History read from disk joins live delivery with no gap and no
+  duplicate. Asking for an offset retention has discarded is a typed error, not
+  a silent restart at the tail. A non-durable stream stays tail-only beyond its
+  bounded replay ring, because there is nothing older to read.
 - **Slow subscribers drop** under the default policy, and lag is surfaced to the
   subscriber. Publishers never block on subscriber speed.
 - **Ephemeral by default.** Nothing survives a broker restart unless the stream
@@ -174,26 +179,27 @@ for behavior at thousands of subscribers or across a network.
   acknowledging it and replays it afterwards. Durable storage is opt-in per
   stream and off unless the broker is started with `FELIX_DURABLE_STORAGE_DIR`.
   Retention and tiering are not implemented, so a durable stream grows without
-  bound today.
+  bound today — which also means a resume never fails for having been trimmed
+  yet.
 
 ---
 
 ## 3. What Felix is being built to become
 
 None of the following exists today. It is listed so the intent is legible, not so
-it can be planned around.
+it can be planned around. Capabilities move up into the table above when they
+ship rather than being marked off here.
 
 | Capability | Status | Current state of the code |
 |---|---|---|
 | Log-backed cache (one core log, many semantics) | 🎯 Target | Cache is a separate storage handle, not a projection over the stream log |
-| Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` has no snapshot or offset parameter |
+| Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` takes an offset, so *changes since a known point* is gap-free. The missing half is the snapshot: there is no way to ask for current state and subsequent changes in one call |
 | Queue semantics (consumer groups, acks, redelivery) | 🎯 Target | Explicitly post-MVP; not started |
-| Durable streams and replay | 🎯 Target | Storage traits and a durable-log sketch exist; no durable data-plane backend |
+| Retention and log trimming | 🎯 Target | Nothing deletes segments on age or size, so a durable stream grows without bound |
 | Tiered / cold storage | 🎯 Target | `TieredStore` trait declared, no implementation |
 | Multi-node clustering and replication | 🎯 Target | Not started |
 | Raft consensus for cluster metadata | 🎯 Target | `felix-consensus` is a configuration struct with no protocol implementation |
 | Cross-region routing and data sovereignty enforcement | 🎯 Target | `felix-router` is a directional region-pair allowlist, not wired into enforcement |
-| Resumable subscriptions after disconnect | 🎯 Target | Not started |
 | At-least-once / quorum acks | 🎯 Target | Not started |
 | Non-Rust client SDKs | 🎯 Target | Rust client only |
 
@@ -224,9 +230,9 @@ whether you could build it on the current release.
 | Internal service event bus | Moderate | Mostly | Works, but NATS and RabbitMQ serve this well already — weak differentiation |
 | Distributed live-state synchronization | Strong | **No** | Needs gap-free snapshot + change stream; drops corrupt local state |
 | Infrastructure / control-plane state distribution | Strong | **No** | Same gap, plus needs multi-node |
-| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state does not |
-| Edge and disconnected operation | Strong | **No** | Needs durability, resumable subscriptions, and replication — none exist |
-| Durable event log, replay, event sourcing | Weak | No | Use Kafka |
+| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state works on one node, without retention or replication |
+| Edge and disconnected operation | Strong | **No** | Durability and resumable subscriptions exist; replication does not, and neither does retention |
+| Durable event log, replay, event sourcing | Weak | Partly | A single-node durable log with offset replay exists. No retention, no tiering, no replication — use Kafka for anything that needs history to outlive one machine |
 | Primary datastore | Weak | No | Use a database |
 | General-purpose key-value store | Weak | No | Use Redis or Valkey |
 | Complex broker routing, workflow messaging | Weak | No | Use RabbitMQ |
@@ -276,8 +282,15 @@ and an incorrect one for the second.
 Closing this requires at least one of: gap-free snapshot-plus-stream subscribe,
 resumable subscriptions with a durable log behind them, or an explicit
 resynchronization protocol triggered by the lag signal subscribers already
-receive. Until one of those lands, "distributed live-state synchronization" is a
-direction, not a supported use case.
+receive.
+
+The second of those now exists for durable streams: a subscriber that records
+the offsets it handles can resume from them, and — because offsets are
+contiguous — can *detect* a drop rather than diverging silently. That narrows
+the case rather than closing it. It does not help a non-durable stream, it
+requires the application to checkpoint, and without retention there is no
+statement yet about how far back a resume can reach. "Distributed live-state
+synchronization" remains a direction, not a supported use case.
 
 ---
 
@@ -286,8 +299,9 @@ direction, not a supported use case.
 Felix should not be positioned against any of these, now or later.
 
 - **Not a Kafka replacement.** Kafka is excellent at durable event history,
-  long-term retention, replay, and data integration. Felix's eventual durability
-  is meant to serve live distribution, not to compete on retention.
+  long-term retention, replay, and data integration. Felix's durability is meant
+  to serve live distribution, not to compete on retention — it is single-node,
+  and nothing trims a log yet.
 - **Not a Redis replacement.** Cache semantics in Felix exist as part of a
   state-distribution model, not as a general-purpose data-structure server.
 - **Not a RabbitMQ replacement.** Elaborate routing topologies and traditional

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -249,6 +249,61 @@ Bounds that hold regardless of log size:
   offset returns `StorageError::Trimmed { requested, oldest }` — those offsets
   existed and are gone, which is a different fact from "nothing here yet".
 
+## Resuming a subscription
+
+Durability is only half of a resume: records surviving a restart is worthless if
+a reconnecting client cannot say where it got to. A subscriber asks for a start
+position — `latest`, `earliest`, or an exact offset — and delivered events carry
+their offsets so the client has something to checkpoint. See
+[the protocol](protocol.md#subscribe).
+
+The hard part is not reading history. It is joining history to live delivery
+without losing a record in between, and the ordering that achieves it is not the
+obvious one.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant B as Broker
+    participant R as Replay ring
+    participant D as Disk
+
+    C->>B: Subscribe(start = offset 3)
+    Note over B,R: Register the live subscription FIRST,<br/>clamped to the oldest offset the ring holds
+    B->>R: register_clamped(3)
+    R-->>B: backlog from 16, live receiver
+    Note over B,D: Only now read the older range.<br/>[3, 16) is closed: nothing can grow it,<br/>and the live edge is already pinned
+    B->>D: read_durable(3 → 16), one page at a time
+    D-->>B: records 3…15
+    B->>C: history
+    B->>C: backlog (16…)
+    B->>C: live events
+```
+
+Registering first is what makes the disk range `[requested, backlog_start)`
+**closed**: every record from `backlog_start` onward is already captured, either
+in the returned backlog or on the subscription's receiver. Nothing can be
+evicted out of the range while it is being read, and nothing published during
+the read can fall between the two halves.
+
+Reading history first and subscribing after is the version that looks natural
+and loses records: a publish landing between the read and the registration
+reaches neither.
+
+Two consequences worth stating plainly:
+
+- **History is paged, never collected.** The broker reads one bounded page at a
+  time and writes it before reading the next, so a client resuming from the
+  start of a large stream costs one page of memory rather than the whole
+  history. A slow client turns into slower reading rather than unbounded
+  buffering.
+- **A discarded offset is an error, not a silent skip.** Asking for an offset
+  below what retention still holds returns `CursorTooOld` naming the oldest
+  available offset. Quietly restarting at the tail — which is what a client got
+  before resume existed — is the failure this exists to remove, so it is not the
+  fallback.
+
 ## Recovery
 
 ```mermaid
@@ -396,7 +451,10 @@ fail rather than print the wrong numbers.
 - **One log per stream.** `StreamMetadata::shards` is carried through to the
   shard key but the data path is not yet sharded, so every stream uses shard 0.
 - **No retention.** `truncate` exists for replication's benefit; nothing deletes
-  segments on age or size yet.
+  segments on age or size yet. So a durable stream grows without bound, and
+  `CursorTooOld` is currently only reachable for an in-memory stream whose replay
+  ring has evicted — the durable path will start returning it once retention
+  lands.
 - **No tiered storage.** [`tiered.rs`](../crates/felix-storage/src/tiered.rs) is
   still trait scaffolding — `TieredStore`, `OffloadedSegment`, `ColdCacheConfig`
   and `RetentionPolicy` are declared, and nothing implements them. There is no

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -52,6 +52,7 @@ Field definitions:
   | `0x0004` | `BINARY_EVENT_BATCH_SHARED` | Payload is a shared binary event batch |
   | `0x0008` | `BINARY_PUBLISH_ACKED` | Modifier on `0x0001`: the batch carries a `request_id` prefix and is owed an ack |
   | `0x0010` | `BINARY_PUBLISH_ACK` | Payload is a binary publish acknowledgement (broker → client) |
+  | `0x0020` | `EVENT_BATCH_OFFSETS` | Modifier on `0x0002` or `0x0004`: the batch carries a `base_offset` |
 
   Because these bits change how the payload is parsed, a receiver MUST reject a
   frame carrying any bit it does not recognise rather than masking it off — see
@@ -77,13 +78,40 @@ Message schemas below are shown in pseudo-struct notation for readability; on th
 
 ### Subscribe
 ```
-{ "type": "subscribe", "tenant_id": "<string>", "namespace": "<string>", "stream": "<string>" }
+{ "type": "subscribe", "tenant_id": "<string>", "namespace": "<string>", "stream": "<string>", "start": <"latest"|"earliest"|{"offset": <number>}> }
 ```
+
+`start` is optional. Omitting it means `latest`, which is what every client sent
+before the field existed — so an old client and a new broker exchange exactly the
+frames they always did.
+
+- `latest` — deliver only what is published from now on.
+- `earliest` — the oldest record still retained. Deliberately not "offset 0":
+  for a stream whose head has been trimmed, offset 0 is gone, and `earliest`
+  means "as far back as you can" rather than an error.
+- `{"offset": n}` — resume at exactly offset `n`, the first record the client has
+  *not* seen. A client that checkpoints the offset it last handled resumes at
+  that offset plus one.
+
+Requesting an offset the broker cannot serve returns `subscribe_cursor_error`
+rather than a silent restart at the tail:
+
+```
+{ "type": "subscribe_cursor_error", "reason": "<too_old|in_future>", "requested": <number>, "available": <number> }
+```
+
+`too_old` means retention has discarded the offset and `available` is the oldest
+still retained. `in_future` means the offset is past the end of the stream and
+`available` is the current tail. The two have opposite remedies, which is why
+they are distinguishable in code rather than only in prose.
 
 ### Event (server -> client)
 ```
-{ "type": "event", "tenant_id": "<string>", "namespace": "<string>", "stream": "<string>", "payload": "<base64>" }
+{ "type": "event", "tenant_id": "<string>", "namespace": "<string>", "stream": "<string>", "payload": "<base64>", "offset": <number|absent> }
 ```
+
+`offset` is present for durable streams and absent for in-memory ones, which
+have no durable position to checkpoint against.
 
 ### CachePut
 ```
@@ -111,12 +139,17 @@ Message schemas below are shown in pseudo-struct notation for readability; on th
 ```
 
 ## Semantics (v1)
-- Subscribe starts at tail (no historical replay).
+- Subscribe starts at the tail unless `start` asks otherwise; a durable stream
+  can be replayed from any retained offset. History read from disk joins live
+  delivery with no gap and no duplicate — see
+  [durable storage](durable-storage.md#resuming-a-subscription).
 - Publish returns `ok` when accepted by the broker unless `ack` is `none`.
 - PublishBatch returns `ok` once for the batch unless `ack` is `none`.
 - CachePut returns `ok` when stored (TTL is optional).
 - CacheGet returns `cache_value` with `null` when missing/expired.
-- Backpressure: v1 is best-effort; subscribers may miss events if they fall behind.
+- Backpressure: v1 is best-effort; subscribers may miss events if they fall
+  behind. With event offsets negotiated a client can *detect* that loss, because
+  a gap between consecutive delivered offsets is exactly a drop.
 
 ## Protocol Flows (v1)
 
@@ -285,6 +318,38 @@ repeated count times:
 The subscription is identified by the preceding `EventStreamHello`, so event
 batches carry no per-subscriber identifier and the broker can share one encoded
 frame across subscribers. The legacy `0x0002` format remains decodable.
+
+## Event batch offsets
+
+When `flags & 0x0020 != 0`, a `u64 base_offset` precedes the `u32 count` — after
+the `u64 subscription_id` on the `0x0002` form, and at the very start of the
+payload on the shared `0x0004` form:
+
+```
+u64 base_offset          # offset of the first payload
+u32 count
+repeated count times:
+  u32 payload_len
+  u8[payload_len] payload
+```
+
+A batch's offsets are contiguous, so one `u64` per *batch* is enough: payload
+`i` sits at `base_offset + i`. That is what keeps offsets off the per-event cost
+model — 8 bytes per batch, not per event.
+
+Offsets belong to the **stream**, not to the subscriber, so the shared
+encode-once frame still serves every subscriber that negotiated the bit. A
+subscriber that did not negotiate it receives the frame without the field, so
+the broker encodes at most one extra variant per batch regardless of how many
+subscribers there are.
+
+Two uses:
+
+- **Checkpointing.** A client records the offset it last handled and resumes at
+  that offset plus one after a reconnect.
+- **Detecting loss.** Subscriber queues drop under `DropNew`, so consecutive
+  delivered batches can have a gap. Without offsets that loss is invisible; with
+  them it is a discontinuity the client can see and act on.
 
 ## Future Compatibility
 - Undefined `flags` bits are reserved. Receivers MUST reject frames carrying an

--- a/scripts/perf/make_charts.py
+++ b/scripts/perf/make_charts.py
@@ -244,6 +244,12 @@ def main():
 
     rows = cast_rows(read_csv(Path(args.input)))
 
+    # One chart is one build. The aggregator already refuses to median across
+    # commits and hosts, but grouping charts only by workload shape put those
+    # separate rows back on the same axes -- bars from different builds side by
+    # side, distinguishable only by a footer reading "git mixed". Comparing
+    # commits is a legitimate thing to want, but it needs a chart that says so,
+    # not one that looks like a single measurement.
     groups = {}
     for row in rows:
         key = (
@@ -251,17 +257,19 @@ def main():
             row["fanout"],
             row["batch"],
             row["binary"],
+            row.get("git_sha"),
+            row.get("hostname"),
         )
         groups.setdefault(key, []).append(row)
 
     date_str = dt.datetime.now(dt.UTC).date().isoformat()
 
     for key, group_rows in groups.items():
-        profile, fanout, batch, binary = key
+        profile, fanout, batch, binary, key_git_sha, key_hostname = key
         warmup = unique_or_mixed([r.get("warmup") for r in group_rows])
         total = unique_or_mixed([r.get("total") for r in group_rows])
         trials = unique_or_mixed([r.get("trial_count") for r in group_rows])
-        git_sha = unique_or_mixed([r.get("git_sha") for r in group_rows])
+        git_sha = key_git_sha
 
         title_prefix = (
             f"latency_demo {profile} fanout={fanout} batch={batch} "
@@ -278,14 +286,21 @@ def main():
                 " queueing delay. Not a request-latency measurement; use batch=1"
                 " with per-message acks for that."
             )
-        footer = f"git {git_sha} | {date_str}"
+        dirty = any(r.get("git_dirty") in (True, "True") for r in group_rows)
+        footer = (
+            f"git {(git_sha or 'unknown')[:12]}{' (DIRTY)' if dirty else ''}"
+            f" | {key_hostname or 'unknown host'} | {date_str}"
+        )
 
         base_dir = CHARTS_DIR / profile
         # `binary` is part of the grouping key, so it must be part of the file
         # name too. Without it a JSON run and a binary run of the same
         # fanout/batch write to the same path and the last one silently wins.
         encoding = "binary" if binary else "json"
-        base_name = base_dir / f"f{fanout}_b{batch}_{encoding}"
+        # The commit is in the path too, so two builds cannot overwrite each
+        # other's charts and it is obvious which build a file describes.
+        build = (key_git_sha or "unknown")[:8]
+        base_name = base_dir / f"f{fanout}_b{batch}_{encoding}_{build}"
 
         chart_group(
             group_rows,

--- a/scripts/perf/make_charts.py
+++ b/scripts/perf/make_charts.py
@@ -20,14 +20,12 @@ except ImportError:
         "  data/raw/latency_demo_runs.jsonl      (raw runs)\n"
         "  data/derived/latency_demo_agg.csv     (aggregated)\n"
         "\n"
-        "Install the charting dependencies and re-run this step alone:\n"
-        "  task perf:deps\n"
-        "  python3 scripts/perf/make_charts.py\n"
-        "\n"
-        "Or in a virtualenv, if this Python is externally managed:\n"
-        "  python3 -m venv .venv-perf\n"
-        "  .venv-perf/bin/pip install -r scripts/perf/requirements.txt\n"
-        "  .venv-perf/bin/python scripts/perf/make_charts.py"
+        "Install the charting dependencies, then re-render without re-running\n"
+        "the benchmark:\n"
+        "  task perf:deps      # creates .venv-perf (system Python is usually\n"
+        "                      # externally managed -- PEP 668 -- so a bare\n"
+        "                      # pip install into it fails)\n"
+        "  task perf:charts    # re-renders from data/derived"
     ) from None
 
 ROOT = Path(__file__).resolve().parents[2]

--- a/scripts/perf/make_charts.py
+++ b/scripts/perf/make_charts.py
@@ -3,6 +3,7 @@ import argparse
 import csv
 import datetime as dt
 import json
+import textwrap
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -139,28 +140,64 @@ def chart_group(
             )
             heights.append(match.get(metric_key) if match else None)
         values = []
+        clipped = []
         for value in heights:
             if value is None:
-                values.append(0.0)
+                # NaN, never 0.0. A zero bar is a *measurement*: on a throughput
+                # chart it reads as total failure and on a latency chart as
+                # perfect. Matplotlib draws NaN as nothing, which is the honest
+                # rendering of "this configuration was never run".
+                values.append(float("nan"))
+                clipped.append(False)
             elif cap_value is not None and value > cap_value:
                 values.append(cap_value / scale if scale else cap_value)
+                clipped.append(True)
             else:
                 values.append(value / scale if scale else value)
-        ax.bar(
-            [p + offsets[idx] for p in payload_positions],
-            values,
-            width=bar_width * 0.95,
-            label=preset,
-        )
+                clipped.append(False)
+        positions = [p + offsets[idx] for p in payload_positions]
+        bars = ax.bar(positions, values, width=bar_width * 0.95, label=preset)
+
+        # A clipped bar is drawn at the cap, which is visually identical to one
+        # that legitimately equals it. Mark them and print the real value, or
+        # the clipping hides exactly the tail a p99 chart exists to show.
+        for bar, was_clipped, raw in zip(bars, clipped, heights):
+            if was_clipped:
+                bar.set_hatch("///")
+                bar.set_edgecolor("black")
+                ax.annotate(
+                    f"{raw / scale:.3g}\u2191" if scale else f"{raw:.3g}\u2191",
+                    (bar.get_x() + bar.get_width() / 2, bar.get_height()),
+                    ha="center",
+                    va="bottom",
+                    fontsize=6,
+                    rotation=90,
+                )
+        # Absent configurations get a visible marker at the baseline, so a gap
+        # cannot be mistaken for a bar too small to see.
+        for position, value in zip(positions, values):
+            if value != value:  # NaN
+                ax.annotate(
+                    "no data",
+                    (position, 0),
+                    ha="center",
+                    va="bottom",
+                    fontsize=6,
+                    rotation=90,
+                    color="0.5",
+                )
 
     ax.set_xticks(payload_positions)
     ax.set_xticklabels([str(p) for p in payloads])
     ax.set_xlabel("payload (bytes)")
     ax.set_ylabel(ylabel)
+    title = title_prefix
     if cap_value is not None:
-        ax.set_title(f"{title_prefix} (clipped p{int(cap_percentile * 100)})")
-    else:
-        ax.set_title(title_prefix)
+        title = f"{title} (clipped p{int(cap_percentile * 100)})"
+    # Wrapped rather than truncated: these titles carry the caveats that keep a
+    # chart from being misread, and a caveat cut off at the figure edge is worse
+    # than no caveat at all.
+    ax.set_title("\n".join(textwrap.wrap(title, width=95)), fontsize=9)
     ax.legend(ncol=3, fontsize=8)
     fig.text(0.99, 0.01, footer, ha="right", va="bottom", fontsize=7)
     fig.tight_layout(rect=[0, 0.02, 1, 1])
@@ -197,7 +234,7 @@ def main():
         )
         groups.setdefault(key, []).append(row)
 
-    date_str = dt.datetime.utcnow().date().isoformat()
+    date_str = dt.datetime.now(dt.UTC).date().isoformat()
 
     for key, group_rows in groups.items():
         profile, fanout, batch, binary = key
@@ -210,16 +247,31 @@ def main():
             f"latency_demo {profile} fanout={fanout} batch={batch} "
             f"binary={binary} warmup={warmup} total={total} trials={trials}"
         )
+        # A batched run measures throughput, not request latency: a batch of 64
+        # waits for the batch to fill. Reading its p99 as Felix's latency is the
+        # single easiest way to conclude performance is terrible from a chart
+        # that is working correctly, so the chart says so itself.
+        latency_caveat = ""
+        if isinstance(batch, int) and batch > 1:
+            latency_caveat = (
+                f" - THROUGHPUT PROFILE (batch={batch}): includes batch fill and"
+                " queueing delay. Not a request-latency measurement; use batch=1"
+                " with per-message acks for that."
+            )
         footer = f"git {git_sha} | {date_str}"
 
         base_dir = CHARTS_DIR / profile
-        base_name = base_dir / f"f{fanout}_b{batch}"
+        # `binary` is part of the grouping key, so it must be part of the file
+        # name too. Without it a JSON run and a binary run of the same
+        # fanout/batch write to the same path and the last one silently wins.
+        encoding = "binary" if binary else "json"
+        base_name = base_dir / f"f{fanout}_b{batch}_{encoding}"
 
         chart_group(
             group_rows,
             "p50_ms_median",
             "p50 latency (ms)",
-            title_prefix,
+            title_prefix + latency_caveat,
             base_name.with_name(base_name.name + "_p50"),
             presets,
             payloads,
@@ -230,35 +282,48 @@ def main():
             group_rows,
             "p99_ms_median",
             "p99 latency (ms)",
-            title_prefix,
+            title_prefix + latency_caveat,
             base_name.with_name(base_name.name + "_p99"),
             presets,
             payloads,
             footer,
             cap_percentile,
         )
-        throughput_values = [
-            r.get("throughput_median")
-            for r in group_rows
-            if r.get("throughput_median") is not None
-        ]
-        scale = None
-        ylabel = "throughput (msg/s)"
-        if throughput_values and max(throughput_values) >= 1_000_000:
-            scale = 1_000_000.0
-            ylabel = "throughput (M msg/s)"
-        chart_group(
-            group_rows,
-            "throughput_median",
-            ylabel,
-            title_prefix,
-            base_name.with_name(base_name.name + "_throughput"),
-            presets,
-            payloads,
-            footer,
-            cap_percentile,
-            scale,
-        )
+        # Two different quantities, charted separately and named explicitly.
+        # `throughput` counts messages a publisher sent; `delivered_throughput`
+        # counts subscriber deliveries, so at fanout N they differ by N. Charting
+        # the publish rate under a bare "throughput" label made fanout-10 look
+        # 10x worse than it is -- the headline fanout numbers are delivered.
+        for metric, label, suffix in (
+            ("throughput_median", "publish throughput", "_publish_throughput"),
+            (
+                "delivered_throughput_median",
+                "delivered throughput",
+                "_delivered_throughput",
+            ),
+        ):
+            values = [
+                r.get(metric) for r in group_rows if r.get(metric) is not None
+            ]
+            if not values:
+                continue
+            scale = None
+            ylabel = f"{label} (msg/s)"
+            if max(values) >= 1_000_000:
+                scale = 1_000_000.0
+                ylabel = f"{label} (M msg/s)"
+            chart_group(
+                group_rows,
+                metric,
+                ylabel,
+                f"{title_prefix} - {label}",
+                base_name.with_name(base_name.name + suffix),
+                presets,
+                payloads,
+                footer,
+                cap_percentile,
+                scale,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/perf/make_charts.py
+++ b/scripts/perf/make_charts.py
@@ -6,7 +6,29 @@ import json
 import textwrap
 from pathlib import Path
 
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    # Charting is the last step of `task perf:latency-matrix`, after a benchmark
+    # run that takes many minutes. A bare ImportError here reads as "the run
+    # failed" when the measurements are already safely on disk, so say what is
+    # missing, what survived, and how to finish.
+    raise SystemExit(
+        "matplotlib is not installed, so charts were not rendered.\n"
+        "\n"
+        "The benchmark data is already written and is NOT lost:\n"
+        "  data/raw/latency_demo_runs.jsonl      (raw runs)\n"
+        "  data/derived/latency_demo_agg.csv     (aggregated)\n"
+        "\n"
+        "Install the charting dependencies and re-run this step alone:\n"
+        "  task perf:deps\n"
+        "  python3 scripts/perf/make_charts.py\n"
+        "\n"
+        "Or in a virtualenv, if this Python is externally managed:\n"
+        "  python3 -m venv .venv-perf\n"
+        "  .venv-perf/bin/pip install -r scripts/perf/requirements.txt\n"
+        "  .venv-perf/bin/python scripts/perf/make_charts.py"
+    ) from None
 
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG = ROOT / "scripts" / "perf" / "presets.yml"

--- a/scripts/perf/normalize_and_aggregate.py
+++ b/scripts/perf/normalize_and_aggregate.py
@@ -3,6 +3,7 @@ import argparse
 import csv
 import json
 import statistics
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -95,7 +96,18 @@ def write_csv(path: Path, rows: list):
             writer.writerow(row)
 
 
-def aggregate(rows: list):
+def aggregate(rows: list, strict: bool = True):
+    """Median each workload group across trials.
+
+    A median is only meaningful over runs that differ by nothing but trial
+    index. The grouping key therefore includes the things that change what is
+    being measured -- commit, host, toolchain, warmup/total -- and not only the
+    workload shape. `run_latency_matrix.py` appends to the same JSONL by
+    default, so without this a second run on a different commit or a different
+    machine silently merges into the first and the median describes no build
+    that ever existed. Recording `git_sha = "mixed"` afterwards labels the
+    problem rather than avoiding it.
+    """
     grouped = {}
     for row in rows:
         key = (
@@ -105,12 +117,52 @@ def aggregate(rows: list):
             row["payload_bytes"],
             row["preset"],
             row["binary"],
+            row.get("git_sha"),
+            row.get("git_dirty"),
+            row.get("hostname"),
+            row.get("platform"),
+            row.get("rustc_version"),
+            row.get("warmup"),
+            row.get("total"),
         )
         grouped.setdefault(key, []).append(row)
 
+    # A dirty tree cannot be attributed to a commit, so its numbers are not
+    # comparable to anything -- including a later run of the "same" sha.
+    dirty = sum(1 for row in rows if row.get("git_dirty"))
+    if dirty:
+        print(
+            f"warning: {dirty}/{len(rows)} runs were recorded from a dirty "
+            "working tree; their git_sha does not identify what was measured",
+            file=sys.stderr,
+        )
+    distinct_builds = {
+        (row.get("git_sha"), row.get("hostname")) for row in rows
+    }
+    if len(distinct_builds) > 1:
+        print(
+            f"warning: input spans {len(distinct_builds)} (commit, host) pairs; "
+            "they are aggregated separately and must not be compared on one chart",
+            file=sys.stderr,
+        )
+
     agg_rows = []
     for key, group in grouped.items():
-        profile, fanout, batch, payload, preset, binary = key
+        (
+            profile,
+            fanout,
+            batch,
+            payload,
+            preset,
+            binary,
+            key_git_sha,
+            key_git_dirty,
+            hostname,
+            platform,
+            rustc_version,
+            key_warmup,
+            key_total,
+        ) = key
         failures = [r for r in group if r.get("parse_error") or r.get("exit_code") != 0]
         successes = [r for r in group if r not in failures]
 
@@ -131,9 +183,9 @@ def aggregate(rows: list):
         def median_ms(values):
             return median(values) / 1000.0 if values else None
 
-        git_shas = sorted({r.get("git_sha") for r in group if r.get("git_sha")})
-        git_sha = git_shas[0] if len(git_shas) == 1 else "mixed"
-        git_dirty = any(r.get("git_dirty") for r in group)
+        # Part of the grouping key now, so it is exact rather than "mixed".
+        git_sha = key_git_sha
+        git_dirty = key_git_dirty
 
         agg_rows.append(
             {
@@ -143,8 +195,11 @@ def aggregate(rows: list):
                 "payload_bytes": payload,
                 "preset": preset,
                 "binary": binary,
-                "warmup": group[0].get("warmup"),
-                "total": group[0].get("total"),
+                "warmup": key_warmup,
+                "total": key_total,
+                "hostname": hostname,
+                "platform": platform,
+                "rustc_version": rustc_version,
                 "trial_count": len(group),
                 "failure_count": len(failures),
                 "git_sha": git_sha,

--- a/scripts/perf/presets.yml
+++ b/scripts/perf/presets.yml
@@ -8,7 +8,8 @@
     "payload_bytes": [0, 256, 1024, 4096],
     "warmup": 2000,
     "total": 20000,
-    "binary": true
+    "_comment_binary": "Both encodings, deliberately. latency-demo enables per-message acks only when batch<=1 && !binary, so a binary-only sweep never measures the request-latency configuration the published headline number comes from -- and comparing the two shows a ~2x regression that does not exist.",
+    "binary": [true, false]
   },
   "profiles": {
     "balanced": {

--- a/scripts/perf/run_latency_matrix.py
+++ b/scripts/perf/run_latency_matrix.py
@@ -187,8 +187,19 @@ def build_matrix(config: dict, trials: int, binary_override=None):
     workload = config["workload"]
     profiles = config["profiles"]
     presets = config["presets"]
+    # `binary` accepts a list so one run can cover both encodings. It is not a
+    # cosmetic switch: the demo enables per-message acks only when
+    # `batch <= 1 && !binary`, so a binary-only sweep never measures the
+    # request-latency configuration the published headline figure comes from.
+    # Comparing a binary-only matrix against that figure shows a ~2x regression
+    # that does not exist.
     binary_default = workload.get("binary", True)
-    binary = binary_override if binary_override is not None else binary_default
+    binary_setting = binary_override if binary_override is not None else binary_default
+    binaries = (
+        [bool(b) for b in binary_setting]
+        if isinstance(binary_setting, (list, tuple))
+        else [bool(binary_setting)]
+    )
 
     matrix = []
     for profile_name, profile in profiles.items():
@@ -196,6 +207,7 @@ def build_matrix(config: dict, trials: int, binary_override=None):
             for batch in workload["batch"]:
                 for payload in workload["payload_bytes"]:
                     for preset_name, preset in presets.items():
+                      for binary in binaries:
                         for trial_index in range(1, trials + 1):
                             matrix.append(
                                 {

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -88,7 +88,7 @@ use writer::{run_connection_writer, write_parts_many, write_parts_to};
 
 use anyhow::Result;
 use felix_broker::Broker;
-use felix_wire::Message;
+use felix_wire::{Message, StartPosition};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -96,6 +96,342 @@ use tokio::sync::mpsc;
 use super::publish::{Outgoing, SubscriptionLimiter, send_outgoing_critical};
 use crate::transport::quic::SUBSCRIPTION_ID;
 use crate::transport::quic::codec::write_message;
+/// Report a failed subscribe on the control stream and keep the stream alive.
+///
+/// Extracted because the tail-only and resume paths fail identically, and
+/// duplicating the ack-queue plumbing between them is how the two drift apart.
+/// Turn a broker error into the most specific protocol message available.
+///
+/// A cursor rejection is machine-readable so the client can choose a remedy;
+/// everything else stays a generic `Error`.
+fn subscribe_error_message(err: felix_broker::BrokerError) -> Message {
+    match err {
+        felix_broker::BrokerError::CursorTooOld { oldest, requested } => {
+            Message::SubscribeCursorError {
+                reason: felix_wire::CursorErrorReason::TooOld,
+                requested,
+                available: oldest,
+            }
+        }
+        felix_broker::BrokerError::CursorInFuture { requested, tail } => {
+            Message::SubscribeCursorError {
+                reason: felix_wire::CursorErrorReason::InFuture,
+                requested,
+                available: tail,
+            }
+        }
+        other => Message::Error {
+            message: other.to_string(),
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn subscribe_failed(
+    message: Message,
+    subscriptions: &Arc<SubscriptionLimiter>,
+    out_ack_tx: &mpsc::Sender<Outgoing>,
+    out_ack_depth: &Arc<std::sync::atomic::AtomicUsize>,
+    ack_throttle_tx: &tokio::sync::watch::Sender<bool>,
+    ack_timeout_state: &Arc<tokio::sync::Mutex<super::publish::AckTimeoutState>>,
+    cancel_tx: &tokio::sync::watch::Sender<bool>,
+) -> Result<bool> {
+    subscriptions.release();
+    t_counter!("felix_subscribe_requests_total", "result" => "error").increment(1);
+    super::publish::handle_ack_enqueue_result(
+        send_outgoing_critical(
+            out_ack_tx,
+            out_ack_depth,
+            "felix_broker_out_ack_depth",
+            ack_throttle_tx,
+            Outgoing::Message(message),
+        )
+        .await,
+        ack_timeout_state,
+        ack_throttle_tx,
+        cancel_tx,
+    )
+    .await?;
+    Ok(true)
+}
+
+/// Write a resumed subscription's stored history and ring backlog.
+///
+/// Disk history is *paged*, never collected: `read_durable` returns at most
+/// `max_bytes` per call and this advances by the last offset it saw, so a client
+/// resuming from the start of a large stream costs the broker one page of memory
+/// at a time rather than the whole history. Each page is written before the next
+/// is read, so backpressure from a slow client propagates naturally into slower
+/// reading rather than unbounded buffering.
+#[allow(clippy::too_many_arguments)]
+async fn write_replay(
+    event_send: &mut quinn::SendStream,
+    broker: &Arc<Broker>,
+    tenant_id: &str,
+    namespace: &str,
+    stream: &str,
+    subscription_id: u64,
+    history: Option<felix_broker::HistoryRange>,
+    backlog: Vec<(u64, bytes::Bytes)>,
+    backlog_start: u64,
+    subscription: &mut felix_broker::Subscription,
+    max_events: usize,
+    max_bytes: usize,
+    offsets_enabled: bool,
+) -> Result<()> {
+    /// One page of history per read. Bounds broker memory for a resume that
+    /// starts arbitrarily far back.
+    const HISTORY_PAGE_BYTES: usize = 1024 * 1024;
+
+    if let Some(range) = history {
+        let mut at = range.from_offset;
+        while at < range.until_offset {
+            let records = broker
+                .read_durable(tenant_id, namespace, stream, at, HISTORY_PAGE_BYTES)
+                .await?;
+            if records.is_empty() {
+                // The range is closed and was on disk when it was computed, so
+                // this only happens if retention trimmed underneath us. Stop
+                // rather than spin; the backlog still joins on cleanly.
+                break;
+            }
+            let mut batch = ReplayBatch::new(max_events, max_bytes);
+            for record in records {
+                if record.offset >= range.until_offset {
+                    break;
+                }
+                at = record.offset + 1;
+                if let Some(ready) = batch.push(record.offset, record.payload.clone()) {
+                    write_replay_batch(event_send, subscription_id, &ready, offsets_enabled)
+                        .await?;
+                }
+            }
+            if let Some(ready) = batch.take() {
+                write_replay_batch(event_send, subscription_id, &ready, offsets_enabled).await?;
+            }
+        }
+    }
+
+    let mut batch = ReplayBatch::new(max_events, max_bytes);
+    let mut delivered_upto = backlog_start;
+    for (offset, payload) in backlog {
+        delivered_upto = offset + 1;
+        if let Some(ready) = batch.push(offset, payload) {
+            write_replay_batch(event_send, subscription_id, &ready, offsets_enabled).await?;
+        }
+    }
+    if let Some(ready) = batch.take() {
+        write_replay_batch(event_send, subscription_id, &ready, offsets_enabled).await?;
+    }
+
+    // Catch-up. The live subscription was registered before any of this ran, so
+    // publishes have been queueing on it the whole time -- into the *ordinary*
+    // bounded subscriber queue, which drops under `DropNew` once it is full.
+    // Relying on that queue to carry the handoff means a long replay silently
+    // loses live records, so instead: drain what is queued, and wherever the
+    // offsets jump, fill the hole from disk. Disk is the authority; the queue is
+    // only a shortcut for the part that has not been evicted.
+    //
+    // Repeated because draining takes time of its own, during which more can
+    // arrive. It terminates because each pass only handles what was already
+    // queued, and a pass that finds nothing ends it.
+    for _ in 0..MAX_CATCH_UP_PASSES {
+        let ready = subscription.drain_ready();
+        if ready.is_empty() {
+            break;
+        }
+        for envelope in ready {
+            if let Some(base) = envelope.base_offset() {
+                if base > delivered_upto {
+                    // The queue dropped records. Page the gap from disk.
+                    delivered_upto = write_history_range(
+                        event_send,
+                        broker,
+                        tenant_id,
+                        namespace,
+                        stream,
+                        subscription_id,
+                        delivered_upto,
+                        base,
+                        max_events,
+                        max_bytes,
+                        offsets_enabled,
+                    )
+                    .await?;
+                }
+                if base + envelope.len() as u64 <= delivered_upto {
+                    // Entirely covered by history already written.
+                    continue;
+                }
+            }
+            let mut batch = ReplayBatch::new(max_events, max_bytes);
+            for (index, payload) in envelope.payloads().iter().enumerate() {
+                let offset = envelope
+                    .base_offset()
+                    .map(|base| base + index as u64)
+                    .unwrap_or(delivered_upto);
+                if offset < delivered_upto {
+                    continue;
+                }
+                delivered_upto = offset + 1;
+                if let Some(chunk) = batch.push(offset, payload.clone()) {
+                    write_replay_batch(event_send, subscription_id, &chunk, offsets_enabled)
+                        .await?;
+                }
+            }
+            if let Some(chunk) = batch.take() {
+                write_replay_batch(event_send, subscription_id, &chunk, offsets_enabled).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Bound on catch-up passes, so a stream being published to faster than it can
+/// be written cannot keep a subscribe from completing. Reaching it hands over to
+/// live delivery, which is correct: offsets are on the wire, so a client can see
+/// any residual gap rather than being misled about it.
+const MAX_CATCH_UP_PASSES: usize = 8;
+
+/// Write `[from, until)` from disk, returning the offset reached.
+#[allow(clippy::too_many_arguments)]
+async fn write_history_range(
+    event_send: &mut quinn::SendStream,
+    broker: &Arc<Broker>,
+    tenant_id: &str,
+    namespace: &str,
+    stream: &str,
+    subscription_id: u64,
+    from: u64,
+    until: u64,
+    max_events: usize,
+    max_bytes: usize,
+    offsets_enabled: bool,
+) -> Result<u64> {
+    const HISTORY_PAGE_BYTES: usize = 1024 * 1024;
+    let mut at = from;
+    while at < until {
+        let records = broker
+            .read_durable(tenant_id, namespace, stream, at, HISTORY_PAGE_BYTES)
+            .await?;
+        if records.is_empty() {
+            break;
+        }
+        let mut batch = ReplayBatch::new(max_events, max_bytes);
+        for record in records {
+            if record.offset >= until {
+                break;
+            }
+            at = record.offset + 1;
+            if let Some(ready) = batch.push(record.offset, record.payload.clone()) {
+                write_replay_batch(event_send, subscription_id, &ready, offsets_enabled).await?;
+            }
+        }
+        if let Some(ready) = batch.take() {
+            write_replay_batch(event_send, subscription_id, &ready, offsets_enabled).await?;
+        }
+    }
+    Ok(at.max(from))
+}
+
+/// Accumulates replay records into frames that are safe to send.
+///
+/// Three things force a flush, and all three are correctness rather than taste:
+///
+/// * **A gap in offsets.** One `base_offset` describes a batch only if its
+///   records are contiguous, so a hole must start a new frame or every offset
+///   after it is wrong.
+/// * **The byte budget.** Chunking by record count alone lets a backlog of
+///   large payloads build a frame past the configured delivery and client frame
+///   limits, which fails the write after allocating the whole thing.
+/// * **The record count**, matching live delivery's batching.
+struct ReplayBatch {
+    payloads: Vec<bytes::Bytes>,
+    base_offset: u64,
+    next_offset: u64,
+    bytes: usize,
+    max_events: usize,
+    max_bytes: usize,
+}
+
+impl ReplayBatch {
+    fn new(max_events: usize, max_bytes: usize) -> Self {
+        Self {
+            payloads: Vec::new(),
+            base_offset: 0,
+            next_offset: 0,
+            bytes: 0,
+            max_events: max_events.max(1),
+            max_bytes: max_bytes.max(1),
+        }
+    }
+
+    /// Add a record, returning a finished batch when this one had to be closed.
+    fn push(&mut self, offset: u64, payload: bytes::Bytes) -> Option<Vec<(u64, bytes::Bytes)>> {
+        let len = payload.len();
+        let breaks_run = !self.payloads.is_empty() && offset != self.next_offset;
+        let over_bytes = !self.payloads.is_empty() && self.bytes + len > self.max_bytes;
+        let ready = if breaks_run || over_bytes {
+            self.take()
+        } else {
+            None
+        };
+        if self.payloads.is_empty() {
+            self.base_offset = offset;
+        }
+        self.payloads.push(payload);
+        self.next_offset = offset + 1;
+        self.bytes += len;
+        if self.payloads.len() >= self.max_events {
+            // Already at the count limit, so hand it over now. A batch closed
+            // here and one closed above can never both be pending.
+            return ready.or_else(|| self.take());
+        }
+        ready
+    }
+
+    fn take(&mut self) -> Option<Vec<(u64, bytes::Bytes)>> {
+        if self.payloads.is_empty() {
+            return None;
+        }
+        let base = self.base_offset;
+        let payloads = std::mem::take(&mut self.payloads);
+        self.bytes = 0;
+        Some(
+            payloads
+                .into_iter()
+                .enumerate()
+                .map(|(index, payload)| (base + index as u64, payload))
+                .collect(),
+        )
+    }
+}
+
+/// Encode and write one replay batch, with or without offsets as negotiated.
+async fn write_replay_batch(
+    event_send: &mut quinn::SendStream,
+    subscription_id: u64,
+    records: &[(u64, bytes::Bytes)],
+    offsets_enabled: bool,
+) -> Result<()> {
+    let base_offset = match records.first() {
+        Some((offset, _)) => *offset,
+        None => return Ok(()),
+    };
+    let payloads: Vec<bytes::Bytes> = records.iter().map(|(_, payload)| payload.clone()).collect();
+    let payloads = payloads.as_slice();
+    let frame = if offsets_enabled {
+        felix_wire::binary::encode_event_batch_bytes_with_offset(
+            subscription_id,
+            payloads,
+            base_offset,
+        )?
+    } else {
+        felix_wire::binary::encode_event_batch_bytes(subscription_id, payloads)?
+    };
+    event_send.write_all(&frame).await?;
+    Ok(())
+}
 
 /// Handle a subscribe request received on the bi-directional control stream.
 ///
@@ -133,7 +469,12 @@ pub(crate) async fn handle_subscribe_message(
     namespace: String,
     stream: String,
     subscription_id: Option<u64>,
+    start: Option<StartPosition>,
+    peer_flags: u16,
 ) -> Result<bool> {
+    // Offsets ride the event batch only for a client that negotiated the bit.
+    // One that did not gets exactly the frames it got before this existed.
+    let offsets_enabled = felix_wire::supports(peer_flags, felix_wire::FLAG_EVENT_BATCH_OFFSETS);
     // Subscribe is a control-plane request: acknowledgements/metadata stay on this bi stream.
     // Actual event delivery happens on a fresh uni stream (broker -> client).
     let span = tracing::trace_span!(
@@ -174,30 +515,50 @@ pub(crate) async fn handle_subscribe_message(
     }
 
     // Ask broker core for a managed subscriber queue.
+    //
+    // Without a start position this is the tail-only path every client used
+    // before resume existed, and it stays byte-for-byte what it was. With one,
+    // the broker registers the live subscription first and hands back the
+    // history needed to reach it -- see `Broker::subscribe_from`.
     // On failure, respond on the control stream (through the ack queue) and keep the stream alive.
-    let subscription = match broker.subscribe(&tenant_id, &namespace, &stream).await {
-        Ok(subscription) => subscription,
-        Err(err) => {
-            subscriptions.release();
-            t_counter!("felix_subscribe_requests_total", "result" => "error").increment(1);
-            super::publish::handle_ack_enqueue_result(
-                send_outgoing_critical(
+    let mut replay = None;
+    let mut subscription = match start {
+        None => match broker.subscribe(&tenant_id, &namespace, &stream).await {
+            Ok(subscription) => subscription,
+            Err(err) => {
+                return subscribe_failed(
+                    subscribe_error_message(err),
+                    subscriptions,
                     out_ack_tx,
                     out_ack_depth,
-                    "felix_broker_out_ack_depth",
                     ack_throttle_tx,
-                    Outgoing::Message(Message::Error {
-                        message: err.to_string(),
-                    }),
+                    ack_timeout_state,
+                    cancel_tx,
                 )
-                .await,
-                ack_timeout_state,
-                ack_throttle_tx,
-                cancel_tx,
-            )
-            .await?;
-            return Ok(true);
-        }
+                .await;
+            }
+        },
+        Some(start) => match broker
+            .subscribe_from(&tenant_id, &namespace, &stream, start)
+            .await
+        {
+            Ok(resumed) => {
+                replay = Some((resumed.history, resumed.backlog, resumed.backlog_start));
+                resumed.subscription
+            }
+            Err(err) => {
+                return subscribe_failed(
+                    subscribe_error_message(err),
+                    subscriptions,
+                    out_ack_tx,
+                    out_ack_depth,
+                    ack_throttle_tx,
+                    ack_timeout_state,
+                    cancel_tx,
+                )
+                .await;
+            }
+        },
     };
 
     // Open a uni stream for event delivery. If this fails, respond with error on control stream.
@@ -250,6 +611,61 @@ pub(crate) async fn handle_subscribe_message(
         return Ok(true);
     }
 
+    // Acknowledge *before* streaming any history.
+    //
+    // The client waits for `Subscribed` before it registers the event stream
+    // with its router and starts reading it. Writing replay first therefore
+    // deadlocks as soon as the history exceeds the QUIC per-stream receive
+    // window (64 MiB by default): the broker blocks for flow-control credit
+    // that the client will not grant until it reads, and the client will not
+    // read until it sees the acknowledgement the broker cannot send. Small
+    // replays fit in the window and hide it, which is what makes it a
+    // production bug rather than a test failure.
+    t_counter!("felix_subscribe_requests_total", "result" => "ok").increment(1);
+    super::publish::handle_ack_enqueue_result(
+        send_outgoing_critical(
+            out_ack_tx,
+            out_ack_depth,
+            "felix_broker_out_ack_depth",
+            ack_throttle_tx,
+            Outgoing::Message(Message::Subscribed { subscription_id }),
+        )
+        .await,
+        ack_timeout_state,
+        ack_throttle_tx,
+        cancel_tx,
+    )
+    .await?;
+
+    // Replay goes out here, on the raw uni stream, before the lane manager is
+    // registered for live delivery. That ordering is the delivery half of the
+    // seam: the broker already registered the live subscription, so events are
+    // queueing in `subscription` while these bytes are written, and they cannot
+    // overtake replay because nothing drains that queue until registration
+    // below. History, then backlog, then live -- contiguous.
+    if let Some((history, backlog, backlog_start)) = replay
+        && let Err(err) = write_replay(
+            &mut event_send,
+            &broker,
+            &tenant_id,
+            &namespace,
+            &stream,
+            subscription_id,
+            history,
+            backlog,
+            backlog_start,
+            &mut subscription,
+            config.event_batch_max_events.max(1),
+            config.event_batch_max_bytes.max(1),
+            offsets_enabled,
+        )
+        .await
+    {
+        subscriptions.release();
+        tracing::info!(error = %err, "subscription replay failed");
+        return Ok(true);
+    }
+
     // Batching configuration.
     // Note: `batch_size` is the “fanout batch size” (publisher -> broker internal),
     // but for subscriber delivery we compute and enforce independent limits.
@@ -265,6 +681,7 @@ pub(crate) async fn handle_subscribe_message(
         max_bytes,
         flush_delay,
         single_event_mode: config.fanout_batch_size <= 1,
+        offsets_enabled,
         flush_max_items: config.subscriber_flush_max_items.max(1),
         flush_max_delay: Duration::from_micros(config.subscriber_flush_max_delay_us.max(1)),
         max_bytes_per_write: config.subscriber_max_bytes_per_write.max(1),
@@ -315,22 +732,6 @@ pub(crate) async fn handle_subscribe_message(
         return Ok(true);
     }
 
-    // Control-plane acknowledgement: subscriber is fully wired for delivery.
-    t_counter!("felix_subscribe_requests_total", "result" => "ok").increment(1);
-    super::publish::handle_ack_enqueue_result(
-        send_outgoing_critical(
-            out_ack_tx,
-            out_ack_depth,
-            "felix_broker_out_ack_depth",
-            ack_throttle_tx,
-            Outgoing::Message(Message::Subscribed { subscription_id }),
-        )
-        .await,
-        ack_timeout_state,
-        ack_throttle_tx,
-        cancel_tx,
-    )
-    .await?;
     let feeder_subscriptions = Arc::clone(subscriptions);
     let feeder_manager = Arc::downgrade(&manager);
     let feeder = async move {

--- a/services/broker/src/transport/quic/handlers/subscribe/config.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/config.rs
@@ -30,6 +30,14 @@ pub(crate) struct EventWriterConfig {
     /// If true, encode each payload as its own one-item EventBatch frame.
     pub(super) single_event_mode: bool,
 
+    /// Whether this subscriber negotiated `FLAG_EVENT_BATCH_OFFSETS`.
+    ///
+    /// Per-subscriber, because a stream can carry subscribers of both kinds and
+    /// each must receive the frame shape it agreed to. The envelope caches both
+    /// encodings, so the cost is at most two per batch however many subscribers
+    /// there are -- the encode-once fanout property still holds.
+    pub(super) offsets_enabled: bool,
+
     /// Max number of lane commands to gather per flush.
     pub(super) flush_max_items: usize,
 

--- a/services/broker/src/transport/quic/handlers/subscribe/feeder.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/feeder.rs
@@ -46,7 +46,11 @@ pub(super) async fn run_lane_feeder(
             let payload_bytes: usize = payloads.iter().map(Bytes::len).sum();
             if payloads.len() <= max_events && payload_bytes <= max_bytes {
                 let prefix_start = t_now_if(t_should_sample());
-                let frame = match envelope.shared_event_frame() {
+                let frame = match if config.offsets_enabled {
+                    envelope.shared_event_frame_with_offsets()
+                } else {
+                    envelope.shared_event_frame()
+                } {
                     Ok(frame) => frame,
                     Err(err) => {
                         tracing::warn!(
@@ -86,7 +90,19 @@ pub(super) async fn run_lane_feeder(
                     end += 1;
                 }
                 let batch = &payloads[start..end];
-                match felix_wire::binary::encode_shared_event_batch_bytes(batch) {
+                // A split batch keeps its own base offset: the envelope's
+                // offsets are contiguous, so this sub-batch begins `start`
+                // records into the run.
+                let encoded = match (config.offsets_enabled, envelope.base_offset()) {
+                    (true, Some(base)) => {
+                        felix_wire::binary::encode_shared_event_batch_bytes_with_offset(
+                            batch,
+                            base + start as u64,
+                        )
+                    }
+                    _ => felix_wire::binary::encode_shared_event_batch_bytes(batch),
+                };
+                match encoded {
                     Ok(frame) => {
                         enqueue_lane_frame(
                             &manager,
@@ -114,6 +130,12 @@ pub(super) async fn run_lane_feeder(
         let mut batch = Vec::with_capacity(max_events);
         let mut batch_bytes = first.len();
         batch.push(first);
+        // Coalescing merges *separate* publishes into one frame, and their
+        // offsets are only contiguous if nothing landed between them. One
+        // `base_offset` describes the frame only while that holds, so a break in
+        // the run ends the batch exactly as a byte or count limit would.
+        let batch_base = envelope.base_offset();
+        let mut expected_next = batch_base.map(|base| base + envelope.len() as u64);
 
         while batch.len() < max_events && batch_bytes < max_bytes {
             let next = if config.single_event_mode {
@@ -131,6 +153,11 @@ pub(super) async fn run_lane_feeder(
                 pending = Some(envelope);
                 break;
             }
+            if config.offsets_enabled && envelope.base_offset() != expected_next {
+                // Numbering this into the current frame would misreport it.
+                pending = Some(envelope);
+                break;
+            }
             let payload = envelope.payloads()[0].clone();
             if batch_bytes.saturating_add(payload.len()) > max_bytes {
                 pending = Some(envelope);
@@ -138,12 +165,19 @@ pub(super) async fn run_lane_feeder(
             }
             batch_bytes += payload.len();
             batch.push(payload);
+            expected_next = expected_next.map(|next| next + 1);
         }
 
         let sample = t_should_sample();
         let enqueue_start = t_now_if(sample);
         let prefix_start = t_now_if(sample);
-        let frame = match felix_wire::binary::encode_shared_event_batch_bytes(&batch) {
+        let encoded = match (config.offsets_enabled, batch_base) {
+            (true, Some(base)) => {
+                felix_wire::binary::encode_shared_event_batch_bytes_with_offset(&batch, base)
+            }
+            _ => felix_wire::binary::encode_shared_event_batch_bytes(&batch),
+        };
+        let frame = match encoded {
             Ok(frame) => frame,
             Err(err) => {
                 tracing::warn!(

--- a/services/broker/src/transport/quic/handlers/subscribe/tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/tests.rs
@@ -180,6 +180,7 @@ async fn run_event_writer_single_closes_on_channel_close() -> Result<()> {
 
     let (tx, rx) = mpsc::channel(4);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 1,
         max_events: 1,
         max_bytes: 1024,
@@ -219,6 +220,7 @@ async fn run_event_writer_single_binary_uses_batch_encoding() -> Result<()> {
 
     let (tx, rx) = mpsc::channel(4);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 9,
         max_events: 1,
         max_bytes: 1024,
@@ -258,6 +260,7 @@ async fn run_event_writer_batches_with_pending_payload() -> Result<()> {
 
     let (tx, rx) = mpsc::channel(4);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 7,
         max_events: 10,
         max_bytes: 5,
@@ -352,6 +355,8 @@ async fn handle_subscribe_message_sends_event_stream_binary_batch() -> Result<()
             "default".to_string(),
             "orders".to_string(),
             Some(7),
+            None,
+            felix_wire::ORIGINAL_V1_FLAGS,
         )
         .await?;
         Result::<bool>::Ok(handled)
@@ -452,6 +457,8 @@ async fn handle_subscribe_message_errors_when_stream_missing() -> Result<()> {
             "default".to_string(),
             "missing".to_string(),
             Some(11),
+            None,
+            felix_wire::ORIGINAL_V1_FLAGS,
         )
         .await
     });
@@ -526,6 +533,8 @@ async fn handle_subscribe_message_batches_by_bytes() -> Result<()> {
             "default".to_string(),
             "orders".to_string(),
             Some(21),
+            None,
+            felix_wire::ORIGINAL_V1_FLAGS,
         )
         .await
     });
@@ -648,6 +657,8 @@ async fn lane_fanout_preserves_order_for_multiple_subscribers() -> Result<()> {
                 "default".to_string(),
                 "orders".to_string(),
                 Some(sub_id),
+                None,
+                felix_wire::ORIGINAL_V1_FLAGS,
             )
             .await?;
         }
@@ -854,6 +865,8 @@ async fn handle_subscribe_message_hashed_pool_with_generated_id() -> Result<()> 
             "default".to_string(),
             "orders".to_string(),
             None,
+            None,
+            felix_wire::ORIGINAL_V1_FLAGS,
         )
         .await
     });
@@ -949,6 +962,8 @@ async fn handle_subscribe_message_open_uni_failure_sends_error_ack() -> Result<(
             "default".to_string(),
             "orders".to_string(),
             Some(900),
+            None,
+            felix_wire::ORIGINAL_V1_FLAGS,
         )
         .await
     });
@@ -1024,6 +1039,7 @@ async fn write_parts_many_writes_two_frames_in_order() -> Result<()> {
 async fn run_event_writer_flushes_by_count_and_deadline() -> Result<()> {
     let (tx, rx) = mpsc::channel(8);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 44,
         max_events: 2,
         max_bytes: 1024,
@@ -1073,6 +1089,7 @@ async fn run_event_writer_flushes_by_count_and_deadline() -> Result<()> {
 async fn run_event_writer_flushes_on_channel_close() -> Result<()> {
     let (tx, rx) = mpsc::channel(4);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 55,
         max_events: 8,
         max_bytes: 1024,
@@ -1095,6 +1112,7 @@ async fn run_event_writer_flushes_on_channel_close() -> Result<()> {
 async fn run_event_writer_single_event_mode_writes_multiple_frames() -> Result<()> {
     let (tx, rx) = mpsc::channel(4);
     let config = EventWriterConfig {
+        offsets_enabled: false,
         subscription_id: 66,
         max_events: 2,
         max_bytes: 1024,

--- a/services/broker/src/transport/quic/streams/control.rs
+++ b/services/broker/src/transport/quic/streams/control.rs
@@ -100,6 +100,9 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
     // Otherwise, we will cancel downstream tasks and tear down the connection cooperatively.
     let mut graceful_close = false;
     let mut auth_ctx: Option<AuthContext> = None;
+    // Frame-flag bits the client understands. Narrowed to the pre-negotiation
+    // set until an `Auth` says otherwise.
+    let mut peer_flags = felix_wire::ORIGINAL_V1_FLAGS;
     let authz_ctx = AuthzResponseContext {
         out_ack_tx: &out_ack_tx,
         out_ack_depth: &out_ack_depth,
@@ -257,6 +260,11 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
                 match auth.authenticate(&tenant_id, &token).await {
                     Ok(ctx) => {
                         auth_ctx = Some(ctx);
+                        // Remembered, not just answered: delivery paths need to
+                        // know which optional frame shapes this client can read.
+                        // Absent means a pre-negotiation client, and the only
+                        // safe reading of that silence is the original bits.
+                        peer_flags = client_flags.unwrap_or(felix_wire::ORIGINAL_V1_FLAGS);
                         // Advertise our flag set only to a client that offered its
                         // own. A client that sent no `client_flags` predates
                         // negotiation and would not understand `AuthOk`, so it must
@@ -394,6 +402,7 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
                 namespace,
                 stream,
                 subscription_id,
+                start,
             } => {
                 if !authorize_stream_simple(
                     auth_ctx.as_ref(),
@@ -424,11 +433,26 @@ pub(super) async fn run_control_loop<S: FrameSource + ?Sized>(
                     namespace,
                     stream,
                     subscription_id,
+                    start,
+                    peer_flags,
                 )
                 .await?;
                 if done {
                     return Ok(true);
                 }
+            }
+            // Broker -> client only; a client sending one is a protocol error.
+            Message::SubscribeCursorError { .. } => {
+                send_control_error(
+                    &out_ack_tx,
+                    &out_ack_depth,
+                    &ack_throttle_tx,
+                    &ack_timeout_state,
+                    &cancel_tx,
+                    "subscribe_cursor_error is a server-to-client message",
+                )
+                .await?;
+                return Ok(false);
             }
             Message::CachePut {
                 tenant_id,

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -961,6 +961,7 @@ async fn control_loop_subscribe_forbidden_sends_error() -> Result<()> {
     let frames = vec![
         Ok(Some(frame_from_message(auth_message(&auth)))),
         Ok(Some(frame_from_message(Message::Subscribe {
+            start: None,
             tenant_id: "t1".to_string(),
             namespace: "default".to_string(),
             stream: "updates".to_string(),
@@ -989,6 +990,7 @@ async fn control_loop_subscribe_returns_true() -> Result<()> {
     let frames = vec![
         Ok(Some(frame_from_message(auth_message(&auth)))),
         Ok(Some(frame_from_message(Message::Subscribe {
+            start: None,
             tenant_id: "t1".to_string(),
             namespace: "default".to_string(),
             stream: "missing".to_string(),
@@ -1013,6 +1015,7 @@ async fn control_loop_subscribe_tenant_mismatch_sends_error() -> Result<()> {
     let frames = vec![
         Ok(Some(frame_from_message(auth_message(&auth)))),
         Ok(Some(frame_from_message(Message::Subscribe {
+            start: None,
             tenant_id: "t2".to_string(),
             namespace: "default".to_string(),
             stream: "updates".to_string(),
@@ -1178,6 +1181,7 @@ async fn control_loop_rejects_subscribe_without_auth() -> Result<()> {
     let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
     let auth = auth_fixture("t1", default_perms());
     let frames = vec![Ok(Some(frame_from_message(Message::Subscribe {
+        start: None,
         tenant_id: "t1".to_string(),
         namespace: "default".to_string(),
         stream: "updates".to_string(),
@@ -3022,6 +3026,7 @@ async fn control_loop_subscribe_done_true() -> Result<()> {
     let frames = vec![
         Ok(Some(frame_from_message(auth_message(&auth)))),
         Ok(Some(frame_from_message(Message::Subscribe {
+            start: None,
             tenant_id: "t1".to_string(),
             namespace: "default".to_string(),
             stream: "missing".to_string(),

--- a/services/broker/tests/quic_subscribe.rs
+++ b/services/broker/tests/quic_subscribe.rs
@@ -416,3 +416,229 @@ async fn quic_subscribe_invalid_frame_closes_stream() -> Result<()> {
     server_task.abort();
     Ok(())
 }
+
+/// The acceptance criterion of #177, end to end over QUIC: a client that
+/// disconnects, reconnects with the offset it last handled, and resumes must
+/// receive every record published in between, exactly once, in order.
+///
+/// Everything before this test exercised the broker API directly. This is the
+/// only one that proves the *wire* carries it: the start position out, the
+/// offsets back, and the join between disk history and live delivery.
+#[tokio::test]
+#[serial]
+async fn quic_subscribe_resumes_from_a_checkpointed_offset() -> Result<()> {
+    unsafe {
+        std::env::set_var("FELIX_ACK_ON_COMMIT", "false");
+    }
+    let dir = tempfile::tempdir()?;
+    let storage = felix_broker::DurableStorage::open(
+        dir.path(),
+        felix_storage::log::LogConfig {
+            // Small enough that the run rolls segments, so history is read
+            // across a boundary rather than out of one file.
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: felix_storage::log::FsyncMode::None,
+            preallocate_segments: false,
+            ..Default::default()
+        },
+    )?;
+    let broker = Arc::new(
+        Broker::new(EphemeralCache::new().into())
+            .with_durable_storage(storage)
+            // A replay ring far smaller than the record count, so the resume
+            // has to come off disk instead of out of memory.
+            .with_log_capacity(4)?,
+    );
+    broker.register_tenant("t1").await?;
+    broker.register_namespace("t1", "default").await?;
+    broker
+        .register_stream(
+            "t1",
+            "default",
+            "orders",
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await?;
+
+    let (server_config, cert) = build_server_config()?;
+    let server = Arc::new(QuicServer::bind(
+        "127.0.0.1:0".parse()?,
+        server_config,
+        TransportConfig::default(),
+    )?);
+    let addr = server.local_addr()?;
+    let config = broker::config::BrokerConfig::from_env()?;
+    let auth = auth_fixture(
+        "t1",
+        vec![
+            "stream.publish:stream:t1/*/*".to_string(),
+            "stream.subscribe:stream:t1/*/*".to_string(),
+        ],
+    );
+    let server_task = tokio::spawn(broker::quic::serve(
+        Arc::clone(&server),
+        Arc::clone(&broker),
+        config,
+        Arc::clone(&auth.auth),
+    ));
+
+    const TOTAL: usize = 40;
+    let client =
+        Client::connect(addr, "localhost", build_client_config(cert.clone(), &auth)?).await?;
+    let publisher = client.publisher().await?;
+
+    // Phase 1: subscribe live, take the first few, then "crash".
+    let mut sub = client.subscribe("t1", "default", "orders").await?;
+    for i in 0..5usize {
+        publisher
+            .publish(
+                "t1",
+                "default",
+                "orders",
+                format!("v{i:03}").into_bytes(),
+                felix_wire::AckMode::None,
+            )
+            .await?;
+    }
+    let mut seen = Vec::new();
+    let mut checkpoint = None;
+    while seen.len() < 5 {
+        let Some(event) = timeout(Duration::from_secs(5), sub.next_event()).await?? else {
+            continue;
+        };
+        checkpoint = Some(
+            event
+                .offset
+                .expect("a durable stream must report offsets on live delivery"),
+        );
+        seen.push(String::from_utf8(event.payload.to_vec())?);
+    }
+    drop(sub);
+    let checkpoint = checkpoint.expect("checkpoint");
+    assert_eq!(checkpoint, 4, "five records occupy offsets 0..=4");
+
+    // Phase 2: publish while nobody is subscribed. These are exactly the records
+    // a tail-only reconnect loses, and there are far more than the ring holds.
+    for i in 5..TOTAL {
+        publisher
+            .publish(
+                "t1",
+                "default",
+                "orders",
+                format!("v{i:03}").into_bytes(),
+                felix_wire::AckMode::None,
+            )
+            .await?;
+    }
+
+    // Phase 3: reconnect and resume from the offset after the last one handled.
+    let client2 = Client::connect(addr, "localhost", build_client_config(cert, &auth)?).await?;
+    let mut resumed = client2
+        .subscribe_from(
+            "t1",
+            "default",
+            "orders",
+            Some(felix_client::StartPosition::Offset(checkpoint + 1)),
+        )
+        .await?;
+
+    while seen.len() < TOTAL {
+        let Some(event) = timeout(Duration::from_secs(10), resumed.next_event()).await?? else {
+            continue;
+        };
+        let offset = event.offset.expect("resumed events carry offsets");
+        assert_eq!(
+            offset as usize,
+            seen.len(),
+            "offsets must be contiguous and match position",
+        );
+        seen.push(String::from_utf8(event.payload.to_vec())?);
+    }
+
+    let expected: Vec<String> = (0..TOTAL).map(|i| format!("v{i:03}")).collect();
+    assert_eq!(
+        seen, expected,
+        "resume must lose nothing and duplicate nothing"
+    );
+
+    drop(resumed);
+    server_task.abort();
+    Ok(())
+}
+
+/// Asking for an offset the log has already passed the end of is a typed
+/// protocol error, not a silent restart at the tail.
+#[tokio::test]
+#[serial]
+async fn quic_subscribe_rejects_a_cursor_past_the_tail() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let storage = felix_broker::DurableStorage::open(
+        dir.path(),
+        felix_storage::log::LogConfig {
+            fsync_mode: felix_storage::log::FsyncMode::None,
+            preallocate_segments: false,
+            ..Default::default()
+        },
+    )?;
+    let broker = Arc::new(Broker::new(EphemeralCache::new().into()).with_durable_storage(storage));
+    broker.register_tenant("t1").await?;
+    broker.register_namespace("t1", "default").await?;
+    broker
+        .register_stream(
+            "t1",
+            "default",
+            "orders",
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+            },
+        )
+        .await?;
+
+    let (server_config, cert) = build_server_config()?;
+    let server = Arc::new(QuicServer::bind(
+        "127.0.0.1:0".parse()?,
+        server_config,
+        TransportConfig::default(),
+    )?);
+    let addr = server.local_addr()?;
+    let config = broker::config::BrokerConfig::from_env()?;
+    let auth = auth_fixture(
+        "t1",
+        vec![
+            "stream.publish:stream:t1/*/*".to_string(),
+            "stream.subscribe:stream:t1/*/*".to_string(),
+        ],
+    );
+    let server_task = tokio::spawn(broker::quic::serve(
+        Arc::clone(&server),
+        Arc::clone(&broker),
+        config,
+        Arc::clone(&auth.auth),
+    ));
+
+    let client = Client::connect(addr, "localhost", build_client_config(cert, &auth)?).await?;
+    let err = client
+        .subscribe_from(
+            "t1",
+            "default",
+            "orders",
+            Some(felix_client::StartPosition::Offset(9_999)),
+        )
+        .await
+        .err()
+        .expect("9999 is far past the tail");
+    let typed = err
+        .downcast_ref::<felix_client::SubscribeCursorError>()
+        .expect("a typed cursor error, not a formatted string");
+    assert_eq!(typed.reason, felix_client::CursorErrorReason::InFuture);
+    assert_eq!(typed.requested, 9_999);
+    assert_eq!(typed.available, 0);
+
+    server_task.abort();
+    Ok(())
+}


### PR DESCRIPTION
Closes #177 — the last M1 data-plane gap. Durable records survived a restart, but nothing could replay them over the wire: a reconnecting client silently restarted at the tail, which from the application's point of view is the same outcome as having no durability at all.

## What lands

`Subscribe` takes an optional `start` (`latest` / `earliest` / an exact offset), and every delivered event carries its offset so a client has something to checkpoint. Omitting `start` produces byte-for-byte the frame clients already sent; offsets ride a negotiated flag bit (`FLAG_EVENT_BATCH_OFFSETS`, `0x0020`), so old and new peers interoperate in both directions.

## The seam, which is the hard part

The correct ordering is not the obvious one. The live subscription is registered **first**, clamped to the oldest entry the replay ring holds, under the single lock that also takes the backlog. That makes the remaining disk range *closed*: everything from `backlog_start` onward is already captured, so nothing can be evicted out of it while it is read.

Reading history first and subscribing after is the version that looks natural and loses every publish landing in between.

Offsets are **carried, never derived**. The replay ring can contain holes — a publish that consumed disk offsets and was cancelled before reaching the ring leaves one — so numbering payloads sequentially from the requested offset both mislabels everything after a hole and hides the missing record. Batches are cut on a gap in offsets as well as on count and byte limits, because one `base_offset` describes a batch only while its records are contiguous.

## Also closed, each of which could lose or mislabel records alone

| | |
|---|---|
| **Flow-control deadlock** | The client waits for `Subscribed` before reading the event stream, so writing replay first deadlocked once history exceeded the 64 MiB stream window. Small replays fit and hid it. Now acknowledged before streaming. |
| **Live records dropped during replay** | The live subscriber's ordinary bounded queue drops under `DropNew`, so a long replay lost records. Whatever queued is now drained and any gap backfilled from disk — disk is the authority, the queue only a shortcut for what has not been evicted. |
| **Live delivery carried no offsets** | A resumed client got offsets for its history and then nothing at the live edge, exactly where it needs to start checkpointing. The envelope caches the offset-bearing and plain encodings separately, so a stream with subscribers of both kinds costs at most two encodings per batch however many subscribers there are — encode-once fanout still holds. |
| **Registration leak** | A subscriber was registered before the too-old check could reject it, stranding a closed sender until some later publish reaped it. The guard is now built at registration, so every error path releases by `Drop`. |
| **Future offsets** | A request past the tail registered for live delivery and then handed over records *below* what was asked for. Now a typed `CursorInFuture`. |
| **Unbounded replay frames** | Backlog was chunked by count alone and could build a frame past the configured limits. |
| **Silent downgrade** | The client had the negotiated flags and ignored them, so resuming against an older broker quietly became a tail subscription. Now a hard error; `Latest` still falls back safely. |

`CursorTooOld` and `CursorInFuture` reach the client as a typed `SubscribeCursorError` carrying `requested` and `available`, not a formatted string — the two have opposite remedies and have to be distinguishable in code.

## Verification

Two end-to-end QUIC acceptance tests, **both verified by inversion**:

- `quic_subscribe_resumes_from_a_checkpointed_offset` — subscribe live, take 5 events and checkpoint, drop the connection, publish 35 more with nobody listening (far more than the 4-entry ring, across rolled segments), reconnect on a fresh client, resume at `checkpoint + 1`, assert all 40 arrive contiguously with offsets matching position. Sending `start: None` makes it fail on the disconnected records; dropping the offset from the delivery envelope makes it fail on *"a durable stream must report offsets on live delivery"*.
- `quic_subscribe_rejects_a_cursor_past_the_tail` — a past-the-tail cursor returns typed `InFuture`, not a silent tail subscription.

Plus 30 broker tests covering the seam, ring holes, the registration leak (50 rejected subscribes leave 0 registrations — fails with 50 without the fix), and both directions of stranded preparation.

`task lint`, `task test` (62 binaries, 0 failures), `task demo:check`, and 74 mermaid diagrams all pass.

## Docs

`protocol.md` documents `start`, the offset fields, the `0x0020` layout and the `subscribe_cursor_error` frame; its "Subscribe starts at tail (no historical replay)" line is now false and gone. `durable-storage.md` gains a *Resuming a subscription* section explaining why registering first is what makes it correct.

The status page had drifted the other way too: durable storage shipped in M1 but sat under *"None of the following exists today"* and was missing from the capability table entirely. Both capabilities move up with their real caveats, and retention appears as its own target row so its absence stays visible.

Adds `CLAUDE.md`.

## Known limits

- No retention, so a durable stream grows without bound and `CursorTooOld` is currently only reachable for in-memory streams.
- Catch-up is bounded at 8 passes; a stream published faster than it can be written hands over to live delivery. Because offsets are on the wire, any residual gap is *visible* to the client rather than silent.
- No offset conformance vectors yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)