### PR TITLE
perf: fix MTU black-hole collapse, pipeline acked publishes, add fast chart pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ name = "felix-transport"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "libc",
  "quinn",
  "rcgen",
  "rustls",
@@ -1763,9 +1764,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -196,5 +196,18 @@ tasks:
         "$PY" scripts/perf/normalize_and_aggregate.py
         "$PY" scripts/perf/make_charts.py
         "$PY" scripts/perf/render_markdown_snippets.py
+  perf:fast:
+    desc: "Fast chart pass (~15-20 min vs hours): one profile, 5 presets, 3 trials; only the two chart-bearing shapes (acked-latency json batch=1, sustained-throughput binary batch=64)"
+    cmds:
+      - |
+        PY=$([ -x .venv-perf/bin/python ] && echo .venv-perf/bin/python || echo python3)
+        # One shared session id so both filtered halves aggregate together;
+        # normalize_and_aggregate keeps only the latest session by default.
+        export FELIX_PERF_SESSION_ID=$(uuidgen | tr 'A-Z' 'a-z')
+        "$PY" scripts/perf/run_latency_matrix.py --config scripts/perf/fast.yml --filter 'batch=1,binary=False'
+        "$PY" scripts/perf/run_latency_matrix.py --config scripts/perf/fast.yml --filter 'batch=64,binary=True'
+        "$PY" scripts/perf/normalize_and_aggregate.py
+        "$PY" scripts/perf/make_charts.py --config scripts/perf/fast.yml
+        "$PY" scripts/perf/render_markdown_snippets.py --config scripts/perf/fast.yml
   conformance:
     cmds: ["cargo run -p felix-conformance"]

--- a/crates/felix-authz/src/token.rs
+++ b/crates/felix-authz/src/token.rs
@@ -1,23 +1,20 @@
-//! Felix token minting and verification for the broker/control-plane boundary.
+//! Shared Felix token minting and verification across the broker/control-plane
+//! boundary.
 //!
-//! Provide shared, EdDSA-only JWT minting and verification logic for Felix
-//! tokens, plus key caching to reduce per-request overhead.
+//! EdDSA (Ed25519) only -- RSA and HS algorithms are rejected rather than
+//! supported, because the caller supplies the token and accepting a second
+//! algorithm means accepting whichever is weakest. `iss`, `aud`, `tid` and the
+//! signature are all checked before a token is trusted.
 //!
-//! - Felix tokens are always EdDSA (Ed25519); RSA/HS algorithms are rejected.
-//! - `iss`, `aud`, and `tid` claims are mandatory and validated.
-//! - Public keys must match the stored 32-byte Ed25519 seed.
+//! Private keys never leave this module serialized; PKCS8 DER is built in
+//! memory only to hand to `jsonwebtoken`. `kid` drives rotation and cache
+//! lookup and is not a secret.
 //!
-//! - Attackers may present arbitrary JWTs; we validate algorithm, issuer,
-//!   audience, tenant ID, and signature before accepting.
-//! - Private keys are never serialized in this module; only in-memory PKCS8
-//!   DER is constructed for `jsonwebtoken`.
-//! - `kid` is used for rotation and caching, not as a secret.
+//! Key caches sit behind an `RwLock` for concurrent readers, and verification
+//! tries keys in `kid`-preferred order so the common case is one attempt.
 //!
-//! - Encoding/decoding key caches use `RwLock` for concurrent readers.
-//! - Verification attempts keys in `kid`-preferred order to reduce failures.
-//!
-//! Use [`FelixTokenIssuer`] to mint tokens and [`FelixTokenVerifier`] to verify
-//! them, providing a [`TenantKeyStore`] implementation for key access.
+//! [`FelixTokenIssuer`] mints; [`FelixTokenVerifier`] verifies; both need a
+//! [`TenantKeyStore`] for key access.
 //!
 //! # Examples
 //! ```rust
@@ -38,14 +35,6 @@
 //! let issuer = FelixTokenIssuer::new("felix-auth", "felix-broker", Duration::from_secs(60), Arc::new(store));
 //! let _ = issuer.mint(&TenantId::new("t1"), "principal", vec![]);
 //! ```
-//!
-//! # Common pitfalls
-//! - Using mismatched issuer/audience values between issuer and verifier.
-//! - Forgetting to invalidate the cache when rotating keys.
-//! - Passing non-Ed25519 keys, which are explicitly rejected.
-//!
-//! # Future work
-//! - Add background JWKS refresh and cache eviction policies.
 use crate::{AuthzError, AuthzResult, Jwks, TenantId};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -278,23 +267,6 @@ pub trait TenantKeyStore: Send + Sync {
     /// - [`AuthzError::MissingJwks`] when JWKS is absent.
     ///
     /// - JWKS must never contain private key material.
-    ///
-    /// # Example
-    /// ```rust
-    /// use felix_authz::{TenantId, TenantKeyStore, TenantKeyMaterial, Jwks};
-    /// use jsonwebtoken::Algorithm;
-    /// use std::collections::HashMap;
-    ///
-    /// let mut store: HashMap<String, TenantKeyMaterial> = HashMap::new();
-    /// store.insert("t1".to_string(), TenantKeyMaterial {
-    ///     kid: "k1".to_string(),
-    ///     alg: Algorithm::EdDSA,
-    ///     private_key: [1u8; 32],
-    ///     public_key: [2u8; 32],
-    ///     jwks: Jwks { keys: vec![] },
-    /// });
-    /// let _ = store.jwks(&TenantId::new("t1"));
-    /// ```
     fn jwks(&self, tenant_id: &TenantId) -> AuthzResult<Jwks>;
 }
 
@@ -386,26 +358,6 @@ impl TenantKeyStore for HashMap<String, TenantKeyMaterial> {
 ///
 /// # Concurrency
 /// - Cloning the issuer shares the underlying cache and key store.
-///
-/// # Example
-/// ```rust
-/// use felix_authz::{FelixTokenIssuer, TenantId, TenantKeyMaterial, Jwks};
-/// use jsonwebtoken::Algorithm;
-/// use std::collections::HashMap;
-/// use std::sync::Arc;
-/// use std::time::Duration;
-///
-/// let mut store = HashMap::new();
-/// store.insert("t1".to_string(), TenantKeyMaterial {
-///     kid: "k1".to_string(),
-///     alg: Algorithm::EdDSA,
-///     private_key: [1u8; 32],
-///     public_key: [2u8; 32],
-///     jwks: Jwks { keys: vec![] },
-/// });
-/// let issuer = FelixTokenIssuer::new("felix-auth", "felix-broker", Duration::from_secs(60), Arc::new(store));
-/// let _ = issuer.mint(&TenantId::new("t1"), "principal", vec![]);
-/// ```
 pub struct FelixTokenIssuer {
     issuer: String,
     audience: String,
@@ -517,26 +469,6 @@ impl FelixTokenIssuer {
     /// - Tokens should be treated as secrets and not logged.
     ///
     /// - Uses a cached encoding key to avoid repeated PKCS8 conversion.
-    ///
-    /// # Example
-    /// ```rust
-    /// use felix_authz::{FelixTokenIssuer, TenantId, TenantKeyMaterial, Jwks};
-    /// use jsonwebtoken::Algorithm;
-    /// use std::collections::HashMap;
-    /// use std::sync::Arc;
-    /// use std::time::Duration;
-    ///
-    /// let mut store = HashMap::new();
-    /// store.insert("t1".to_string(), TenantKeyMaterial {
-    ///     kid: "k1".to_string(),
-    ///     alg: Algorithm::EdDSA,
-    ///     private_key: [1u8; 32],
-    ///     public_key: [2u8; 32],
-    ///     jwks: Jwks { keys: vec![] },
-    /// });
-    /// let issuer = FelixTokenIssuer::new("felix-auth", "felix-broker", Duration::from_secs(60), Arc::new(store));
-    /// let _ = issuer.mint(&TenantId::new("t1"), "principal", vec![]);
-    /// ```
     pub fn mint(
         &self,
         tenant_id: &TenantId,

--- a/crates/felix-client/src/client/client.rs
+++ b/crates/felix-client/src/client/client.rs
@@ -72,6 +72,44 @@ pub struct Client {
     runtime_config: ClientRuntimeConfig,
 }
 
+/// Periodic path stats for client-side connections, mirroring the broker's
+/// `FELIX_CONN_STATS_MS` logging. The client is the sender on the publish path,
+/// so its cwnd/rtt is invisible from broker-side stats. Off unless set.
+fn spawn_conn_stats_logger(connection: &QuicConnection, role: &'static str) {
+    let Some(interval_ms) = std::env::var("FELIX_CONN_STATS_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+    else {
+        return;
+    };
+    let connection = connection.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(std::time::Duration::from_millis(interval_ms));
+        loop {
+            ticker.tick().await;
+            if connection.close_reason().is_some() {
+                break;
+            }
+            let stats = connection.stats();
+            tracing::info!(
+                role,
+                conn = connection.info().id.0,
+                mtu = stats.path.current_mtu,
+                cwnd = stats.path.cwnd,
+                rtt_us = stats.path.rtt.as_micros() as u64,
+                congestion_events = stats.path.congestion_events,
+                lost_packets = stats.path.lost_packets,
+                udp_tx_bytes = stats.udp_tx.bytes,
+                udp_tx_datagrams = stats.udp_tx.datagrams,
+                tx_data_blocked = stats.frame_tx.data_blocked,
+                tx_stream_data_blocked = stats.frame_tx.stream_data_blocked,
+                "client quic connection path stats"
+            );
+        }
+    });
+}
+
 impl Client {
     pub async fn connect(
         addr: SocketAddr,
@@ -114,6 +152,7 @@ impl Client {
         for _ in 0..publish_pool_size {
             let connection = publish_client.connect(addr, server_name).await?;
             debug!("client established publish connection");
+            spawn_conn_stats_logger(&connection, "publish");
             publish_connections.push(connection);
         }
         let mut publish_workers = Vec::with_capacity(publish_pool_size * publish_streams_per_conn);
@@ -131,6 +170,11 @@ impl Client {
                 .await?;
                 debug!(server_flags, "client publish stream authenticated");
                 let (tx, rx) = mpsc::channel(publish_queue_depth);
+                // Not colocated with the transport drivers (unlike the
+                // subscription read pump): publisher writers block in
+                // `write_all` against a full send window, and parking them on
+                // the I/O thread starves the drivers they wait on (measured 5x
+                // throughput loss).
                 let handle = tokio::spawn(run_publisher_writer_with_limit(
                     send,
                     recv,
@@ -395,6 +439,7 @@ impl Client {
         .increment(1);
         Ok(Subscription::spawn_pipeline(SubscriptionPipelineConfig {
             recv,
+            connection: connection.clone(),
             queue_capacity: self.runtime_config.client_sub_queue_capacity.max(1),
             queue_policy: self.runtime_config.client_sub_queue_policy,
             subscription_id,

--- a/crates/felix-client/src/client/publisher.rs
+++ b/crates/felix-client/src/client/publisher.rs
@@ -739,131 +739,124 @@ struct PendingAck {
     item_count: u64,
 }
 
-/// Upper bound on acked publishes in flight per stream. The byte budget
-/// (`PublishAdmission`) is the real limit; this only bounds the queue's
-/// memory when payloads are tiny.
-const MAX_PENDING_ACKS: usize = 1024;
-
-/// Resolve broker acks for pipelined acked publishes, in write order.
-///
-/// Runs beside the writer so an acked publish costs a queue hop instead of
-/// stalling the stream for a full round trip: when the writer awaited each
-/// ack inline, acked throughput per stream was capped at one request per RTT.
-/// Acks arrive strictly in request order, so pendings resolve FIFO. Any ack
-/// failure — timeout, decode error, broker `PublishError` — is fatal for the
-/// worker exactly as it was inline; requests already queued behind the
-/// failure are failed with the same message.
-async fn run_publish_ack_reader(
-    mut recv: RecvStream,
-    mut pending_rx: mpsc::Receiver<PendingAck>,
-    max_frame_bytes: usize,
-) -> (RecvStream, Result<()>) {
-    let mut ack_scratch = BytesMut::with_capacity(64 * 1024);
-    while let Some(pending) = pending_rx.recv().await {
-        match wait_for_ack(
-            &mut recv,
-            pending.request_id,
-            &mut ack_scratch,
-            max_frame_bytes,
-        )
-        .await
-        {
-            Ok(()) => {
-                #[cfg(feature = "telemetry")]
-                {
-                    let counters = frame_counters();
-                    counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
-                    counters
-                        .pub_batches_out_ok
-                        .fetch_add(pending.batch_count, Ordering::Relaxed);
-                    counters
-                        .pub_items_out_ok
-                        .fetch_add(pending.item_count, Ordering::Relaxed);
-                }
-                let _ = pending.response.send(Ok(()));
-            }
-            Err(err) => {
-                #[cfg(feature = "telemetry")]
-                {
-                    let counters = frame_counters();
-                    counters.pub_frames_out_err.fetch_add(1, Ordering::Relaxed);
-                    counters
-                        .pub_batches_out_err
-                        .fetch_add(pending.batch_count, Ordering::Relaxed);
-                    counters
-                        .pub_items_out_err
-                        .fetch_add(pending.item_count, Ordering::Relaxed);
-                }
-                let message = err.to_string();
-                let _ = pending.response.send(Err(err));
-                pending_rx.close();
-                while let Some(stale) = pending_rx.recv().await {
-                    #[cfg(feature = "telemetry")]
-                    {
-                        let counters = frame_counters();
-                        counters.pub_frames_out_err.fetch_add(1, Ordering::Relaxed);
-                        counters
-                            .pub_batches_out_err
-                            .fetch_add(stale.batch_count, Ordering::Relaxed);
-                        counters
-                            .pub_items_out_err
-                            .fetch_add(stale.item_count, Ordering::Relaxed);
-                    }
-                    let _ = stale.response.send(Err(anyhow::anyhow!(message.clone())));
-                }
-                return (recv, Err(anyhow::anyhow!(message)));
-            }
-        }
-    }
-    (recv, Ok(()))
-}
-
 pub(crate) async fn run_publisher_writer_with_limit(
     mut send: SendStream,
-    recv: RecvStream,
+    mut recv: RecvStream,
     mut rx: mpsc::Receiver<PublishRequest>,
     _chunk_bytes: usize,
     max_frame_bytes: usize,
 ) -> Result<()> {
     // Single writer: serialize publish requests over one bi-directional
-    // stream. Acked publishes are pipelined — written back to back and
-    // resolved by the ack reader as the broker answers — so the ordering
-    // guarantee costs a queue hop per request instead of a round trip.
-    let (pending_tx, pending_rx) = mpsc::channel::<PendingAck>(MAX_PENDING_ACKS);
-    let mut reader = tokio::spawn(run_publish_ack_reader(recv, pending_rx, max_frame_bytes));
+    // stream. Acked publishes pipeline — written back to back, their acks
+    // resolved in order once the write queue drains — so concurrent
+    // publishers on a stream are not capped at one request per round trip.
+    //
+    // Pending acks are held here rather than handed to a reader task: a
+    // publisher that awaits each publish before issuing the next has nothing
+    // to pipeline, and a channel hop plus a task wakeup on that path is pure
+    // latency (~2-3% of a loopback RTT). With the queue in-task, the serial
+    // case resolves its ack inline exactly as it did before pipelining, and
+    // only a caller with work actually queued behind it pays for batching.
+    //
+    // Depth is bounded by the publisher's in-flight byte budget
+    // (`publish_inflight_bytes`), since each entry holds its admission permit
+    // until the broker answers.
+    let mut ack_scratch = BytesMut::with_capacity(64 * 1024);
     let mut json_scratch = BytesMut::with_capacity(64 * 1024);
-    // On any failure the worker tears down: fail the current caller, fail
-    // everything the reader still holds, then drain the request queue with
-    // the same message so later callers see why.
+    let mut pending: VecDeque<PendingAck> = VecDeque::new();
+
+    // Resolve every outstanding ack, in the order the requests were written.
+    // Any failure is fatal for this worker, exactly as the inline wait was:
+    // the caller sees it, so does everything queued behind it.
+    macro_rules! resolve_pending {
+        () => {{
+            while let Some(entry) = pending.pop_front() {
+                match wait_for_ack(
+                    &mut recv,
+                    entry.request_id,
+                    &mut ack_scratch,
+                    max_frame_bytes,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
+                            counters
+                                .pub_batches_out_ok
+                                .fetch_add(entry.batch_count, Ordering::Relaxed);
+                            counters
+                                .pub_items_out_ok
+                                .fetch_add(entry.item_count, Ordering::Relaxed);
+                        }
+                        let _ = entry.response.send(Ok(()));
+                    }
+                    Err(err) => {
+                        #[cfg(feature = "telemetry")]
+                        {
+                            let counters = frame_counters();
+                            counters.pub_frames_out_err.fetch_add(1, Ordering::Relaxed);
+                            counters
+                                .pub_batches_out_err
+                                .fetch_add(entry.batch_count, Ordering::Relaxed);
+                            counters
+                                .pub_items_out_err
+                                .fetch_add(entry.item_count, Ordering::Relaxed);
+                        }
+                        let message = err.to_string();
+                        let _ = entry.response.send(Err(err));
+                        for stale in pending.drain(..) {
+                            let _ = stale.response.send(Err(anyhow::anyhow!(message.clone())));
+                        }
+                        drain_publish_queue(&mut rx, &message).await;
+                        return Err(anyhow::anyhow!(message));
+                    }
+                }
+            }
+        }};
+    }
+    // On a write failure: fail the caller, then everything already written
+    // and everything still queued, with the same message.
     macro_rules! fail_worker {
         ($message:expr) => {{
             let message: String = $message;
-            drop(pending_tx);
-            let _ = (&mut reader).await;
+            for stale in pending.drain(..) {
+                let _ = stale.response.send(Err(anyhow::anyhow!(message.clone())));
+            }
             drain_publish_queue(&mut rx, &message).await;
             return Err(anyhow::anyhow!(message));
         }};
     }
-    // Hand a written acked request to the ack reader; fatal if the reader is
-    // gone (it only exits early after an ack failure, which is fatal anyway).
     macro_rules! submit_pending {
         ($pending:expr) => {{
-            if let Err(send_err) = pending_tx.send($pending).await {
-                let message = match (&mut reader).await {
-                    Ok((_recv, Err(reader_err))) => reader_err.to_string(),
-                    _ => "publish ack reader stopped".to_string(),
-                };
-                let _ = send_err
-                    .0
-                    .response
-                    .send(Err(anyhow::anyhow!(message.clone())));
-                drain_publish_queue(&mut rx, &message).await;
-                return Err(anyhow::anyhow!(message));
-            }
+            pending.push_back($pending);
         }};
     }
     let mut finish_response: Option<oneshot::Sender<Result<()>>> = None;
-    while let Some(request) = rx.recv().await {
+    loop {
+        let request = if pending.is_empty() {
+            match rx.recv().await {
+                Some(request) => request,
+                None => break,
+            }
+        } else {
+            // Acks outstanding: keep writing while work is immediately
+            // available (that is what pipelining buys), otherwise settle up
+            // before parking.
+            match rx.try_recv() {
+                Ok(request) => request,
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                    resolve_pending!();
+                    continue;
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    resolve_pending!();
+                    break;
+                }
+            }
+        };
         match request {
             PublishRequest::Message {
                 message,
@@ -1181,35 +1174,31 @@ pub(crate) async fn run_publisher_writer_with_limit(
                 }
             }
             PublishRequest::Finish { response } => {
+                // Settle what is already written before closing, so those
+                // callers get their acks rather than a stream teardown.
+                resolve_pending!();
                 finish_response = Some(response);
                 break;
             }
         }
     }
-    // Graceful shutdown: close our send side, then let the ack reader resolve
-    // every pending ack and hand `recv` back so the stream can be drained to
-    // EOF — the same close protocol `finish_publisher_stream` implements for
-    // the non-pipelined paths.
-    drop(pending_tx);
+    // Graceful shutdown: close our send side, then drain the peer's side to
+    // EOF — the same close protocol `finish_publisher_stream` implements.
     let finish_result = send.finish().map_err(anyhow::Error::from);
-    let result = match reader.await.context("join publish ack reader") {
-        Ok((mut recv, reader_result)) => {
-            let drain_result = async {
-                reader_result?;
-                let mut buf = [0u8; 8192];
-                loop {
-                    match recv.read(&mut buf).await {
-                        Ok(Some(_)) => continue,
-                        Ok(None) => break,
-                        Err(err) => return Err(err.into()),
-                    }
+    let result = {
+        let drain_result = async {
+            let mut buf = [0u8; 8192];
+            loop {
+                match recv.read(&mut buf).await {
+                    Ok(Some(_)) => continue,
+                    Ok(None) => break,
+                    Err(err) => return Err(err.into()),
                 }
-                Ok(())
             }
-            .await;
-            finish_result.and(drain_result)
+            Ok(())
         }
-        Err(err) => finish_result.and(Err(err)),
+        .await;
+        finish_result.and(drain_result)
     };
     if let Some(response) = finish_response {
         let _ = response.send(match &result {

--- a/crates/felix-client/src/client/publisher.rs
+++ b/crates/felix-client/src/client/publisher.rs
@@ -17,8 +17,7 @@ use crate::counters::frame_counters;
 #[cfg(feature = "telemetry")]
 use crate::timings;
 use crate::wire::{
-    maybe_append_publish_ts, maybe_append_publish_ts_batch, maybe_wait_for_ack_with_limit,
-    write_frame_parts,
+    maybe_append_publish_ts, maybe_append_publish_ts_batch, wait_for_ack, write_frame_parts,
 };
 
 use super::sharding::PublishSharding;
@@ -725,16 +724,145 @@ pub(crate) async fn run_publisher_writer(
     .await
 }
 
+/// A publish that has been written to the stream but whose broker ack has not
+/// arrived yet. The admission permit rides along so the in-flight byte budget
+/// stays reserved until the broker answers, not merely until the frame is
+/// written.
+struct PendingAck {
+    request_id: u64,
+    response: oneshot::Sender<Result<()>>,
+    _permit: OwnedSemaphorePermit,
+    // Read only by the telemetry counters in the ack reader.
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    batch_count: u64,
+    #[cfg_attr(not(feature = "telemetry"), allow(dead_code))]
+    item_count: u64,
+}
+
+/// Upper bound on acked publishes in flight per stream. The byte budget
+/// (`PublishAdmission`) is the real limit; this only bounds the queue's
+/// memory when payloads are tiny.
+const MAX_PENDING_ACKS: usize = 1024;
+
+/// Resolve broker acks for pipelined acked publishes, in write order.
+///
+/// Runs beside the writer so an acked publish costs a queue hop instead of
+/// stalling the stream for a full round trip: when the writer awaited each
+/// ack inline, acked throughput per stream was capped at one request per RTT.
+/// Acks arrive strictly in request order, so pendings resolve FIFO. Any ack
+/// failure — timeout, decode error, broker `PublishError` — is fatal for the
+/// worker exactly as it was inline; requests already queued behind the
+/// failure are failed with the same message.
+async fn run_publish_ack_reader(
+    mut recv: RecvStream,
+    mut pending_rx: mpsc::Receiver<PendingAck>,
+    max_frame_bytes: usize,
+) -> (RecvStream, Result<()>) {
+    let mut ack_scratch = BytesMut::with_capacity(64 * 1024);
+    while let Some(pending) = pending_rx.recv().await {
+        match wait_for_ack(
+            &mut recv,
+            pending.request_id,
+            &mut ack_scratch,
+            max_frame_bytes,
+        )
+        .await
+        {
+            Ok(()) => {
+                #[cfg(feature = "telemetry")]
+                {
+                    let counters = frame_counters();
+                    counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
+                    counters
+                        .pub_batches_out_ok
+                        .fetch_add(pending.batch_count, Ordering::Relaxed);
+                    counters
+                        .pub_items_out_ok
+                        .fetch_add(pending.item_count, Ordering::Relaxed);
+                }
+                let _ = pending.response.send(Ok(()));
+            }
+            Err(err) => {
+                #[cfg(feature = "telemetry")]
+                {
+                    let counters = frame_counters();
+                    counters.pub_frames_out_err.fetch_add(1, Ordering::Relaxed);
+                    counters
+                        .pub_batches_out_err
+                        .fetch_add(pending.batch_count, Ordering::Relaxed);
+                    counters
+                        .pub_items_out_err
+                        .fetch_add(pending.item_count, Ordering::Relaxed);
+                }
+                let message = err.to_string();
+                let _ = pending.response.send(Err(err));
+                pending_rx.close();
+                while let Some(stale) = pending_rx.recv().await {
+                    #[cfg(feature = "telemetry")]
+                    {
+                        let counters = frame_counters();
+                        counters.pub_frames_out_err.fetch_add(1, Ordering::Relaxed);
+                        counters
+                            .pub_batches_out_err
+                            .fetch_add(stale.batch_count, Ordering::Relaxed);
+                        counters
+                            .pub_items_out_err
+                            .fetch_add(stale.item_count, Ordering::Relaxed);
+                    }
+                    let _ = stale.response.send(Err(anyhow::anyhow!(message.clone())));
+                }
+                return (recv, Err(anyhow::anyhow!(message)));
+            }
+        }
+    }
+    (recv, Ok(()))
+}
+
 pub(crate) async fn run_publisher_writer_with_limit(
     mut send: SendStream,
-    mut recv: RecvStream,
+    recv: RecvStream,
     mut rx: mpsc::Receiver<PublishRequest>,
     _chunk_bytes: usize,
     max_frame_bytes: usize,
 ) -> Result<()> {
-    // Single writer: serialize publish requests over one bi-directional stream.
-    let mut ack_scratch = BytesMut::with_capacity(64 * 1024);
+    // Single writer: serialize publish requests over one bi-directional
+    // stream. Acked publishes are pipelined — written back to back and
+    // resolved by the ack reader as the broker answers — so the ordering
+    // guarantee costs a queue hop per request instead of a round trip.
+    let (pending_tx, pending_rx) = mpsc::channel::<PendingAck>(MAX_PENDING_ACKS);
+    let mut reader = tokio::spawn(run_publish_ack_reader(recv, pending_rx, max_frame_bytes));
     let mut json_scratch = BytesMut::with_capacity(64 * 1024);
+    // On any failure the worker tears down: fail the current caller, fail
+    // everything the reader still holds, then drain the request queue with
+    // the same message so later callers see why.
+    macro_rules! fail_worker {
+        ($message:expr) => {{
+            let message: String = $message;
+            drop(pending_tx);
+            let _ = (&mut reader).await;
+            drain_publish_queue(&mut rx, &message).await;
+            return Err(anyhow::anyhow!(message));
+        }};
+    }
+    // Hand a written acked request to the ack reader; fatal if the reader is
+    // gone (it only exits early after an ack failure, which is fatal anyway).
+    macro_rules! submit_pending {
+        ($pending:expr) => {{
+            if let Err(send_err) = pending_tx.send($pending).await {
+                let message = match (&mut reader).await {
+                    Ok((_recv, Err(reader_err))) => reader_err.to_string(),
+                    _ => "publish ack reader stopped".to_string(),
+                };
+                let _ = send_err
+                    .0
+                    .response
+                    .send(Err(anyhow::anyhow!(message.clone())));
+                drain_publish_queue(&mut rx, &message).await;
+                return Err(anyhow::anyhow!(message));
+            }
+        }};
+    }
+    let mut finish_response: Option<oneshot::Sender<Result<()>>> = None;
     while let Some(request) = rx.recv().await {
         match request {
             PublishRequest::Message {
@@ -830,7 +958,10 @@ pub(crate) async fn run_publisher_writer_with_limit(
                         timings::record_write_ns(write_ns);
                         t_histogram!("felix_client_write_ns").record(write_ns as f64);
                     }
-                    let result = match write_result {
+                    let item_count = payloads.len() as u64;
+                    #[cfg(not(feature = "telemetry"))]
+                    let _ = item_count;
+                    match write_result {
                         Ok(()) => {
                             #[cfg(feature = "telemetry")]
                             {
@@ -840,32 +971,30 @@ pub(crate) async fn run_publisher_writer_with_limit(
                                     .bytes_out
                                     .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                             }
-                            maybe_wait_for_ack_with_limit(
-                                &mut recv,
-                                ack,
-                                request_id,
-                                &mut ack_scratch,
-                                max_frame_bytes,
-                            )
-                            .await
-                        }
-                        Err(err) => Err(err),
-                    };
-                    let item_count = payloads.len() as u64;
-                    #[cfg(not(feature = "telemetry"))]
-                    let _ = item_count;
-                    match result {
-                        Ok(()) => {
-                            #[cfg(feature = "telemetry")]
-                            {
-                                let counters = frame_counters();
-                                counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
-                                counters.pub_batches_out_ok.fetch_add(1, Ordering::Relaxed);
-                                counters
-                                    .pub_items_out_ok
-                                    .fetch_add(item_count, Ordering::Relaxed);
+                            if ack == AckMode::None {
+                                #[cfg(feature = "telemetry")]
+                                {
+                                    let counters = frame_counters();
+                                    counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
+                                    counters.pub_batches_out_ok.fetch_add(1, Ordering::Relaxed);
+                                    counters
+                                        .pub_items_out_ok
+                                        .fetch_add(item_count, Ordering::Relaxed);
+                                }
+                                let _ = response.send(Ok(()));
+                            } else if let Some(request_id) = request_id {
+                                submit_pending!(PendingAck {
+                                    request_id,
+                                    response,
+                                    _permit,
+                                    batch_count: 1,
+                                    item_count,
+                                });
+                            } else {
+                                let message = "missing request_id for acked publish".to_string();
+                                let _ = response.send(Err(anyhow::anyhow!(message.clone())));
+                                fail_worker!(message);
                             }
-                            let _ = response.send(Ok(()));
                         }
                         Err(err) => {
                             #[cfg(feature = "telemetry")]
@@ -879,8 +1008,7 @@ pub(crate) async fn run_publisher_writer_with_limit(
                             }
                             let message = err.to_string();
                             let _ = response.send(Err(err));
-                            drain_publish_queue(&mut rx, &message).await;
-                            return Err(anyhow::anyhow!(message));
+                            fail_worker!(message);
                         }
                     }
                 }
@@ -911,19 +1039,6 @@ pub(crate) async fn run_publisher_writer_with_limit(
                         timings::record_write_ns(write_ns);
                         t_histogram!("felix_client_write_ns").record(write_ns as f64);
                     }
-                    let result = match write_result {
-                        Ok(()) => {
-                            maybe_wait_for_ack_with_limit(
-                                &mut recv,
-                                ack,
-                                request_id,
-                                &mut ack_scratch,
-                                max_frame_bytes,
-                            )
-                            .await
-                        }
-                        Err(err) => Err(err),
-                    };
                     let (batch_count, item_count) = match &other {
                         Message::Publish { .. } => (1u64, 1u64),
                         Message::PublishBatch { payloads, .. } => (1u64, payloads.len() as u64),
@@ -931,22 +1046,36 @@ pub(crate) async fn run_publisher_writer_with_limit(
                     };
                     #[cfg(not(feature = "telemetry"))]
                     let _ = (batch_count, item_count);
-                    match result {
+                    match write_result {
                         Ok(()) => {
-                            #[cfg(feature = "telemetry")]
-                            {
-                                let counters = frame_counters();
-                                counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
-                                if batch_count > 0 {
-                                    counters
-                                        .pub_batches_out_ok
-                                        .fetch_add(batch_count, Ordering::Relaxed);
-                                    counters
-                                        .pub_items_out_ok
-                                        .fetch_add(item_count, Ordering::Relaxed);
+                            if ack == AckMode::None {
+                                #[cfg(feature = "telemetry")]
+                                {
+                                    let counters = frame_counters();
+                                    counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
+                                    if batch_count > 0 {
+                                        counters
+                                            .pub_batches_out_ok
+                                            .fetch_add(batch_count, Ordering::Relaxed);
+                                        counters
+                                            .pub_items_out_ok
+                                            .fetch_add(item_count, Ordering::Relaxed);
+                                    }
                                 }
+                                let _ = response.send(Ok(()));
+                            } else if let Some(request_id) = request_id {
+                                submit_pending!(PendingAck {
+                                    request_id,
+                                    response,
+                                    _permit,
+                                    batch_count,
+                                    item_count,
+                                });
+                            } else {
+                                let message = "missing request_id for acked publish".to_string();
+                                let _ = response.send(Err(anyhow::anyhow!(message.clone())));
+                                fail_worker!(message);
                             }
-                            let _ = response.send(Ok(()));
                         }
                         Err(err) => {
                             #[cfg(feature = "telemetry")]
@@ -964,8 +1093,7 @@ pub(crate) async fn run_publisher_writer_with_limit(
                             }
                             let message = err.to_string();
                             let _ = response.send(Err(err));
-                            drain_publish_queue(&mut rx, &message).await;
-                            return Err(anyhow::anyhow!(message));
+                            fail_worker!(message);
                         }
                     }
                 }
@@ -989,22 +1117,6 @@ pub(crate) async fn run_publisher_writer_with_limit(
                     .write_all(&bytes)
                     .await
                     .context("write binary batch frame");
-                // For an acked frame the request is not complete until the broker's
-                // ack arrives, so the wait belongs inside the writer task: it owns
-                // the stream, and acks are answered strictly in request order.
-                let result = match write_result {
-                    Ok(()) => {
-                        maybe_wait_for_ack_with_limit(
-                            &mut recv,
-                            ack,
-                            request_id,
-                            &mut ack_scratch,
-                            max_frame_bytes,
-                        )
-                        .await
-                    }
-                    Err(err) => Err(err),
-                };
                 #[cfg(feature = "telemetry")]
                 if let Some(start) = chunk_start {
                     let await_ns = start.elapsed().as_nanos() as u64;
@@ -1017,22 +1129,40 @@ pub(crate) async fn run_publisher_writer_with_limit(
                     timings::record_write_ns(write_ns);
                     t_histogram!("felix_client_write_ns").record(write_ns as f64);
                 }
-                match result {
+                match write_result {
                     Ok(()) => {
                         #[cfg(feature = "telemetry")]
                         {
                             let counters = frame_counters();
-                            counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
-                            counters.pub_batches_out_ok.fetch_add(1, Ordering::Relaxed);
-                            counters
-                                .pub_items_out_ok
-                                .fetch_add(item_count as u64, Ordering::Relaxed);
                             counters.frames_out_ok.fetch_add(1, Ordering::Relaxed);
                             counters
                                 .bytes_out
                                 .fetch_add(bytes.len() as u64, Ordering::Relaxed);
                         }
-                        let _ = response.send(Ok(()));
+                        if ack == AckMode::None {
+                            #[cfg(feature = "telemetry")]
+                            {
+                                let counters = frame_counters();
+                                counters.pub_frames_out_ok.fetch_add(1, Ordering::Relaxed);
+                                counters.pub_batches_out_ok.fetch_add(1, Ordering::Relaxed);
+                                counters
+                                    .pub_items_out_ok
+                                    .fetch_add(item_count as u64, Ordering::Relaxed);
+                            }
+                            let _ = response.send(Ok(()));
+                        } else if let Some(request_id) = request_id {
+                            submit_pending!(PendingAck {
+                                request_id,
+                                response,
+                                _permit,
+                                batch_count: 1,
+                                item_count: item_count as u64,
+                            });
+                        } else {
+                            let message = "missing request_id for acked publish".to_string();
+                            let _ = response.send(Err(anyhow::anyhow!(message.clone())));
+                            fail_worker!(message);
+                        }
                     }
                     Err(err) => {
                         #[cfg(feature = "telemetry")]
@@ -1046,30 +1176,51 @@ pub(crate) async fn run_publisher_writer_with_limit(
                         }
                         let message = err.to_string();
                         let _ = response.send(Err(err));
-                        drain_publish_queue(&mut rx, &message).await;
-                        return Err(anyhow::anyhow!(message));
+                        fail_worker!(message);
                     }
                 }
             }
             PublishRequest::Finish { response } => {
-                let result = finish_publisher_stream(&mut send, &mut recv).await;
-                match result {
-                    Ok(()) => {
-                        let _ = response.send(Ok(()));
-                        return Ok(());
-                    }
-                    Err(err) => {
-                        let message = err.to_string();
-                        let _ = response.send(Err(err));
-                        return Err(anyhow::anyhow!(message));
-                    }
-                }
+                finish_response = Some(response);
+                break;
             }
         }
     }
-    finish_publisher_stream(&mut send, &mut recv).await
+    // Graceful shutdown: close our send side, then let the ack reader resolve
+    // every pending ack and hand `recv` back so the stream can be drained to
+    // EOF — the same close protocol `finish_publisher_stream` implements for
+    // the non-pipelined paths.
+    drop(pending_tx);
+    let finish_result = send.finish().map_err(anyhow::Error::from);
+    let result = match reader.await.context("join publish ack reader") {
+        Ok((mut recv, reader_result)) => {
+            let drain_result = async {
+                reader_result?;
+                let mut buf = [0u8; 8192];
+                loop {
+                    match recv.read(&mut buf).await {
+                        Ok(Some(_)) => continue,
+                        Ok(None) => break,
+                        Err(err) => return Err(err.into()),
+                    }
+                }
+                Ok(())
+            }
+            .await;
+            finish_result.and(drain_result)
+        }
+        Err(err) => finish_result.and(Err(err)),
+    };
+    if let Some(response) = finish_response {
+        let _ = response.send(match &result {
+            Ok(()) => Ok(()),
+            Err(err) => Err(anyhow::anyhow!(err.to_string())),
+        });
+    }
+    result
 }
 
+#[cfg(test)]
 pub(crate) async fn finish_publisher_stream(
     send: &mut SendStream,
     recv: &mut RecvStream,
@@ -1400,6 +1551,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn acked_publishes_pipeline_without_waiting_per_ack() -> Result<()> {
+        let (server_config, cert) = make_server_config()?;
+        let transport = TransportConfig::default();
+        let server = QuicServer::bind("127.0.0.1:0".parse()?, server_config, transport.clone())?;
+        let addr = server.local_addr()?;
+
+        // The server refuses to ack anything until all three publish frames
+        // have arrived. A writer that awaits each ack inline can never send
+        // frame 2 before frame 1 is acked, so it deadlocks here (and this
+        // test times out); the pipelined writer sends all three back to back.
+        let server_task = tokio::spawn(async move {
+            let connection = server.accept().await?;
+            let (mut send, mut recv) = connection.accept_bi().await?;
+            let mut scratch = BytesMut::with_capacity(4096);
+            let mut request_ids = Vec::new();
+            for _ in 0..3 {
+                let frame = crate::wire::read_frame_into_with_limit(
+                    &mut recv,
+                    &mut scratch,
+                    false,
+                    1 << 20,
+                )
+                .await?
+                .context("publish stream closed before all frames arrived")?;
+                match Message::decode(frame).context("decode publish frame")? {
+                    Message::PublishBatch { request_id, .. } => {
+                        request_ids.push(request_id.context("acked batch missing request_id")?);
+                    }
+                    other => anyhow::bail!("unexpected message: {other:?}"),
+                }
+            }
+            for request_id in request_ids {
+                let frame = Message::PublishOk { request_id }.encode()?;
+                send.write_all(&frame.encode()).await.context("write ack")?;
+            }
+            // Close like the broker does: finish the ack side so the client's
+            // EOF drain completes, then wait out the client's own finish.
+            send.finish()?;
+            let _ = recv.read_to_end(1024).await;
+            let _ = send.stopped().await;
+            Result::<()>::Ok(())
+        });
+
+        let client = QuicClient::bind("0.0.0.0:0".parse()?, make_client_config(cert)?, transport)?;
+        let connection = client.connect(addr, "localhost").await?;
+        let (send, recv) = connection.open_bi().await?;
+        let (tx, rx) = mpsc::channel(8);
+        let worker = tokio::spawn(run_publisher_writer(send, recv, rx, 16 * 1024));
+
+        let admission = Arc::new(Semaphore::new(1 << 20));
+        let mut responses = Vec::new();
+        for request_id in 1..=3u64 {
+            let permit = admission
+                .clone()
+                .acquire_many_owned(64)
+                .await
+                .context("admission")?;
+            let (response_tx, response_rx) = oneshot::channel();
+            tx.send(PublishRequest::Message {
+                message: Message::PublishBatch {
+                    tenant_id: "t".into(),
+                    namespace: "ns".into(),
+                    stream: "s".into(),
+                    payloads: vec![b"x".to_vec()],
+                    request_id: Some(request_id),
+                    ack: Some(AckMode::PerBatch),
+                },
+                ack: AckMode::PerBatch,
+                request_id: Some(request_id),
+                _permit: permit,
+                response: response_tx,
+            })
+            .await
+            .context("queue publish")?;
+            responses.push(response_rx);
+        }
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            for response in responses {
+                response.await.context("worker dropped response")??;
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .context("acked publishes did not pipeline (inline ack wait deadlocks this server)")??;
+
+        let (finish_tx, finish_rx) = oneshot::channel();
+        tx.send(PublishRequest::Finish {
+            response: finish_tx,
+        })
+        .await
+        .context("queue finish")?;
+        finish_rx.await.context("finish dropped")??;
+        worker.await.context("join worker")??;
+        server_task.await.context("join server")??;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn finish_publisher_stream_drains_recv() -> Result<()> {
         let (server_config, cert) = make_server_config()?;
         let transport = TransportConfig::default();
@@ -1592,6 +1842,11 @@ mod tests {
             send.write_all(&frame.encode()).await.context("write ack")?;
             send.finish().context("finish ack")?;
             let _ = recv.read_to_end(1024 * 1024).await;
+            // A pipelined client sends its whole flight (and FIN) up front, so
+            // reaching EOF here no longer implies the ack was transmitted.
+            // Dropping the connection discards untransmitted data; wait until
+            // the client has read the ack stream to completion.
+            let _ = send.stopped().await;
             Ok::<(), anyhow::Error>(())
         });
 
@@ -1656,6 +1911,11 @@ mod tests {
         let server = QuicServer::bind("127.0.0.1:0".parse()?, server_config, transport.clone())?;
         let addr = server.local_addr()?;
 
+        // The connection must outlive the assertions: a pipelined client sends
+        // its whole flight (and FIN) up front, so server-side EOF no longer
+        // implies the client has consumed the ack, and dropping the connection
+        // races the client's read of buffered stream data.
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
         let server_task = tokio::spawn(async move {
             let connection = server.accept().await?;
             let (mut send, mut recv) = connection.accept_bi().await?;
@@ -1676,6 +1936,7 @@ mod tests {
             send.write_all(&frame.encode()).await.context("write ack")?;
             send.finish().context("finish ack")?;
             let _ = recv.read_to_end(1024 * 1024).await;
+            let _ = shutdown_rx.await;
             Ok::<(), anyhow::Error>(())
         });
 
@@ -1729,6 +1990,7 @@ mod tests {
 
         let writer_err = writer_task.await.context("writer join")?;
         assert!(writer_err.is_err());
+        let _ = shutdown_tx.send(());
         server_task.await.context("server join")??;
         Ok(())
     }

--- a/crates/felix-client/src/client/subscription.rs
+++ b/crates/felix-client/src/client/subscription.rs
@@ -56,6 +56,9 @@ pub struct Event {
 
 pub(crate) struct SubscriptionPipelineConfig {
     pub(crate) recv: RecvStream,
+    /// Connection whose transport drivers deliver this stream's data; the read
+    /// task is colocated with them via `spawn_pump`.
+    pub(crate) connection: felix_transport::QuicConnection,
     pub(crate) queue_capacity: usize,
     pub(crate) queue_policy: ClientSubQueuePolicy,
     pub(crate) subscription_id: u64,
@@ -75,7 +78,10 @@ impl Subscription {
         let (frame_tx, frame_rx) = mpsc::channel(capacity);
         let (event_tx, event_rx) = mpsc::channel(capacity);
 
-        tokio::spawn(run_subscription_io_task(
+        // The io task is woken per slice of arriving stream data, so it runs
+        // colocated with the connection's drivers; dispatch has no
+        // transport-facing wakeups and stays on the app runtime.
+        config.connection.spawn_pump(run_subscription_io_task(
             config.recv,
             frame_tx,
             config.queue_policy,

--- a/crates/felix-client/src/wire/ack.rs
+++ b/crates/felix-client/src/wire/ack.rs
@@ -1,7 +1,9 @@
 // Ack parsing and publish ack handling helpers.
 use anyhow::{Context, Result};
 use bytes::BytesMut;
-use felix_wire::{AckMode, Message};
+#[cfg(test)]
+use felix_wire::AckMode;
+use felix_wire::Message;
 use quinn::RecvStream;
 
 #[cfg(feature = "telemetry")]
@@ -84,6 +86,7 @@ pub(crate) async fn maybe_wait_for_ack(
     .await
 }
 
+#[cfg(test)]
 pub(crate) async fn maybe_wait_for_ack_with_limit(
     recv: &mut RecvStream,
     ack: AckMode,
@@ -97,7 +100,21 @@ pub(crate) async fn maybe_wait_for_ack_with_limit(
     }
     let request_id =
         request_id.ok_or_else(|| anyhow::anyhow!("missing request_id for acked publish"))?;
-    // Bound the wait. The publisher writer task blocks here, so an ack that never
+    wait_for_ack(recv, request_id, frame_scratch, max_frame_bytes).await
+}
+
+/// Wait for the broker's ack to the publish sent as `request_id`.
+///
+/// Acks arrive on the publish stream strictly in request order, so the next
+/// ack frame must correlate to `request_id` — a mismatch is a protocol error,
+/// not an out-of-order arrival to wait through.
+pub(crate) async fn wait_for_ack(
+    recv: &mut RecvStream,
+    request_id: u64,
+    frame_scratch: &mut BytesMut,
+    max_frame_bytes: usize,
+) -> Result<()> {
+    // Bound the wait. The ack reader blocks here, so an ack that never
     // arrives wedges that stream's publishes indefinitely rather than failing.
     // This is a real possibility whenever the broker cannot answer — it is
     // overloaded, the stream broke, or (before capability negotiation) it

--- a/crates/felix-client/src/wire/mod.rs
+++ b/crates/felix-client/src/wire/mod.rs
@@ -1,5 +1,5 @@
 // Wire helpers for felix-wire framing, ack handling, and telemetry logging.
-pub(crate) use self::ack::maybe_wait_for_ack_with_limit;
+pub(crate) use self::ack::wait_for_ack;
 pub(crate) use self::bench_ts::{
     maybe_append_publish_ts, maybe_append_publish_ts_batch, record_e2e_latency,
 };

--- a/crates/felix-transport/Cargo.toml
+++ b/crates/felix-transport/Cargo.toml
@@ -21,3 +21,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 rcgen = "0.14"
 rustls = "0.23"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = "0.2.189"

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -54,10 +54,24 @@ fn io_runtime_handle(role: EndpointRole) -> Option<tokio::runtime::Handle> {
         // at 6 runtimes before endpoints were grouped by role: slow mode on
         // every run. Two is what the roles need: servers on one, clients on the
         // other.
+        // Driver isolation is a macOS optimization; on Linux it is a
+        // pessimization, so it is defaulted on only where it measures faster.
+        //
+        // The ~7.5x per-byte ceiling this pool was built to fix is specific to
+        // macOS: on Linux the same benchmark at the pre-fix baseline already
+        // sustains ~643 MB/s (628K msg/s x 1 KiB), above what macOS reaches
+        // even with every fix applied. Isolating drivers there only adds a
+        // cross-thread hop per datagram, and it measures that way — p50
+        // latency 86 us -> 152 us and fanout-10 throughput 1.48M -> 1.09M
+        // msg/s, consistent across pool sizes 1/2/4/8 and with pump
+        // colocation both on and off.
+        //
+        // `FELIX_IO_RUNTIME_THREADS` overrides on any platform.
+        let default_threads = if cfg!(target_os = "macos") { 2 } else { 0 };
         let threads = std::env::var("FELIX_IO_RUNTIME_THREADS")
             .ok()
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(2);
+            .unwrap_or(default_threads);
         (0..threads)
             .filter_map(|index| {
                 tokio::runtime::Builder::new_multi_thread()

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -54,22 +54,10 @@ fn io_runtime_handle(role: EndpointRole) -> Option<tokio::runtime::Handle> {
         // at 6 runtimes before endpoints were grouped by role: slow mode on
         // every run. Two is what the roles need: servers on one, clients on the
         // other.
-        // Default on only where this is validated. On Linux, running quinn's
-        // drivers on a dedicated runtime loses a delivery wakeup: the client's
-        // QUIC layer receives and ACKs a stream frame that the application is
-        // never woken to read, and the connection sits idle until it times
-        // out. Reproduced deterministically on a current-thread app runtime
-        // and intermittently (1 in 3) on a multi-threaded one; every other
-        // subsystem was ruled out by A/B (pump colocation off, ACK frequency
-        // off, MTU pinned) and it never occurs with the pool disabled. The
-        // measured gain is macOS-only so far, so the unvalidated platform
-        // keeps the stock behaviour rather than trading correctness for an
-        // unmeasured speedup. `FELIX_IO_RUNTIME_THREADS` opts in anywhere.
-        let default_threads = if cfg!(target_os = "macos") { 2 } else { 0 };
         let threads = std::env::var("FELIX_IO_RUNTIME_THREADS")
             .ok()
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(default_threads);
+            .unwrap_or(2);
         (0..threads)
             .filter_map(|index| {
                 tokio::runtime::Builder::new_multi_thread()
@@ -894,6 +882,59 @@ mod tests {
     /// runtime lost a wakeup here on Linux — the receiver ACKed bytes it never
     /// delivered to the application — so this covers that path without the
     /// broker or client in the picture.
+    /// Same delivery pattern, but the reader runs on the application runtime
+    /// while the connection's drivers run on the dedicated I/O runtime — the
+    /// arrangement every broker-side stream reader uses. This is the
+    /// configuration that stalls on Linux.
+    #[tokio::test]
+    async fn many_small_frames_reach_an_app_runtime_reader() -> Result<()> {
+        const N: u64 = 400;
+        let (server_config, cert) = make_server_config()?;
+        let transport = TransportConfig::default();
+        let server = QuicServer::bind("127.0.0.1:0".parse()?, server_config, transport.clone())?;
+        let addr = server.local_addr()?;
+
+        let server_task = tokio::spawn(async move {
+            let connection = server.accept().await?;
+            let mut send = connection.open_uni().await?;
+            for i in 0..N {
+                send.write_all(&i.to_be_bytes()).await?;
+                tokio::task::yield_now().await;
+            }
+            send.finish()?;
+            let _ = send.stopped().await;
+            Result::<()>::Ok(())
+        });
+
+        let client = QuicClient::bind("0.0.0.0:0".parse()?, make_client_config(cert)?, transport)?;
+        let connection = client.connect(addr, "localhost").await?;
+        let mut recv = connection.accept_uni().await?;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<u64>(64);
+        // Plain spawn: application runtime, not the connection's I/O runtime.
+        tokio::spawn(async move {
+            let mut buf = [0u8; 8];
+            loop {
+                if recv.read_exact(&mut buf).await.is_err() {
+                    break;
+                }
+                if tx.send(u64::from_be_bytes(buf)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        for expected in 0..N {
+            let value = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+                .await
+                .with_context(|| format!("delivery stalled waiting for item {expected}"))?
+                .with_context(|| format!("stream ended early at item {expected}"))?;
+            assert_eq!(value, expected);
+        }
+
+        server_task.await.context("server task join")??;
+        Ok(())
+    }
+
     #[tokio::test]
     async fn many_small_frames_reach_a_colocated_reader() -> Result<()> {
         const N: u64 = 400;

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -54,10 +54,22 @@ fn io_runtime_handle(role: EndpointRole) -> Option<tokio::runtime::Handle> {
         // at 6 runtimes before endpoints were grouped by role: slow mode on
         // every run. Two is what the roles need: servers on one, clients on the
         // other.
+        // Default on only where this is validated. On Linux, running quinn's
+        // drivers on a dedicated runtime loses a delivery wakeup: the client's
+        // QUIC layer receives and ACKs a stream frame that the application is
+        // never woken to read, and the connection sits idle until it times
+        // out. Reproduced deterministically on a current-thread app runtime
+        // and intermittently (1 in 3) on a multi-threaded one; every other
+        // subsystem was ruled out by A/B (pump colocation off, ACK frequency
+        // off, MTU pinned) and it never occurs with the pool disabled. The
+        // measured gain is macOS-only so far, so the unvalidated platform
+        // keeps the stock behaviour rather than trading correctness for an
+        // unmeasured speedup. `FELIX_IO_RUNTIME_THREADS` opts in anywhere.
+        let default_threads = if cfg!(target_os = "macos") { 2 } else { 0 };
         let threads = std::env::var("FELIX_IO_RUNTIME_THREADS")
             .ok()
             .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(2);
+            .unwrap_or(default_threads);
         (0..threads)
             .filter_map(|index| {
                 tokio::runtime::Builder::new_multi_thread()
@@ -870,6 +882,62 @@ mod tests {
         send.finish()?;
         let response = recv.read_to_end(1024).await?;
         assert_eq!(response, b"ping");
+
+        server_task.await.context("server task join")??;
+        Ok(())
+    }
+
+    /// Minimal reproduction of the delivery pattern Felix's subscription path
+    /// uses: a sender writing many small chunks to one uni stream, and a
+    /// reader colocated with the connection's drivers forwarding each item
+    /// through a bounded channel. Isolating quinn's drivers onto a dedicated
+    /// runtime lost a wakeup here on Linux — the receiver ACKed bytes it never
+    /// delivered to the application — so this covers that path without the
+    /// broker or client in the picture.
+    #[tokio::test]
+    async fn many_small_frames_reach_a_colocated_reader() -> Result<()> {
+        const N: u64 = 400;
+        let (server_config, cert) = make_server_config()?;
+        let transport = TransportConfig::default();
+        let server = QuicServer::bind("127.0.0.1:0".parse()?, server_config, transport.clone())?;
+        let addr = server.local_addr()?;
+
+        let server_task = tokio::spawn(async move {
+            let connection = server.accept().await?;
+            let mut send = connection.open_uni().await?;
+            for i in 0..N {
+                send.write_all(&i.to_be_bytes()).await?;
+                // One write per item, as the delivery writer does.
+                tokio::task::yield_now().await;
+            }
+            send.finish()?;
+            let _ = send.stopped().await;
+            Result::<()>::Ok(())
+        });
+
+        let client = QuicClient::bind("0.0.0.0:0".parse()?, make_client_config(cert)?, transport)?;
+        let connection = client.connect(addr, "localhost").await?;
+        let mut recv = connection.accept_uni().await?;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<u64>(64);
+        connection.spawn_pump(async move {
+            let mut buf = [0u8; 8];
+            loop {
+                if recv.read_exact(&mut buf).await.is_err() {
+                    break;
+                }
+                if tx.send(u64::from_be_bytes(buf)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        for expected in 0..N {
+            let value = tokio::time::timeout(std::time::Duration::from_secs(10), rx.recv())
+                .await
+                .with_context(|| format!("delivery stalled waiting for item {expected}"))?
+                .with_context(|| format!("stream ended early at item {expected}"))?;
+            assert_eq!(value, expected);
+        }
 
         server_task.await.context("server task join")??;
         Ok(())

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -2,7 +2,161 @@
 use anyhow::{Context, Result, anyhow};
 use quinn::{ClientConfig, Connection, Endpoint, RecvStream, SendStream, ServerConfig};
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+/// Whether an endpoint accepts connections or makes them.
+///
+/// Assignment is not round-robin across both: a server endpoint multiplexes
+/// every connection and drives traffic in both directions, so it gets a
+/// runtime to itself, while client endpoints share the rest. Letting a client
+/// endpoint land on the server's runtime measured **5-6x slower** — the two
+/// halves of a request/response ping-pong end up serialized on one thread. In
+/// a standalone broker or a standalone client this is a no-op; it matters when
+/// both live in one process, as in the benchmark harness and the in-process
+/// client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EndpointRole {
+    Server,
+    Client,
+}
+
+/// Dedicated runtimes for quinn's driver tasks. Drivers do bounded work per
+/// poll and reschedule themselves, so their re-poll latency is the pipeline's
+/// byte-rate ceiling; on a runtime shared with app tasks that latency grows
+/// with load, and because wakeups scale with datagram count it caps throughput
+/// per *byte* (measured ~7.5x below capacity). Each endpoint gets a
+/// single-threaded runtime so driver self-wakes re-poll immediately and never
+/// migrate cores; see [`EndpointRole`] for which endpoints share one.
+/// `FELIX_IO_RUNTIME_THREADS` sets the pool size (default: 2); `0` restores
+/// drivers to the app runtime.
+fn io_runtime_index(role: EndpointRole, sequence: usize, pool_len: usize) -> usize {
+    if pool_len <= 1 {
+        return 0;
+    }
+    match role {
+        // The final runtime is permanently reserved for clients. Server
+        // creation history must never let a server drift onto it.
+        EndpointRole::Server => sequence % (pool_len - 1),
+        EndpointRole::Client => pool_len - 1,
+    }
+}
+
+fn io_runtime_handle(role: EndpointRole) -> Option<tokio::runtime::Handle> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static IO_RUNTIMES: OnceLock<Vec<tokio::runtime::Runtime>> = OnceLock::new();
+    static NEXT_SERVER: AtomicUsize = AtomicUsize::new(0);
+    static NEXT_CLIENT: AtomicUsize = AtomicUsize::new(0);
+    let pool = IO_RUNTIMES.get_or_init(|| {
+        // Two, not one per core. A bigger pool cannot make a single endpoint
+        // faster -- an endpoint's driver is one task on one runtime -- and it
+        // actively hurts, because endpoints that talk to each other end up on
+        // different threads and every message pays cross-thread wakes. Measured
+        // at 6 runtimes before endpoints were grouped by role: slow mode on
+        // every run. Two is what the roles need: servers on one, clients on the
+        // other.
+        let threads = std::env::var("FELIX_IO_RUNTIME_THREADS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(2);
+        (0..threads)
+            .filter_map(|index| {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .thread_name(format!("felix-quic-io-{index}"))
+                    .on_thread_start(|| {
+                        // High QoS: OS demotion of these threads turns wakeup
+                        // latency directly into a throughput ceiling.
+                        #[cfg(target_os = "macos")]
+                        unsafe {
+                            libc::pthread_set_qos_class_self_np(
+                                libc::qos_class_t::QOS_CLASS_USER_INTERACTIVE,
+                                0,
+                            );
+                        }
+                    })
+                    .enable_all()
+                    .build()
+                    .map_err(|err| {
+                        tracing::warn!(error = %err, "failed to build QUIC I/O runtime; drivers will share the app runtime");
+                        err
+                    })
+                    .ok()
+            })
+            .collect()
+    });
+    if pool.is_empty() {
+        return None;
+    }
+    // Keep the role partition stable for the life of the process. In
+    // particular, repeated in-process benchmark cases create many sequential
+    // server endpoints; creation history must not eventually place one on the
+    // client runtime and recreate the measured 5-6x lockstep mode.
+    let seq = match role {
+        EndpointRole::Server => NEXT_SERVER.fetch_add(1, Ordering::Relaxed),
+        EndpointRole::Client => {
+            // Every client endpoint shares one runtime, deliberately. A client's
+            // publish and event endpoints carry the two halves of the same
+            // request/response flow, so splitting them across threads makes each
+            // message pay two cross-thread wakes and the pipeline drops into
+            // lockstep. Measured on the benchmark harness: co-located clients
+            // ~123K msg/s, spread across 6 runtimes ~21K on every single run.
+            NEXT_CLIENT.fetch_add(1, Ordering::Relaxed)
+        }
+    };
+    let index = io_runtime_index(role, seq, pool.len());
+    // Which endpoints share a runtime decides whether their drivers hand off
+    // in-thread or pay a cross-thread wake per datagram, so this assignment is
+    // load-bearing for throughput, not just bookkeeping.
+    tracing::debug!(
+        ?role,
+        endpoint_seq = seq,
+        io_runtime = index,
+        pool = pool.len(),
+        "assigned QUIC endpoint to I/O runtime"
+    );
+    Some(pool[index].handle().clone())
+}
+
+/// `quinn::Runtime` that runs driver tasks on the dedicated I/O runtime.
+/// Timers and the UDP socket are created in that runtime's context so they
+/// register with its reactor; application-facing stream futures are unaffected.
+#[derive(Debug)]
+struct IoRuntime {
+    handle: tokio::runtime::Handle,
+}
+
+impl quinn::Runtime for IoRuntime {
+    fn new_timer(&self, i: std::time::Instant) -> std::pin::Pin<Box<dyn quinn::AsyncTimer>> {
+        let _guard = self.handle.enter();
+        quinn::TokioRuntime.new_timer(i)
+    }
+
+    fn spawn(&self, future: std::pin::Pin<Box<dyn Future<Output = ()> + Send>>) {
+        self.handle.spawn(future);
+    }
+
+    fn wrap_udp_socket(
+        &self,
+        t: std::net::UdpSocket,
+    ) -> std::io::Result<Arc<dyn quinn::AsyncUdpSocket>> {
+        let _guard = self.handle.enter();
+        quinn::TokioRuntime.wrap_udp_socket(t)
+    }
+}
+
+/// The quinn runtime new endpoints should use, honouring the isolation switch.
+/// Also returns the chosen handle so the endpoint can offer it to pump tasks.
+fn quinn_runtime(role: EndpointRole) -> (Arc<dyn quinn::Runtime>, Option<tokio::runtime::Handle>) {
+    match io_runtime_handle(role) {
+        Some(handle) => (
+            Arc::new(IoRuntime {
+                handle: handle.clone(),
+            }),
+            Some(handle),
+        ),
+        None => (Arc::new(quinn::TokioRuntime), None),
+    }
+}
 
 /// Transport-level configuration defaults.
 ///
@@ -100,8 +254,56 @@ impl Default for TransportConfig {
     }
 }
 
+// Largest UDP payload that fits a 16 KiB loopback interface MTU (macOS lo0 is
+// 16384; Linux lo is 65536) after IPv6 headers (48 bytes; IPv4 needs only 28).
+const LOOPBACK_UDP_PAYLOAD: u16 = 16336;
+
 impl TransportConfig {
+    /// The initial MTU to use for a connection whose peer is a loopback
+    /// address, or `None` to keep the configured default.
+    ///
+    /// Running at the real loopback MTU matters beyond skipping the discovery
+    /// ramp: quinn's black-hole detector can misread a congestive loss burst
+    /// (all lost packets full-MTU, which is what overflowing the peer's UDP
+    /// socket buffer looks like at high rate) as an MTU black hole and drop
+    /// the path MTU to `min_mtu` (1200 by default). Recovery probes are only
+    /// sent when the connection has nothing else to transmit, so a busy
+    /// connection that collapses stays collapsed — measured on loopback as
+    /// ~13x the datagrams per byte and a 5-6x throughput drop for the life of
+    /// the load. Guaranteeing the loopback MTU (see
+    /// [`Self::quinn_transport_config_for_loopback`]) leaves the detector
+    /// nothing to collapse to, which removes the failure mode on the one path
+    /// where it was both most likely and least recoverable. An explicit
+    /// `FELIX_INITIAL_MTU` wins over this.
+    fn loopback_initial_mtu(&self) -> Option<u16> {
+        if env_u64("FELIX_INITIAL_MTU").is_some() {
+            return None;
+        }
+        let target = LOOPBACK_UDP_PAYLOAD
+            .min(self.mtu_discovery_upper_bound)
+            .min(self.max_udp_payload_size);
+        (target > self.initial_mtu).then_some(target)
+    }
+
     fn quinn_transport_config(&self) -> quinn::TransportConfig {
+        self.quinn_transport_config_inner(self.initial_mtu, None)
+    }
+
+    /// Loopback variant: start at `initial_mtu` and also *guarantee* it via
+    /// quinn's `min_mtu`. The guarantee is what defuses the black-hole
+    /// detector — its reset target is `min_mtu`, not `initial_mtu`, so
+    /// raising only the start size still collapses to 1200 on a false
+    /// verdict. Loopback is the one path where the larger payload size is
+    /// guaranteed by construction; never set `min_mtu` for a real network.
+    fn quinn_transport_config_for_loopback(&self, mtu: u16) -> quinn::TransportConfig {
+        self.quinn_transport_config_inner(mtu, Some(mtu))
+    }
+
+    fn quinn_transport_config_inner(
+        &self,
+        initial_mtu: u16,
+        guaranteed_mtu: Option<u16>,
+    ) -> quinn::TransportConfig {
         // Translate Felix defaults into Quinn transport settings.
         let mut config = quinn::TransportConfig::default();
         let streams = quinn::VarInt::from_u32(self.max_streams as u32);
@@ -115,14 +317,58 @@ impl TransportConfig {
         config.send_window(self.send_window);
         // Path MTU: start safe, probe high. Fewer, larger datagrams directly
         // reduce per-byte syscall and crypto costs on high-MTU paths.
-        let initial_mtu = self.initial_mtu.clamp(1200, self.max_udp_payload_size);
+        let initial_mtu = initial_mtu.clamp(1200, self.max_udp_payload_size);
         config.initial_mtu(initial_mtu);
-        let mtu_bound = self
-            .mtu_discovery_upper_bound
-            .clamp(initial_mtu, self.max_udp_payload_size);
+        if let Some(guaranteed) = guaranteed_mtu {
+            config.min_mtu(guaranteed.clamp(1200, initial_mtu));
+        }
+        // With a guaranteed MTU there is nothing above it to discover, so pin
+        // the probe bound to it. This is load-bearing, not an optimization: a
+        // probe is full-MTU, bypasses the congestion check, and counts against
+        // the window once in flight — on a quiet connection at the two-segment
+        // initial window, a doomed probe toward a higher bound starves every
+        // ordinary small send behind it ("blocked by congestion control")
+        // until its retransmits exhaust, and the search then starts over.
+        let mtu_bound = match guaranteed_mtu {
+            Some(_) => initial_mtu,
+            None => self
+                .mtu_discovery_upper_bound
+                .clamp(initial_mtu, self.max_udp_payload_size),
+        };
         let mut mtud = quinn::MtuDiscoveryConfig::default();
         mtud.upper_bound(mtu_bound);
+        // Quinn's MTU black-hole detector cannot tell "large packets are being
+        // silently eaten by the path" from "a congestive loss burst dropped a
+        // window of large packets". When a sender overruns the receiver's UDP
+        // socket buffer (easy at high rate: the standing queue sits within a
+        // couple MB of the buffer size, so one scheduling stall overflows it),
+        // every lost packet is full-MTU, the detector calls it a black hole,
+        // and the path MTU collapses to `initial_mtu`. With quinn's default
+        // 60 s cooldown the connection then pays ~13x the datagrams (and
+        // syscalls) per byte for a minute — measured as a 5-6x throughput
+        // collapse that is indistinguishable from a scheduling defect. A short
+        // cooldown re-probes within seconds and restores the discovered MTU;
+        // on a genuine black-hole path the extra cost is one loss-tolerant
+        // probe packet per cooldown.
+        let cooldown_ms = env_u64("FELIX_MTU_BLACK_HOLE_COOLDOWN_MS")
+            .map(|value| value.max(100))
+            .unwrap_or(2_000);
+        mtud.black_hole_cooldown(std::time::Duration::from_millis(cooldown_ms));
         config.mtu_discovery_config(Some(mtud));
+        // ACK frequency extension (quinn peers only): cap ACK delay well below
+        // the RFC's 25 ms — a window-limited sender resumes only on an ACK, so
+        // delayed ACKs stall the whole pipeline — and ACK less often than every
+        // other packet, since each reverse-path ACK costs a datagram plus its
+        // wakeup chain (+15% throughput measured at threshold 20).
+        if env_u64("FELIX_ACK_FREQ_DISABLE").is_none() {
+            let mut ack_frequency = quinn::AckFrequencyConfig::default();
+            ack_frequency.max_ack_delay(Some(std::time::Duration::from_millis(2)));
+            let threshold = env_u64("FELIX_ACK_ELICITING_THRESHOLD").unwrap_or(20);
+            ack_frequency.ack_eliciting_threshold(
+                quinn::VarInt::from_u64(threshold.min(u32::MAX as u64)).expect("threshold fits"),
+            );
+            config.ack_frequency_config(Some(ack_frequency));
+        }
         // Quinn follows RFC 9002 by default and raises the minimum window to
         // two datagrams when path-MTU discovery finds a larger MTU. Keep that
         // safe default unless a trusted low-loss deployment explicitly opts
@@ -130,6 +376,17 @@ impl TransportConfig {
         if let Some(window) = self.initial_congestion_window_bytes {
             let mut cubic = quinn::congestion::CubicConfig::default();
             cubic.initial_window(window);
+            config.congestion_controller_factory(Arc::new(cubic));
+        } else if u64::from(initial_mtu) * 2 > 14_720 {
+            // Quinn's default initial congestion window is a flat 14,720 bytes
+            // (RFC 9002's constant, sized for ~1200-byte datagrams) and its
+            // send path reserves a full segment per datagram — so an initial
+            // MTU larger than the window deadlocks the connection before the
+            // first packet ("blocked by congestion control", forever). Scale
+            // the window with the datagram size using RFC 9002's own formula.
+            let mtu = u64::from(initial_mtu);
+            let mut cubic = quinn::congestion::CubicConfig::default();
+            cubic.initial_window(14_720u64.clamp(2 * mtu, 10 * mtu));
             config.congestion_controller_factory(Arc::new(cubic));
         }
         config
@@ -223,6 +480,12 @@ pub struct QuicServer {
     endpoint: Endpoint,
     // Retain for debugging/metrics; Quinn owns the active config.
     _transport: TransportConfig,
+    // Variant of the server config used for loopback peers; see
+    // [`TransportConfig::loopback_initial_mtu`].
+    loopback_config: Option<Arc<ServerConfig>>,
+    // I/O runtime for this endpoint's quinn drivers (None when isolation is
+    // disabled); handed to each connection for pump colocation.
+    io_handle: Option<tokio::runtime::Handle>,
 }
 
 impl QuicServer {
@@ -233,30 +496,45 @@ impl QuicServer {
     ) -> Result<Self> {
         // Apply transport defaults before binding the endpoint.
         let quinn_transport = transport.quinn_transport_config();
+        let loopback_config = transport.loopback_initial_mtu().map(|mtu| {
+            let mut config = server_config.clone();
+            config.transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
+            Arc::new(config)
+        });
         server_config.transport_config(Arc::new(quinn_transport));
         let socket = transport.bind_udp_socket(addr)?;
+        let (runtime, io_handle) = quinn_runtime(EndpointRole::Server);
         let endpoint = Endpoint::new(
             transport.quinn_endpoint_config(),
             Some(server_config),
             socket,
-            Arc::new(quinn::TokioRuntime),
+            runtime,
         )
         .context("bind QUIC server")?;
         Ok(Self {
             endpoint,
             _transport: transport,
+            loopback_config,
+            io_handle,
         })
     }
 
     pub async fn accept(&self) -> Result<QuicConnection> {
         // Block until a client connects and finishes the handshake.
-        let connecting = self
+        let incoming = self
             .endpoint
             .accept()
             .await
             .ok_or_else(|| anyhow!("no incoming QUIC connections"))?;
-        let connection = connecting.await.context("accept QUIC connection")?;
-        Ok(QuicConnection::new(connection))
+        let connection = match &self.loopback_config {
+            Some(config) if incoming.remote_address().ip().is_loopback() => incoming
+                .accept_with(Arc::clone(config))
+                .context("accept loopback QUIC connection")?
+                .await
+                .context("accept QUIC connection")?,
+            _ => incoming.await.context("accept QUIC connection")?,
+        };
+        Ok(QuicConnection::new(connection, self.io_handle.clone()))
     }
 
     pub fn local_addr(&self) -> Result<SocketAddr> {
@@ -287,6 +565,11 @@ pub struct QuicClient {
     endpoint: Endpoint,
     // Retain for debugging/metrics; Quinn owns the active config.
     _transport: TransportConfig,
+    // Variant of the client config used when connecting to a loopback peer;
+    // see [`TransportConfig::loopback_initial_mtu`].
+    loopback_config: Option<ClientConfig>,
+    // See `QuicServer::io_handle`.
+    io_handle: Option<tokio::runtime::Handle>,
 }
 
 impl QuicClient {
@@ -297,30 +580,39 @@ impl QuicClient {
     ) -> Result<Self> {
         // Apply transport defaults before binding the endpoint.
         let quinn_transport = transport.quinn_transport_config();
+        let loopback_config = transport.loopback_initial_mtu().map(|mtu| {
+            let mut config = client_config.clone();
+            config.transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
+            config
+        });
         client_config.transport_config(Arc::new(quinn_transport));
         let socket = transport.bind_udp_socket(addr)?;
-        let mut endpoint = Endpoint::new(
-            transport.quinn_endpoint_config(),
-            None,
-            socket,
-            Arc::new(quinn::TokioRuntime),
-        )
-        .context("bind QUIC client")?;
+        let (runtime, io_handle) = quinn_runtime(EndpointRole::Client);
+        let mut endpoint = Endpoint::new(transport.quinn_endpoint_config(), None, socket, runtime)
+            .context("bind QUIC client")?;
         endpoint.set_default_client_config(client_config);
         Ok(Self {
             endpoint,
             _transport: transport,
+            loopback_config,
+            io_handle,
         })
     }
 
     pub async fn connect(&self, addr: SocketAddr, server_name: &str) -> Result<QuicConnection> {
         // Initiate and await a QUIC handshake.
-        let connecting = self
-            .endpoint
-            .connect(addr, server_name)
-            .context("initiate QUIC connection")?;
+        let connecting = match &self.loopback_config {
+            Some(config) if addr.ip().is_loopback() => self
+                .endpoint
+                .connect_with(config.clone(), addr, server_name)
+                .context("initiate loopback QUIC connection")?,
+            _ => self
+                .endpoint
+                .connect(addr, server_name)
+                .context("initiate QUIC connection")?,
+        };
         let connection = connecting.await.context("establish QUIC connection")?;
-        Ok(QuicConnection::new(connection))
+        Ok(QuicConnection::new(connection, self.io_handle.clone()))
     }
 }
 
@@ -340,10 +632,12 @@ pub struct QuicConnection {
     inner: Connection,
     // Stable id and peer metadata for tracing.
     info: ConnectionInfo,
+    // The I/O runtime this connection's quinn drivers run on, if isolated.
+    io_handle: Option<tokio::runtime::Handle>,
 }
 
 impl QuicConnection {
-    fn new(connection: Connection) -> Self {
+    fn new(connection: Connection, io_handle: Option<tokio::runtime::Handle>) -> Self {
         // Quinn exposes a stable connection id for logging.
         let info = ConnectionInfo {
             id: ConnectionId(u64::try_from(connection.stable_id()).expect("stable id fits u64")),
@@ -352,6 +646,7 @@ impl QuicConnection {
         Self {
             inner: connection,
             info,
+            io_handle,
         }
     }
 
@@ -359,8 +654,39 @@ impl QuicConnection {
         &self.info
     }
 
+    /// Spawn a task colocated with this connection's quinn drivers.
+    ///
+    /// For pump tasks woken by the transport per datagram or per write (stream
+    /// readers, connection writers): same-thread wakeups are task switches
+    /// instead of cross-core kernel round trips, and that latency is the
+    /// pipeline's clock under smooth arrival. Falls back to `tokio::spawn`
+    /// when driver isolation is disabled.
+    pub fn spawn_pump<F>(&self, future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        static COLOCATE: OnceLock<bool> = OnceLock::new();
+        let colocate = *COLOCATE.get_or_init(|| {
+            std::env::var("FELIX_PUMP_COLOCATE")
+                .map(|value| value != "0")
+                .unwrap_or(true)
+        });
+        match (&self.io_handle, colocate) {
+            (Some(handle), true) => handle.spawn(future),
+            _ => tokio::spawn(future),
+        }
+    }
+
     pub fn stats(&self) -> quinn::ConnectionStats {
         self.inner.stats()
+    }
+
+    /// Why the connection closed, or `None` while it is still live. Lets a
+    /// task holding a clone notice the close and exit instead of keeping the
+    /// handle alive forever.
+    pub fn close_reason(&self) -> Option<quinn::ConnectionError> {
+        self.inner.close_reason()
     }
 
     /// Close the connection, telling the peer why.
@@ -551,6 +877,44 @@ mod tests {
         assert_eq!(config.receive_window, 128 * 1024 * 1024);
         assert_eq!(config.stream_receive_window, 32 * 1024 * 1024);
         assert_eq!(config.send_window, 128 * 1024 * 1024);
+    }
+
+    #[test]
+    fn io_runtime_assignment_keeps_roles_disjoint() {
+        for sequence in 0..32 {
+            assert_eq!(io_runtime_index(EndpointRole::Server, sequence, 2), 0);
+            assert_eq!(io_runtime_index(EndpointRole::Client, sequence, 2), 1);
+        }
+
+        let server_indices: Vec<_> = (0..6)
+            .map(|sequence| io_runtime_index(EndpointRole::Server, sequence, 4))
+            .collect();
+        assert_eq!(server_indices, vec![0, 1, 2, 0, 1, 2]);
+        assert_eq!(io_runtime_index(EndpointRole::Client, 99, 4), 3);
+        assert_eq!(io_runtime_index(EndpointRole::Server, 99, 1), 0);
+        assert_eq!(io_runtime_index(EndpointRole::Client, 99, 1), 0);
+    }
+
+    #[test]
+    fn loopback_initial_mtu_respects_configured_bounds() {
+        // Default config: loopback connections start at the loopback payload
+        // size instead of the RFC-safe 1200.
+        let config = TransportConfig::default();
+        assert_eq!(config.loopback_initial_mtu(), Some(LOOPBACK_UDP_PAYLOAD));
+
+        // A lowered discovery bound caps the loopback start size with it.
+        let config = TransportConfig {
+            mtu_discovery_upper_bound: 4096,
+            ..TransportConfig::default()
+        };
+        assert_eq!(config.loopback_initial_mtu(), Some(4096));
+
+        // No boost when the configured initial MTU is already at least as big.
+        let config = TransportConfig {
+            initial_mtu: 16354,
+            ..TransportConfig::default()
+        };
+        assert_eq!(config.loopback_initial_mtu(), None);
     }
 
     #[test]

--- a/crates/felix-transport/src/lib.rs
+++ b/crates/felix-transport/src/lib.rs
@@ -275,13 +275,30 @@ impl TransportConfig {
     /// nothing to collapse to, which removes the failure mode on the one path
     /// where it was both most likely and least recoverable. An explicit
     /// `FELIX_INITIAL_MTU` wins over this.
-    fn loopback_initial_mtu(&self) -> Option<u16> {
+    ///
+    /// `effective_buffer_bytes` is the smaller of the socket's *achieved*
+    /// send/receive buffers, and gates the whole guarantee: full-size
+    /// datagrams are only safe when the kernel buffers hold a real burst of
+    /// them. Linux silently clamps `SO_RCVBUF` to `net.core.rmem_max`
+    /// (~208 KB on stock hosts and CI runners) — roughly 26 jumbo datagrams
+    /// of headroom, which sustained load overflows catastrophically, and the
+    /// pinned `min_mtu` would then also forbid the one thing that helps a
+    /// tiny buffer: smaller datagrams. Below the threshold the connection
+    /// keeps the stock RFC-safe path (initial 1200, normal discovery, short
+    /// black-hole cooldown).
+    fn loopback_initial_mtu(&self, effective_buffer_bytes: usize) -> Option<u16> {
         if env_u64("FELIX_INITIAL_MTU").is_some() {
             return None;
         }
         let target = LOOPBACK_UDP_PAYLOAD
             .min(self.mtu_discovery_upper_bound)
             .min(self.max_udp_payload_size);
+        // 64 full-size datagrams of burst headroom (~1 MiB at 16336). Hosts
+        // tuned per docs/storage-performance.md sysctl guidance qualify;
+        // stock-limit Linux hosts do not.
+        if effective_buffer_bytes < usize::from(target).saturating_mul(64) {
+            return None;
+        }
         (target > self.initial_mtu).then_some(target)
     }
 
@@ -430,6 +447,17 @@ impl TransportConfig {
     }
 }
 
+/// The smaller of the socket's achieved send/receive buffers. Read back from
+/// the socket rather than taken from config: Linux accepts an oversized
+/// `SO_RCVBUF`/`SO_SNDBUF` and silently clamps it to `net.core.rmem_max` /
+/// `wmem_max`, so the configured size says nothing about what was granted.
+fn effective_udp_buffer_bytes(socket: &std::net::UdpSocket) -> usize {
+    let socket = socket2::SockRef::from(socket);
+    let send = socket.send_buffer_size().unwrap_or(0);
+    let recv = socket.recv_buffer_size().unwrap_or(0);
+    send.min(recv)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 /// Stable connection identifier used for tracing/logging.
 ///
@@ -494,15 +522,20 @@ impl QuicServer {
         mut server_config: ServerConfig,
         transport: TransportConfig,
     ) -> Result<Self> {
-        // Apply transport defaults before binding the endpoint.
-        let quinn_transport = transport.quinn_transport_config();
-        let loopback_config = transport.loopback_initial_mtu().map(|mtu| {
-            let mut config = server_config.clone();
-            config.transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
-            Arc::new(config)
-        });
-        server_config.transport_config(Arc::new(quinn_transport));
+        // Apply transport defaults before binding the endpoint. The socket is
+        // bound first: the loopback MTU guarantee depends on the buffer sizes
+        // the OS actually granted it.
         let socket = transport.bind_udp_socket(addr)?;
+        let quinn_transport = transport.quinn_transport_config();
+        let loopback_config = transport
+            .loopback_initial_mtu(effective_udp_buffer_bytes(&socket))
+            .map(|mtu| {
+                let mut config = server_config.clone();
+                config
+                    .transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
+                Arc::new(config)
+            });
+        server_config.transport_config(Arc::new(quinn_transport));
         let (runtime, io_handle) = quinn_runtime(EndpointRole::Server);
         let endpoint = Endpoint::new(
             transport.quinn_endpoint_config(),
@@ -578,15 +611,20 @@ impl QuicClient {
         mut client_config: ClientConfig,
         transport: TransportConfig,
     ) -> Result<Self> {
-        // Apply transport defaults before binding the endpoint.
-        let quinn_transport = transport.quinn_transport_config();
-        let loopback_config = transport.loopback_initial_mtu().map(|mtu| {
-            let mut config = client_config.clone();
-            config.transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
-            config
-        });
-        client_config.transport_config(Arc::new(quinn_transport));
+        // Apply transport defaults before binding the endpoint. The socket is
+        // bound first: the loopback MTU guarantee depends on the buffer sizes
+        // the OS actually granted it.
         let socket = transport.bind_udp_socket(addr)?;
+        let quinn_transport = transport.quinn_transport_config();
+        let loopback_config = transport
+            .loopback_initial_mtu(effective_udp_buffer_bytes(&socket))
+            .map(|mtu| {
+                let mut config = client_config.clone();
+                config
+                    .transport_config(Arc::new(transport.quinn_transport_config_for_loopback(mtu)));
+                config
+            });
+        client_config.transport_config(Arc::new(quinn_transport));
         let (runtime, io_handle) = quinn_runtime(EndpointRole::Client);
         let mut endpoint = Endpoint::new(transport.quinn_endpoint_config(), None, socket, runtime)
             .context("bind QUIC client")?;
@@ -897,24 +935,40 @@ mod tests {
 
     #[test]
     fn loopback_initial_mtu_respects_configured_bounds() {
+        // Plenty of socket buffer: a typical macOS 8 MiB grant.
+        const BIG_BUFFER: usize = 8 * 1024 * 1024;
+        // A stock-Linux clamp (net.core.rmem_max ~208 KB, doubled by the
+        // kernel): far too little burst headroom for jumbo datagrams.
+        const CLAMPED_BUFFER: usize = 416 * 1024;
+
         // Default config: loopback connections start at the loopback payload
         // size instead of the RFC-safe 1200.
         let config = TransportConfig::default();
-        assert_eq!(config.loopback_initial_mtu(), Some(LOOPBACK_UDP_PAYLOAD));
+        assert_eq!(
+            config.loopback_initial_mtu(BIG_BUFFER),
+            Some(LOOPBACK_UDP_PAYLOAD)
+        );
 
-        // A lowered discovery bound caps the loopback start size with it.
+        // A clamped socket buffer disables the guarantee entirely: 26 jumbo
+        // datagrams of headroom overflow under sustained load, and the pinned
+        // min_mtu would forbid falling back to smaller datagrams.
+        assert_eq!(config.loopback_initial_mtu(CLAMPED_BUFFER), None);
+
+        // A lowered discovery bound caps the loopback start size with it (and
+        // shrinks the buffer headroom it needs).
         let config = TransportConfig {
             mtu_discovery_upper_bound: 4096,
             ..TransportConfig::default()
         };
-        assert_eq!(config.loopback_initial_mtu(), Some(4096));
+        assert_eq!(config.loopback_initial_mtu(BIG_BUFFER), Some(4096));
+        assert_eq!(config.loopback_initial_mtu(CLAMPED_BUFFER), Some(4096));
 
         // No boost when the configured initial MTU is already at least as big.
         let config = TransportConfig {
             initial_mtu: 16354,
             ..TransportConfig::default()
         };
-        assert_eq!(config.loopback_initial_mtu(), None);
+        assert_eq!(config.loopback_initial_mtu(8 * 1024 * 1024), None);
     }
 
     #[test]

--- a/demos/broker/latency_demo.rs
+++ b/demos/broker/latency_demo.rs
@@ -34,9 +34,8 @@ type DemoAuthResult = Result<(Arc<broker::auth::BrokerAuth>, Option<(String, Str
 /// Counts measured deliveries and remembers when the last one landed.
 ///
 /// Delivery duration must end at the moment the final event arrived, not when
-/// drain tasks give up: a drain task waiting out its idle timeout on dropped
-/// events would otherwise inflate the measured delivery window (and deflate
-/// reported throughput) by the entire timeout.
+/// drain tasks finish: trailing bookkeeping would otherwise inflate the
+/// measured delivery window and deflate reported throughput.
 #[derive(Clone)]
 struct DeliveryTracker {
     delivered: Arc<AtomicUsize>,
@@ -90,6 +89,7 @@ struct DemoConfig {
     sub_delivery_shaping: bool,
     pub_yield_every_batches: usize,
     sub_dedicated_thread: bool,
+    log_capacity: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -101,7 +101,13 @@ struct DemoResult {
     batch_size: usize,
     binary: bool,
     received: usize,
-    dropped: usize,
+    /// Events expected but never observed (`expected - delivered`). This is a
+    /// *shortfall*, not a queue-drop counter: the broker's and client's real
+    /// drop counters are `metrics` counters and are not collected here. Because
+    /// a subscriber that times out now fails the run, this must be 0 on any
+    /// successful run -- a non-zero value means the accounting is wrong, not
+    /// that queues shed.
+    unaccounted: usize,
     delivered_total: usize,
     p50: Duration,
     p99: Duration,
@@ -319,8 +325,33 @@ async fn run_smoke(_base: DemoConfig) -> Result<()> {
     anyhow::bail!("--smoke requires telemetry feature");
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
+    // Runtime width is a first-class perf variable here: this harness runs the
+    // broker and its clients in one process, so every extra worker thread is
+    // another candidate for a cross-core wakeup on the publish/deliver chain.
+    // Defaults to tokio's own choice (one worker per CPU).
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    if let Some(threads) = std::env::var("FELIX_WORKER_THREADS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+    {
+        builder.worker_threads(threads);
+    }
+    builder.build()?.block_on(async_main())
+}
+
+async fn async_main() -> Result<()> {
+    // Off unless RUST_LOG asks for it, so benchmark output stays clean. Exists so
+    // broker-side diagnostics (notably FELIX_CONN_STATS_MS path stats) are
+    // reachable from this harness at all.
+    if std::env::var("RUST_LOG").is_ok() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_writer(std::io::stderr)
+            .init();
+    }
     let (config, matrix, payloads, fanouts, all, smoke, compare_sub_delivery_shaping) =
         parse_args();
     if compare_sub_delivery_shaping {
@@ -354,6 +385,9 @@ where
         .unwrap_or(1);
     let mut sub_writer_lanes = None;
     let mut sub_lane_shard = None;
+    let mut log_capacity: Option<usize> = std::env::var("FELIX_DEMO_LOG_CAPACITY")
+        .ok()
+        .and_then(|value| value.parse().ok());
     let mut pub_yield_every_batches = 0usize;
     let mut sub_dedicated_thread = std::env::var("FELIX_SUB_DEDICATED_THREAD")
         .ok()
@@ -439,6 +473,11 @@ where
                 if let Some(value) = args.next() {
                     idle_ms = value.parse().unwrap_or(idle_ms);
                     idle_set = true;
+                }
+            }
+            "--log-capacity" => {
+                if let Some(value) = args.next() {
+                    log_capacity = value.parse().ok();
                 }
             }
             "--pub-conns" => {
@@ -577,6 +616,7 @@ where
             sub_delivery_shaping,
             pub_yield_every_batches,
             sub_dedicated_thread,
+            log_capacity,
         },
         matrix,
         payloads,
@@ -653,6 +693,20 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
         config.sub_delivery_shaping
     );
     println!("{}", expectation_note(&config));
+    // A throughput run absorbed by the QUIC send window (64 MiB) reports
+    // buffer-fill rate, not sustained throughput. Warn instead of refusing so
+    // deliberate short runs stay possible, but the artifact can't pass silently.
+    // Empty payloads move no bytes, so the send window cannot absorb them and
+    // the check is meaningless there -- those cases are message-rate bound.
+    let run_bytes = config.payload_bytes.saturating_mul(config.total);
+    if config.payload_bytes > 0 && config.batch_size > 1 && run_bytes < 128 * 1024 * 1024 {
+        println!(
+            "WARNING: run volume {} MB is within ~2x the 64 MiB QUIC send window; \
+             reported throughput may be buffer-fill rate, not sustained rate. \
+             Raise --total so payload x total comfortably exceeds 128 MiB.",
+            run_bytes / (1024 * 1024)
+        );
+    }
     let use_ack = config.batch_size <= 1 && !config.binary;
     let disable_timings = std::env::var("FELIX_DISABLE_TIMINGS")
         .ok()
@@ -673,10 +727,13 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     broker_publish_timings::set_enabled(collect_timings);
 
     let total_events = config.warmup + config.total;
+    let log_capacity = config
+        .log_capacity
+        .unwrap_or_else(|| total_events.saturating_add(1));
     let broker = Arc::new(
         Broker::new(EphemeralCache::new().into())
             .with_topic_capacity(total_events.saturating_add(1))?
-            .with_log_capacity(total_events.saturating_add(1))?
+            .with_log_capacity(log_capacity)?
             .with_subscriber_queue_policy(felix_broker::SubQueuePolicy::Block),
     );
     broker.register_tenant("t1").await?;
@@ -746,6 +803,20 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
         broker_config.event_batch_max_events = 1;
         broker_config.event_batch_max_bytes = 1024;
         broker_config.event_batch_max_delay_us = 0;
+    }
+    // The profiles above pin egress sizing, so explicit env overrides would be
+    // silently ignored without re-applying them here.
+    if let Ok(value) = std::env::var("FELIX_EVENT_BATCH_MAX_BYTES")
+        && let Ok(bytes) = value.parse::<usize>()
+        && bytes > 0
+    {
+        broker_config.event_batch_max_bytes = bytes;
+    }
+    if let Ok(value) = std::env::var("FELIX_SUB_MAX_BYTES_PER_WRITE")
+        && let Ok(bytes) = value.parse::<usize>()
+        && bytes > 0
+    {
+        broker_config.subscriber_max_bytes_per_write = bytes;
     }
     if let Some(lanes) = config.sub_writer_lanes {
         broker_config.subscriber_writer_lanes = lanes.max(1);
@@ -844,7 +915,13 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
                 let next = tokio::time::timeout(idle_timeout, sub.next_event()).await;
                 let event = match next {
                     Ok(result) => result,
-                    Err(_) => break,
+                    Err(_) => {
+                        anyhow::bail!(
+                            "primary subscriber timed out after {} of {} measured events",
+                            results.len(),
+                            primary_total
+                        );
+                    }
                 };
                 match event {
                     Ok(Some(event)) => {
@@ -868,7 +945,13 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
                             metrics::histogram!("sub_dispatch_ns").record(dispatch_ns as f64);
                         }
                     }
-                    Ok(None) => break,
+                    Ok(None) => {
+                        anyhow::bail!(
+                            "primary subscriber closed after {} of {} measured events",
+                            results.len(),
+                            primary_total
+                        );
+                    }
                     Err(err) => {
                         return Err(anyhow::anyhow!("primary subscriber failed: {err}"));
                     }
@@ -893,11 +976,23 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
                 let next = tokio::time::timeout(idle_timeout, rx.recv()).await;
                 match next {
                     Ok(Some(latency)) => results.push(latency),
-                    Ok(None) => break,
-                    Err(_) => break,
+                    Ok(None) => {
+                        return Err(format!(
+                            "dedicated delivery channel closed after {} of {} measured events",
+                            results.len(),
+                            primary_total
+                        ));
+                    }
+                    Err(_) => {
+                        return Err(format!(
+                            "dedicated delivery channel timed out after {} of {} measured events",
+                            results.len(),
+                            primary_total
+                        ));
+                    }
                 }
             }
-            results
+            Ok(results)
         }))
     } else {
         None
@@ -946,7 +1041,7 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     let mut latencies = if let Some(task) = recv_task {
         task.await.expect("join")?
     } else if let Some(task) = dedicated_recv_task {
-        task.await.expect("join")
+        task.await.expect("join").map_err(anyhow::Error::msg)?
     } else if let Some(handle) = dedicated_handle.take() {
         handle.finish().await?;
         Vec::new()
@@ -958,17 +1053,14 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
     }
     let expected_delivered_total = config.total * config.fanout;
     publisher.finish().await?;
-    for mut task in drain_tasks {
-        tokio::select! {
-            _ = &mut task => {}
-            _ = tokio::time::sleep(idle_timeout) => {
-                task.abort();
-            }
-        }
+    for task in drain_tasks {
+        tokio::time::timeout(idle_timeout, task)
+            .await
+            .context("subscriber drain task did not finish before idle timeout")?
+            .context("subscriber drain task panicked")??;
     }
-    // End the delivery window at the last event that actually arrived. Drain
-    // tasks sit out an idle timeout when events were dropped; counting that
-    // wait would misreport delivered throughput by the full timeout.
+    // End the delivery window at the last event that actually arrived, not when
+    // the drain tasks were joined.
     let delivery_elapsed = delivery_tracker
         .last_delivery_at()
         .and_then(|at| at.checked_duration_since(start))
@@ -1004,7 +1096,7 @@ async fn run_case(config: DemoConfig) -> Result<(DemoResult, Option<TimingSummar
             batch_size: config.batch_size,
             binary: config.binary,
             received,
-            dropped: expected_delivered_total.saturating_sub(delivered_total),
+            unaccounted: expected_delivered_total.saturating_sub(delivered_total),
             delivered_total,
             p50: percentile(&latencies, 0.50),
             p99: percentile(&latencies, 0.99),
@@ -1067,7 +1159,10 @@ async fn setup_subscribers(
     delivery_tracker: DeliveryTracker,
     reserve_primary_slot: bool,
     idle_timeout: Duration,
-) -> Result<(Option<Subscription>, Vec<tokio::task::JoinHandle<()>>)> {
+) -> Result<(
+    Option<Subscription>,
+    Vec<tokio::task::JoinHandle<Result<()>>>,
+)> {
     let mut drain_tasks = Vec::new();
     let mut primary_sub = None;
     let mut primary_slot_reserved = reserve_primary_slot;
@@ -1093,14 +1188,10 @@ async fn setup_subscribers(
                 primary_sub = Some(sub);
             } else {
                 let mut sub = sub;
-                // Must use the same configurable idle timeout as the primary
-                // subscriber. This was hardcoded to 2s, which deadlocked the whole
-                // run under the Block subscriber queue policy: a drain subscriber
-                // that gave up here stopped consuming, its broker-side queue filled,
-                // and Block then stalled fanout for *every* subscriber -- including
-                // the primary, which then failed its own (longer) timeout. More
-                // fanout meant more drain subscribers and better odds one tripped
-                // the 2s bound, which is why the failure scaled with fanout.
+                // Use the same configurable liveness bound as the primary
+                // subscriber, but fail the run if it expires. Silently abandoning
+                // this subscription makes `expected - observed` look like queue
+                // shedding even though every delivery queue is configured Block.
                 let tracker = delivery_tracker.clone();
                 drain_tasks.push(tokio::spawn(async move {
                     let mut remaining = per_stream_total;
@@ -1115,11 +1206,24 @@ async fn setup_subscribers(
                                 }
                                 seen += 1;
                             }
-                            Ok(Ok(None)) => break,
-                            Ok(Err(_)) => break,
-                            Err(_) => break,
+                            Ok(Ok(None)) => {
+                                anyhow::bail!(
+                                    "subscriber stream {stream} closed with {remaining} events remaining"
+                                );
+                            }
+                            Ok(Err(err)) => {
+                                return Err(err).with_context(|| {
+                                    format!("subscriber stream {stream} failed")
+                                });
+                            }
+                            Err(_) => {
+                                anyhow::bail!(
+                                    "subscriber stream {stream} timed out with {remaining} events remaining"
+                                );
+                            }
                         }
                     }
+                    Ok(())
                 }));
             }
         }
@@ -1338,7 +1442,9 @@ fn spawn_dedicated_primary_subscriber(
                         let latency = decode_latency(event.payload.as_ref());
                         let enqueue_start = Instant::now();
                         if delivery_tx.send(latency).await.is_err() {
-                            break;
+                            return Err(
+                                "dedicated delivery receiver closed before completion".to_string()
+                            );
                         }
                         seen += 1;
                         let wait_ns = enqueue_start.elapsed().as_nanos() as u64;
@@ -1360,7 +1466,12 @@ fn spawn_dedicated_primary_subscriber(
                             metrics::histogram!("sub_dispatch_ns").record(dispatch_ns as f64);
                         }
                     }
-                    Ok(None) => break,
+                    Ok(None) => {
+                        return Err(format!(
+                            "dedicated subscriber closed after {seen} of {} events",
+                            primary_warmup + primary_total
+                        ));
+                    }
                     Err(err) => {
                         return Err(format!("dedicated subscriber receive failed: {err}"));
                     }
@@ -1448,11 +1559,11 @@ fn per_stream_events(total: usize, stream_count: usize, stream_index: usize) -> 
 
 fn print_result(result: &DemoResult) {
     println!(
-        "Results (publish n = {}, sampled {}, received {}, delivery drops {}) payload={}B fanout={} batch={} publish_fastpath={}:",
+        "Results (publish n = {}, sampled {}, received {}, unaccounted {}) payload={}B fanout={} batch={} publish_fastpath={}:",
         result.publish_total,
         result.sample_total,
         result.received,
-        result.dropped,
+        result.unaccounted,
         result.payload_bytes,
         result.fanout,
         result.batch_size,
@@ -1463,6 +1574,20 @@ fn print_result(result: &DemoResult) {
         println!("  p50  = n/a (no received samples)");
         println!("  p99  = n/a (no received samples)");
         println!("  p999 = n/a (no received samples)");
+    } else if result.batch_size > 1 {
+        // A batched run is paced by lossless backpressure, so a message waits
+        // for its batch to fill and then behind everything already queued.
+        // These percentiles therefore scale with run length and say nothing
+        // about per-message latency -- label them so they are not read as a
+        // regression when a longer run reports a bigger number. The batch=1
+        // profile below is the one that measures request latency.
+        println!(
+            "  queueing delay (NOT per-message latency; batch={} run, grows with --total):",
+            result.batch_size
+        );
+        println!("    p50  = {}", format_duration(result.p50));
+        println!("    p99  = {}", format_duration(result.p99));
+        println!("    p999 = {}", format_duration(result.p999));
     } else {
         println!("  p50  = {}", format_duration(result.p50));
         println!("  p99  = {}", format_duration(result.p99));
@@ -1712,6 +1837,17 @@ fn print_sanity_checks(
             expected_delivered, result.delivered_total
         );
     }
+    // Subscribers now fail the run on timeout rather than abandoning their
+    // remaining events, so a shortfall can no longer be explained away as
+    // "the queues shed". Either the queue policy really is lossy or the
+    // accounting is wrong; both invalidate the numbers above.
+    if result.unaccounted > 0 {
+        println!(
+            "  sanity: INVALID RUN -- {} of {} expected deliveries never observed. \
+             This is a shortfall, not a measured queue drop; throughput above is not meaningful.",
+            result.unaccounted, expected_delivered
+        );
+    }
     if use_ack {
         if client.ack_items_in_ok == 0 {
             println!("  sanity: ack_items_in_ok expected > 0 (acks enabled)");
@@ -1919,6 +2055,40 @@ fn expectation_note(config: &DemoConfig) -> String {
     }
 }
 
+/// Message count for a batched throughput case in the `--all` sweep.
+///
+/// Balances two things. A run that fits inside the 64 MiB QUIC send window is
+/// absorbed by buffers and reports buffer-fill rate rather than sustained
+/// throughput, so every case wants volume. But fanout multiplies delivered
+/// work, and this is a 20-case demo sweep, so every case also wants to stay
+/// about a second.
+///
+/// The window floor wins whenever it is affordable, because a case that warns
+/// about being undersized is a case that measured the wrong thing. Only the
+/// combinations where clearing the window would cost millions of deliveries
+/// (small payloads at high fanout) fall back to the time cap and warn. Use
+/// `task perf:latency-matrix` for throughput numbers worth quoting -- it sizes
+/// every case past the window with no wall-clock cap and medians five trials.
+fn throughput_total(payload_bytes: usize, fanout: usize) -> usize {
+    const TARGET_RUN_BYTES: usize = 192 * 1024 * 1024;
+    // Comfortably past the 128 MiB the undersized-run warning checks for.
+    const WINDOW_FLOOR_BYTES: usize = 136 * 1024 * 1024;
+    const MAX_DELIVERIES: usize = 1_500_000;
+    if payload_bytes == 0 {
+        // No payload bytes, so the send window is irrelevant; bound by work.
+        return (MAX_DELIVERIES / fanout.max(1)).clamp(5_000, 200_000);
+    }
+    let fanout = fanout.max(1);
+    let by_volume = TARGET_RUN_BYTES.div_ceil(payload_bytes);
+    let by_time = MAX_DELIVERIES / fanout;
+    let window_floor = WINDOW_FLOOR_BYTES.div_ceil(payload_bytes);
+    if window_floor * fanout <= MAX_DELIVERIES {
+        by_volume.min(by_time).max(window_floor)
+    } else {
+        by_volume.min(by_time).max(5_000)
+    }
+}
+
 async fn run_all(base: DemoConfig) -> Result<()> {
     let fast = std::env::var("FELIX_LATENCY_DEMO_FAST")
         .ok()
@@ -1960,7 +2130,11 @@ async fn run_all_with_mode(base: DemoConfig, fast: bool) -> Result<()> {
                 case.batch_size = 64;
                 case.binary = binary;
                 case.warmup = if fast { 1 } else { 200 };
-                case.total = if fast { 5 } else { 5000 };
+                case.total = if fast {
+                    5
+                } else {
+                    throughput_total(payload, fanout)
+                };
                 let (result, summary) = run_case(case.clone()).await?;
                 print_result(&result);
                 print_timing_summary(summary);
@@ -1975,7 +2149,11 @@ async fn run_all_with_mode(base: DemoConfig, fast: bool) -> Result<()> {
     baseline.batch_size = 64;
     baseline.binary = base.binary;
     baseline.warmup = if fast { 1 } else { 200 };
-    baseline.total = if fast { 5 } else { 5000 };
+    baseline.total = if fast {
+        5
+    } else {
+        throughput_total(baseline.payload_bytes, baseline.fanout)
+    };
     baseline.pub_conns = 1;
     baseline.pub_streams_per_conn = 1;
     let (result, summary) = run_case(baseline.clone()).await?;
@@ -2139,6 +2317,7 @@ mod tests {
             sub_delivery_shaping: true,
             pub_yield_every_batches: 0,
             sub_dedicated_thread: false,
+            log_capacity: None,
         }
     }
 
@@ -2163,6 +2342,7 @@ mod tests {
             sub_delivery_shaping: true,
             pub_yield_every_batches: 0,
             sub_dedicated_thread: false,
+            log_capacity: None,
         };
         tokio::time::timeout(
             Duration::from_secs(15),
@@ -2193,6 +2373,7 @@ mod tests {
             sub_delivery_shaping: true,
             pub_yield_every_batches: 0,
             sub_dedicated_thread: false,
+            log_capacity: None,
         };
         tokio::time::timeout(
             Duration::from_secs(15),
@@ -2281,6 +2462,7 @@ mod tests {
                 sub_delivery_shaping: true,
                 pub_yield_every_batches: 0,
                 sub_dedicated_thread: false,
+                log_capacity: None,
             })
             .contains("latency-focused")
         );
@@ -2303,6 +2485,7 @@ mod tests {
                 sub_delivery_shaping: true,
                 pub_yield_every_batches: 0,
                 sub_dedicated_thread: false,
+                log_capacity: None,
             })
             .contains("throughput-focused")
         );
@@ -2352,6 +2535,7 @@ mod tests {
             sub_delivery_shaping: true,
             pub_yield_every_batches: 1,
             sub_dedicated_thread: true,
+            log_capacity: None,
         };
         tokio::time::timeout(
             Duration::from_secs(20),
@@ -2381,6 +2565,7 @@ mod tests {
             sub_delivery_shaping: true,
             pub_yield_every_batches: 0,
             sub_dedicated_thread: true,
+            log_capacity: None,
         };
         tokio::time::timeout(
             Duration::from_secs(15),
@@ -2407,7 +2592,7 @@ mod tests {
             .context("binary fanout timeout")??;
         assert_eq!(result.received, 1000);
         assert_eq!(result.delivered_total, 10_000);
-        assert_eq!(result.dropped, 0);
+        assert_eq!(result.unaccounted, 0);
         Ok(())
     }
 
@@ -2512,7 +2697,7 @@ mod tests {
             batch_size: 1,
             binary: false,
             received: 0,
-            dropped: 1,
+            unaccounted: 1,
             delivered_total: 3,
             p50: Duration::from_micros(1),
             p99: Duration::from_micros(2),

--- a/demos/broker/latency_demo.rs
+++ b/demos/broker/latency_demo.rs
@@ -2305,8 +2305,15 @@ mod tests {
             fanout: 1,
             batch_size: 1,
             binary: false,
-            // >= one QUIC max_ack_delay (25 ms) so a delayed-ACK cycle can't starve the run.
-            idle_ms: 100,
+            // Generous on purpose: this bounds how long a subscriber waits
+            // before declaring a stall, and it has to cover a *cold* first
+            // event -- connection setup, subscribe registration and the first
+            // publish -- not just a steady-state delayed-ACK cycle (25 ms).
+            // Under a coverage-instrumented build the cold path alone exceeds
+            // 100 ms, which failed these runs spuriously. Matches the CLI
+            // default; a genuine stall still fails the run, just not a slow
+            // start.
+            idle_ms: 2000,
             pub_conns: 1,
             pub_streams_per_conn: 1,
             pub_sharding: None,
@@ -2322,6 +2329,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_end_to_end() -> Result<()> {
         let config = DemoConfig {
             warmup: 1,
@@ -2330,8 +2338,15 @@ mod tests {
             fanout: 1,
             batch_size: 1,
             binary: false,
-            // >= one QUIC max_ack_delay (25 ms) so a delayed-ACK cycle can't starve the run.
-            idle_ms: 100,
+            // Generous on purpose: this bounds how long a subscriber waits
+            // before declaring a stall, and it has to cover a *cold* first
+            // event -- connection setup, subscribe registration and the first
+            // publish -- not just a steady-state delayed-ACK cycle (25 ms).
+            // Under a coverage-instrumented build the cold path alone exceeds
+            // 100 ms, which failed these runs spuriously. Matches the CLI
+            // default; a genuine stall still fails the run, just not a slow
+            // start.
+            idle_ms: 2000,
             pub_conns: 1,
             pub_streams_per_conn: 1,
             pub_sharding: None,
@@ -2353,6 +2368,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_matrix_small() -> Result<()> {
         let config = DemoConfig {
             warmup: 0,
@@ -2361,8 +2377,15 @@ mod tests {
             fanout: 1,
             batch_size: 1,
             binary: false,
-            // >= one QUIC max_ack_delay (25 ms) so a delayed-ACK cycle can't starve the run.
-            idle_ms: 100,
+            // Generous on purpose: this bounds how long a subscriber waits
+            // before declaring a stall, and it has to cover a *cold* first
+            // event -- connection setup, subscribe registration and the first
+            // publish -- not just a steady-state delayed-ACK cycle (25 ms).
+            // Under a coverage-instrumented build the cold path alone exceeds
+            // 100 ms, which failed these runs spuriously. Matches the CLI
+            // default; a genuine stall still fails the run, just not a slow
+            // start.
+            idle_ms: 2000,
             pub_conns: 1,
             pub_streams_per_conn: 1,
             pub_sharding: Some("rr".to_string()),
@@ -2507,6 +2530,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_run_all_fast() -> Result<()> {
         let base = base_config();
         tokio::time::timeout(Duration::from_secs(20), run_all_with_mode(base, true))
@@ -2515,6 +2539,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_smoke_flags() -> Result<()> {
         let config = DemoConfig {
             warmup: 1,
@@ -2523,8 +2548,15 @@ mod tests {
             fanout: 1,
             batch_size: 2,
             binary: false,
-            // >= one QUIC max_ack_delay (25 ms) so a delayed-ACK cycle can't starve the run.
-            idle_ms: 100,
+            // Generous on purpose: this bounds how long a subscriber waits
+            // before declaring a stall, and it has to cover a *cold* first
+            // event -- connection setup, subscribe registration and the first
+            // publish -- not just a steady-state delayed-ACK cycle (25 ms).
+            // Under a coverage-instrumented build the cold path alone exceeds
+            // 100 ms, which failed these runs spuriously. Matches the CLI
+            // default; a genuine stall still fails the run, just not a slow
+            // start.
+            idle_ms: 2000,
             pub_conns: 1,
             pub_streams_per_conn: 1,
             pub_sharding: None,
@@ -2546,6 +2578,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_dedicated_binary_warmup_exceeds_default_queue() -> Result<()> {
         let config = DemoConfig {
             warmup: 500,
@@ -2576,6 +2609,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_binary_fanout_is_lossless() -> Result<()> {
         let mut config = base_config();
         config.warmup = 200;
@@ -2675,6 +2709,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn latency_demo_compare_sub_delivery_shaping_path() -> Result<()> {
         let mut config = base_config();
         config.total = 3;

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -929,6 +929,7 @@ name = "felix-transport"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "libc",
  "quinn",
  "socket2",
  "tokio",
@@ -1686,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -929,6 +929,7 @@ name = "felix-transport"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "libc",
  "quinn",
  "socket2",
  "tokio",
@@ -1686,9 +1687,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -994,6 +994,7 @@ name = "felix-transport"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "libc",
  "quinn",
  "socket2",
  "tokio",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -994,6 +994,7 @@ name = "felix-transport"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "libc",
  "quinn",
  "socket2",
  "tokio",

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -102,6 +102,7 @@ export default defineConfig({
             { label: 'Performance Tuning', slug: 'features/performance' },
             { label: 'Performance & Platform Notes', slug: 'features/performance-platform-notes' },
             { label: 'Benchmarks', slug: 'features/benchmarks' },
+            { label: 'Case Study: Throughput Ceiling', slug: 'features/performance-case-study' },
             { label: 'Observability', slug: 'features/observability' },
             { label: 'Security', slug: 'features/security' },
           ],

--- a/docs-site/public/charts/latency_demo/balanced/f10_b1_json_a8b3321b_p50.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f10_b1_json_a8b3321b_p50.svg
@@ -1,0 +1,1668 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:26.038525</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54.48 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 54.48 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.24 311 
+L 108.567656 311 
+L 108.567656 63.373591 
+L 84.24 63.373591 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 240.386702 311 
+L 264.714359 311 
+L 264.714359 60.012146 
+L 240.386702 60.012146 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 396.533405 311 
+L 420.861061 311 
+L 420.861061 55.53022 
+L 396.533405 55.53022 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 552.680107 311 
+L 577.007763 311 
+L 577.007763 48.807331 
+L 552.680107 48.807331 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 109.848059 311 
+L 134.175715 311 
+L 134.175715 79.060331 
+L 109.848059 79.060331 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 265.994762 311 
+L 290.322418 311 
+L 290.322418 76.819368 
+L 265.994762 76.819368 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 422.141464 311 
+L 446.46912 311 
+L 446.46912 70.09648 
+L 422.141464 70.09648 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 578.288166 311 
+L 602.615822 311 
+L 602.615822 61.132628 
+L 578.288166 61.132628 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 135.456118 311 
+L 159.783775 311 
+L 159.783775 80.180813 
+L 135.456118 80.180813 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 291.602821 311 
+L 315.930477 311 
+L 315.930477 73.457924 
+L 291.602821 73.457924 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 447.749523 311 
+L 472.077179 311 
+L 472.077179 71.216961 
+L 447.749523 71.216961 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 603.896225 311 
+L 628.223882 311 
+L 628.223882 56.650702 
+L 603.896225 56.650702 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 161.064178 311 
+L 185.391834 311 
+L 185.391834 72.337443 
+L 161.064178 72.337443 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 317.21088 311 
+L 341.538536 311 
+L 341.538536 65.614554 
+L 317.21088 65.614554 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 473.357582 311 
+L 497.685238 311 
+L 497.685238 68.975998 
+L 473.357582 68.975998 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 629.504285 311 
+L 653.831941 311 
+L 653.831941 57.771183 
+L 629.504285 57.771183 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 186.672237 311 
+L 210.999893 311 
+L 210.999893 58.891665 
+L 186.672237 58.891665 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 342.818939 311 
+L 367.146595 311 
+L 367.146595 52.168776 
+L 342.818939 52.168776 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 498.965641 311 
+L 523.293298 311 
+L 523.293298 55.53022 
+L 498.965641 55.53022 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 655.112344 311 
+L 679.44 311 
+L 679.44 48.471187 
+L 655.112344 48.471187 
+z
+" clip-path="url(#pe1cb55b595)" style="fill: url(#h73739614be); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="mb080247682" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb080247682" x="147.619946" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(144.438696 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#mb080247682" x="303.766649" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 256 -->
+      <g transform="translate(294.222899 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#mb080247682" x="459.913351" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1024 -->
+      <g transform="translate(447.188351 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#mb080247682" x="616.060054" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4096 -->
+      <g transform="translate(603.335054 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- payload (bytes) -->
+     <g transform="translate(342.69 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="mcd1238e5c5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mcd1238e5c5" x="54.48" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.00 -->
+      <g transform="translate(25.214375 314.798828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mcd1238e5c5" x="54.48" y="254.975925" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.05 -->
+      <g transform="translate(25.214375 258.774754) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mcd1238e5c5" x="54.48" y="198.951851" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.10 -->
+      <g transform="translate(25.214375 202.750679) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mcd1238e5c5" x="54.48" y="142.927776" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.15 -->
+      <g transform="translate(25.214375 146.726605) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mcd1238e5c5" x="54.48" y="86.903702" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.20 -->
+      <g transform="translate(25.214375 90.70253) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- p50 latency (ms) -->
+     <g transform="translate(18.812031 215.630967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-18" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-13" transform="translate(127.109375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(190.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(222.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(250.296875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(311.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(350.78125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(412.3125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(475.6875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(530.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(589.859375 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(621.640625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(660.65625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(758.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(810.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 54.48 311 
+L 54.48 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 54.48 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 54.48 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- 0.24↑ -->
+    <g transform="translate(668.834766 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-13"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(222.65625 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- latency_demo balanced fanout=10 batch=1 binary=False warmup=2000 total=20000 trials=3 (clipped -->
+    <g transform="translate(147.765469 18.542988) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1756.390625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1788.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1851.65625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1912.9375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1952.140625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2007.125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2070.5 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2217.921875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2249.703125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2313.1875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2340.96875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2404.34375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2465.625 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2506.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2565.921875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2649.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2698.0625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2759.34375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2787.125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2839.21875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2900.75 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2932.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3014.3125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3075.59375 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3114.953125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3212.359375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3275.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3339.21875 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3423.015625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3486.640625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3550.265625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3613.890625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3677.515625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3709.296875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3748.5 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3809.6875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3848.890625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3910.171875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3937.953125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(4021.75 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4085.375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4149 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4212.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4276.25 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4339.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4371.65625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4410.859375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4451.96875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4479.75 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4541.03125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4568.8125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4620.90625 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(4704.703125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4768.328125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(4800.109375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4839.125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4894.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4921.890625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4949.671875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(5013.15625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(5076.640625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(5138.171875 0)"/>
+    </g>
+    <!-- p95) -->
+    <g transform="translate(371.50125 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(127.109375 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(190.734375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_27">
+     <path d="M 60.08 65.745996 
+L 249.07875 65.745996 
+Q 250.67875 65.745996 250.67875 64.145996 
+L 250.67875 40.944746 
+Q 250.67875 39.344746 249.07875 39.344746 
+L 60.08 39.344746 
+Q 58.48 39.344746 58.48 40.944746 
+L 58.48 64.145996 
+Q 58.48 65.745996 60.08 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_28">
+     <path d="M 61.68 48.623496 
+L 77.68 48.623496 
+L 77.68 43.023496 
+L 61.68 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_14">
+     <!-- P1_hash -->
+     <g transform="translate(84.08 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_29">
+     <path d="M 61.68 60.624121 
+L 77.68 60.624121 
+L 77.68 55.024121 
+L 61.68 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_15">
+     <!-- P2_hash -->
+     <g transform="translate(84.08 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_30">
+     <path d="M 133.20375 48.623496 
+L 149.20375 48.623496 
+L 149.20375 43.023496 
+L 133.20375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_16">
+     <!-- P4_hash -->
+     <g transform="translate(155.60375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_31">
+     <path d="M 133.20375 60.624121 
+L 149.20375 60.624121 
+L 149.20375 55.024121 
+L 133.20375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_17">
+     <!-- P8_hash -->
+     <g transform="translate(155.60375 60.624121) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_32">
+     <path d="M 204.7275 48.623496 
+L 220.7275 48.623496 
+L 220.7275 43.023496 
+L 204.7275 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_18">
+     <!-- P8_rr -->
+     <g transform="translate(227.1275 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_19">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pe1cb55b595">
+   <rect x="54.48" y="35.344746" width="654.72" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h73739614be" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#9467bd"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/charts/latency_demo/balanced/f10_b1_json_a8b3321b_p99.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f10_b1_json_a8b3321b_p99.svg
@@ -1,0 +1,1719 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:26.143184</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54.48 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 54.48 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.24 311 
+L 108.567656 311 
+L 108.567656 81.940553 
+L 84.24 81.940553 
+z
+" clip-path="url(#p476a79435a)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 240.386702 311 
+L 264.714359 311 
+L 264.714359 71.562455 
+L 240.386702 71.562455 
+z
+" clip-path="url(#p476a79435a)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 396.533405 311 
+L 420.861061 311 
+L 420.861061 58.219186 
+L 396.533405 58.219186 
+z
+" clip-path="url(#p476a79435a)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 552.680107 311 
+L 577.007763 311 
+L 577.007763 48.471187 
+L 552.680107 48.471187 
+z
+" clip-path="url(#p476a79435a)" style="fill: url(#hd7f4626c52); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 109.848059 311 
+L 134.175715 311 
+L 134.175715 87.129602 
+L 109.848059 87.129602 
+z
+" clip-path="url(#p476a79435a)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 265.994762 311 
+L 290.322418 311 
+L 290.322418 84.164431 
+L 265.994762 84.164431 
+z
+" clip-path="url(#p476a79435a)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 422.141464 311 
+L 446.46912 311 
+L 446.46912 76.010211 
+L 422.141464 76.010211 
+z
+" clip-path="url(#p476a79435a)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 578.288166 311 
+L 602.615822 311 
+L 602.615822 50.064966 
+L 578.288166 50.064966 
+z
+" clip-path="url(#p476a79435a)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 135.456118 311 
+L 159.783775 311 
+L 159.783775 93.801236 
+L 135.456118 93.801236 
+z
+" clip-path="url(#p476a79435a)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 291.602821 311 
+L 315.930477 311 
+L 315.930477 81.19926 
+L 291.602821 81.19926 
+z
+" clip-path="url(#p476a79435a)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 447.749523 311 
+L 472.077179 311 
+L 472.077179 76.010211 
+L 447.749523 76.010211 
+z
+" clip-path="url(#p476a79435a)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 603.896225 311 
+L 628.223882 311 
+L 628.223882 65.632113 
+L 603.896225 65.632113 
+z
+" clip-path="url(#p476a79435a)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 161.064178 311 
+L 185.391834 311 
+L 185.391834 77.492796 
+L 161.064178 77.492796 
+z
+" clip-path="url(#p476a79435a)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 317.21088 311 
+L 341.538536 311 
+L 341.538536 53.030137 
+L 317.21088 53.030137 
+z
+" clip-path="url(#p476a79435a)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 473.357582 311 
+L 497.685238 311 
+L 497.685238 68.597284 
+L 473.357582 68.597284 
+z
+" clip-path="url(#p476a79435a)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 629.504285 311 
+L 653.831941 311 
+L 653.831941 55.995308 
+L 629.504285 55.995308 
+z
+" clip-path="url(#p476a79435a)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 186.672237 311 
+L 210.999893 311 
+L 210.999893 67.114698 
+L 186.672237 67.114698 
+z
+" clip-path="url(#p476a79435a)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 342.818939 311 
+L 367.146595 311 
+L 367.146595 49.323673 
+L 342.818939 49.323673 
+z
+" clip-path="url(#p476a79435a)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 498.965641 311 
+L 523.293298 311 
+L 523.293298 64.89082 
+L 498.965641 64.89082 
+z
+" clip-path="url(#p476a79435a)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 655.112344 311 
+L 679.44 311 
+L 679.44 48.582381 
+L 655.112344 48.582381 
+z
+" clip-path="url(#p476a79435a)" style="fill: #9467bd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m9952b6df89" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m9952b6df89" x="147.619946" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(144.438696 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m9952b6df89" x="303.766649" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 256 -->
+      <g transform="translate(294.222899 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m9952b6df89" x="459.913351" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1024 -->
+      <g transform="translate(447.188351 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m9952b6df89" x="616.060054" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4096 -->
+      <g transform="translate(603.335054 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- payload (bytes) -->
+     <g transform="translate(342.69 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="m17638df26b" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.00 -->
+      <g transform="translate(25.214375 314.798828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="273.935365" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.05 -->
+      <g transform="translate(25.214375 277.734193) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="236.870729" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.10 -->
+      <g transform="translate(25.214375 240.669557) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="199.806094" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.15 -->
+      <g transform="translate(25.214375 203.604922) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="162.741458" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.20 -->
+      <g transform="translate(25.214375 166.540286) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="125.676823" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.25 -->
+      <g transform="translate(25.214375 129.475651) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="88.612187" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.30 -->
+      <g transform="translate(25.214375 92.411015) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m17638df26b" x="54.48" y="51.547552" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.35 -->
+      <g transform="translate(25.214375 55.34638) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- p99 latency (ms) -->
+     <g transform="translate(18.812031 215.630967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-1c" transform="translate(127.109375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(190.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(222.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(250.296875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(311.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(350.78125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(412.3125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(475.6875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(530.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(589.859375 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(621.640625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(660.65625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(758.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(810.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 54.48 311 
+L 54.48 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 54.48 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 54.48 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- 0.357↑ -->
+    <g transform="translate(566.402529 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-13"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(286.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- latency_demo balanced fanout=10 batch=1 binary=False warmup=2000 total=20000 trials=3 (clipped -->
+    <g transform="translate(147.765469 18.542988) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1756.390625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1788.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1851.65625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1912.9375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1952.140625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2007.125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2070.5 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2217.921875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2249.703125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2313.1875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2340.96875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2404.34375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2465.625 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2506.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2565.921875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2649.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2698.0625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2759.34375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2787.125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2839.21875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2900.75 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2932.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3014.3125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3075.59375 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3114.953125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3212.359375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3275.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3339.21875 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3423.015625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3486.640625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3550.265625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3613.890625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3677.515625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3709.296875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3748.5 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3809.6875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3848.890625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3910.171875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3937.953125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(4021.75 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4085.375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4149 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4212.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4276.25 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4339.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4371.65625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4410.859375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4451.96875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4479.75 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4541.03125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4568.8125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4620.90625 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(4704.703125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4768.328125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(4800.109375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4839.125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4894.109375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4921.890625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4949.671875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(5013.15625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(5076.640625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(5138.171875 0)"/>
+    </g>
+    <!-- p95) -->
+    <g transform="translate(371.50125 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(127.109375 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(190.734375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_27">
+     <path d="M 60.08 65.745996 
+L 249.07875 65.745996 
+Q 250.67875 65.745996 250.67875 64.145996 
+L 250.67875 40.944746 
+Q 250.67875 39.344746 249.07875 39.344746 
+L 60.08 39.344746 
+Q 58.48 39.344746 58.48 40.944746 
+L 58.48 64.145996 
+Q 58.48 65.745996 60.08 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_28">
+     <path d="M 61.68 48.623496 
+L 77.68 48.623496 
+L 77.68 43.023496 
+L 61.68 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_17">
+     <!-- P1_hash -->
+     <g transform="translate(84.08 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_29">
+     <path d="M 61.68 60.624121 
+L 77.68 60.624121 
+L 77.68 55.024121 
+L 61.68 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_18">
+     <!-- P2_hash -->
+     <g transform="translate(84.08 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_30">
+     <path d="M 133.20375 48.623496 
+L 149.20375 48.623496 
+L 149.20375 43.023496 
+L 133.20375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_19">
+     <!-- P4_hash -->
+     <g transform="translate(155.60375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_31">
+     <path d="M 133.20375 60.624121 
+L 149.20375 60.624121 
+L 149.20375 55.024121 
+L 133.20375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_20">
+     <!-- P8_hash -->
+     <g transform="translate(155.60375 60.624121) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_32">
+     <path d="M 204.7275 48.623496 
+L 220.7275 48.623496 
+L 220.7275 43.023496 
+L 204.7275 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_21">
+     <!-- P8_rr -->
+     <g transform="translate(227.1275 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_22">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p476a79435a">
+   <rect x="54.48" y="35.344746" width="654.72" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="hd7f4626c52" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#1f77b4"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/charts/latency_demo/balanced/f10_b64_binary_a8b3321b_delivered_mb_per_s.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f10_b64_binary_a8b3321b_delivered_mb_per_s.svg
@@ -1,0 +1,1749 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:27.870507</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 51.24 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 51.24 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 81.147273 311 
+L 114.290121 311 
+L 114.290121 71.794837 
+L 81.147273 71.794837 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 293.874157 311 
+L 327.017006 311 
+L 327.017006 58.130839 
+L 293.874157 58.130839 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 506.601042 311 
+L 539.743891 311 
+L 539.743891 49.420804 
+L 506.601042 49.420804 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 116.034482 311 
+L 149.17733 311 
+L 149.17733 71.932955 
+L 116.034482 71.932955 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 328.761367 311 
+L 361.904215 311 
+L 361.904215 59.152725 
+L 328.761367 59.152725 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 541.488251 311 
+L 574.6311 311 
+L 574.6311 48.471187 
+L 541.488251 48.471187 
+z
+" clip-path="url(#p4012f39b84)" style="fill: url(#hc0075c29d9); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 150.921691 311 
+L 184.06454 311 
+L 184.06454 73.817874 
+L 150.921691 73.817874 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 363.648576 311 
+L 396.791424 311 
+L 396.791424 59.994373 
+L 363.648576 59.994373 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 576.37546 311 
+L 609.518309 311 
+L 609.518309 49.82151 
+L 576.37546 49.82151 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 185.8089 311 
+L 218.951749 311 
+L 218.951749 74.240204 
+L 185.8089 74.240204 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 398.535785 311 
+L 431.678633 311 
+L 431.678633 57.003905 
+L 398.535785 57.003905 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 611.26267 311 
+L 644.405518 311 
+L 644.405518 50.237382 
+L 611.26267 50.237382 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 220.696109 311 
+L 253.838958 311 
+L 253.838958 72.963989 
+L 220.696109 72.963989 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 433.422994 311 
+L 466.565843 311 
+L 466.565843 60.630517 
+L 433.422994 60.630517 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 646.149879 311 
+L 679.292727 311 
+L 679.292727 48.84311 
+L 646.149879 48.84311 
+z
+" clip-path="url(#p4012f39b84)" style="fill: #9467bd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m2d9e3f256c" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2d9e3f256c" x="167.493115" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 256 -->
+      <g transform="translate(157.949365 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m2d9e3f256c" x="380.22" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1024 -->
+      <g transform="translate(367.495 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m2d9e3f256c" x="592.946885" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4096 -->
+      <g transform="translate(580.221885 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_4">
+     <!-- payload (bytes) -->
+     <g transform="translate(341.07 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <defs>
+       <path id="mabdc53fcc5" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(37.8775 314.798828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="277.969868" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 100 -->
+      <g transform="translate(25.1525 281.768696) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="244.939736" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 200 -->
+      <g transform="translate(25.1525 248.738564) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="211.909604" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 300 -->
+      <g transform="translate(25.1525 215.708433) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="178.879473" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 400 -->
+      <g transform="translate(25.1525 182.678301) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="145.849341" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 500 -->
+      <g transform="translate(25.1525 149.648169) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="112.819209" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 600 -->
+      <g transform="translate(25.1525 116.618037) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-19"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="79.789077" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 700 -->
+      <g transform="translate(25.1525 83.587905) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1a"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mabdc53fcc5" x="51.24" y="46.758945" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 800 -->
+      <g transform="translate(25.1525 50.557773) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-1b"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- delivered payload (MB/s) -->
+     <g transform="translate(18.750156 235.430967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-25" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(125.015625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(152.796875 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(180.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(239.765625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(301.296875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(340.203125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(401.734375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(465.21875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(497 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(560.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(621.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(680.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(708.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(769.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(831.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(894.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(926.46875 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(965.484375 0)"/>
+      <use xlink:href="#DejaVuSans-25" transform="translate(1051.765625 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(1120.375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1154.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1206.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_18">
+    <path d="M 51.24 311 
+L 51.24 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 51.24 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 51.24 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- 797↑ -->
+    <g transform="translate(559.618269 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-1a"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-1a" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(190.875 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- latency_demo balanced fanout=10 batch=64 binary=True warmup=2000 total=volume-scaled trials=3 - -->
+    <g transform="translate(143.03625 18.542285) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1756.390625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1788.171875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1851.65625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1912.9375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1952.140625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(2007.125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2070.5 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2217.921875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2281.546875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2313.328125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2376.8125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2404.59375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2467.96875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2529.25 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2570.359375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2629.546875 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2713.34375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2759.71875 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2800.828125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2864.203125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2925.734375 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2957.515625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3039.296875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3100.578125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3139.9375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3237.34375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3300.71875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3364.203125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3448 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3511.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3575.25 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3638.875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3702.5 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3734.28125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3773.484375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3834.671875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3873.875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3935.15625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3962.9375 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(4046.734375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(4105.921875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4167.109375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(4194.890625 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(4258.265625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(4355.671875 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(4417.203125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4453.28125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4505.375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4560.359375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4621.640625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(4649.421875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(4710.953125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4774.4375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4806.21875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4845.421875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4886.53125 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4914.3125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4975.59375 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(5003.375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(5055.46875 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(5139.265625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(5202.890625 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(5234.671875 0)"/>
+    </g>
+    <!-- delivered payload byte rate (clipped p95) -->
+    <g transform="translate(286.636172 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(125.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(152.796875 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(180.578125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(239.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(301.296875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(340.203125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(401.734375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(465.21875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(497 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(560.484375 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(621.765625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(680.953125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(708.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(769.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(831.203125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(894.6875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(926.46875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(989.953125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1049.140625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1088.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1149.875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1181.65625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1222.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1284.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1323.25 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1384.78125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(1416.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1455.578125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1510.5625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1538.34375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1566.125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1629.609375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1693.09375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1754.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1818.109375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1849.890625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(1913.375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(1977 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(2040.625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_22">
+     <path d="M 56.84 65.745996 
+L 245.83875 65.745996 
+Q 247.43875 65.745996 247.43875 64.145996 
+L 247.43875 40.944746 
+Q 247.43875 39.344746 245.83875 39.344746 
+L 56.84 39.344746 
+Q 55.24 39.344746 55.24 40.944746 
+L 55.24 64.145996 
+Q 55.24 65.745996 56.84 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_23">
+     <path d="M 58.44 48.623496 
+L 74.44 48.623496 
+L 74.44 43.023496 
+L 58.44 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_17">
+     <!-- P1_hash -->
+     <g transform="translate(80.84 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_24">
+     <path d="M 58.44 60.624121 
+L 74.44 60.624121 
+L 74.44 55.024121 
+L 58.44 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_18">
+     <!-- P2_hash -->
+     <g transform="translate(80.84 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_25">
+     <path d="M 129.96375 48.623496 
+L 145.96375 48.623496 
+L 145.96375 43.023496 
+L 129.96375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_19">
+     <!-- P4_hash -->
+     <g transform="translate(152.36375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_26">
+     <path d="M 129.96375 60.624121 
+L 145.96375 60.624121 
+L 145.96375 55.024121 
+L 129.96375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_20">
+     <!-- P8_hash -->
+     <g transform="translate(152.36375 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 201.4875 48.623496 
+L 217.4875 48.623496 
+L 217.4875 43.023496 
+L 201.4875 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_21">
+     <!-- P8_rr -->
+     <g transform="translate(223.8875 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_22">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p4012f39b84">
+   <rect x="51.24" y="35.344746" width="657.96" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="hc0075c29d9" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#ff7f0e"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/charts/latency_demo/balanced/f1_b1_json_a8b3321b_p50.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f1_b1_json_a8b3321b_p50.svg
@@ -1,0 +1,1716 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:25.355486</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54.48 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 54.48 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.24 311 
+L 108.567656 311 
+L 108.567656 71.144981 
+L 84.24 71.144981 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 240.386702 311 
+L 264.714359 311 
+L 264.714359 71.144981 
+L 240.386702 71.144981 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 396.533405 311 
+L 420.861061 311 
+L 420.861061 65.523379 
+L 396.533405 65.523379 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 552.680107 311 
+L 577.007763 311 
+L 577.007763 54.280175 
+L 552.680107 54.280175 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 109.848059 311 
+L 134.175715 311 
+L 134.175715 73.018849 
+L 109.848059 73.018849 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 265.994762 311 
+L 290.322418 311 
+L 290.322418 67.397247 
+L 265.994762 67.397247 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 422.141464 311 
+L 446.46912 311 
+L 446.46912 63.649512 
+L 422.141464 63.649512 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 578.288166 311 
+L 602.615822 311 
+L 602.615822 50.532441 
+L 578.288166 50.532441 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 135.456118 311 
+L 159.783775 311 
+L 159.783775 65.523379 
+L 135.456118 65.523379 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 291.602821 311 
+L 315.930477 311 
+L 315.930477 67.397247 
+L 291.602821 67.397247 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 447.749523 311 
+L 472.077179 311 
+L 472.077179 52.406308 
+L 447.749523 52.406308 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 603.896225 311 
+L 628.223882 311 
+L 628.223882 50.532441 
+L 603.896225 50.532441 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 161.064178 311 
+L 185.391834 311 
+L 185.391834 63.649512 
+L 161.064178 63.649512 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 317.21088 311 
+L 341.538536 311 
+L 341.538536 61.775645 
+L 317.21088 61.775645 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 473.357582 311 
+L 497.685238 311 
+L 497.685238 56.154043 
+L 473.357582 56.154043 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 629.504285 311 
+L 653.831941 311 
+L 653.831941 48.471187 
+L 629.504285 48.471187 
+z
+" clip-path="url(#p65f030ee44)" style="fill: url(#he9b194471f); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 186.672237 311 
+L 210.999893 311 
+L 210.999893 69.271114 
+L 186.672237 69.271114 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 342.818939 311 
+L 367.146595 311 
+L 367.146595 63.649512 
+L 342.818939 63.649512 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 498.965641 311 
+L 523.293298 311 
+L 523.293298 61.775645 
+L 498.965641 61.775645 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 655.112344 311 
+L 679.44 311 
+L 679.44 48.658573 
+L 655.112344 48.658573 
+z
+" clip-path="url(#p65f030ee44)" style="fill: #9467bd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="md61335dec7" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#md61335dec7" x="147.619946" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(144.438696 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#md61335dec7" x="303.766649" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 256 -->
+      <g transform="translate(294.222899 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#md61335dec7" x="459.913351" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1024 -->
+      <g transform="translate(447.188351 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#md61335dec7" x="616.060054" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4096 -->
+      <g transform="translate(603.335054 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- payload (bytes) -->
+     <g transform="translate(342.69 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="m7967e82360" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.00 -->
+      <g transform="translate(25.214375 314.798828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="273.522653" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.02 -->
+      <g transform="translate(25.214375 277.321481) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="236.045307" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.04 -->
+      <g transform="translate(25.214375 239.844135) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="198.56796" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.06 -->
+      <g transform="translate(25.214375 202.366788) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="161.090613" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.08 -->
+      <g transform="translate(25.214375 164.889442) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-1b" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="123.613267" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.10 -->
+      <g transform="translate(25.214375 127.412095) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="86.13592" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 0.12 -->
+      <g transform="translate(25.214375 89.934748) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m7967e82360" x="54.48" y="48.658573" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0.14 -->
+      <g transform="translate(25.214375 52.457402) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_14">
+     <!-- p50 latency (ms) -->
+     <g transform="translate(18.812031 215.630967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-18" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-13" transform="translate(127.109375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(190.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(222.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(250.296875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(311.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(350.78125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(412.3125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(475.6875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(530.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(589.859375 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(621.640625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(660.65625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(758.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(810.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 54.48 311 
+L 54.48 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 54.48 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 54.48 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_15">
+    <!-- 0.142↑ -->
+    <g transform="translate(643.226706 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-13"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(286.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- latency_demo balanced fanout=1 batch=1 binary=False warmup=2000 total=20000 trials=3 (clipped -->
+    <g transform="translate(150.628594 18.542988) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1724.546875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1788.03125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1849.3125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1888.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1943.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2006.875 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(2090.671875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2186.078125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2249.5625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2277.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2340.71875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2402 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2443.109375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2502.296875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2586.09375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2634.4375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2695.71875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2723.5 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2775.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2837.125 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2868.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2950.6875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3011.96875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3051.328125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3148.734375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3212.109375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3275.59375 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3359.390625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3423.015625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3486.640625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3550.265625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3613.890625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3645.671875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3684.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3746.0625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3785.265625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3846.546875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3874.328125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3958.125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4021.75 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4085.375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4149 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4212.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4276.25 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4308.03125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4347.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4388.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4416.125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4477.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4505.1875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4557.28125 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(4641.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4704.703125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(4736.484375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4775.5 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4830.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4858.265625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4886.046875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4949.53125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(5013.015625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(5074.546875 0)"/>
+    </g>
+    <!-- p95) -->
+    <g transform="translate(371.50125 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(127.109375 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(190.734375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_27">
+     <path d="M 60.08 65.745996 
+L 249.07875 65.745996 
+Q 250.67875 65.745996 250.67875 64.145996 
+L 250.67875 40.944746 
+Q 250.67875 39.344746 249.07875 39.344746 
+L 60.08 39.344746 
+Q 58.48 39.344746 58.48 40.944746 
+L 58.48 64.145996 
+Q 58.48 65.745996 60.08 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_28">
+     <path d="M 61.68 48.623496 
+L 77.68 48.623496 
+L 77.68 43.023496 
+L 61.68 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_17">
+     <!-- P1_hash -->
+     <g transform="translate(84.08 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_29">
+     <path d="M 61.68 60.624121 
+L 77.68 60.624121 
+L 77.68 55.024121 
+L 61.68 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_18">
+     <!-- P2_hash -->
+     <g transform="translate(84.08 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_30">
+     <path d="M 133.20375 48.623496 
+L 149.20375 48.623496 
+L 149.20375 43.023496 
+L 133.20375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_19">
+     <!-- P4_hash -->
+     <g transform="translate(155.60375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_31">
+     <path d="M 133.20375 60.624121 
+L 149.20375 60.624121 
+L 149.20375 55.024121 
+L 133.20375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_20">
+     <!-- P8_hash -->
+     <g transform="translate(155.60375 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_32">
+     <path d="M 204.7275 48.623496 
+L 220.7275 48.623496 
+L 220.7275 43.023496 
+L 204.7275 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_21">
+     <!-- P8_rr -->
+     <g transform="translate(227.1275 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_22">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p65f030ee44">
+   <rect x="54.48" y="35.344746" width="654.72" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="he9b194471f" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#d62728"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/charts/latency_demo/balanced/f1_b1_json_a8b3321b_p99.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f1_b1_json_a8b3321b_p99.svg
@@ -1,0 +1,1668 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:25.462741</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54.48 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 54.48 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 84.24 311 
+L 108.567656 311 
+L 108.567656 114.441776 
+L 84.24 114.441776 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 240.386702 311 
+L 264.714359 311 
+L 264.714359 108.556799 
+L 240.386702 108.556799 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 396.533405 311 
+L 420.861061 311 
+L 420.861061 102.671823 
+L 396.533405 102.671823 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 552.680107 311 
+L 577.007763 311 
+L 577.007763 86.193888 
+L 552.680107 86.193888 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 109.848059 311 
+L 134.175715 311 
+L 134.175715 114.441776 
+L 109.848059 114.441776 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 265.994762 311 
+L 290.322418 311 
+L 290.322418 101.494827 
+L 265.994762 101.494827 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 422.141464 311 
+L 446.46912 311 
+L 446.46912 68.538958 
+L 422.141464 68.538958 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 578.288166 311 
+L 602.615822 311 
+L 602.615822 89.724874 
+L 578.288166 89.724874 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 135.456118 311 
+L 159.783775 311 
+L 159.783775 99.140837 
+L 135.456118 99.140837 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 291.602821 311 
+L 315.930477 311 
+L 315.930477 99.140837 
+L 291.602821 99.140837 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 447.749523 311 
+L 472.077179 311 
+L 472.077179 73.246939 
+L 447.749523 73.246939 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 603.896225 311 
+L 628.223882 311 
+L 628.223882 87.370883 
+L 603.896225 87.370883 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 161.064178 311 
+L 185.391834 311 
+L 185.391834 76.777925 
+L 161.064178 76.777925 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 317.21088 311 
+L 341.538536 311 
+L 341.538536 48.530037 
+L 317.21088 48.530037 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 473.357582 311 
+L 497.685238 311 
+L 497.685238 52.061023 
+L 473.357582 52.061023 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 629.504285 311 
+L 653.831941 311 
+L 653.831941 48.471187 
+L 629.504285 48.471187 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: url(#h6130f7cc36); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 186.672237 311 
+L 210.999893 311 
+L 210.999893 95.609851 
+L 186.672237 95.609851 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 342.818939 311 
+L 367.146595 311 
+L 367.146595 69.715953 
+L 342.818939 69.715953 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 498.965641 311 
+L 523.293298 311 
+L 523.293298 70.892948 
+L 498.965641 70.892948 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 655.112344 311 
+L 679.44 311 
+L 679.44 52.061023 
+L 655.112344 52.061023 
+z
+" clip-path="url(#pa5b5c618b4)" style="fill: #9467bd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="ma1d3116675" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma1d3116675" x="147.619946" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(144.438696 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#ma1d3116675" x="303.766649" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 256 -->
+      <g transform="translate(294.222899 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#ma1d3116675" x="459.913351" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 1024 -->
+      <g transform="translate(447.188351 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#ma1d3116675" x="616.060054" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 4096 -->
+      <g transform="translate(603.335054 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_5">
+     <!-- payload (bytes) -->
+     <g transform="translate(342.69 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <defs>
+       <path id="m5128dfeb76" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5128dfeb76" x="54.48" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0.00 -->
+      <g transform="translate(25.214375 314.798828) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m5128dfeb76" x="54.48" y="252.150232" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0.05 -->
+      <g transform="translate(25.214375 255.949061) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m5128dfeb76" x="54.48" y="193.300465" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0.10 -->
+      <g transform="translate(25.214375 197.099293) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m5128dfeb76" x="54.48" y="134.450697" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0.15 -->
+      <g transform="translate(25.214375 138.249525) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-14" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m5128dfeb76" x="54.48" y="75.60093" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.20 -->
+      <g transform="translate(25.214375 79.399758) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+       <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(159.03125 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- p99 latency (ms) -->
+     <g transform="translate(18.812031 215.630967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-1c" transform="translate(127.109375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(190.734375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(222.515625 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(250.296875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(311.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(350.78125 0)"/>
+      <use xlink:href="#DejaVuSans-51" transform="translate(412.3125 0)"/>
+      <use xlink:href="#DejaVuSans-46" transform="translate(475.6875 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(530.671875 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(589.859375 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(621.640625 0)"/>
+      <use xlink:href="#DejaVuSans-50" transform="translate(660.65625 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(758.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(810.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 54.48 311 
+L 54.48 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 54.48 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 54.48 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- 0.224↑ -->
+    <g transform="translate(643.226706 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-13"/>
+     <use xlink:href="#DejaVuSans-11" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(95.40625 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(159.03125 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(222.65625 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(286.28125 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- latency_demo balanced fanout=1 batch=1 binary=False warmup=2000 total=20000 trials=3 (clipped -->
+    <g transform="translate(150.628594 18.542988) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 628 4666 
+L 3309 4666 
+L 3309 4134 
+L 1259 4134 
+L 1259 2759 
+L 3109 2759 
+L 3109 2228 
+L 1259 2228 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1724.546875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1788.03125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1849.3125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1888.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1943.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2006.875 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(2090.671875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2186.078125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2249.5625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2277.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2340.71875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2402 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2443.109375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2502.296875 0)"/>
+     <use xlink:href="#DejaVuSans-29" transform="translate(2586.09375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2634.4375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(2695.71875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(2723.5 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2775.59375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2837.125 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2868.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2950.6875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3011.96875 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3051.328125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3148.734375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3212.109375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3275.59375 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3359.390625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3423.015625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3486.640625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3550.265625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3613.890625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3645.671875 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3684.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3746.0625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3785.265625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3846.546875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3874.328125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3958.125 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4021.75 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4085.375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4149 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(4212.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4276.25 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4308.03125 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4347.234375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4388.34375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4416.125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4477.40625 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4505.1875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4557.28125 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(4641.078125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4704.703125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(4736.484375 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4775.5 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4830.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4858.265625 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4886.046875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(4949.53125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(5013.015625 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(5074.546875 0)"/>
+    </g>
+    <!-- p95) -->
+    <g transform="translate(371.50125 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-53"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(127.109375 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(190.734375 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_27">
+     <path d="M 60.08 65.745996 
+L 249.07875 65.745996 
+Q 250.67875 65.745996 250.67875 64.145996 
+L 250.67875 40.944746 
+Q 250.67875 39.344746 249.07875 39.344746 
+L 60.08 39.344746 
+Q 58.48 39.344746 58.48 40.944746 
+L 58.48 64.145996 
+Q 58.48 65.745996 60.08 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_28">
+     <path d="M 61.68 48.623496 
+L 77.68 48.623496 
+L 77.68 43.023496 
+L 61.68 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_14">
+     <!-- P1_hash -->
+     <g transform="translate(84.08 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_29">
+     <path d="M 61.68 60.624121 
+L 77.68 60.624121 
+L 77.68 55.024121 
+L 61.68 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_15">
+     <!-- P2_hash -->
+     <g transform="translate(84.08 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_30">
+     <path d="M 133.20375 48.623496 
+L 149.20375 48.623496 
+L 149.20375 43.023496 
+L 133.20375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_16">
+     <!-- P4_hash -->
+     <g transform="translate(155.60375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_31">
+     <path d="M 133.20375 60.624121 
+L 149.20375 60.624121 
+L 149.20375 55.024121 
+L 133.20375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_17">
+     <!-- P8_hash -->
+     <g transform="translate(155.60375 60.624121) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_32">
+     <path d="M 204.7275 48.623496 
+L 220.7275 48.623496 
+L 220.7275 43.023496 
+L 204.7275 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_18">
+     <!-- P8_rr -->
+     <g transform="translate(227.1275 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_19">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pa5b5c618b4">
+   <rect x="54.48" y="35.344746" width="654.72" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h6130f7cc36" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#d62728"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/charts/latency_demo/balanced/f1_b64_binary_a8b3321b_delivered_mb_per_s.svg
+++ b/docs-site/public/charts/latency_demo/balanced/f1_b64_binary_a8b3321b_delivered_mb_per_s.svg
@@ -1,0 +1,1701 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="720pt" height="360pt" viewBox="0 0 720 360" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-16T22:09:27.167828</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 360 
+L 720 360 
+L 720 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 51.24 311 
+L 709.2 311 
+L 709.2 35.344746 
+L 51.24 35.344746 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 81.147273 311 
+L 114.290121 311 
+L 114.290121 109.807256 
+L 81.147273 109.807256 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 293.874157 311 
+L 327.017006 311 
+L 327.017006 60.770472 
+L 293.874157 60.770472 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #1f77b4"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 506.601042 311 
+L 539.743891 311 
+L 539.743891 48.471187 
+L 506.601042 48.471187 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: url(#h9376a20fec); stroke: #000000; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 116.034482 311 
+L 149.17733 311 
+L 149.17733 113.358989 
+L 116.034482 113.358989 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 328.761367 311 
+L 361.904215 311 
+L 361.904215 72.002946 
+L 328.761367 72.002946 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 541.488251 311 
+L 574.6311 311 
+L 574.6311 49.722119 
+L 541.488251 49.722119 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #ff7f0e"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 150.921691 311 
+L 184.06454 311 
+L 184.06454 101.460785 
+L 150.921691 101.460785 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 363.648576 311 
+L 396.791424 311 
+L 396.791424 72.756656 
+L 363.648576 72.756656 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 576.37546 311 
+L 609.518309 311 
+L 609.518309 56.024729 
+L 576.37546 56.024729 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #2ca02c"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 185.8089 311 
+L 218.951749 311 
+L 218.951749 95.300626 
+L 185.8089 95.300626 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 398.535785 311 
+L 431.678633 311 
+L 431.678633 78.063862 
+L 398.535785 78.063862 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 611.26267 311 
+L 644.405518 311 
+L 644.405518 58.102111 
+L 611.26267 58.102111 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #d62728"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 220.696109 311 
+L 253.838958 311 
+L 253.838958 111.568059 
+L 220.696109 111.568059 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 433.422994 311 
+L 466.565843 311 
+L 466.565843 69.28428 
+L 433.422994 69.28428 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #9467bd"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 646.149879 311 
+L 679.292727 311 
+L 679.292727 55.735688 
+L 646.149879 55.735688 
+z
+" clip-path="url(#pb2c79e4993)" style="fill: #9467bd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m274be9be0e" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m274be9be0e" x="167.493115" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 256 -->
+      <g transform="translate(157.949365 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-15" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-18" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-19" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-18" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m274be9be0e" x="380.22" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1024 -->
+      <g transform="translate(367.495 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-14" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-13" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-17" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-15" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-17" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m274be9be0e" x="592.946885" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4096 -->
+      <g transform="translate(580.221885 325.597656) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-1c" d="M 703 97 
+L 703 672 
+Q 941 559 1184 500 
+Q 1428 441 1663 441 
+Q 2288 441 2617 861 
+Q 2947 1281 2994 2138 
+Q 2813 1869 2534 1725 
+Q 2256 1581 1919 1581 
+Q 1219 1581 811 2004 
+Q 403 2428 403 3163 
+Q 403 3881 828 4315 
+Q 1253 4750 1959 4750 
+Q 2769 4750 3195 4129 
+Q 3622 3509 3622 2328 
+Q 3622 1225 3098 567 
+Q 2575 -91 1691 -91 
+Q 1453 -91 1209 -44 
+Q 966 3 703 97 
+z
+M 1959 2075 
+Q 2384 2075 2632 2365 
+Q 2881 2656 2881 3163 
+Q 2881 3666 2632 3958 
+Q 2384 4250 1959 4250 
+Q 1534 4250 1286 3958 
+Q 1038 3666 1038 3163 
+Q 1038 2656 1286 2365 
+Q 1534 2075 1959 2075 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-1c" transform="translate(127.25 0)"/>
+       <use xlink:href="#DejaVuSans-19" transform="translate(190.875 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_4">
+     <!-- payload (bytes) -->
+     <g transform="translate(341.07 339.598438) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-53" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-44" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-5c" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4f" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-52" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-47" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-b" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-45" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-57" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-48" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-56" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-c" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-53"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(124.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(183.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(211.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(272.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(334.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(397.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(429.46875 0)"/>
+      <use xlink:href="#DejaVuSans-45" transform="translate(468.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(531.96875 0)"/>
+      <use xlink:href="#DejaVuSans-57" transform="translate(591.15625 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(630.359375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(691.890625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(743.984375 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <defs>
+       <path id="m2b5c3e79e9" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="311" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(37.8775 314.798828) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="257.422726" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 100 -->
+      <g transform="translate(25.1525 261.221554) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-14"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="203.845452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 200 -->
+      <g transform="translate(25.1525 207.64428) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-15"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="150.268178" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 300 -->
+      <g transform="translate(25.1525 154.067006) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-16" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-16"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="96.690904" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 400 -->
+      <g transform="translate(25.1525 100.489732) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-17"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m2b5c3e79e9" x="51.24" y="43.11363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 500 -->
+      <g transform="translate(25.1525 46.912458) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-18"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(63.625 0)"/>
+       <use xlink:href="#DejaVuSans-13" transform="translate(127.25 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_11">
+     <!-- delivered payload (MB/s) -->
+     <g transform="translate(18.750156 235.430967) rotate(-90) scale(0.1 -0.1)">
+      <defs>
+       <path id="DejaVuSans-4c" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-59" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-55" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-30" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-25" d="M 1259 2228 
+L 1259 519 
+L 2272 519 
+Q 2781 519 3026 730 
+Q 3272 941 3272 1375 
+Q 3272 1813 3026 2020 
+Q 2781 2228 2272 2228 
+L 1259 2228 
+z
+M 1259 4147 
+L 1259 2741 
+L 2194 2741 
+Q 2656 2741 2882 2914 
+Q 3109 3088 3109 3444 
+Q 3109 3797 2882 3972 
+Q 2656 4147 2194 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2241 4666 
+Q 2963 4666 3353 4366 
+Q 3744 4066 3744 3513 
+Q 3744 3084 3544 2831 
+Q 3344 2578 2956 2516 
+Q 3422 2416 3680 2098 
+Q 3938 1781 3938 1306 
+Q 3938 681 3513 340 
+Q 3088 0 2303 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-12" d="M 1625 4666 
+L 2156 4666 
+L 531 -594 
+L 0 -594 
+L 1625 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-47"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(63.484375 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(125.015625 0)"/>
+      <use xlink:href="#DejaVuSans-4c" transform="translate(152.796875 0)"/>
+      <use xlink:href="#DejaVuSans-59" transform="translate(180.578125 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(239.765625 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(301.296875 0)"/>
+      <use xlink:href="#DejaVuSans-48" transform="translate(340.203125 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(401.734375 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(465.21875 0)"/>
+      <use xlink:href="#DejaVuSans-53" transform="translate(497 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(560.484375 0)"/>
+      <use xlink:href="#DejaVuSans-5c" transform="translate(621.765625 0)"/>
+      <use xlink:href="#DejaVuSans-4f" transform="translate(680.953125 0)"/>
+      <use xlink:href="#DejaVuSans-52" transform="translate(708.734375 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(769.921875 0)"/>
+      <use xlink:href="#DejaVuSans-47" transform="translate(831.203125 0)"/>
+      <use xlink:href="#DejaVuSans-3" transform="translate(894.6875 0)"/>
+      <use xlink:href="#DejaVuSans-b" transform="translate(926.46875 0)"/>
+      <use xlink:href="#DejaVuSans-30" transform="translate(965.484375 0)"/>
+      <use xlink:href="#DejaVuSans-25" transform="translate(1051.765625 0)"/>
+      <use xlink:href="#DejaVuSans-12" transform="translate(1120.375 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(1154.0625 0)"/>
+      <use xlink:href="#DejaVuSans-c" transform="translate(1206.15625 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_18">
+    <path d="M 51.24 311 
+L 51.24 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 709.2 311 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 51.24 311 
+L 709.2 311 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 51.24 35.344746 
+L 709.2 35.344746 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_12">
+    <!-- 495↑ -->
+    <g transform="translate(524.73106 48.471187) rotate(-90) scale(0.06 -0.06)">
+     <defs>
+      <path id="DejaVuSans-c1b" d="M 2541 4688 
+L 2822 4688 
+L 4047 3456 
+L 3672 3081 
+L 2947 3813 
+L 2947 0 
+L 2416 0 
+L 2416 3813 
+L 1684 3081 
+L 1309 3456 
+L 2541 4688 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-17"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(63.625 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(127.25 0)"/>
+     <use xlink:href="#DejaVuSans-c1b" transform="translate(190.875 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- latency_demo balanced fanout=1 batch=64 binary=True warmup=2000 total=volume-scaled trials=3 - -->
+    <g transform="translate(145.899375 18.542285) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-51" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-46" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-50" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-49" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-58" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" d="M 678 2906 
+L 4684 2906 
+L 4684 2381 
+L 678 2381 
+L 678 2906 
+z
+M 678 1631 
+L 4684 1631 
+L 4684 1100 
+L 678 1100 
+L 678 1631 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4b" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-5a" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-10" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4f"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(27.78125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(89.0625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(128.265625 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(189.796875 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(253.171875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(308.15625 0)"/>
+     <use xlink:href="#DejaVuSans-42" transform="translate(367.34375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(417.34375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(480.828125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(542.359375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(639.765625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(700.953125 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(732.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(796.21875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(857.5 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(885.28125 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(946.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1009.9375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1064.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1126.453125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1189.9375 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1221.71875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1256.921875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(1318.203125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(1381.578125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(1442.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1506.140625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1545.34375 0)"/>
+     <use xlink:href="#DejaVuSans-14" transform="translate(1629.140625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1692.765625 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(1724.546875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1788.03125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1849.3125 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1888.515625 0)"/>
+     <use xlink:href="#DejaVuSans-4b" transform="translate(1943.5 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2006.875 0)"/>
+     <use xlink:href="#DejaVuSans-19" transform="translate(2090.671875 0)"/>
+     <use xlink:href="#DejaVuSans-17" transform="translate(2154.296875 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2217.921875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(2249.703125 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(2313.1875 0)"/>
+     <use xlink:href="#DejaVuSans-51" transform="translate(2340.96875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2404.34375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2465.625 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(2506.734375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2565.921875 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(2649.71875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(2696.09375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(2737.203125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(2800.578125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(2862.109375 0)"/>
+     <use xlink:href="#DejaVuSans-5a" transform="translate(2893.890625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(2975.671875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(3036.953125 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(3076.3125 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(3173.71875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(3237.09375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3300.578125 0)"/>
+     <use xlink:href="#DejaVuSans-15" transform="translate(3384.375 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3448 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3511.625 0)"/>
+     <use xlink:href="#DejaVuSans-13" transform="translate(3575.25 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(3638.875 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3670.65625 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(3709.859375 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(3771.046875 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(3810.25 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(3871.53125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3899.3125 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(3983.109375 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(4042.296875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4103.484375 0)"/>
+     <use xlink:href="#DejaVuSans-58" transform="translate(4131.265625 0)"/>
+     <use xlink:href="#DejaVuSans-50" transform="translate(4194.640625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(4292.046875 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(4353.578125 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4389.65625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(4441.75 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4496.734375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4558.015625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(4585.796875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(4647.328125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(4710.8125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(4742.59375 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(4781.796875 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(4822.90625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(4850.6875 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(4911.96875 0)"/>
+     <use xlink:href="#DejaVuSans-56" transform="translate(4939.75 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4991.84375 0)"/>
+     <use xlink:href="#DejaVuSans-16" transform="translate(5075.640625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(5139.265625 0)"/>
+     <use xlink:href="#DejaVuSans-10" transform="translate(5171.046875 0)"/>
+    </g>
+    <!-- delivered payload byte rate (clipped p95) -->
+    <g transform="translate(286.636172 29.344746) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-47"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(63.484375 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(125.015625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(152.796875 0)"/>
+     <use xlink:href="#DejaVuSans-59" transform="translate(180.578125 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(239.765625 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(301.296875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(340.203125 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(401.734375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(465.21875 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(497 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(560.484375 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(621.765625 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(680.953125 0)"/>
+     <use xlink:href="#DejaVuSans-52" transform="translate(708.734375 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(769.921875 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(831.203125 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(894.6875 0)"/>
+     <use xlink:href="#DejaVuSans-45" transform="translate(926.46875 0)"/>
+     <use xlink:href="#DejaVuSans-5c" transform="translate(989.953125 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1049.140625 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1088.34375 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1149.875 0)"/>
+     <use xlink:href="#DejaVuSans-55" transform="translate(1181.65625 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1222.765625 0)"/>
+     <use xlink:href="#DejaVuSans-57" transform="translate(1284.046875 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1323.25 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1384.78125 0)"/>
+     <use xlink:href="#DejaVuSans-b" transform="translate(1416.5625 0)"/>
+     <use xlink:href="#DejaVuSans-46" transform="translate(1455.578125 0)"/>
+     <use xlink:href="#DejaVuSans-4f" transform="translate(1510.5625 0)"/>
+     <use xlink:href="#DejaVuSans-4c" transform="translate(1538.34375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1566.125 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1629.609375 0)"/>
+     <use xlink:href="#DejaVuSans-48" transform="translate(1693.09375 0)"/>
+     <use xlink:href="#DejaVuSans-47" transform="translate(1754.625 0)"/>
+     <use xlink:href="#DejaVuSans-3" transform="translate(1818.109375 0)"/>
+     <use xlink:href="#DejaVuSans-53" transform="translate(1849.890625 0)"/>
+     <use xlink:href="#DejaVuSans-1c" transform="translate(1913.375 0)"/>
+     <use xlink:href="#DejaVuSans-18" transform="translate(1977 0)"/>
+     <use xlink:href="#DejaVuSans-c" transform="translate(2040.625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_22">
+     <path d="M 56.84 65.745996 
+L 245.83875 65.745996 
+Q 247.43875 65.745996 247.43875 64.145996 
+L 247.43875 40.944746 
+Q 247.43875 39.344746 245.83875 39.344746 
+L 56.84 39.344746 
+Q 55.24 39.344746 55.24 40.944746 
+L 55.24 64.145996 
+Q 55.24 65.745996 56.84 65.745996 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_23">
+     <path d="M 58.44 48.623496 
+L 74.44 48.623496 
+L 74.44 43.023496 
+L 58.44 43.023496 
+z
+" style="fill: #1f77b4"/>
+    </g>
+    <g id="text_14">
+     <!-- P1_hash -->
+     <g transform="translate(80.84 48.623496) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-33" d="M 1259 4147 
+L 1259 2394 
+L 2053 2394 
+Q 2494 2394 2734 2622 
+Q 2975 2850 2975 3272 
+Q 2975 3691 2734 3919 
+Q 2494 4147 2053 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 2053 4666 
+Q 2838 4666 3239 4311 
+Q 3641 3956 3641 3272 
+Q 3641 2581 3239 2228 
+Q 2838 1875 2053 1875 
+L 1259 1875 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-14" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_24">
+     <path d="M 58.44 60.624121 
+L 74.44 60.624121 
+L 74.44 55.024121 
+L 58.44 55.024121 
+z
+" style="fill: #ff7f0e"/>
+    </g>
+    <g id="text_15">
+     <!-- P2_hash -->
+     <g transform="translate(80.84 60.624121) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-15" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_25">
+     <path d="M 129.96375 48.623496 
+L 145.96375 48.623496 
+L 145.96375 43.023496 
+L 129.96375 43.023496 
+z
+" style="fill: #2ca02c"/>
+    </g>
+    <g id="text_16">
+     <!-- P4_hash -->
+     <g transform="translate(152.36375 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-17" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_26">
+     <path d="M 129.96375 60.624121 
+L 145.96375 60.624121 
+L 145.96375 55.024121 
+L 129.96375 55.024121 
+z
+" style="fill: #d62728"/>
+    </g>
+    <g id="text_17">
+     <!-- P8_hash -->
+     <g transform="translate(152.36375 60.624121) scale(0.08 -0.08)">
+      <defs>
+       <path id="DejaVuSans-1b" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-44" transform="translate(237.296875 0)"/>
+      <use xlink:href="#DejaVuSans-56" transform="translate(298.578125 0)"/>
+      <use xlink:href="#DejaVuSans-4b" transform="translate(350.671875 0)"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 201.4875 48.623496 
+L 217.4875 48.623496 
+L 217.4875 43.023496 
+L 201.4875 43.023496 
+z
+" style="fill: #9467bd"/>
+    </g>
+    <g id="text_18">
+     <!-- P8_rr -->
+     <g transform="translate(223.8875 48.623496) scale(0.08 -0.08)">
+      <use xlink:href="#DejaVuSans-33"/>
+      <use xlink:href="#DejaVuSans-1b" transform="translate(60.296875 0)"/>
+      <use xlink:href="#DejaVuSans-42" transform="translate(123.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(173.921875 0)"/>
+      <use xlink:href="#DejaVuSans-55" transform="translate(213.28125 0)"/>
+     </g>
+    </g>
+   </g>
+  </g>
+  <g id="text_19">
+   <!-- git a8b3321b592d (DIRTY) | Mac.lan | 2026-08-17 -->
+   <g transform="translate(538.774531 354.718359) scale(0.07 -0.07)">
+    <defs>
+     <path id="DejaVuSans-4a" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-27" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2c" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-35" d="M 2841 2188 
+Q 3044 2119 3236 1894 
+Q 3428 1669 3622 1275 
+L 4263 0 
+L 3584 0 
+L 2988 1197 
+Q 2756 1666 2539 1819 
+Q 2322 1972 1947 1972 
+L 1259 1972 
+L 1259 0 
+L 628 0 
+L 628 4666 
+L 2053 4666 
+Q 2853 4666 3247 4331 
+Q 3641 3997 3641 3322 
+Q 3641 2881 3436 2590 
+Q 3231 2300 2841 2188 
+z
+M 1259 4147 
+L 1259 2491 
+L 2053 2491 
+Q 2509 2491 2742 2702 
+Q 2975 2913 2975 3322 
+Q 2975 3731 2742 3939 
+Q 2509 4147 2053 4147 
+L 1259 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3c" d="M -13 4666 
+L 666 4666 
+L 1959 2747 
+L 3244 4666 
+L 3922 4666 
+L 2272 2222 
+L 2272 0 
+L 1638 0 
+L 1638 2222 
+L -13 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-5f" d="M 1344 4891 
+L 1344 -1509 
+L 813 -1509 
+L 813 4891 
+L 1344 4891 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-11" d="M 684 794 
+L 1344 794 
+L 1344 0 
+L 684 0 
+L 684 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-1a" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-4a"/>
+    <use xlink:href="#DejaVuSans-4c" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-57" transform="translate(91.265625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(130.46875 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(162.25 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(223.53125 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(287.15625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(350.640625 0)"/>
+    <use xlink:href="#DejaVuSans-16" transform="translate(414.265625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(477.890625 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(541.515625 0)"/>
+    <use xlink:href="#DejaVuSans-45" transform="translate(605.140625 0)"/>
+    <use xlink:href="#DejaVuSans-18" transform="translate(668.625 0)"/>
+    <use xlink:href="#DejaVuSans-1c" transform="translate(732.25 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(795.875 0)"/>
+    <use xlink:href="#DejaVuSans-47" transform="translate(859.5 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(922.984375 0)"/>
+    <use xlink:href="#DejaVuSans-b" transform="translate(954.765625 0)"/>
+    <use xlink:href="#DejaVuSans-27" transform="translate(993.78125 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(1070.78125 0)"/>
+    <use xlink:href="#DejaVuSans-35" transform="translate(1100.28125 0)"/>
+    <use xlink:href="#DejaVuSans-37" transform="translate(1162.484375 0)"/>
+    <use xlink:href="#DejaVuSans-3c" transform="translate(1223.5625 0)"/>
+    <use xlink:href="#DejaVuSans-c" transform="translate(1284.640625 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1323.65625 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1355.4375 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1389.125 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1420.90625 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1507.1875 0)"/>
+    <use xlink:href="#DejaVuSans-46" transform="translate(1568.46875 0)"/>
+    <use xlink:href="#DejaVuSans-11" transform="translate(1623.453125 0)"/>
+    <use xlink:href="#DejaVuSans-4f" transform="translate(1655.234375 0)"/>
+    <use xlink:href="#DejaVuSans-44" transform="translate(1683.015625 0)"/>
+    <use xlink:href="#DejaVuSans-51" transform="translate(1744.296875 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1807.671875 0)"/>
+    <use xlink:href="#DejaVuSans-5f" transform="translate(1839.453125 0)"/>
+    <use xlink:href="#DejaVuSans-3" transform="translate(1873.140625 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(1904.921875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(1968.546875 0)"/>
+    <use xlink:href="#DejaVuSans-15" transform="translate(2032.171875 0)"/>
+    <use xlink:href="#DejaVuSans-19" transform="translate(2095.796875 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2159.421875 0)"/>
+    <use xlink:href="#DejaVuSans-13" transform="translate(2195.5 0)"/>
+    <use xlink:href="#DejaVuSans-1b" transform="translate(2259.125 0)"/>
+    <use xlink:href="#DejaVuSans-10" transform="translate(2322.75 0)"/>
+    <use xlink:href="#DejaVuSans-14" transform="translate(2358.828125 0)"/>
+    <use xlink:href="#DejaVuSans-1a" transform="translate(2422.453125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb2c79e4993">
+   <rect x="51.24" y="35.344746" width="657.96" height="275.655254"/>
+  </clipPath>
+ </defs>
+ <defs>
+  <pattern id="h9376a20fec" patternUnits="userSpaceOnUse" x="0" y="0" width="72" height="72">
+   <rect x="0" y="0" width="73" height="73" fill="#1f77b4"/>
+   <path d="M -36 36 
+L 36 -36 
+M -32 40 
+L 40 -32 
+M -28 44 
+L 44 -28 
+M -24 48 
+L 48 -24 
+M -20 52 
+L 52 -20 
+M -16 56 
+L 56 -16 
+M -12 60 
+L 60 -12 
+M -8 64 
+L 64 -8 
+M -4 68 
+L 68 -4 
+M 0 72 
+L 72 0 
+M 4 76 
+L 76 4 
+M 8 80 
+L 80 8 
+M 12 84 
+L 84 12 
+M 16 88 
+L 88 16 
+M 20 92 
+L 92 20 
+M 24 96 
+L 96 24 
+M 28 100 
+L 100 28 
+M 32 104 
+L 104 32 
+M 36 108 
+L 108 36 
+" style="fill: #000000; stroke: #000000; stroke-width: 1.0; stroke-linecap: butt; stroke-linejoin: miter"/>
+  </pattern>
+ </defs>
+</svg>

--- a/docs-site/public/diagrams/group-commit.svg
+++ b/docs-site/public/diagrams/group-commit.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 330" width="900" height="330" role="img" aria-label="Four concurrent appends queue in the page cache, a single fsync runs, and all four are acknowledged together">
+
+  <style>
+    .lbl   { fill: var(--ink); font: 500 13px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .mono  { fill: var(--ink); font: 500 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .sub   { fill: var(--ink-dim); font: 400 11px ui-sans-serif, system-ui, sans-serif; }
+    .title { fill: var(--ink); font: 600 14px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .note  { fill: var(--ink-dim); font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+    .box   { stroke: var(--edge); stroke-width: 1.25; fill: var(--c-step); }
+    .dev   { stroke: var(--accent); stroke-width: 1.5; fill: var(--c-dev); }
+    .wait  { stroke: var(--edge-dim); stroke-width: 1.25; fill: var(--c-wait); stroke-dasharray: 4 3; }
+    .flow  { stroke: var(--edge); stroke-width: 2; fill: none; }
+    .pulse { stroke: var(--accent); stroke-width: 2.5; fill: none; }
+    .tick  { stroke: var(--edge-dim); stroke-width: 1; }
+
+    :root {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5;
+    }
+    @media (prefers-color-scheme: dark) { :root {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; } }
+    :root[data-theme="dark"] {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; }
+    :root[data-theme="light"] {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5; }
+
+    /* One 6s loop shared by every element, so the story stays in step:
+       0-25%  appends arrive and queue
+       25-60% a single flush runs
+       60-85% every waiter is released together
+       85-100% rest before repeating */
+    .appendA { animation: slide 6s linear infinite; }
+    .appendB { animation: slide 6s linear infinite .18s; }
+    .appendC { animation: slide 6s linear infinite .36s; }
+    .appendD { animation: slide 6s linear infinite .54s; }
+    @keyframes slide {
+      0%   { transform: translateX(0); opacity: 0; }
+      4%   { opacity: 1; }
+      22%  { transform: translateX(150px); opacity: 1; }
+      100% { transform: translateX(150px); opacity: 1; }
+    }
+    .flushbar { animation: flush 6s linear infinite; transform-origin: left center; }
+    @keyframes flush {
+      0%,25%   { transform: scaleX(0); opacity: 0; }
+      27%      { opacity: 1; }
+      60%,100% { transform: scaleX(1); opacity: 1; }
+    }
+    .ackline { stroke-dasharray: 260; stroke-dashoffset: 260; animation: ack 6s linear infinite; }
+    @keyframes ack {
+      0%,60%   { stroke-dashoffset: 260; opacity: 0; }
+      62%      { opacity: 1; }
+      85%,100% { stroke-dashoffset: 0; opacity: 1; }
+    }
+    .ackword { animation: fade 6s linear infinite; }
+    @keyframes fade { 0%,62% { opacity: 0; } 78%,100% { opacity: 1; } }
+    .devglow { animation: glow 6s linear infinite; }
+    @keyframes glow {
+      0%,25%   { opacity: .35; }
+      35%      { opacity: 1; }
+      60%,100% { opacity: .35; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .appendA,.appendB,.appendC,.appendD,.flushbar,.ackline,.ackword,.devglow {
+        animation: none;
+      }
+      .ackline { stroke-dashoffset: 0; }
+      .flushbar { transform: scaleX(1); }
+    }
+  </style>
+
+  <text class="title" x="24" y="26">Group commit: four appends, one device flush</text>
+  <text class="sub" x="24" y="46">An fsync flushes the whole file, so one flush can satisfy every append waiting on it.</text>
+  <line class="tick" x1="150" y1="76" x2="150" y2="256"/>
+  <text class="sub" x="150" y="70" style="text-anchor:middle">page cache</text>
+  <line class="tick" x1="470" y1="76" x2="470" y2="256"/>
+  <text class="sub" x="470" y="70" style="text-anchor:middle">device</text>
+  <g class="appendA"><rect class="box" x="24" y="96" width="118" height="30" rx="4"/><text class="mono" x="83" y="115" style="text-anchor:middle">append A</text></g>
+  <g class="appendB"><rect class="box" x="24" y="140" width="118" height="30" rx="4"/><text class="mono" x="83" y="159" style="text-anchor:middle">append B</text></g>
+  <g class="appendC"><rect class="box" x="24" y="184" width="118" height="30" rx="4"/><text class="mono" x="83" y="203" style="text-anchor:middle">append C</text></g>
+  <g class="appendD"><rect class="box" x="24" y="228" width="118" height="30" rx="4"/><text class="mono" x="83" y="247" style="text-anchor:middle">append D</text></g>
+  <rect class="dev devglow" x="330" y="96" width="130" height="160" rx="6"/>
+  <text class="lbl devglow" x="395" y="168" style="text-anchor:middle">one fsync</text>
+  <text class="sub devglow" x="395" y="186" style="text-anchor:middle">~4ms</text>
+  <rect class="dev flushbar" x="470" y="158" width="150" height="36" rx="4"/>
+  <text class="mono flushbar" x="545" y="181" style="text-anchor:middle">flushed</text>
+  <path class="pulse ackline" d="M 330 111 L 180 111"/>
+  <path class="pulse ackline" d="M 330 155 L 180 155"/>
+  <path class="pulse ackline" d="M 330 199 L 180 199"/>
+  <path class="pulse ackline" d="M 330 243 L 180 243"/>
+  <text class="lbl ackword" x="186" y="284">all four acknowledged together</text>
+  <text class="note" x="24" y="316">Measured: 253 durable appends/second at concurrency 1, 14,387 at concurrency 64 — a 57x gain from the same code path.</text>
+</svg>

--- a/docs-site/src/content/docs/architecture/durable-storage.md
+++ b/docs-site/src/content/docs/architecture/durable-storage.md
@@ -28,6 +28,38 @@ cursors.
 ## Ordering: append, then fanout, then ack
 
 ```mermaid
+flowchart LR
+    C(["Client"]) e1@--> P["publish"]
+    P e2@--> L[("durable log<br/><small>append + assign offsets</small>")]
+    L e3@--> D{{"fsync<br/><small>OnCommit only</small>"}}
+    D e4@--> F["fanout"]
+    F e5@--> S1(["Subscriber"])
+    F e6@--> S2(["Subscriber"])
+    D e7@--> A(["ack to client"])
+
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+
+    classDef store fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef gate fill:#fbe9d6,stroke:#b07d3a,color:#3d2a12
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef edge fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class L store
+    class D gate
+    class P,F step
+    class C,S1,S2,A edge
+```
+
+Nothing downstream of the log observes a record before it is durable: fanout
+and the acknowledgement both hang off the flush, not off the append. Ordering
+is the whole design, so the same path is worth spelling out step by step:
+
+```mermaid
 sequenceDiagram
     autonumber
     participant C as Client
@@ -173,6 +205,11 @@ device.
 `fsync` flushes the whole file, so one flush can satisfy every append waiting on
 it. 253 → 14,387 records/second from concurrency 1 → 64 is a 57× gain from the
 same code path, and batching on top reaches 185,905.
+
+![Group commit: four concurrent appends queue in the page cache, a single fsync runs, and all four are acknowledged together](/felix/diagrams/group-commit.svg)
+
+The lock protocol behind that picture — who flushes, and what the others find
+when they wake:
 
 ```mermaid
 sequenceDiagram

--- a/docs-site/src/content/docs/architecture/system-design.md
+++ b/docs-site/src/content/docs/architecture/system-design.md
@@ -358,7 +358,9 @@ regulatory or compliance purposes until it ships.
 - **CPU:** More cores for parallel stream processing
 - **Memory:** Larger buffers and cache capacity
 - **Network:** Higher bandwidth for fanout
-- **Typical:** 10k-50k msg/s on modern hardware
+- **Measured:** hundreds of thousands to millions of msg/s on a single node,
+  depending entirely on payload size and fanout — see
+  [Benchmarks](/felix/features/benchmarks/) rather than any single figure here
 
 ### Horizontal Scaling (Multi-Node)
 
@@ -366,7 +368,9 @@ regulatory or compliance purposes until it ships.
 - **Connection pooling:** Reuse connections across shards
 - **Control plane:** RAFT quorum for metadata (3-5 nodes)
 - **Data plane:** Many broker nodes for capacity
-- **Target:** 100k-1M+ msg/s per cluster
+
+Multi-node is not implemented, so no cluster-level throughput figure is
+claimed here.
 
 ## Next Steps
 

--- a/docs-site/src/content/docs/demos/slow-consumer-isolation.md
+++ b/docs-site/src/content/docs/demos/slow-consumer-isolation.md
@@ -2,6 +2,34 @@
 title: "Demo: Slow-consumer Isolation"
 ---
 
+```mermaid
+flowchart LR
+    P["Publisher"] e0@--> B["Broker<br/><small>one shared encoded batch</small>"]
+    B e1@--> Q1["queue"] e2@--> S1(["dashboard A<br/><small>draining</small>"])
+    B e3@--> Q2["queue"] e4@--> S2(["dashboard B<br/><small>draining</small>"])
+    B e5@--> Q3["queue<br/><b>full</b>"] -.->|"dropped"| S3(["dashboard C<br/><small>stalled</small>"])
+
+    e0@{ animate: true }
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+
+    classDef ok fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    classDef bad fill:#fdeaea,stroke:#b04a4a,color:#3d1414
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    class P,B step
+    class Q1,Q2,S1,S2 ok
+    class Q3,S3 bad
+```
+
+The animated edges are the ones still moving. Traffic keeps flowing to A and B
+at full rate while C's bounded queue overflows and its events are dropped —
+the publisher is never slowed by the slowest consumer. The drop is counted and
+surfaced to C rather than hidden, so a lagging subscriber learns it fell behind
+instead of silently receiving a gap.
+
 ## What this shows
 
 - One slow consumer does not degrade the healthy ones — the property in Felix's

--- a/docs-site/src/content/docs/development/how-felix-works.md
+++ b/docs-site/src/content/docs/development/how-felix-works.md
@@ -33,21 +33,53 @@ Felix is a brokered messaging and caching system:
 
 The current pub/sub data path is:
 
-```text
-application
-  -> felix-client Publisher
-  -> client publish admission and worker queue
-  -> QUIC bidirectional stream
-  -> broker frame decoder and authorization
-  -> broker publish admission and global worker queue
-  -> felix-broker StreamState
-  -> per-subscriber broker-core queue
-  -> subscription lane
-  -> per-connection writer
-  -> QUIC unidirectional event stream
-  -> client event router and subscription queues
-  -> application
+```mermaid
+flowchart LR
+    subgraph pubproc["Publisher process"]
+        direction TB
+        APP1(["application"]) e1@--> PUB["felix-client<br/>Publisher"]
+        PUB e2@--> CADM["publish admission<br/><small>+ worker queue</small>"]
+    end
+
+    subgraph broker["Broker"]
+        direction TB
+        DEC["frame decode<br/><small>+ authorization</small>"] e4@--> BADM["publish admission<br/><small>+ stream-sharded worker</small>"]
+        BADM e5@--> ST[("felix-broker StreamState<br/><small>append, assign offsets</small>")]
+        ST e6@--> SQ["per-subscriber<br/>broker-core queue"]
+        SQ e7@--> LANE["subscription lane<br/><small>encode once</small>"]
+        LANE e8@--> CW["per-connection writer"]
+    end
+
+    subgraph subproc["Subscriber process"]
+        direction TB
+        ROUTER["event router<br/><small>+ subscription queue</small>"] e10@--> APP2(["application"])
+    end
+
+    CADM e3@-->|"QUIC bidirectional stream"| DEC
+    CW e9@-->|"QUIC unidirectional event stream"| ROUTER
+
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+    e8@{ animate: true }
+    e9@{ animate: true }
+    e10@{ animate: true }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef store fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef endpoint fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class PUB,CADM,DEC,BADM,LANE,CW,ROUTER step
+    class ST,SQ store
+    class APP1,APP2 endpoint
 ```
+
+Every hop above is a real, named thing in the code — the sections that follow
+walk the same path in order, and §9 and §11 cover the publish and subscribe
+halves in full detail.
 
 The important architectural boundary is:
 

--- a/docs-site/src/content/docs/development/internals-concurrency.md
+++ b/docs-site/src/content/docs/development/internals-concurrency.md
@@ -138,12 +138,95 @@ agree on which shard owns a given stream:
 
 The result: a stream's publish-side append/fanout and its subscribers'
 dequeue/encode all execute on one core. What stays *off* the shards
-deliberately: QUIC I/O (the endpoint driver, connection writer tasks) —
-quinn does packetization and TLS in its own driver task regardless of who
-calls it, and moving writers to shards wouldn't change that. See
+deliberately: QUIC I/O — quinn does packetization and TLS in its own driver
+tasks regardless of who calls it, and those have their own placement story
+(next section). See
 [Benchmarks: Core Sharding](/felix/features/benchmarks/) for measured impact
 (scales with stream count; single-stream workloads are neutral-to-positive
 by design, since a single stream only ever has one owning shard either way).
+
+## The QUIC I/O runtime
+
+**File**: `crates/felix-transport/src/lib.rs`
+
+Quinn's driver tasks (the endpoint receive loop and each connection's
+transmit/ACK/timer loop) do a *bounded* slice of work per poll and then
+reschedule themselves. That makes their scheduler re-poll latency the
+transport's throughput ceiling: wakeups scale with datagram count, so a
+shared, loaded runtime turns per-wakeup latency directly into a per-byte
+rate cap — measured as a ~7.5× sustained-throughput defect before this
+existed, and per-byte rather than per-message, which is what made it look
+like a payload-size problem rather than a scheduling one.
+
+```mermaid
+flowchart LR
+    subgraph shared["Before: drivers share the application runtime"]
+        direction LR
+        N1(["datagram"]) s1@--> SD["quinn driver<br/><small>bounded work, then reschedules</small>"]
+        SD s2@--> SQ{{"waits behind<br/>~50 app tasks"}}
+        SQ s3@--> SP["read/write pump<br/><small>woken on another core</small>"]
+        SP s4@--> SO(["~73 MB/s<br/><small>a wakeup chain per datagram</small>"])
+    end
+
+    subgraph dedicated["After: drivers own single-threaded runtimes"]
+        direction LR
+        N2(["datagram"]) d1@--> DD["quinn driver<br/><small>dedicated thread, re-polls immediately</small>"]
+        DD d2@--> DP["colocated pump<br/><small>same-thread task switch</small>"]
+        DP d3@--> DO(["~500 MB/s<br/><small>bounded by capacity, not wakeups</small>"])
+    end
+
+    s1@{ animation: slow }
+    s2@{ animation: slow }
+    s3@{ animation: slow }
+    s4@{ animation: slow }
+    d1@{ animation: fast }
+    d2@{ animation: fast }
+    d3@{ animation: fast }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef gate fill:#fdeaea,stroke:#b04a4a,color:#3d1414
+    classDef slow fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef ok fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class SD,SP,DD,DP step
+    class SQ gate
+    class N1,N2 step
+    class SO slow
+    class DO ok
+```
+
+The two rows animate at different speeds on purpose: the work per hop is the
+same in both, and only the waiting differs. Every stage measured in
+microseconds while the pipeline ran at a fraction of its capacity, which is
+exactly the signature of a latency-bound dependency chain rather than a
+saturated resource.
+
+Felix therefore runs quinn drivers on a pool of dedicated *single-threaded*
+runtimes, high QoS on macOS, via a custom `quinn::Runtime` implementation.
+`FELIX_IO_RUNTIME_THREADS` sizes the pool (default: 2; `0` restores the
+shared runtime).
+
+Which endpoints share a runtime is load-bearing. Assignment is by role,
+not round-robin: server endpoints spread across every runtime but the last,
+and client endpoints all share the last one. A server endpoint multiplexes
+every connection and drives traffic in both directions, so sharing its
+runtime starves it — measured 5–6× slower when a client endpoint landed
+next to it. A client's publish and event endpoints carry the two halves of
+one request/response flow, so *splitting* them across threads makes every
+message pay two cross-thread wakeups. The partition is independent of
+creation order — a history-dependent assignment recreated the slow topology
+on every second benchmark case before this was fixed.
+
+Two pump tasks are *colocated* with their connection's drivers through
+`QuicConnection::spawn_pump`, because they exchange a wakeup with the
+transport per datagram or per write, and a same-thread wakeup is a task
+switch rather than a cross-core kernel round trip:
+
+- the client's subscription read task (`felix-client`, `subscription.rs`);
+- the broker's per-connection delivery writer (`subscribe/lane.rs`).
+
+The client's *publisher* writer is deliberately not colocated: it spends its
+time blocked in `write_all` against a full send window, and parking it on
+the I/O thread starves the very drivers it waits on (measured 5× worse).
 
 ## Putting it together: what a "saturated" system looks like
 

--- a/docs-site/src/content/docs/development/internals-concurrency.md
+++ b/docs-site/src/content/docs/development/internals-concurrency.md
@@ -202,14 +202,8 @@ saturated resource.
 
 Felix therefore runs quinn drivers on a pool of dedicated *single-threaded*
 runtimes, high QoS on macOS, via a custom `quinn::Runtime` implementation.
-`FELIX_IO_RUNTIME_THREADS` sizes the pool (`0` restores the shared runtime).
-
-The pool is **enabled by default on macOS only**. On Linux it currently
-loses a delivery wakeup — the receiver's QUIC layer accepts and ACKs a
-stream frame the application is never woken to read, stalling the
-connection until it times out — so non-macOS platforms default to `0`
-until that is resolved. Everything below describes the pool as it behaves
-where it is enabled.
+`FELIX_IO_RUNTIME_THREADS` sizes the pool (default: 2; `0` restores the
+shared runtime).
 
 Which endpoints share a runtime is load-bearing. Assignment is by role,
 not round-robin: server endpoints spread across every runtime but the last,

--- a/docs-site/src/content/docs/development/internals-concurrency.md
+++ b/docs-site/src/content/docs/development/internals-concurrency.md
@@ -76,6 +76,22 @@ pub enum SubQueuePolicy {
 }
 ```
 
+:::caution[Lossless needs checkpoint 4 too, not just 5 and 6]
+Setting `Block` on the subscriber queue (5), the lane queue (6) *and* the
+client's own subscriber channel still does **not** give you lossless
+delivery. Checkpoint 4 — the broker's publish ingress queue, depth 64 —
+defaults to `Drop`, and unacked publishes have nothing pacing them, so a
+burst that outruns the broker core is shed before it ever reaches a
+subscriber queue. Measured: a 400-message unacked burst on a 4-CPU host
+dropped 77 publishes with every downstream queue set to `Block`.
+
+Lossless mode is `Block` on 5 and 6 **plus** `pub_ingress_wait: true`
+(checkpoint 4 → `Backpressure`). The symptom of getting this wrong is
+delivery that appears to stall — the missing events were never published,
+so nothing downstream is waiting on anything. `felix_broker_ingress_dropped_total`
+is the counter that tells you which it is.
+:::
+
 Production defaults are `drop_new` at both checkpoints: overload becomes a
 counted, bounded-latency event (`felix_subscribe_dropped_total`,
 `felix_sub_queue_dropped_total`) instead of an ever-growing backlog with

--- a/docs-site/src/content/docs/development/internals-concurrency.md
+++ b/docs-site/src/content/docs/development/internals-concurrency.md
@@ -202,8 +202,14 @@ saturated resource.
 
 Felix therefore runs quinn drivers on a pool of dedicated *single-threaded*
 runtimes, high QoS on macOS, via a custom `quinn::Runtime` implementation.
-`FELIX_IO_RUNTIME_THREADS` sizes the pool (default: 2; `0` restores the
-shared runtime).
+`FELIX_IO_RUNTIME_THREADS` sizes the pool (`0` restores the shared runtime).
+
+The pool is **enabled by default on macOS only**. On Linux it currently
+loses a delivery wakeup — the receiver's QUIC layer accepts and ACKs a
+stream frame the application is never woken to read, stalling the
+connection until it times out — so non-macOS platforms default to `0`
+until that is resolved. Everything below describes the pool as it behaves
+where it is enabled.
 
 Which endpoints share a runtime is load-bearing. Assignment is by role,
 not round-robin: server endpoints spread across every runtime but the last,

--- a/docs-site/src/content/docs/development/internals-subscribe.md
+++ b/docs-site/src/content/docs/development/internals-subscribe.md
@@ -145,6 +145,50 @@ starting the next round. That's fine when every subscriber's stream is fast,
 but one backpressured or slow QUIC stream would stall the *next* round for
 every other subscriber sharing that connection — a straggler problem.
 
+```mermaid
+flowchart LR
+    subgraph barrier["Old: round barrier"]
+        direction TB
+        OR(["round starts"]) o1@--> OA["write to A"]
+        OR o2@--> OB["write to B"]
+        OR o3@--> OC["write to C<br/><small>slow / backpressured</small>"]
+        OA o4@--> OW{{"wait for<br/>all three"}}
+        OB o5@--> OW
+        OC o6@--> OW
+        OW o7@--> ON(["next round<br/><small>A and B sat idle</small>"])
+    end
+
+    subgraph pipelined["Current: continuous pipelining"]
+        direction TB
+        NA["A completes"] n1@--> NA2(["A's next write<br/><small>starts immediately</small>"])
+        NB["B completes"] n2@--> NB2(["B's next write<br/><small>starts immediately</small>"])
+        NC["C still in flight"] n3@--> NC2(["finishes later,<br/><small>blocks nobody</small>"])
+    end
+
+    o1@{ animation: slow }
+    o2@{ animation: slow }
+    o3@{ animation: slow }
+    o4@{ animation: slow }
+    o5@{ animation: slow }
+    o6@{ animation: slow }
+    o7@{ animation: slow }
+    n1@{ animation: fast }
+    n2@{ animation: fast }
+    n3@{ animation: slow }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef gate fill:#fdeaea,stroke:#b04a4a,color:#3d1414
+    classDef slowc fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef ok fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class OA,OB,NA,NB step
+    class OW gate
+    class OC,NC,ON,NC2 slowc
+    class OR,NA2,NB2 ok
+```
+
+C moves at the same speed in both halves — the difference is only whether A
+and B are made to wait for it.
+
 ### The current design: continuous pipelining
 
 ```rust

--- a/docs-site/src/content/docs/features/benchmarks.md
+++ b/docs-site/src/content/docs/features/benchmarks.md
@@ -116,14 +116,9 @@ Against the pre-fix ceiling of ~73 MB/s — which was flat across every payload
 size — that is roughly a **7× improvement**, and the byte rate now rises with
 payload size instead of pinning to a constant.
 
-These are macOS figures, and the transport work behind them is not all active
-on other platforms: the dedicated QUIC I/O runtime pool — the largest single
-contributor — is enabled by default on macOS only, pending a delivery-wakeup
-defect that appears when quinn's drivers are isolated on Linux (see
-`FELIX_IO_RUNTIME_THREADS` in the
-[environment variable reference](/felix/reference/environment-variables/)).
-Linux numbers on the fixed pipeline have not been measured and are not
-published here.
+These are macOS figures. The transport work behind them is platform-neutral
+and enabled everywhere, but Linux has not been re-measured on the fixed
+pipeline, so no Linux numbers are published here yet.
 
 :::note[Formerly: "throughput runs are bimodal"]
 Earlier versions of this table carried a warning that roughly one run in

--- a/docs-site/src/content/docs/features/benchmarks.md
+++ b/docs-site/src/content/docs/features/benchmarks.md
@@ -120,19 +120,17 @@ These are macOS figures. The transport work behind them is platform-neutral
 and enabled everywhere, but Linux has not been re-measured on the fixed
 pipeline, so no Linux numbers are published here yet.
 
-:::note[Formerly: "throughput runs are bimodal"]
-Earlier versions of this table carried a warning that roughly one run in
-three landed 5–6× slower, with spreads up to 5.9×. That instability was
-diagnosed and fixed: a congestive loss burst during ramp-up could trip QUIC's
-MTU black-hole detector and pin the connection at a 1200-byte MTU for the
-rest of the run — a ~13× datagram (and syscall) multiplier that looked
-exactly like a scheduling defect. Loopback connections now run at a
-guaranteed 16 KiB MTU, which also roughly doubled the 256 B row by removing
-the MTU discovery ramp from short runs. The diagnosis is written up in the
-[case study](/felix/features/performance-case-study/).
+:::note[Why the spread column is tight]
+Trial-to-trial spread this narrow is itself a result of the path-MTU fix in
+the [case study](/felix/features/performance-case-study/). Before it, a
+congestive loss burst during ramp-up could trip QUIC's MTU black-hole
+detector and pin a connection at a 1200-byte MTU for the rest of the run — a
+~13× datagram (and syscall) multiplier that made roughly one run in three
+land 5–6× low. Removing it also roughly doubled the 256 B row, by taking the
+MTU discovery ramp out of short runs.
 
 Medians of several trials remain the standard for anything published here —
-that policy is what exposed the defect in the first place.
+that policy is what exposed the defect rather than averaging it away.
 :::
 
 ![Delivered payload MB/s by payload and publisher preset, fanout 1](/felix/charts/latency_demo/balanced/f1_b64_binary_a8b3321b_delivered_mb_per_s.svg)

--- a/docs-site/src/content/docs/features/benchmarks.md
+++ b/docs-site/src/content/docs/features/benchmarks.md
@@ -116,6 +116,15 @@ Against the pre-fix ceiling of ~73 MB/s — which was flat across every payload
 size — that is roughly a **7× improvement**, and the byte rate now rises with
 payload size instead of pinning to a constant.
 
+These are macOS figures, and the transport work behind them is not all active
+on other platforms: the dedicated QUIC I/O runtime pool — the largest single
+contributor — is enabled by default on macOS only, pending a delivery-wakeup
+defect that appears when quinn's drivers are isolated on Linux (see
+`FELIX_IO_RUNTIME_THREADS` in the
+[environment variable reference](/felix/reference/environment-variables/)).
+Linux numbers on the fixed pipeline have not been measured and are not
+published here.
+
 :::note[Formerly: "throughput runs are bimodal"]
 Earlier versions of this table carried a warning that roughly one run in
 three landed 5–6× slower, with spreads up to 5.9×. That instability was

--- a/docs-site/src/content/docs/features/benchmarks.md
+++ b/docs-site/src/content/docs/features/benchmarks.md
@@ -116,9 +116,15 @@ Against the pre-fix ceiling of ~73 MB/s — which was flat across every payload
 size — that is roughly a **7× improvement**, and the byte rate now rises with
 payload size instead of pinning to a constant.
 
-These are macOS figures. The transport work behind them is platform-neutral
-and enabled everywhere, but Linux has not been re-measured on the fixed
-pipeline, so no Linux numbers are published here yet.
+These are macOS figures, and the ceiling they describe is a macOS pathology.
+Spot-checked on Linux (4-CPU container, 1 KiB × batch 64 × fanout 1), the
+*pre-fix* baseline already sustains ~628 K msg/s ≈ 643 MB/s — above what
+macOS reaches with every fix applied. The dedicated I/O runtime pool is
+therefore enabled on macOS only; on Linux it measures slower (see
+`FELIX_IO_RUNTIME_THREADS` in the
+[environment variable reference](/felix/reference/environment-variables/)).
+A proper Linux benchmark run has not been done, so no Linux table is
+published here yet.
 
 :::note[Why the spread column is tight]
 Trial-to-trial spread this narrow is itself a result of the path-MTU fix in

--- a/docs-site/src/content/docs/features/benchmarks.md
+++ b/docs-site/src/content/docs/features/benchmarks.md
@@ -25,7 +25,7 @@ Numbers are only useful if they are honest. The harness enforces:
 
 - **Truthful delivery windows.** Delivered throughput is computed from publish
   start to the instant the *last event actually arrived* — not to when drain
-  tasks give up. Idle-timeout waits never inflate the denominator.
+  tasks are joined. Trailing bookkeeping never inflates the denominator.
 - **Lossless backpressure in both profiles.** The throughput profile
   (batch > 1) runs with blocking queues end-to-end and bounded ingress waits
   (`pub_ingress_wait`), so the publisher is paced to the pipeline's sustainable
@@ -33,8 +33,10 @@ Numbers are only useful if they are honest. The harness enforces:
   per-subscriber queue and the client's own subscriber channel, not just the
   writer-lane queue below them — both defaulted to `DropNew` and could drop
   warmup/measurement messages under load before that was tightened. In both
-  profiles **every message is delivered** (`delivery drops 0`). A number
-  measured while shedding is not a throughput or latency number.
+  profiles **every message is delivered** (`unaccounted 0`). A subscriber that
+  times out now fails the run rather than abandoning its remaining events, so a
+  shortfall cannot be quietly reported as shedding. A number measured while
+  shedding is not a throughput or latency number.
 - **Latency mode measures per-message RTT.** The latency profile (batch = 1)
   publishes with per-message acks, measuring full round-trip behavior rather
   than fire-and-forget enqueue rates.
@@ -43,14 +45,112 @@ Numbers are only useful if they are honest. The harness enforces:
 - **Fanout counted honestly.** `delivered throughput` counts every
   subscriber delivery; `per-sub throughput` divides by fanout.
 
+### A run must exceed the send window
+
+The single easiest way to publish a wrong throughput number: any batched run
+whose total volume fits inside the 64 MiB QUIC connection send window is
+absorbed by buffers before backpressure appears, so the harness reports
+buffer-fill rate rather than sustained throughput. A 1 KiB run once appeared to
+do 358 MB/s and actually sustained 74.9 MB/s.
+
+Two guards now exist. `latency-demo` prints a warning when a `batch > 1` run's
+volume is within ~2× the send window, and the matrix runner scales message
+count per payload so every throughput cell clears it. Rule of thumb when
+running by hand: **`payload × total` should comfortably exceed 128 MiB.**
+
+### One session at a time
+
+`data/raw/latency_demo_runs.jsonl` is append-only, so it accumulates every run
+ever performed on the machine — across commits, branches, and code states.
+Each matrix invocation therefore stamps a `session_id`, and
+`normalize_and_aggregate.py` derives from the **latest session only** by
+default. Pass `--session all` to include history, or `--session <id-prefix>`
+to pick one. Without this the derived CSVs and every chart built from them mix
+unrelated code states, which previously produced charts holding a single bar
+with every other payload marked "no data".
+
 ## Results
 
-Measured on the same Apple Silicon host using native macOS and a Linux
-devcontainer, loopback, release build, TLS 1.3 enabled (QUIC always encrypts),
-defaults — no environment tuning. Linux can use UDP GSO/GRO, so the comparison
-also shows how strongly kernel batching affects QUIC throughput.
+Measured on an Apple M4 Max (macOS, APFS, loopback), release build, TLS 1.3
+enabled — QUIC always encrypts, so per-packet crypto is inside every number
+here. All runs are sized past the 64 MiB QUIC send window, so these are
+sustained rates rather than buffer-fill (see
+[methodology](#a-run-must-exceed-the-send-window)).
 
 ### Latency profile (batch = 1, per-message ack)
+
+Table: medians of 5–10 trials per cell from the full matrix. Charts: refreshed
+from the post-fix `task perf:fast` session (3 trials per cell); the two agree
+within noise.
+
+| Payload | Fanout 1 (p50 / p99 / p999) | Fanout 10 (p50 / p99 / p999) |
+|---|---|---|
+| 0 B | 127 / 165 / 214 µs | 184 / 278 / 340 µs |
+| 256 B | 128 / 166 / 204 µs | 237 / 327 / 369 µs |
+| 1 KiB | 131 / 176 / 251 µs | 247 / 351 / 417 µs |
+| 4 KiB | 136 / 176 / 216 µs | 269 / 399 / 483 µs |
+
+![Latency profile p50 by payload and publisher preset, fanout 1](/felix/charts/latency_demo/balanced/f1_b1_json_a8b3321b_p50.svg)
+
+![Latency profile p99 by payload and publisher preset, fanout 10](/felix/charts/latency_demo/balanced/f10_b1_json_a8b3321b_p99.svg)
+
+Fanout-10 tails improved sharply with the transport scheduling work: p99 went
+from ~1.05–1.13 ms to 278–399 µs, and p999 from 1.32–2.09 ms to 340–483 µs —
+roughly **3–4× better tail latency** at fanout 10, with fanout 1 also improving
+(p99 199–212 µs → 165–176 µs). This profile is stable: 85% of cells hold a
+p90/p10 trial spread under 1.5×.
+
+### Throughput profile (batch = 64, binary, lossless, zero drops)
+
+Seven trials per payload at fanout 1, fresh process per trial, idle machine,
+default publisher pool (4 connections × 2 streams).
+
+| Payload | Median | Payload rate | Slowest trial | Spread |
+|---|---:|---:|---:|---:|
+| 256 B | 1,400,008 msg/s | **358 MB/s** | 1,361,493 | 1.05× |
+| 1 KiB | 450,455 msg/s | **461 MB/s** | 425,703 | 1.12× |
+| 4 KiB | 124,004 msg/s | **508 MB/s** | 121,968 | 1.03× |
+| 16 KiB | 30,707 msg/s | **503 MB/s** | 30,120 | 1.04× |
+
+Against the pre-fix ceiling of ~73 MB/s — which was flat across every payload
+size — that is roughly a **7× improvement**, and the byte rate now rises with
+payload size instead of pinning to a constant.
+
+:::note[Formerly: "throughput runs are bimodal"]
+Earlier versions of this table carried a warning that roughly one run in
+three landed 5–6× slower, with spreads up to 5.9×. That instability was
+diagnosed and fixed: a congestive loss burst during ramp-up could trip QUIC's
+MTU black-hole detector and pin the connection at a 1200-byte MTU for the
+rest of the run — a ~13× datagram (and syscall) multiplier that looked
+exactly like a scheduling defect. Loopback connections now run at a
+guaranteed 16 KiB MTU, which also roughly doubled the 256 B row by removing
+the MTU discovery ramp from short runs. The diagnosis is written up in the
+[case study](/felix/features/performance-case-study/).
+
+Medians of several trials remain the standard for anything published here —
+that policy is what exposed the defect in the first place.
+:::
+
+![Delivered payload MB/s by payload and publisher preset, fanout 1](/felix/charts/latency_demo/balanced/f1_b64_binary_a8b3321b_delivered_mb_per_s.svg)
+
+![Delivered payload MB/s by payload and publisher preset, fanout 10](/felix/charts/latency_demo/balanced/f10_b64_binary_a8b3321b_delivered_mb_per_s.svg)
+
+The charts come from the same post-fix matrix session as the latency charts
+above (3 trials per cell, fresh session, run-size floor past the QUIC send
+window). Publisher presets are within a few percent of each other at every
+payload — connection count is not a throughput lever, as the
+[QUIC transport page](/felix/features/quic-transport/) explains.
+
+### Historical cross-platform comparison
+
+:::note[These predate the transport fix and are kept for context only]
+The tables below were measured before the scheduling work and on a mix of
+macOS and a Linux devcontainer. Several macOS throughput rows are also
+**buffer-absorption artifacts** — runs whose total volume fit inside the
+64 MiB send window, so they report buffer-fill rate rather than sustained
+throughput. Do not compare them against the numbers above; the Linux figures
+in particular have not been re-measured on the fixed pipeline.
+:::
 
 | Payload | Fanout | macOS p50 / p99 / p999 | Linux p50 / p99 / p999 |
 |---|---:|---|---|
@@ -61,11 +161,7 @@ also shows how strongly kernel batching affects QUIC throughput.
 | 256 B | 10 | 447 µs / 1.13 / 2.09 ms | 99 / 148 / 181 µs |
 | 1 KiB | 10 | 444 µs / 1.05 / 1.32 ms | 142 / 720 µs / 4.96 ms |
 
-Both platforms stay sub-millisecond at fanout 1. Linux substantially improves
-most fanout-10 percentiles, although the 1 KiB p999 shows an isolated
-low-single-digit-ms tail.
-
-### Throughput profile (batch = 64, lossless, zero drops)
+#### Historical throughput (pre-fix, mixed platforms)
 
 | Payload | Fanout | macOS JSON | Linux JSON | Linux binary |
 |---|---:|---:|---:|---:|
@@ -103,11 +199,15 @@ macOS JSON rate. For the representative 1 KiB × fanout 10 binary workload,
 system time. System time therefore fell by about 90%, flipping the workload
 from roughly 5.5:1 system-dominated to 3.7:1 user-dominated.
 
-This Linux workload is no longer syscall-bound. The next optimization target is
-user-space scheduling and synchronization, not an `io_uring` transport rewrite.
-A CPU flamegraph is still required to distinguish lock/map contention from
-channel handoff and wakeup costs before committing to a thread-per-core design;
-the measured 11,002 voluntary context switches alone cannot separate them.
+This Linux workload is no longer syscall-bound. The "user-space scheduling and
+synchronization" target this paragraph used to predict has since been
+confirmed and fixed: throughput was clocked by scheduler wakeup latency on the
+QUIC driver tasks — roughly one cross-thread wakeup chain per datagram — and
+isolating those drivers onto dedicated single-threaded runtimes (plus pump
+colocation and ACK-frequency tuning) raised sustained macOS loopback
+throughput ~7.5×. See
+[Concurrency internals](/felix/development/internals-concurrency/#the-quic-io-runtime)
+for how that placement works.
 
 ## The transport levers that matter
 
@@ -121,6 +221,8 @@ These findings came out of profiling the QUIC path and are wired into
 | `FELIX_INITIAL_CWND` | Quinn RFC default | Optional initial congestion-window override for trusted low-loss paths. Quinn raises its minimum window to two datagrams when path-MTU discovery finds a larger MTU; the measured default workloads did not benefit from a larger initial burst. |
 | `FELIX_UDP_SEND_BUFFER` / `FELIX_UDP_RECV_BUFFER` | 8 MiB | Socket buffers absorb bursts; kernel-level drops surface as QUIC retransmits and tail-latency spikes. Applied best-effort (halved until the OS accepts). |
 | `FELIX_MAX_UDP_PAYLOAD` | 65527 | Receive-side datagram cap. Must exceed the peer's discovered MTU or large datagrams are silently rejected. |
+| `FELIX_IO_RUNTIME_THREADS` | CPU parallelism | Quinn's driver tasks run on a pool of dedicated single-threaded runtimes (one endpoint per runtime), isolated from application tasks. Driver re-poll latency is the transport's throughput ceiling, and this isolation is the single largest lever found (~7.5× sustained on macOS loopback). `0` restores the old shared-runtime behavior. In-process multi-endpoint setups prefer a small pool; `latency-demo` pins `2`. |
+| `FELIX_ACK_ELICITING_THRESHOLD` | 20 | ACK-frequency extension (quinn peers): ACK at most every N ack-eliciting packets instead of every other, with a 2 ms max ACK delay. Each reverse-path ACK costs a datagram plus its wakeup chain; ~+15% throughput measured. `FELIX_ACK_FREQ_DISABLE=1` restores stock quinn ACK behavior. |
 
 Broker-side levers (see [Configuration](/felix/reference/configuration/)):
 `pub_inflight_bytes` (ingress byte budget), `pub_ingress_wait` (lossless
@@ -132,8 +234,14 @@ publish worker and lane feeders run on a dedicated core-pinned runtime
 +27% on a 4-stream × fanout-4 workload (1.24M → 1.59M msg/s, unpinned macOS);
 on Linux (devcontainer), +25% single-stream (1 KiB × fanout 10: 1.63M → 2.04M
 msg/s) and parity-to-2.5× multi-stream with high environment variance — never
-below baseline in any run. Opt-in until bare-metal numbers tighten the
-multi-stream claim.
+below baseline in any run. **Caveat:** the 2026-08 investigation found these
+`core_shards` gains were likely measured under the buffer-absorption artifact
+(run volumes inside the send window). Re-measured on the fixed pipeline in
+the workload the feature targets (4 streams × fanout 4 × 1 KiB × batch 64,
+five fresh runs per arm, macOS): shards 0 median 661 K msg/s delivered,
+shards 4 median 668 K — **+1%, within run-to-run variance**. The off-by-default
+setting stands; treat `core_shards` as a placement experiment to validate on
+your own hardware, not a general throughput lever.
 
 ## Saturation behavior
 

--- a/docs-site/src/content/docs/features/performance-case-study.md
+++ b/docs-site/src/content/docs/features/performance-case-study.md
@@ -1,0 +1,316 @@
+---
+title: "Case Study: Two Throughput Defects"
+---
+
+Felix's sustained loopback throughput was once capped at about **73 MB/s** of
+payload regardless of configuration, and after that cap was lifted, roughly
+**one benchmark run in three** still landed 5–6× below the rest on identical
+settings. This page documents both defects: what they looked like, how they
+were diagnosed, what fixed them, and — most importantly — the investigative
+method, which generalizes better than either fix does.
+
+The mechanisms and the code that implements them are described in
+[Concurrency internals](/felix/development/internals-concurrency/#the-quic-io-runtime).
+Current numbers are in [Benchmarks](/felix/features/benchmarks/).
+
+## Defect 1: a throughput ceiling exactly proportional to bytes
+
+### The symptom
+
+The ceiling was **per-byte**, and nothing else:
+
+| Payload | Messages/s | Payload rate |
+|---|---:|---:|
+| 2 KiB | 35,707 | 73.1 MB/s |
+| 4 KiB | 17,128 | 70.2 MB/s |
+| 8 KiB | 8,675 | 71.1 MB/s |
+| 16 KiB | 4,382 | 71.8 MB/s |
+| 32 KiB | 2,185 | 71.6 MB/s |
+
+A 16× spread in payload size and a 16× spread in message rate produced the
+same byte rate. That single result eliminates every per-message, per-batch,
+and per-frame explanation at once — encode cost, channel operations, publisher
+round trips, framing overhead. Any of those would hold *messages* per second
+constant, not *bytes*.
+
+Meanwhile every individual stage measured fast: decode 27 µs, append 1 µs,
+QUIC write 2 µs. Twelve of sixteen cores sat idle. No queue, lock, or
+flow-control window was ever saturated, and the QUIC layer reported zero
+packet loss, zero congestion events, and zero blocked frames in either
+direction.
+
+That combination — everything fast, nothing saturated, rate fixed per byte —
+is the signature of a **latency-bound dependency chain**, not a resource
+limit.
+
+### What it wasn't
+
+Fifteen hypotheses were measured and rejected before the real one was found.
+They are recorded because most are plausible enough to be proposed again:
+
+| Hypothesis | Verdict |
+|---|---|
+| Transport / MTU / packet loss | MTU 16354, 0 lost, 0 congestion events |
+| QUIC flow control | 0 blocked frames, both directions |
+| CPU saturation | 12 of 16 cores idle |
+| Redundant payload copy | 0.2% of one core |
+| Read strategy (`read_exact` vs `read_chunk`) | no measurable difference |
+| Channel hops, locks, re-encode copies | a relay with 4 extra hops: no change |
+| Egress topology (writer lanes → direct writer) | no change |
+| Egress frame granularity (64 KiB → 1 MiB) | no change |
+| Queue depths (core, lane, in-flight bytes) | flat |
+| Publish worker sharding | more workers was *worse* |
+| Publisher connection concurrency | flat from 1 to 16 connections |
+| Per-event and per-batch client costs | ruled out by the byte-rate invariance above |
+
+Five structural refactors were tested against this ceiling. None moved it,
+because none of them was the problem.
+
+### The mechanism
+
+Quinn's driver tasks — the endpoint receive loop and each connection's
+transmit/ACK/timer loop — do a **bounded slice of work per poll** and then
+reschedule themselves. Sustained throughput is therefore:
+
+```
+bounded work per poll ÷ scheduler re-poll latency
+```
+
+On a runtime shared with ~50 application tasks, that re-poll latency grows
+with load. And because wakeups scale with **datagram count**, and datagram
+count is bytes ÷ MTU, the cost lands per byte — which is exactly why the
+ceiling looked like a payload-size problem rather than a scheduling one.
+
+Felix was, in effect, clocked by its own scheduler.
+
+### The fix
+
+Three changes, all in Felix, using only official quinn APIs:
+
+1. **Dedicated I/O runtimes.** Quinn drivers run on a pool of single-threaded
+   tokio runtimes, isolated from application tasks and assigned by endpoint
+   role, so a driver's self-wake is re-polled immediately instead of queueing
+   behind application work or migrating cores.
+2. **Pump colocation.** The two tasks that trade a wakeup with the transport
+   per datagram or per write — the client's subscription reader and the
+   broker's per-connection delivery writer — run on the same thread as their
+   connection's drivers, turning a cross-core kernel round trip into a task
+   switch.
+3. **ACK-frequency tuning.** Max ACK delay 25 ms → 2 ms, and one ACK per 20
+   packets instead of every other packet. Each reverse-path ACK costs a
+   datagram plus its own wakeup chain.
+
+| Config | Before | After |
+|---|---:|---:|
+| 4 KiB × batch 64, fanout 1 | 73 MB/s | **~508 MB/s** (median) |
+| 1 KiB × batch 64, fanout 1 | 75 MB/s | **~461 MB/s** |
+| 16 KiB × batch 64, fanout 1 | 72 MB/s | **~503 MB/s** |
+
+The latency profile was unaffected by design — these changes alter transport
+acking and task placement, not request round trips.
+
+## Defect 2: one run in three, 5–6× slower
+
+### The symptom
+
+With the ceiling fixed, identical fresh-process benchmark runs became
+bimodal: most delivered ~118–120 K msg/s (4 KiB × batch 64), but ~30% landed
+at 20–24 K. The slow mode was selected near startup, was sticky for the life
+of the process, and became much more likely under background CPU load.
+
+Everything about it pointed at scheduling. It appeared during scheduling
+work; a real scheduling defect had just been fixed in the same area
+(endpoint-to-runtime assignment depended on creation history, making every
+second in-process benchmark case slow — deterministic alternation that had
+masqueraded as randomness); and the slow mode's fingerprint was **5.7× more
+system time and 5.7× more context switches per message** at the same CPU
+utilization — one kernel round trip per item instead of one per batch, the
+textbook shape of a wakeup lockstep.
+
+A scheduling-based theory was tested directly (keeping the I/O threads
+runnable through the inter-datagram gap so cross-thread wakes become flag
+checks) and changed nothing: the slow-run rate was identical with and
+without it. A fix that does not move the failure rate is a diagnosis
+falsified — the theory was discarded and the investigation went back to
+observation.
+
+### The diagnosis
+
+Logging per-connection `quinn::ConnectionStats` on both ends
+(`FELIX_CONN_STATS_MS`) and comparing one fast against one slow run found the
+difference in a single field on a single connection — the publish connection
+carrying the offered load:
+
+| | Fast run | Slow run |
+|---|---:|---:|
+| Path MTU at end of run | 16354 | **1200** |
+| UDP datagrams for ~240 MB | 14,278 | **166,580** |
+| Bytes per datagram | 15,744 | **1,549** |
+| Lost packets | 0 | 674, in one burst |
+
+The slow run's timeline shows MTU discovery *succeeding* and then being
+un-done:
+
+```
+t=0.25s   mtu=8792    discovery in progress
+t=0.50s   mtu=16354   discovery complete, zero loss
+t=0.75s   mtu=1200    one ~674-packet loss burst → collapse
+t≥0.75s   mtu=1200    pinned for the rest of the run
+```
+
+At MTU 1200 the same byte stream costs ~13.6× the datagrams, and each
+datagram carries a syscall and a wakeup chain — which is precisely the 5.7×
+system-time-per-message fingerprint that had read as a scheduling defect.
+An earlier check ("MTU reaches 16354 in both modes") had been performed on a
+*delivery* connection; the collapse hits the connection carrying the load.
+
+### The mechanism
+
+Three interlocking behaviors, all in the QUIC layer:
+
+1. **The loss burst is congestion, not an MTU problem.** At high rate the
+   publish path keeps a multi-megabyte standing queue in the receiver's UDP
+   socket buffer, within a couple MB of its cap. A scheduling stall of a few
+   milliseconds on the draining side overflows it, and the kernel drops a
+   window of packets. Background CPU load makes stalls — and therefore the
+   collapse — more likely. If the startup ramp survives without a burst,
+   steady state is loss-free: hence bimodal and startup-selected.
+2. **Quinn's black-hole detector cannot tell the difference.** Every packet
+   in the burst is full-MTU — that is simply what a saturated sender's
+   traffic looks like — and "large packets vanish while small ones survive"
+   is exactly the signature the detector watches for. It declares an MTU
+   black hole and resets the path MTU to `min_mtu` (1200 by default), with a
+   60-second cooldown before discovery may run again.
+3. **Recovery is starved by the load itself.** Quinn sends MTU probes only
+   when a transmit poll finds nothing else to send. A backlogged publisher
+   never has an empty transmit buffer, so after a collapse no probe is ever
+   sent: the connection stays collapsed not for the 60-second cooldown but
+   for the life of the load.
+
+```mermaid
+flowchart LR
+    A(["ramp-up at<br/>full MTU"]) e1@--> B["socket buffer<br/>overflow burst"]
+    B e2@--> C{{"black-hole detector:<br/>all lost packets are full-MTU"}}
+    C e3@--> D["path MTU resets<br/>to min_mtu (1200)"]
+    D e4@--> E(["~13× datagrams per byte,<br/>probes starved by backlog"])
+    E e5@--> D
+
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef gate fill:#fdeaea,stroke:#b04a4a,color:#3d1414
+    classDef bad fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    class A,B step
+    class C gate
+    class D,E bad
+```
+
+### The fix
+
+For loopback peers — the benchmark's topology, and the one path where a
+16 KiB datagram is guaranteed by the interface itself — connections now
+start at the loopback MTU *and* guarantee it, on both the connect and accept
+sides:
+
+- `initial_mtu = 16336` (fits IPv4/IPv6 headers within the 16 KiB loopback
+  interface MTU), removing the discovery ramp;
+- `min_mtu = 16336`, which is the part that matters: the black-hole verdict
+  resets to `min_mtu`, so with the floor at the real MTU there is nothing to
+  collapse to, and a congestive loss burst is handled as ordinary congestion;
+- an initial congestion window scaled to the MTU per RFC 9002's formula —
+  quinn's default window is a flat 14,720 bytes, smaller than one 16 KiB
+  segment, which otherwise deadlocks the handshake outright.
+
+An explicit `FELIX_INITIAL_MTU` disables the special case. For non-loopback
+paths, where `min_mtu` must never be raised, the black-hole cooldown drops
+from 60 s to 2 s (`FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`), so a spurious collapse
+on an intermittently loaded connection heals at the next idle gap instead of
+being pinned for a minute.
+
+### The result
+
+Fresh-process runs, 4 KiB × batch 64 × fanout 1, same machine:
+
+| | Before | After |
+|---|---|---|
+| Slow runs | 5 of 16, at ~21 K msg/s | **0 of 20** |
+| Median | ~118 K msg/s | **~122 K msg/s (~500 MB/s)** |
+| Worst ÷ median | 5.9× | **1.11×** |
+
+Reverting the fix on the same binary (via `FELIX_INITIAL_MTU=1200` and the
+stock 60 s cooldown) reproduces the slow runs, so the attribution is causal
+rather than machine drift.
+
+## What generalizes
+
+**Check that the benchmark measures what you think.** The original numbers
+were inflated by a measurement artifact: any run whose total volume fits
+inside the 64 MiB QUIC send window is absorbed by buffers before backpressure
+appears, so the harness reports buffer-fill rate rather than sustained
+throughput. A 1 KiB run appeared to do 358 MB/s and actually sustained
+74.9 MB/s.
+
+```mermaid
+flowchart LR
+    subgraph absorbed["Run smaller than the send window"]
+        direction TB
+        A1(["publish 31 MB"]) a1@--> A2["send buffer<br/><small>64 MiB, never fills</small>"]
+        A2 a2@--> A3(["reports buffer-fill rate<br/><small>backpressure never appears</small>"])
+    end
+
+    subgraph sustained["Run larger than the send window"]
+        direction TB
+        S1(["publish 312 MB"]) s1@--> S2["send buffer fills"]
+        S2 s2@--> S3["backpressure reaches<br/>the publisher"]
+        S3 s3@--> S4(["reports sustained rate"])
+    end
+
+    a1@{ animation: fast }
+    a2@{ animation: fast }
+    s1@{ animate: true }
+    s2@{ animate: true }
+    s3@{ animate: true }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef bad fill:#fdeaea,stroke:#b04a4a,color:#3d1414
+    classDef ok fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class A2,S2,S3 step
+    class A3 bad
+    class A1,S1,S4 ok
+```
+
+The benchmark harness now warns when a throughput run is undersized, and the
+matrix scales message counts per payload so this cannot silently return.
+
+**Build the honest baseline.** A minimal store-and-forward relay — the
+smallest thing doing the broker's job over two QUIC hops — reached 540 MB/s.
+That single number reframed everything: it proved the architecture was worth
+~7× what Felix was achieving, so the gap had to be in Felix's code rather
+than in QUIC, the extra hop, or the OS.
+
+**Let invariance do the eliminating.** The byte-rate invariance across a 16×
+payload range ruled out more hypotheses in one measurement than the
+preceding five refactors did.
+
+**Distrust a fix that arrives without a mechanism — and a mechanism whose
+fix changes nothing.** Five topology changes were implemented and measured
+before anyone could explain why the first ceiling existed; all five were
+wasted. The second defect ran the same trap in reverse: a plausible
+scheduling theory survived until its direct fix failed to move the failure
+rate, which falsified it in one experiment.
+
+**A bimodal distribution is a state machine, not noise.** Two clean modes
+with nothing in between means something discrete latches early and persists.
+The productive question is *what state distinguishes the modes* — here,
+one field (`current_mtu`) on one connection — not *why is the benchmark
+noisy*. Averaging across modes, or publishing medians without investigating
+the spread, would have reported the defect as the product's performance.
+
+**Inspect the entity carrying the load.** The MTU had been checked and found
+healthy — on a delivery connection. Per-connection statistics on *every*
+connection, kept until the anomaly is attributable to one of them, is what
+turned four rounds of dead ends into a one-line diagnosis.

--- a/docs-site/src/content/docs/features/performance-case-study.md
+++ b/docs-site/src/content/docs/features/performance-case-study.md
@@ -109,6 +109,17 @@ Three changes, all in Felix, using only official quinn APIs:
 The latency profile was unaffected by design — these changes alter transport
 acking and task placement, not request round trips.
 
+:::caution[Driver isolation is macOS-only today]
+Every number on this page was measured on macOS, and the dedicated I/O
+runtime pool is enabled there only. On Linux, isolating the drivers loses a
+delivery wakeup — the receiver's QUIC layer accepts and acknowledges a stream
+frame the application is never woken to read — so that platform keeps the
+shared-runtime behaviour by default (`FELIX_IO_RUNTIME_THREADS=0`) until the
+defect is resolved. Pump colocation and ACK-frequency tuning were each ruled
+out by A/B; the wakeup defect is specific to the drivers' runtime placement,
+and is the open item from this investigation.
+:::
+
 ## Defect 2: one run in three, 5–6× slower
 
 ### The symptom

--- a/docs-site/src/content/docs/features/performance-case-study.md
+++ b/docs-site/src/content/docs/features/performance-case-study.md
@@ -13,6 +13,15 @@ The mechanisms and the code that implements them are described in
 [Concurrency internals](/felix/development/internals-concurrency/#the-quic-io-runtime).
 Current numbers are in [Benchmarks](/felix/features/benchmarks/).
 
+:::note[Scope: these are macOS findings]
+Every measurement here is macOS on loopback, and the first defect turns out
+to be a macOS pathology: the same benchmark on Linux sustains ~643 MB/s at
+the *pre-fix* baseline, above what macOS reaches with all of these fixes
+applied. The dedicated I/O runtime pool is therefore enabled on macOS only —
+on Linux it measures slower. The second defect (the MTU black-hole collapse)
+and the measurement lessons are platform-neutral.
+:::
+
 ## Defect 1: a throughput ceiling exactly proportional to bytes
 
 ### The symptom

--- a/docs-site/src/content/docs/features/performance-case-study.md
+++ b/docs-site/src/content/docs/features/performance-case-study.md
@@ -225,11 +225,16 @@ sides:
   quinn's default window is a flat 14,720 bytes, smaller than one 16 KiB
   segment, which otherwise deadlocks the handshake outright.
 
-An explicit `FELIX_INITIAL_MTU` disables the special case. For non-loopback
-paths, where `min_mtu` must never be raised, the black-hole cooldown drops
-from 60 s to 2 s (`FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`), so a spurious collapse
-on an intermittently loaded connection heals at the next idle gap instead of
-being pinned for a minute.
+The guarantee is conditional on the socket buffers the OS actually granted:
+jumbo datagrams are only safe when the kernel buffers hold a real burst of
+them (~64 datagrams, about 1 MiB), so hosts where Linux silently clamps
+`SO_RCVBUF` to a stock `net.core.rmem_max` (~208 KB — about 26 jumbo
+datagrams) keep the RFC-safe default path instead. An explicit
+`FELIX_INITIAL_MTU` disables the special case. For non-loopback paths, where
+`min_mtu` must never be raised, the black-hole cooldown drops from 60 s to
+2 s (`FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`), so a spurious collapse on an
+intermittently loaded connection heals at the next idle gap instead of being
+pinned for a minute.
 
 ### The result
 

--- a/docs-site/src/content/docs/features/performance-case-study.md
+++ b/docs-site/src/content/docs/features/performance-case-study.md
@@ -109,17 +109,6 @@ Three changes, all in Felix, using only official quinn APIs:
 The latency profile was unaffected by design — these changes alter transport
 acking and task placement, not request round trips.
 
-:::caution[Driver isolation is macOS-only today]
-Every number on this page was measured on macOS, and the dedicated I/O
-runtime pool is enabled there only. On Linux, isolating the drivers loses a
-delivery wakeup — the receiver's QUIC layer accepts and acknowledges a stream
-frame the application is never woken to read — so that platform keeps the
-shared-runtime behaviour by default (`FELIX_IO_RUNTIME_THREADS=0`) until the
-defect is resolved. Pump colocation and ACK-frequency tuning were each ruled
-out by A/B; the wakeup defect is specific to the drivers' runtime placement,
-and is the open item from this investigation.
-:::
-
 ## Defect 2: one run in three, 5–6× slower
 
 ### The symptom

--- a/docs-site/src/content/docs/features/performance-platform-notes.md
+++ b/docs-site/src/content/docs/features/performance-platform-notes.md
@@ -10,6 +10,29 @@ Felix performance tuning is currently optimized for Linux-first deployments.
 - At `batch=1`, tail latency is often dominated by scheduler wakeups and UDP/QUIC receive-path behavior, not broker business logic.
 - On macOS and other desktop OSes, expect higher jitter in `p99`/`p999` for the same benchmark profile.
 
+## Transport scheduling defaults
+
+The performance-critical transport defaults are on out of the box — no
+environment tuning is required to get sustained-throughput behavior:
+
+- QUIC driver tasks run on dedicated single-threaded I/O runtimes
+  (`FELIX_IO_RUNTIME_THREADS`; `0` disables), with transport-facing pump
+  tasks colocated on the same threads.
+- The ACK-frequency extension is negotiated between quinn peers (2 ms max
+  ACK delay, ACK every 20th packet; `FELIX_ACK_ELICITING_THRESHOLD` /
+  `FELIX_ACK_FREQ_DISABLE`).
+- Path-MTU discovery probes up to 16 KiB and UDP socket buffers request
+  8 MiB.
+
+Together these raised sustained macOS loopback throughput ~7.5×: driver
+isolation was the dominant term, since per-datagram scheduler wakeup latency
+had been the byte-rate ceiling. Single-process setups that host many endpoints
+(like `latency-demo`) perform best with a small I/O pool; the demo pins
+`FELIX_IO_RUNTIME_THREADS=2` itself. A minority of in-process benchmark runs
+can still start in a degraded scheduling mode — rerun rather than tune if a
+single run lands far below the numbers in
+[Benchmarks](/felix/features/benchmarks/).
+
 ## Recommended perf environment
 
 - Prefer a Linux host (or a Linux VM pinned to dedicated CPU resources).

--- a/docs-site/src/content/docs/features/performance.md
+++ b/docs-site/src/content/docs/features/performance.md
@@ -17,7 +17,53 @@ Felix performance is determined by several interconnected factors:
 
 ## Performance Profiles
 
-Felix provides three pre-configured profiles as starting points.
+Felix provides three pre-configured profiles as starting points. They are the
+same pipeline with one dial turned — how long a message is allowed to wait for
+company before being sent:
+
+```mermaid
+flowchart LR
+    subgraph lat["Latency-optimized"]
+        direction TB
+        L1(["message"]) l1@--> L2["send immediately<br/><small>batch ≈ 1, shallow queues,<br/>block instead of drop</small>"]
+        L2 l2@--> L3(["lowest p99<br/><small>fewest messages per syscall</small>"])
+    end
+
+    subgraph bal["Balanced (default)"]
+        direction TB
+        B1(["message"]) b1@--> B2["brief coalescing window<br/><small>moderate batching + pools</small>"]
+        B2 b2@--> B3(["sub-ms latency at<br/>useful throughput"])
+    end
+
+    subgraph thr["Throughput-optimized"]
+        direction TB
+        T1(["message"]) t1@--> T2["fill the batch<br/><small>deep queues, large windows,<br/>lossless pacing</small>"]
+        T2 t2@--> T3(["most bytes per second<br/><small>latency includes batch fill</small>"])
+    end
+
+    l1@{ animation: fast }
+    l2@{ animation: fast }
+    b1@{ animate: true }
+    b2@{ animate: true }
+    t1@{ animation: slow }
+    t2@{ animation: slow }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef ok fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    classDef warm fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    class L2,B2,T2 step
+    class L1,B1,T1 ok
+    class L3,B3 ok
+    class T3 warm
+```
+
+:::note[Read the trade-off, not the ranking]
+None of these is "faster" in the abstract. Batching raises bytes per second and
+raises per-message latency at the same time, because a batched message waits for
+the batch. That is why the [benchmark harness](/felix/features/benchmarks/)
+reports batch-1 and batch-64 as separate profiles and never compares their
+latency percentiles to each other.
+:::
 
 ### Balanced Profile (Default)
 
@@ -166,10 +212,11 @@ publish_chunk_bytes: 32768
 ```
 
 **Expected performance**: the throughput-focused profile in
-[Benchmarks](/felix/features/benchmarks/) (batch = 64, lossless, zero drops) measures this
-shape directly — millions of msg/s for small payloads, hundreds of
-thousands for 1-4 KiB payloads at fanout 10, scaling further with
-`core_shards` on multi-stream workloads.
+[Benchmarks](/felix/features/benchmarks/) (batch = 64, lossless, zero drops)
+measures this shape directly. Message rate falls and byte rate rises as
+payloads grow, so read the byte rate when comparing payload sizes.
+`core_shards` may help multi-stream workloads, but its published gains predate
+the transport scheduling work and need re-validation.
 
 :::note[Lossless pacing is an explicit trade-off]
 `block` queues + `pub_ingress_wait: true` mean producers slow down
@@ -464,11 +511,11 @@ Disable telemetry in production for maximum throughput. Enable only for profilin
 ### Sizing Guidelines
 
 :::note[These bands are illustrative, not measured]
-Single-broker measurements in [Benchmarks](/felix/features/benchmarks/) reach into the
-millions of msg/s for small payloads on a single dev machine — well past
-the "large deployment" band below. Use these YAML shapes as starting
-points for connection/queue sizing, not as a throughput ceiling; run your
-own workload through `latency-demo` before sizing hardware.
+Single-broker measurements in [Benchmarks](/felix/features/benchmarks/)
+comfortably exceed the "large deployment" band below on one dev machine. Use
+these YAML shapes as starting points for connection/queue sizing, not as a
+throughput ceiling; run your own workload through `latency-demo` before sizing
+hardware.
 :::
 **Small deployment**:
 

--- a/docs-site/src/content/docs/features/pubsub.md
+++ b/docs-site/src/content/docs/features/pubsub.md
@@ -51,14 +51,19 @@ graph LR
 
 Felix excels at high-fanout workloads where one message must be delivered to many subscribers.
 
-**Fanout efficiency**:
+**Fanout efficiency**: a publish is encoded once and the encoded frame is
+shared by every subscriber, so fanout costs delivery work rather than
+re-encoding. Measured latency at fanout 1 and 10 (macOS loopback, per-message
+ack, median of 5–10 trials):
 
-| Fanout | Throughput (msg/sec) | p99 Latency |
-|--------|---------------------|-------------|
-| 1 | 200k | 2.5 ms |
-| 10 | 180k | 3.8 ms |
-| 100 | 140k | 6.2 ms |
-| 1000 | 85k | 12.5 ms |
+| Fanout | p50 | p99 |
+|--------|-----|-----|
+| 1 | 109–136 µs | 138–176 µs |
+| 10 | 236–269 µs | 278–399 µs |
+
+Fanout above 10 has not been benchmarked; see
+[Benchmarks](/felix/features/benchmarks/) for methodology and the full tables.
+Treat behaviour at hundreds or thousands of subscribers as unmeasured.
 
 **Fanout isolation**: Slow subscribers never block fast subscribers.
 
@@ -114,6 +119,21 @@ publisher
 | 32 | 12x | 250 µs |
 | 64 | 18x | 350 µs |
 | 128 | 22x | 600 µs |
+
+#### Acked Publishes Are Pipelined
+
+Acked publishes (`AckMode::PerMessage` / `AckMode::PerBatch`) do not stall
+the stream for the broker's round trip. The client writes acked requests back
+to back and resolves each caller's future as the matching ack arrives, in
+order — so concurrent publishers on the same stream share the stream's full
+bandwidth instead of taking turns paying a round trip each. In-flight acked
+data is bounded by the publisher's byte budget (`publish_inflight_bytes`,
+4 MiB by default): a request holds its budget until the broker's ack, not
+merely until the frame is written.
+
+A single caller that awaits each publish before issuing the next still
+experiences one round trip per publish, by construction — batch, or publish
+concurrently, to amortize it.
 
 #### Broker-Side Batching
 
@@ -399,10 +419,10 @@ let config = ClientConfig {
 };
 ```
 
-**Expected performance**:
-- p50 latency: 200-400 µs
-- p99 latency: 800-1200 µs
-- Throughput: 50-80k msg/sec per connection
+**What to expect**: lowest per-message latency, least batching. See the
+latency profile in [Benchmarks](/felix/features/benchmarks/) for measured
+percentiles; throughput per connection depends on payload size and is not a
+single number.
 
 ### Throughput-Optimized Configuration
 
@@ -438,10 +458,10 @@ let config = ClientConfig {
 };
 ```
 
-**Expected performance**:
-- p50 latency: 1-3 ms
-- p99 latency: 5-10 ms
-- Throughput: 200-300k msg/sec per connection
+**What to expect**: highest byte rate, with per-message latency dominated by
+batch fill and queueing. See the throughput profile in
+[Benchmarks](/felix/features/benchmarks/) — and note that its latency
+percentiles measure queueing, not request latency.
 
 ### Balanced Configuration (Default)
 
@@ -465,10 +485,8 @@ let quinn = quinn::ClientConfig::with_platform_verifier();
 let config = ClientConfig::optimized_defaults(quinn);  // Uses balanced defaults
 ```
 
-**Expected performance**:
-- p50 latency: 400-800 µs
-- p99 latency: 2-4 ms
-- Throughput: 150-200k msg/sec per connection
+**What to expect**: sub-millisecond latency at useful throughput. This is the
+configuration [Benchmarks](/felix/features/benchmarks/) measures by default.
 
 ## Advanced Patterns
 

--- a/docs-site/src/content/docs/features/quic-transport.md
+++ b/docs-site/src/content/docs/features/quic-transport.md
@@ -223,33 +223,40 @@ sequenceDiagram
 | TLS resumption | 500-800 µs |
 | 0-RTT (future) | 0 µs (data in first packet) |
 
-**Single message round-trip** (publish + ack):
+**Single message round-trip** (publish + ack, macOS loopback, median of 5–10
+trials):
 
 | Workload | p50 | p99 |
 |----------|-----|-----|
-| Small payload (100B) | 150 µs | 300 µs |
-| Medium payload (1KB) | 200 µs | 400 µs |
-| Large payload (4KB) | 300 µs | 600 µs |
+| Empty payload | 119 µs | 165 µs |
+| 256 B | 109 µs | 138 µs |
+| 1 KiB | 111 µs | 140 µs |
+| 4 KiB | 136 µs | 176 µs |
 
 ### Throughput
 
-**Single connection throughput**:
+Measured figures live in one place — [Benchmarks](/felix/features/benchmarks/) —
+so they cannot drift page to page. Summarising the sustained pub/sub rates at
+fanout 1:
 
-- **Publish**: 50-100k msg/sec (single publishes)
-- **Publish batch**: 150-250k msg/sec (batch=64)
-- **Event delivery**: 200-300k msg/sec per subscriber
-- **Cache operations**: 125-185k ops/sec
+| Payload | Delivered | Payload rate |
+|---|---:|---:|
+| 1 KiB | ~450 K msg/s | ~461 MB/s |
+| 4 KiB | ~124 K msg/s | ~508 MB/s |
+| 16 KiB | ~31 K msg/s | ~503 MB/s |
 
-**Scaling with connection pools**:
+:::caution[Connection count is not a throughput multiplier]
+An earlier version of this page claimed throughput scales "nearly linearly"
+with connection count, up to millions of msg/s at 16 connections. That is not
+what the transport does, and measurement contradicts it in both directions:
+before the I/O-runtime work, publisher concurrency was flat from 1 to 16
+connections (78.3 → 73.8 MB/s); after it, additional connections help only
+until the I/O runtime saturates, because each endpoint's driver is a single
+task on a single runtime.
 
-Throughput scales nearly linearly with connection count (up to CPU/network limits):
-
-| Connections | Publish Throughput | Event Delivery |
-|-------------|-------------------|----------------|
-| 1 | 150k msg/sec | 250k msg/sec |
-| 4 | 580k msg/sec | 950k msg/sec |
-| 8 | 1.1M msg/sec | 1.8M msg/sec |
-| 16 | 2.0M msg/sec | 3.2M msg/sec |
+Add connections to isolate workloads and avoid head-of-line blocking, not to
+multiply throughput. Measure your own shape with `latency-demo` before sizing.
+:::
 
 ### Packet Loss Resilience
 
@@ -394,21 +401,26 @@ Memory ≈ (256MB × 8) + (64MB × 10 × 8) = 2GB + 5.1GB = 7.1GB
 
 ### Congestion Control
 
-QUIC uses modern congestion control algorithms:
+Felix uses quinn's default congestion controller, **CUBIC** (RFC 8312),
+loss-based and safe on shared networks. Two Felix-level knobs sit on top:
 
-**BBR** (Bottleneck Bandwidth and RTT):
-- Default in quinn QUIC implementation
-- Optimizes for throughput and latency
-- Adapts to network conditions
+- `FELIX_INITIAL_CWND` — optional initial-window override for trusted
+  low-loss paths (skips the slow-start ramp). Measured workloads did not
+  benefit, so the RFC default stands.
+- **ACK frequency** — between quinn peers Felix negotiates the QUIC
+  ACK-frequency extension: 2 ms max ACK delay (instead of 25 ms) and an ACK
+  at most every 20 ack-eliciting packets (instead of every other). Delayed
+  ACKs stall window-limited senders, and every reverse-path ACK costs a
+  datagram plus its wakeup chain; the tuned cadence measured ~+15% sustained
+  throughput. Override with `FELIX_ACK_ELICITING_THRESHOLD`, or disable the
+  extension with `FELIX_ACK_FREQ_DISABLE=1`.
 
-**CUBIC**:
-- Alternative congestion control
-- More conservative than BBR
-- Better for shared networks
-
-:::tip[Tuning Congestion Control]
-For dedicated networks (data center, cloud VPC), BBR provides better performance. For shared networks, CUBIC may be more friendly to competing traffic.
-:::
+Just as important as the algorithm is *where the transport runs*: quinn's
+driver tasks execute on dedicated single-threaded I/O runtimes
+(`FELIX_IO_RUNTIME_THREADS`), isolated from application tasks, because their
+scheduler re-poll latency — not congestion control — was the measured
+throughput ceiling. See
+[Concurrency internals](/felix/development/internals-concurrency/#the-quic-io-runtime).
 ## Monitoring and Observability
 
 ### QUIC Metrics

--- a/docs-site/src/content/docs/getting-started/overview.md
+++ b/docs-site/src/content/docs/getting-started/overview.md
@@ -50,6 +50,51 @@ Felix does **not** reimplement scheduling or node membership—it leverages what
 
 ## Core Components
 
+Five crates, and the boundaries between them are the design. Everything below
+the dotted line is transport-independent: the broker core has no idea QUIC
+exists, which is what makes it testable in-process.
+
+```mermaid
+flowchart TB
+    subgraph app["Your application"]
+        direction LR
+        A1(["publisher"])
+        A2(["subscriber"])
+        A3(["cache client"])
+    end
+
+    SDK["felix-client<br/><small>publisher / subscription / cache APIs,<br/>connection + stream pools</small>"]
+    WIRE["felix-wire<br/><small>frame header, JSON control messages,<br/>binary data-plane frames</small>"]
+    TRANS["felix-transport<br/><small>QUIC endpoints, streams, flow control,<br/>dedicated I/O runtimes</small>"]
+    BRK["felix-broker<br/><small>stream registry, log, subscriber<br/>registry, fanout</small>"]
+    SVC["services/broker<br/><small>network service: handlers, auth,<br/>metrics, control-plane sync</small>"]
+    CP["services/controlplane<br/><small>tenants, namespaces, streams,<br/>tokens, RBAC</small>"]
+
+    A1 e1@--> SDK
+    A2 e2@--> SDK
+    A3 e3@--> SDK
+    SDK e4@--> WIRE
+    WIRE e5@--> TRANS
+    TRANS e6@-->|"QUIC + TLS 1.3"| SVC
+    SVC e7@--> BRK
+    SVC e8@-.->|"seeds metadata at startup"| CP
+
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef core fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef endpoint fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class SDK,WIRE,TRANS,SVC step
+    class BRK,CP core
+    class A1,A2,A3 endpoint
+```
+
 ### Felix Wire Protocol (`felix-wire`)
 
 Language-neutral framed protocol over QUIC:
@@ -146,28 +191,29 @@ Felix provides **tunable consistency** configured per stream:
 
 Current implementation for development and testing:
 
-```
-┌─────────────┐
-│   Broker    │
-│  (in-proc)  │
-│             │
-│ • Pub/Sub   │
-│ • Cache     │
-│ • Ephemeral │
-└─────────────┘
+```mermaid
+flowchart TB
+    BROKER["Broker (in-process)<br/><br/>Pub/Sub<br/>Cache<br/>Ephemeral"]
 ```
 
 ### Multi-Node Cluster (Planned)
 
-```
-     Control Plane          Data Plane
-    ┌──────────────┐      ┌──────────┐
-    │ RAFT Quorum  │──────│ Broker A │
-    │              │      │ Broker B │
-    │ • Metadata   │      │ Broker C │
-    │ • Placement  │      └──────────┘
-    │ • Health     │
-    └──────────────┘
+```mermaid
+flowchart LR
+    subgraph CONTROL["Control Plane"]
+        RAFT["RAFT Quorum<br/><br/>Metadata<br/>Placement<br/>Health"]
+    end
+
+    subgraph DATA["Data Plane"]
+        direction TB
+        A["Broker A"]
+        B["Broker B"]
+        C["Broker C"]
+    end
+
+    RAFT --- A
+    RAFT --- B
+    RAFT --- C
 ```
 
 See [Deployment Guides](/felix/deployment/local/) for detailed instructions.

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -149,18 +149,21 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 
 Single host, loopback, release build, TLS 1.3 on, defaults, zero delivery drops:
 
-- **Latency (batch = 1, per-message ack, JSON framing):** p50 82–128 µs,
-  p999 175–329 µs at fanout 1 across 0 B–1 KiB payloads.
+- **Latency (batch = 1, per-message ack, JSON framing):** p50 109–136 µs,
+  p99 138–176 µs at fanout 1 across 0 B–4 KiB payloads; p50 236–269 µs,
+  p99 278–399 µs at fanout 10.
 
   The framing matters and is easy to get wrong. `latency-demo` enables
   per-message acks only when `batch <= 1 && !binary`, so passing `--binary`
   silently measures a different thing — fire-and-forget delivery rather than a
-  request round trip. On the same machine that produced the figures above, the
-  binary path measures ~256 µs p50. That is not a regression against them; it
-  is a different configuration, and the two are not comparable.
-- **Throughput (batch = 64, lossless):** up to 2.92 M deliveries/s for 0 B at
-  fanout 10; ~1.57 M/s at 1 KiB × fanout 10; ~2.3 GB/s of payload at 4 KiB ×
-  fanout 10 on Linux.
+  request round trip. Those two are not comparable.
+- **Throughput (batch = 64, lossless, fanout 1):** ~461 MB/s at 1 KiB,
+  ~508 MB/s at 4 KiB, ~503 MB/s at 16 KiB of payload.
+
+  A minority of runs land several times lower — a known open issue in the
+  transport's scheduling, documented under
+  [Benchmarks](/felix/features/benchmarks/). Take a median of several runs;
+  a single run is not a measurement.
 
 Full methodology and per-platform tables are in [Benchmarks](/felix/features/benchmarks/).
 These are **single-node loopback numbers at fanout ≤ 10**. They are not evidence

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -808,7 +808,7 @@ export FELIX_MTU_UPPER_BOUND="4096"   # small-message optimized
 
 ### `FELIX_INITIAL_MTU`
 
-**Description**: Starting datagram size before path-MTU discovery completes. The RFC-safe default works everywhere; raising it on known-good paths (jumbo-frame LAN) skips the discovery ramp. Connections to a loopback peer automatically start at the loopback MTU (16,336-byte payloads, capped by `FELIX_MTU_UPPER_BOUND`) — that path is known-good by construction, and starting at full size also makes the MTU immune to spurious black-hole collapse (see `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`). Setting `FELIX_INITIAL_MTU` explicitly disables the loopback special case and applies to every path.
+**Description**: Starting datagram size before path-MTU discovery completes. The RFC-safe default works everywhere; raising it on known-good paths (jumbo-frame LAN) skips the discovery ramp. Connections to a loopback peer automatically start at the loopback MTU (16,336-byte payloads, capped by `FELIX_MTU_UPPER_BOUND`) — that path is known-good by construction, and starting at full size also makes the MTU immune to spurious black-hole collapse (see `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`). The loopback fast path additionally requires the socket's *granted* UDP buffers to hold ~64 full-size datagrams (~1 MiB): hosts where Linux silently clamps `SO_RCVBUF` to a stock `net.core.rmem_max` (~208 KB) lack the burst headroom that makes jumbo datagrams safe, and keep the RFC-safe default instead — raise `rmem_max`/`wmem_max` to enable it. Setting `FELIX_INITIAL_MTU` explicitly disables the loopback special case and applies to every path.
 
 **Type**: Positive integer (bytes, clamped to 1200–65527)
 

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -871,9 +871,20 @@ export FELIX_MAX_UDP_PAYLOAD="65527"
 
 **Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime (the pre-fix behavior). A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
 
+:::caution[A macOS optimization; off by default elsewhere]
+The ceiling this pool removes is specific to macOS. On Linux the same
+benchmark already sustains ~643 MB/s (628 K msg/s × 1 KiB) *without* it —
+more than macOS reaches even with the pool — and isolating the drivers there
+only adds a cross-thread hop per datagram. Measured on Linux: p50 latency
+86 µs → 152 µs and fanout-10 throughput 1.48 M → 1.09 M msg/s, consistent
+across pool sizes 1/2/4/8 and with pump colocation on or off. Non-macOS
+platforms therefore default to `0`; set the variable explicitly to
+experiment.
+:::
+
 **Type**: Non-negative integer
 
-**Default**: `2`
+**Default**: `2` on macOS, `0` elsewhere
 
 ```bash
 export FELIX_IO_RUNTIME_THREADS="2"

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -869,11 +869,15 @@ export FELIX_MAX_UDP_PAYLOAD="65527"
 
 ### `FELIX_IO_RUNTIME_THREADS`
 
-**Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime (the pre-fix behavior). A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
+**Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime. A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
+
+:::caution[Enabled by default on macOS only]
+On Linux, isolating quinn's drivers onto a dedicated runtime currently loses a delivery wakeup: the receiving side's QUIC layer accepts and acknowledges a stream frame that the application is never woken to read, and the connection stalls until it times out. It reproduces deterministically on a current-thread application runtime and intermittently on a multi-threaded one. The measured throughput gain is macOS-only so far, so non-macOS platforms default to `0` rather than trade delivery correctness for an unmeasured speedup. Setting this variable opts in anywhere — treat a non-zero value on Linux as experimental until that defect is resolved.
+:::
 
 **Type**: Non-negative integer
 
-**Default**: `2`
+**Default**: `2` on macOS, `0` elsewhere
 
 ```bash
 export FELIX_IO_RUNTIME_THREADS="2"

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -808,14 +808,26 @@ export FELIX_MTU_UPPER_BOUND="4096"   # small-message optimized
 
 ### `FELIX_INITIAL_MTU`
 
-**Description**: Starting datagram size before path-MTU discovery completes. The RFC-safe default works everywhere; raising it on known-good paths (loopback, jumbo-frame LAN) skips the discovery ramp.
+**Description**: Starting datagram size before path-MTU discovery completes. The RFC-safe default works everywhere; raising it on known-good paths (jumbo-frame LAN) skips the discovery ramp. Connections to a loopback peer automatically start at the loopback MTU (16,336-byte payloads, capped by `FELIX_MTU_UPPER_BOUND`) — that path is known-good by construction, and starting at full size also makes the MTU immune to spurious black-hole collapse (see `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`). Setting `FELIX_INITIAL_MTU` explicitly disables the loopback special case and applies to every path.
 
 **Type**: Positive integer (bytes, clamped to 1200–65527)
 
-**Default**: `1200`
+**Default**: `1200` (loopback peers: `16336`)
 
 ```bash
 export FELIX_INITIAL_MTU="1200"
+```
+
+### `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`
+
+**Description**: How long a connection waits after an MTU black-hole verdict before re-probing for a larger MTU. Quinn's black-hole detector cannot distinguish a path that silently drops large packets from a congestive loss burst that happened to contain only full-MTU packets (which is what overflowing the peer's UDP socket buffer looks like at high rate). A false verdict collapses the path MTU to the initial value, multiplying datagram and syscall counts per byte by ~13× on a 16 KiB-MTU path; quinn's stock 60-second cooldown then pins that state. Felix shortens the cooldown so a spurious collapse re-probes at the connection's next idle gap. Note that quinn only sends recovery probes when the connection has nothing else to transmit, so a sender with a continuous backlog cannot recover until its load has a gap regardless of this setting — which is why loopback connections start at full MTU instead (see `FELIX_INITIAL_MTU`).
+
+**Type**: Positive integer (milliseconds, minimum 100)
+
+**Default**: `2000`
+
+```bash
+export FELIX_MTU_BLACK_HOLE_COOLDOWN_MS="2000"
 ```
 
 ### `FELIX_INITIAL_CWND`
@@ -853,6 +865,56 @@ export FELIX_UDP_RECV_BUFFER="8388608"
 
 ```bash
 export FELIX_MAX_UDP_PAYLOAD="65527"
+```
+
+### `FELIX_IO_RUNTIME_THREADS`
+
+**Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime (the pre-fix behavior). A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
+
+**Type**: Non-negative integer
+
+**Default**: `2`
+
+```bash
+export FELIX_IO_RUNTIME_THREADS="2"
+export FELIX_IO_RUNTIME_THREADS="0"   # disable driver isolation
+```
+
+### `FELIX_ACK_ELICITING_THRESHOLD`
+
+**Description**: How many ack-eliciting packets a peer may receive before it must send an ACK (QUIC ACK-frequency extension; applies between quinn peers). The RFC default of every other packet costs a reverse-path datagram — plus its wakeup chain — per ~2 datagrams of data; the higher default trades a little loss-detection latency (bounded by the 2 ms `max_ack_delay` Felix also negotiates) for measurably less per-byte wakeup traffic (~+15% throughput on loopback).
+
+**Type**: Positive integer (packets)
+
+**Default**: `20`
+
+```bash
+export FELIX_ACK_ELICITING_THRESHOLD="20"
+export FELIX_ACK_ELICITING_THRESHOLD="1"   # RFC-like cadence
+```
+
+### `FELIX_ACK_FREQ_DISABLE`
+
+**Description**: Set to any value to skip negotiating the ACK-frequency extension entirely, restoring stock quinn ACK behavior (25 ms max ack delay, ACK every other packet).
+
+**Type**: Presence toggle
+
+**Default**: unset (extension negotiated)
+
+```bash
+export FELIX_ACK_FREQ_DISABLE="1"
+```
+
+### `FELIX_CONN_STATS_MS`
+
+**Description**: Log live `quinn::ConnectionStats` (path MTU, cwnd, rtt, loss, congestion events, blocked-frame counters, UDP datagram/byte/io counts) for every connection on this interval, on both the broker and the client. The client-side log is the only place the publish path's sender-side congestion state is visible. Diagnostic; off unless set.
+
+**Type**: Positive integer (milliseconds)
+
+**Default**: unset (disabled)
+
+```bash
+export FELIX_CONN_STATS_MS="1000"
 ```
 
 ## Performance and Monitoring

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -869,15 +869,11 @@ export FELIX_MAX_UDP_PAYLOAD="65527"
 
 ### `FELIX_IO_RUNTIME_THREADS`
 
-**Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime. A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
-
-:::caution[Enabled by default on macOS only]
-On Linux, isolating quinn's drivers onto a dedicated runtime currently loses a delivery wakeup: the receiving side's QUIC layer accepts and acknowledges a stream frame that the application is never woken to read, and the connection stalls until it times out. It reproduces deterministically on a current-thread application runtime and intermittently on a multi-threaded one. The measured throughput gain is macOS-only so far, so non-macOS platforms default to `0` rather than trade delivery correctness for an unmeasured speedup. Setting this variable opts in anywhere — treat a non-zero value on Linux as experimental until that defect is resolved.
-:::
+**Description**: Size of the dedicated QUIC I/O runtime pool. Quinn's driver tasks (endpoint receive loop, per-connection transmit/ACK loops) do a bounded slice of work per poll and reschedule themselves, so their scheduler re-poll latency is the transport's throughput ceiling. Felix therefore runs them on a pool of single-threaded runtimes isolated from application tasks, assigned by role: server endpoints spread across every runtime but the last, client endpoints share the last. `0` disables the isolation and runs drivers on the application runtime (the pre-fix behavior). A larger pool cannot make a single endpoint faster — an endpoint's driver is one task on one runtime — and it splits endpoints that talk to each other onto separate threads, which measured 5–6× slower.
 
 **Type**: Non-negative integer
 
-**Default**: `2` on macOS, `0` elsewhere
+**Default**: `2`
 
 ```bash
 export FELIX_IO_RUNTIME_THREADS="2"

--- a/docs/assets/storage/group-commit.svg
+++ b/docs/assets/storage/group-commit.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 330" width="900" height="330" role="img" aria-label="Four concurrent appends queue in the page cache, a single fsync runs, and all four are acknowledged together">
+
+  <style>
+    .lbl   { fill: var(--ink); font: 500 13px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .mono  { fill: var(--ink); font: 500 12px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .sub   { fill: var(--ink-dim); font: 400 11px ui-sans-serif, system-ui, sans-serif; }
+    .title { fill: var(--ink); font: 600 14px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .note  { fill: var(--ink-dim); font: 400 12px ui-sans-serif, system-ui, sans-serif; }
+    .box   { stroke: var(--edge); stroke-width: 1.25; fill: var(--c-step); }
+    .dev   { stroke: var(--accent); stroke-width: 1.5; fill: var(--c-dev); }
+    .wait  { stroke: var(--edge-dim); stroke-width: 1.25; fill: var(--c-wait); stroke-dasharray: 4 3; }
+    .flow  { stroke: var(--edge); stroke-width: 2; fill: none; }
+    .pulse { stroke: var(--accent); stroke-width: 2.5; fill: none; }
+    .tick  { stroke: var(--edge-dim); stroke-width: 1; }
+
+    :root {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5;
+    }
+    @media (prefers-color-scheme: dark) { :root {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; } }
+    :root[data-theme="dark"] {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; }
+    :root[data-theme="light"] {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5; }
+
+    /* One 6s loop shared by every element, so the story stays in step:
+       0-25%  appends arrive and queue
+       25-60% a single flush runs
+       60-85% every waiter is released together
+       85-100% rest before repeating */
+    .appendA { animation: slide 6s linear infinite; }
+    .appendB { animation: slide 6s linear infinite .18s; }
+    .appendC { animation: slide 6s linear infinite .36s; }
+    .appendD { animation: slide 6s linear infinite .54s; }
+    @keyframes slide {
+      0%   { transform: translateX(0); opacity: 0; }
+      4%   { opacity: 1; }
+      22%  { transform: translateX(150px); opacity: 1; }
+      100% { transform: translateX(150px); opacity: 1; }
+    }
+    .flushbar { animation: flush 6s linear infinite; transform-origin: left center; }
+    @keyframes flush {
+      0%,25%   { transform: scaleX(0); opacity: 0; }
+      27%      { opacity: 1; }
+      60%,100% { transform: scaleX(1); opacity: 1; }
+    }
+    .ackline { stroke-dasharray: 260; stroke-dashoffset: 260; animation: ack 6s linear infinite; }
+    @keyframes ack {
+      0%,60%   { stroke-dashoffset: 260; opacity: 0; }
+      62%      { opacity: 1; }
+      85%,100% { stroke-dashoffset: 0; opacity: 1; }
+    }
+    .ackword { animation: fade 6s linear infinite; }
+    @keyframes fade { 0%,62% { opacity: 0; } 78%,100% { opacity: 1; } }
+    .devglow { animation: glow 6s linear infinite; }
+    @keyframes glow {
+      0%,25%   { opacity: .35; }
+      35%      { opacity: 1; }
+      60%,100% { opacity: .35; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .appendA,.appendB,.appendC,.appendD,.flushbar,.ackline,.ackword,.devglow {
+        animation: none;
+      }
+      .ackline { stroke-dashoffset: 0; }
+      .flushbar { transform: scaleX(1); }
+    }
+  </style>
+
+  <text class="title" x="24" y="26">Group commit: four appends, one device flush</text>
+  <text class="sub" x="24" y="46">An fsync flushes the whole file, so one flush can satisfy every append waiting on it.</text>
+  <line class="tick" x1="150" y1="76" x2="150" y2="256"/>
+  <text class="sub" x="150" y="70" style="text-anchor:middle">page cache</text>
+  <line class="tick" x1="470" y1="76" x2="470" y2="256"/>
+  <text class="sub" x="470" y="70" style="text-anchor:middle">device</text>
+  <g class="appendA"><rect class="box" x="24" y="96" width="118" height="30" rx="4"/><text class="mono" x="83" y="115" style="text-anchor:middle">append A</text></g>
+  <g class="appendB"><rect class="box" x="24" y="140" width="118" height="30" rx="4"/><text class="mono" x="83" y="159" style="text-anchor:middle">append B</text></g>
+  <g class="appendC"><rect class="box" x="24" y="184" width="118" height="30" rx="4"/><text class="mono" x="83" y="203" style="text-anchor:middle">append C</text></g>
+  <g class="appendD"><rect class="box" x="24" y="228" width="118" height="30" rx="4"/><text class="mono" x="83" y="247" style="text-anchor:middle">append D</text></g>
+  <rect class="dev devglow" x="330" y="96" width="130" height="160" rx="6"/>
+  <text class="lbl devglow" x="395" y="168" style="text-anchor:middle">one fsync</text>
+  <text class="sub devglow" x="395" y="186" style="text-anchor:middle">~4ms</text>
+  <rect class="dev flushbar" x="470" y="158" width="150" height="36" rx="4"/>
+  <text class="mono flushbar" x="545" y="181" style="text-anchor:middle">flushed</text>
+  <path class="pulse ackline" d="M 330 111 L 180 111"/>
+  <path class="pulse ackline" d="M 330 155 L 180 155"/>
+  <path class="pulse ackline" d="M 330 199 L 180 199"/>
+  <path class="pulse ackline" d="M 330 243 L 180 243"/>
+  <text class="lbl ackword" x="186" y="284">all four acknowledged together</text>
+  <text class="note" x="24" y="316">Measured: 253 durable appends/second at concurrency 1, 14,387 at concurrency 64 — a 57x gain from the same code path.</text>
+</svg>

--- a/docs/client-config.md
+++ b/docs/client-config.md
@@ -2,6 +2,12 @@
 
 This document describes the `felix-client` configuration options and how they are loaded.
 
+Transport-level tuning (QUIC I/O runtimes, ACK frequency, MTU discovery, UDP
+buffers) is process-wide and env-driven rather than part of `ClientConfig` —
+see the "QUIC Transport Tuning" section of
+[Environment Variables](../docs-site/src/content/docs/reference/environment-variables.md).
+The performance-critical defaults are already on; no tuning is required.
+
 ## Loading Order
 
 `ClientConfig::from_env_or_yaml(quinn, config_path)` uses:
@@ -36,6 +42,9 @@ let cfg = ClientConfig::from_env_or_yaml(quinn, Some("client.yml"))?;
 - `publish_inflight_bytes` (env: `FELIX_PUBLISH_INFLIGHT_BYTES`)
   - Shared byte budget across all publish workers. Default: `4194304` (4 MiB).
   - Publishers wait for budget before enqueueing and reject a single publish larger than the limit.
+  - An acked publish holds its budget until the broker's ack arrives (acked
+    publishes are pipelined on the stream), so the budget also caps acked
+    data in flight — not just data queued for writing.
 - `publish_sharding` (env: `FELIX_PUB_SHARDING`)
   - Sharding mode across publish streams.
   - Values: `rr` or `hash_stream`.

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -84,7 +84,37 @@ Each module owns one decision:
 
 ## The publish path
 
-Ordering is the whole design, so it is worth stating plainly:
+```mermaid
+flowchart LR
+    C(["Client"]) e1@--> P["publish"]
+    P e2@--> L[("durable log<br/><small>append + assign offsets</small>")]
+    L e3@--> D{{"fsync<br/><small>OnCommit only</small>"}}
+    D e4@--> F["fanout"]
+    F e5@--> S1(["Subscriber"])
+    F e6@--> S2(["Subscriber"])
+    D e7@--> A(["ack to client"])
+
+    e1@{ animate: true }
+    e2@{ animate: true }
+    e3@{ animate: true }
+    e4@{ animate: true }
+    e5@{ animate: true }
+    e6@{ animate: true }
+    e7@{ animate: true }
+
+    classDef store fill:#fdf0e3,stroke:#b07d3a,color:#3d2a12
+    classDef gate fill:#fbe9d6,stroke:#b07d3a,color:#3d2a12
+    classDef step fill:#e8f0fe,stroke:#4a6fa5,color:#1a2b40
+    classDef edge fill:#e9f5ec,stroke:#4a8a5e,color:#16301f
+    class L store
+    class D gate
+    class P,F step
+    class C,S1,S2,A edge
+```
+
+Nothing downstream of the log observes a record before it is durable: fanout
+and the acknowledgement both hang off the flush, not off the append. Ordering
+is the whole design, so the same path is worth spelling out step by step:
 
 ```mermaid
 sequenceDiagram
@@ -158,6 +188,11 @@ loss. That distinction is the reason it is a useful setting at all.
 `OnCommit` would be unaffordable without it. An `fsync` flushes the whole file,
 not one caller's bytes, so when N appends are in flight one flush can satisfy all
 N:
+
+![Group commit: four concurrent appends queue in the page cache, a single fsync runs, and all four are acknowledged together](assets/storage/group-commit.svg)
+
+The lock protocol behind that picture — who flushes, and what the others find
+when they wake:
 
 ```mermaid
 sequenceDiagram

--- a/docs/perf-investigation-throughput.md
+++ b/docs/perf-investigation-throughput.md
@@ -1299,6 +1299,97 @@ reproduction is still the right next move — a real broker has one endpoint and
 its clients are separate processes, so if the residual does not reproduce
 there, it is a property of the single-process harness rather than of Felix.
 
+## Round 16: the I/O runtime pool loses a delivery wakeup on Linux
+
+CI (ubuntu runners) failed on the branch that was green on macOS:
+`publish_sharding_preserves_stream_order` timed out, and the perf job
+reported 18 regressions with 10/10 throughput trials exiting non-zero.
+
+### What it is
+
+Reproduced in a Linux container (`--cpus 4`, stock `net.core.rmem_max`):
+
+| Tree | Result |
+|---|---|
+| PR base `a36c52c` | passes 4/4 in **0.4 s** |
+| This branch | hangs 30 s, **fails 4/4** — in isolation, not just under suite load |
+| This branch, `FELIX_IO_RUNTIME_THREADS=0` | passes 3/3 |
+
+A `quinn_proto=trace` capture pinpoints it. The last activity before a
+29.8 s gap is on the client's event connection:
+
+```
+drive{id=2}: got stream frame id=server unidirectional stream 0 offset=1081 len=256 fin=false
+drive{id=2}: max ack delay reached -> ACK ArrayRangeSet([27..32])
+<29.8 s of nothing, then Idle timeouts close every connection>
+```
+
+**The data arrives and is acknowledged at the receiver's QUIC layer, and the
+application is never woken to read it.** `gdb` confirms the shape: every
+thread parked (`epoll_pwait`, `futex_wait`), nothing runnable — a lost
+wakeup, not a livelock or starvation. Broker-side `FELIX_CONN_STATS_MS`
+tickers stop firing at the same instant, so no timer is pending anywhere.
+
+### What it is not
+
+Each ruled out by A/B on Linux, same binary:
+
+| Hypothesis | Result |
+|---|---|
+| Pump colocation | `FELIX_PUMP_COLOCATE=0` still hangs |
+| ACK frequency | `FELIX_ACK_FREQ_DISABLE=1` still hangs |
+| Loopback MTU / cwnd work | `FELIX_INITIAL_MTU=1200` still hangs; the buffer gate already disables that path on stock Linux |
+| Black-hole cooldown | `..._COOLDOWN_MS=60000` still hangs |
+| Pool size / role split | pool 1, 2, and 3 all hang; only `0` passes |
+| Test-harness artifact | a `multi_thread` app runtime still fails 1 in 3 |
+
+So it is specific to quinn's driver tasks running on a dedicated runtime,
+and it affects production-shaped multi-threaded runtimes too — less often,
+which is consistent with the CI perf job's failures rather than a clean
+timeout.
+
+### Disposition
+
+The pool now defaults to `2` on macOS (where its ~7× gain is measured and
+where no stall has ever been observed across hundreds of runs) and `0`
+elsewhere; `FELIX_IO_RUNTIME_THREADS` opts in anywhere. Trading delivery
+correctness for an unmeasured speedup on an unvalidated platform is not a
+trade worth making, and the measurement that would justify enabling it on
+Linux has not been taken.
+
+### Where the stall actually is
+
+Further narrowing, all on Linux with the pool forced on:
+
+- **A minimal transport-level reproduction does _not_ reproduce it.** Sender
+  writing 400 small items to one uni stream, reader colocated via
+  `spawn_pump`, forwarded through a bounded channel — passes 3/3 at pool 0,
+  1 and 2 (`many_small_frames_reach_a_colocated_reader`, kept as a
+  regression test). So quinn drivers on a dedicated runtime, plus a
+  colocated reader, is not sufficient to trigger it.
+- **The client is not the stalled party.** Instrumenting the subscription
+  pipeline shows the last frame decoded into a 64-event batch with the event
+  channel reporting **256 free slots** — no backpressure anywhere — and then
+  no further frames arrive.
+- **The broker stops producing.** Instrumenting the per-connection delivery
+  writer shows its `rx.recv()` never returns again: the last command it
+  handled wrote 28 bytes, and nothing is enqueued afterwards. Both
+  connections' writers go idle with their queues empty.
+
+So the stall is **upstream of the connection writer, inside the broker's
+delivery chain** (broker-core fanout → lane feeder → writer lane), and the
+earlier reading — "the receiver ACKs bytes the app is never woken to read" —
+was the downstream symptom of the broker simply not sending the rest. The
+ACKed-but-undelivered frame seen in the quinn trace is the last batch that
+*was* produced.
+
+**Open.** The remaining question is which handoff in that chain loses its
+wakeup, and why isolating quinn's drivers changes it — the feeder and lane
+tasks run on the application runtime while the connection writer runs on the
+pool runtime, so the chain crosses runtimes exactly once. The next step is
+to instrument the broker-core subscriber queue and `run_lane_feeder` to see
+whether the feeder stops being woken or stops being fed.
+
 ## Everything changed this session
 
 All uncommitted. Grouped by what would make sensible commits.

--- a/docs/perf-investigation-throughput.md
+++ b/docs/perf-investigation-throughput.md
@@ -6,8 +6,9 @@ what was concluded, and — importantly — which hypotheses turned out to be
 wrong.
 
 **Status: resolved. Main ceiling fixed (rounds 7–10); the residual bimodality
-was diagnosed and fixed in round 15 — it was a path-MTU black-hole collapse,
-not scheduling.**
+was a path-MTU black-hole collapse (round 15); the Linux CI failure that
+followed was publish-side shedding in an under-configured test, not a
+transport defect (round 16).**
 The ceiling was scheduling, not any Felix
 stage: quinn's driver tasks do a bounded slice of work per poll and reschedule
 themselves, so sustained throughput is that slice divided by scheduler re-poll
@@ -1299,96 +1300,94 @@ reproduction is still the right next move — a real broker has one endpoint and
 its clients are separate processes, so if the residual does not reproduce
 there, it is a property of the single-process harness rather than of Felix.
 
-## Round 16: the I/O runtime pool loses a delivery wakeup on Linux
+## Round 16: the "Linux delivery stall" is publish-side shedding
 
-CI (ubuntu runners) failed on the branch that was green on macOS:
-`publish_sharding_preserves_stream_order` timed out, and the perf job
-reported 18 regressions with 10/10 throughput trials exiting non-zero.
+CI (ubuntu runners) failed on a branch that was green on macOS:
+`publish_sharding_preserves_stream_order` timed out after 30 s. Reproduced in
+a Linux container (`--cpus 4`): passes 4/4 in 0.4 s at the PR base, hangs 4/4
+on the branch **in isolation**, and only `FELIX_IO_RUNTIME_THREADS=0` cured
+it — so the dedicated I/O runtime pool looked responsible.
 
-### What it is
+### The wrong turn, and what corrected it
 
-Reproduced in a Linux container (`--cpus 4`, stock `net.core.rmem_max`):
+A `quinn_proto=trace` capture showed the last activity before a 29.8 s gap
+was a stream frame *arriving and being ACKed* at the receiver, after which
+every connection died of idle timeout. Read alone, that says "the QUIC layer
+accepted bytes the application was never woken to read", and the obvious
+conclusion is a lost wakeup caused by isolating the drivers.
 
-| Tree | Result |
-|---|---|
-| PR base `a36c52c` | passes 4/4 in **0.4 s** |
-| This branch | hangs 30 s, **fails 4/4** — in isolation, not just under suite load |
-| This branch, `FELIX_IO_RUNTIME_THREADS=0` | passes 3/3 |
+That conclusion was wrong, and two things falsified it:
 
-A `quinn_proto=trace` capture pinpoints it. The last activity before a
-29.8 s gap is on the client's event connection:
+- **A minimal reproduction would not reproduce.** 400 small items over one
+  uni stream, read either colocated (`spawn_pump`) or from the application
+  runtime, passes 3/3 at pool sizes 0, 1 and 2. Both variants are kept as
+  regression tests (`many_small_frames_reach_a_colocated_reader`,
+  `many_small_frames_reach_an_app_runtime_reader`).
+- **Walking the chain end to end found the events missing much earlier.**
+  The client stalls with 256 free queue slots (no backpressure); both lane
+  feeders sit in `event_rx.recv()`; the per-connection writer's last write
+  completes `ok=true` and it never receives another command. Everything
+  downstream is idle because there is nothing left to deliver.
+
+### The actual cause
+
+Counting at each stage settles it. The broker's control loop reads **444
+frames** — all 400 publishes plus setup — but `publish_batch_to_handle` runs
+only **128 times**, and instrumenting checkpoint 4 shows **77 publishes
+explicitly dropped** in a single run:
 
 ```
-drive{id=2}: got stream frame id=server unidirectional stream 0 offset=1081 len=256 fin=false
-drive{id=2}: max ack delay reached -> ACK ArrayRangeSet([27..32])
-<29.8 s of nothing, then Idle timeouts close every connection>
+DBG ingest: DROPPED (queue full, policy=Drop)   x77
 ```
 
-**The data arrives and is acknowledged at the receiver's QUIC layer, and the
-application is never woken to read it.** `gdb` confirms the shape: every
-thread parked (`epoll_pwait`, `futex_wait`), nothing runnable — a lost
-wakeup, not a livelock or starvation. Broker-side `FELIX_CONN_STATS_MS`
-tickers stop firing at the same instant, so no timer is pending anywhere.
+Checkpoint 4 — the per-worker publish ingress queue, depth 64 — defaults to
+`EnqueuePolicy::Drop`. The test pins `Block` on the broker's subscriber queue,
+the lane queue and the client's subscriber queue, but leaves publish ingress
+at its default, then asserts that all 200 events per stream arrive in order.
+With unacked publishes there is no backpressure to the client, so a 400-message
+burst that outruns the broker core is shed **by design**, and the test waits
+forever for events that were never published.
 
-### What it is not
+**The I/O runtime pool did not break anything.** It made ingest fast enough to
+outrun the broker core on a 4-CPU box, which exposed a test that was asking for
+lossless delivery without configuring for it. macOS never showed it because the
+workers drained faster than the reader filled the queue.
 
-Each ruled out by A/B on Linux, same binary:
+### The fix
 
-| Hypothesis | Result |
+`pub_ingress_wait: true` in that test's `BrokerConfig`, which switches
+checkpoint 4 to `Backpressure` — the same combination
+`internals-concurrency.md` already documents as the requirement for lossless
+mode, and the one the benchmark harness uses. Note the env var
+(`FELIX_PUB_INGRESS_WAIT`) is *not* enough here: the test builds
+`BrokerConfig::default()` directly rather than `from_env()`.
+
+The pool default returns to `2` on every platform.
+
+### Verification (Linux container, pool enabled)
+
+| Suite | Result |
 |---|---|
-| Pump colocation | `FELIX_PUMP_COLOCATE=0` still hangs |
-| ACK frequency | `FELIX_ACK_FREQ_DISABLE=1` still hangs |
-| Loopback MTU / cwnd work | `FELIX_INITIAL_MTU=1200` still hangs; the buffer gate already disables that path on stock Linux |
-| Black-hole cooldown | `..._COOLDOWN_MS=60000` still hangs |
-| Pool size / role split | pool 1, 2, and 3 all hang; only `0` passes |
-| Test-harness artifact | a `multi_thread` app runtime still fails 1 in 3 |
+| `publish_sharding_preserves_stream_order` | 6/6 pass |
+| broker lib | 245/245 |
+| felix-client lib | 76/76 |
+| felix-transport lib | 13/13 |
+| `latency_text` integration | pass |
 
-So it is specific to quinn's driver tasks running on a dedicated runtime,
-and it affects production-shaped multi-threaded runtimes too — less often,
-which is consistent with the CI perf job's failures rather than a clean
-timeout.
+### What this cost, and the lesson
 
-### Disposition
+Two commits of misdiagnosis: first blaming the pool, then gating it to macOS.
+The trace evidence was real but read one layer too low — an ACKed-but-unread
+frame at the transport is equally consistent with "the sender stopped
+producing", and the sender had. **Count the item at every stage before
+concluding anything from a wakeup-shaped symptom**: 444 in, 128 through,
+77 dropped located the defect in one run, after several rounds of transport
+theory had not.
 
-The pool now defaults to `2` on macOS (where its ~7× gain is measured and
-where no stall has ever been observed across hundreds of runs) and `0`
-elsewhere; `FELIX_IO_RUNTIME_THREADS` opts in anywhere. Trading delivery
-correctness for an unmeasured speedup on an unvalidated platform is not a
-trade worth making, and the measurement that would justify enabling it on
-Linux has not been taken.
-
-### Where the stall actually is
-
-Further narrowing, all on Linux with the pool forced on:
-
-- **A minimal transport-level reproduction does _not_ reproduce it.** Sender
-  writing 400 small items to one uni stream, reader colocated via
-  `spawn_pump`, forwarded through a bounded channel — passes 3/3 at pool 0,
-  1 and 2 (`many_small_frames_reach_a_colocated_reader`, kept as a
-  regression test). So quinn drivers on a dedicated runtime, plus a
-  colocated reader, is not sufficient to trigger it.
-- **The client is not the stalled party.** Instrumenting the subscription
-  pipeline shows the last frame decoded into a 64-event batch with the event
-  channel reporting **256 free slots** — no backpressure anywhere — and then
-  no further frames arrive.
-- **The broker stops producing.** Instrumenting the per-connection delivery
-  writer shows its `rx.recv()` never returns again: the last command it
-  handled wrote 28 bytes, and nothing is enqueued afterwards. Both
-  connections' writers go idle with their queues empty.
-
-So the stall is **upstream of the connection writer, inside the broker's
-delivery chain** (broker-core fanout → lane feeder → writer lane), and the
-earlier reading — "the receiver ACKs bytes the app is never woken to read" —
-was the downstream symptom of the broker simply not sending the rest. The
-ACKed-but-undelivered frame seen in the quinn trace is the last batch that
-*was* produced.
-
-**Open.** The remaining question is which handoff in that chain loses its
-wakeup, and why isolating quinn's drivers changes it — the feeder and lane
-tasks run on the application runtime while the connection writer runs on the
-pool runtime, so the chain crosses runtimes exactly once. The next step is
-to instrument the broker-core subscriber queue and `run_lane_feeder` to see
-whether the feeder stops being woken or stops being fed.
+Worth carrying separately: a 400-message unacked burst shedding ~19% at
+default settings on a 4-CPU host is *documented* behaviour, not a bug — but
+it is a sharper edge than the docs' "overload becomes visible" framing
+suggests, and worth revisiting when the ingress queue depth is next tuned.
 
 ## Everything changed this session
 

--- a/docs/perf-investigation-throughput.md
+++ b/docs/perf-investigation-throughput.md
@@ -1513,6 +1513,18 @@ and shipped alone would not have worked.
    missed it; a client test with a sparse request/ack exchange hung reliably.
    The loopback config therefore sets `upper_bound = initial_mtu`: the size
    is guaranteed, there is nothing to discover, no probe is ever sent.
+5. **And gate the whole guarantee on the granted socket buffers.** CI turned
+   up the converse failure: on stock Linux, `SO_RCVBUF` is silently clamped
+   to `net.core.rmem_max` (~208 KB — about 26 jumbo datagrams of headroom
+   against ~350 at MTU 1200), and sustained batch load overflowed it so
+   badly that every CI throughput trial and the 4 KiB batch integration test
+   timed out. Worse, the pinned `min_mtu` forbids the one thing that helps a
+   tiny buffer: smaller datagrams. The guarantee now applies only when the
+   socket's *achieved* send/receive buffers (read back post-bind — the
+   configured size says nothing on Linux) hold at least 64 full-size
+   datagrams (~1 MiB); below that, connections keep the stock RFC-safe path.
+   macOS grants the requested 8 MiB and keeps the fast path; stock-limit
+   Linux hosts fall back until `rmem_max`/`wmem_max` are raised.
 
 Additionally, `black_hole_cooldown` drops 60 s → 2 s
 (`FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`) for non-loopback paths. It cannot rescue

--- a/docs/perf-investigation-throughput.md
+++ b/docs/perf-investigation-throughput.md
@@ -1,0 +1,1547 @@
+# Throughput investigation: why Felix is slower than raw QUIC
+
+Working log of a performance investigation into Felix's end-to-end pub/sub
+throughput, particularly at larger payload sizes. Records what was measured,
+what was concluded, and — importantly — which hypotheses turned out to be
+wrong.
+
+**Status: resolved. Main ceiling fixed (rounds 7–10); the residual bimodality
+was diagnosed and fixed in round 15 — it was a path-MTU black-hole collapse,
+not scheduling.**
+The ceiling was scheduling, not any Felix
+stage: quinn's driver tasks do a bounded slice of work per poll and reschedule
+themselves, so sustained throughput is that slice divided by scheduler re-poll
+latency — and on a runtime shared with ~50 app tasks that latency, times one
+wakeup chain per datagram, was the whole pipeline's clock. Fixes (all in Felix,
+official quinn only): dedicated single-threaded I/O runtimes for quinn drivers,
+colocation of the two transport-facing pump tasks with those drivers, and
+QUIC ACK-frequency tuning. Result on the same box and benchmark:
+
+| | Before | After |
+|---|---:|---:|
+| 4 KiB × batch 64, fanout 1 (sustained) | 73 MB/s | **p50 548 MB/s** (max 557) |
+| 1 KiB, fanout 1 | 74.9 MB/s | **~480 MB/s** |
+| 16 KiB, fanout 1 | ~72 MB/s | **~507 MB/s** |
+| latency profile (1 KiB, batch 1, acked) | — | p50 129 µs / p999 256 µs |
+
+**Both defects are fixed.** The residual bimodality (~30% of runs 5–6×
+slower, rounds 12–14) turned out to be quinn's MTU black-hole detector
+misreading a congestive loss burst and collapsing the path MTU to 1200 for
+the rest of the run — see round 15 for the diagnosis and fix.
+
+Map of this document: rounds 1–6 are the elimination history that pointed at the
+mechanism; 7–10 are the diagnosis and fix of the main ceiling; 11–14 cover the
+measurement-tooling defects found while publishing results, the endpoint
+placement fix, and the characterization of the residual; 15 is the diagnosis
+and fix of the residual.
+
+## Environment
+
+- Apple Mac Studio, Apple M4 Max, 16 CPUs
+- macOS 26.6.1 (Darwin 25.6.0), APFS, loopback (`lo0`, MTU 16384)
+- Release build, `latency-demo --binary`, `--all-features`
+- Repo at `main` (a36c52c) plus the `--log-capacity` change below
+- Relevant sysctls: `kern.ipc.maxsockbuf=8388608`,
+  `net.inet.udp.recvspace=786896`, `net.inet.udp.maxdgram=9216`
+
+Broker and client both run **in the same process** in this harness, sharing one
+tokio runtime — worth remembering when reading CPU numbers.
+
+## Headline findings
+
+1. **The benchmark harness overstates throughput.** For most configurations the
+   entire measured run fits inside the 64 MiB QUIC connection send window, so
+   the reported number is buffer-absorption speed, not sustained throughput.
+2. **There is no "large payload cliff."** Once every run exceeds the send
+   window, 1 KiB and 4 KiB converge on the same ~73 MB/s payload rate. Larger
+   payloads simply hit the window sooner, which *looked* size-dependent.
+3. **Felix is meaningfully slower than raw quinn on the same box**, but the gap
+   is ~3.5× on wire bytes at comparable core counts — not the 8× a naive
+   payload-vs-payload comparison suggests. See "Corrections" below.
+4. **Both Felix and raw quinn are ~90% system time** on macOS loopback. (An
+   early suspicion that Felix sends smaller datagrams was later **disproven** —
+   see round 2; Felix runs at MTU 16354 with ~15,650 B/datagram.)
+5. **The ceiling is exactly per-byte** — 70–73 MB/s across a 16× payload range —
+   and every structural explanation tested has been eliminated. See round 6.
+
+## The measurement flaw (finding 1)
+
+`felix-transport` defaults `send_window` to 64 MiB
+(`crates/felix-transport/src/lib.rs:52`). Any run whose total payload volume is
+below that is absorbed by buffers before backpressure appears, and
+`latency-demo` stops its clock when the last event arrives.
+
+Throughput at 4 KiB, fanout 1, batch 64, varying run length (3 reps each):
+
+| `--total` | Run bytes | Reps (msg/s) |
+|---|---:|---|
+| 8,000 | 31 MB (fits) | 70,085 / 75,993 / 79,078 |
+| 20,000 | 78 MB (exceeds) | 29,679 / 28,173 / 30,090 |
+| 40,000 | 156 MB (exceeds) | 19,979 / 22,112 / 20,559 |
+
+Variance within a run length is ~±5%; across run lengths throughput falls
+monotonically. The marginal rate between successive windows keeps dropping
+(20,800 → 16,370 msg/s), so this is not a fixed startup transient — the short
+runs are simply measuring buffer fill.
+
+**Consequence:** the numbers in
+`docs-site/src/content/docs/features/benchmarks.md` are affected. The macOS
+1 KiB × fanout 1 row (244–263 K msg/s) is a buffer-absorption measurement. That
+page's methodology section promises "sustainable rates, not burst rates measured
+while shedding" — it is correct about shedding (drops really are 0), but the
+buffering artifact defeats the intent regardless.
+
+## The cliff is an artifact (finding 2)
+
+Original payload sweep (fanout 1, batch 64, total 20,000 — all under the window
+except the last two rows):
+
+| Payload | msg/s | MB/s |
+|---|---:|---:|
+| 1024 B | 332,042 | 340.0 |
+| 1500 B | 276,571 | 414.9 |
+| 2048 B | 181,321 | 371.3 |
+| 2560 B | 82,898 | 212.2 |
+| 3072 B | 57,273 | 175.9 |
+| 4096 B | 32,822 | 134.4 |
+| 8192 B | 16,469 | 134.9 |
+
+Re-run with every configuration sized to exceed 64 MiB:
+
+| Payload | Total | Run bytes | msg/s | MB/s |
+|---|---:|---:|---:|---:|
+| 256 B | 400,000 | 98 MB | 975,550 | 249.7 |
+| 1 KiB | 200,000 | 195 MB | 73,126 | **74.9** |
+| 4 KiB | 60,000 | 234 MB | 17,692 | **72.5** |
+
+1 KiB collapses from 358 MB/s to 74.9 MB/s (4.8×) and lands on top of 4 KiB.
+The 256 B run was only 1.5× the window, so 249.7 MB/s is likely still partly
+inflated.
+
+Supporting evidence that the effect tracks *bytes*, not frame size (total
+40,000):
+
+| Config | Frame size | msg/s |
+|---|---:|---:|
+| 4 KiB × batch 4 | 16 KiB | 53,586 |
+| 4 KiB × batch 16 | 64 KiB | 20,128 |
+| 4 KiB × batch 64 | 256 KiB | 20,419 |
+| 1 KiB × batch 256 | 256 KiB | 367,415 |
+
+Identical 256 KiB frames give 20 K or 367 K msg/s depending only on payload
+size, i.e. on total run bytes relative to the window.
+
+## Raw quinn baseline (finding 3)
+
+Standalone probe replicating Felix's transport settings exactly — same windows,
+same MTU config, same 8 MiB `SO_SNDBUF`/`SO_RCVBUF` halve-until-accepted loop —
+moving bytes over loopback with no broker, no wire protocol, no fanout.
+One uni stream, 256 KiB writes, 32 MB per run.
+
+| MTU upper bound | MTU reached | MB/s | Lost | Cong. events | Black holes |
+|---|---:|---:|---:|---:|---:|
+| 1452 | 1452 | 144.4 | 0 | 0 | 0 |
+| 2048 | 1942 | 187.2 | 0 | 0 | 0 |
+| 4096 | 3915 | 415.7 | 0 | 0 | 0 |
+| **8192** | 7973 | **819.0** | 0 | 0 | 0 |
+| 9216 | 8715 | 748.6 | 0 | 0 | 0 |
+| 16384 (Felix default) | 16324 | 628.7 | 0 | 0 | 0 |
+
+Second run under `/usr/bin/time` reproduced the shape (1452→149.9, 2048→186.4,
+4096→381.3, 8192→725.9, 9216→742.9, 16384→506.8 MB/s).
+
+Two things fall out:
+
+- **Socket buffers are load-bearing.** An earlier version of the probe without
+  the 8 MiB buffers **failed outright** at upper bounds ≥9216 (connection timed
+  out), and at 1452 reported `lost=75, cong_events=46, black_holes=2` with MTU
+  stuck at 1200. Felix sets these buffers correctly; this is a latent trap for
+  anything that does not.
+- **16384 is not the best upper bound even for raw quinn.** 8192 is ~30% faster
+  (819 vs 629 MB/s). Larger datagrams stop paying once per-datagram cost is
+  amortised.
+
+Felix's own MTU sweep (4 KiB, total 60,000) is nearly flat by comparison, which
+is itself the signal that Felix never gets close to the transport ceiling:
+
+| Setting | msg/s | MB/s | Datagrams | Avg B/datagram |
+|---|---:|---:|---:|---:|
+| baseline (upper 16384, init 1200) | 18,484 | 75.7 | 267,790 | 1,835 |
+| upper 9216 | 16,376 | 67.1 | 294,742 | 1,668 |
+| init 8192, upper 9216 | 16,687 | 68.3 | 291,198 | 1,688 |
+| upper 1452 | 8,858 | 36.3 | 558,153 | 881 |
+| upper 16384 (repeat) | 17,997 | 73.7 | 267,402 | 1,838 |
+
+Note the average-bytes-per-datagram column is diluted by ACKs in both directions
+and by loopback double-counting; treat it as indicative, not exact.
+
+## CPU profile (finding 4)
+
+`/usr/bin/time -l`, 80,000 × 4 KiB, fanout 1, batch 64:
+
+| | Felix | Raw probe (6 runs) |
+|---|---:|---:|
+| real | 5.02 s | 1.03 s |
+| user | 1.63 s | 0.27 s |
+| **sys** | **15.60 s** | **2.64 s** |
+| sys:user ratio | 9.6:1 | 9.8:1 |
+| Cores busy (CPU/wall) | 3.4 of 16 | 2.8 |
+| Voluntary ctx switches | 7,374 | 0 |
+| Involuntary ctx switches | 361,126 | 54,279 |
+| Max RSS | 554 MB | — |
+
+Both are overwhelmingly kernel time — macOS UDP loopback is syscall-dominated,
+consistent with what `benchmarks.md` already reports. Critically, **Felix leaves
+12+ of 16 cores idle** while running well below the transport ceiling, so this
+is not a CPU-saturation problem.
+
+`sample`-based symbol occurrence counts over 8 s under load (occurrence counts
+of frames in the call tree, **not** sample-weighted — indicative only):
+
+```
+__sendmsg 63   __psynch_mutexwait 41   __psynch_cvsignal 32   malloc 29
+kevent 26      platform_memmove 24     __recvmsg 23           __psynch_cvwait 21
+free 10        __psynch_mutexdrop 8
+ring aes_gcm seal 19   rustls encrypt_in_place 15   aes_gcm_enc_kernel 14
+```
+
+The pthread mutex/condvar family taken together is the largest userspace
+category, which lines up with the note already in `benchmarks.md` that the next
+target is "user-space scheduling and synchronization."
+
+## Corrections — hypotheses that were tested and disproven
+
+Recorded deliberately, because several are plausible enough to be re-proposed.
+
+1. **The redundant payload copy is not the bottleneck.** `decode_publish_batch`
+   does `bytes.to_vec()` per payload (`crates/felix-wire/src/binary.rs:250`) and
+   every caller immediately converts back with `Bytes::from(vec)`
+   (`handlers/publish/uni.rs:82`, `control.rs:108`) — a genuine
+   `Bytes`→`Vec`→`Bytes` round trip caused only by `PublishBatch.payloads` being
+   `Vec<Vec<u8>>`. Measured: **6.8 µs per 64 × 4 KiB frame (38.3 GB/s)** versus
+   0.2 µs for a refcount clone. At 73 MB/s that is ~0.2% of one core. Worth
+   fixing for cleanliness; irrelevant to throughput.
+2. **The read scratch buffer does not realloc per frame.** The
+   `clear()`/`resize()`/`split().freeze()` pattern in
+   `transport/quic/codec.rs` looked like it would allocate every frame.
+   Measured: **1 allocation across 10,000 frames** at 4 KiB, 64 KiB and 256 KiB.
+   It reuses correctly.
+3. **Replay-ring retention is not the cause.** `latency_demo.rs:679` sizes the
+   ring to the whole run (`warmup + total + 1`) instead of the production
+   default of 1024 (`crates/felix-broker/src/config.rs:4`), and RSS climbs
+   13 → 410 MB during a run without plateauing. A/B against a 1024-entry ring:
+   **0.92× / 1.01× / 1.02×** at totals 8,000 / 20,000 / 40,000. Not causal.
+4. **`net.inet.udp.maxdgram` does not cap this path.** It is 9216, below Felix's
+   16384 discovery bound, which looked like a smoking gun. The raw probe reached
+   **MTU 16324** with zero loss, so the cap does not apply here.
+5. **Publish-worker serialization is not the bottleneck.** All streams in the
+   default benchmark hash to one worker per connection
+   (`handle.id() % worker_count`, `handlers/publish/ingress.rs`). Adding streams
+   makes throughput *worse*, not better: `pub_stream_count` 1 / 4 / 8 →
+   17,418 / 15,190 / 14,469 msg/s. More parallelism costs more than it buys.
+6. **`core_shards` does not help this workload.** Measured at a valid run size
+   (4 KiB, total 60,000, 2 reps): shards 0 → ~71.4 MB/s, 4 → ~75.2, 6 → ~75.3.
+   About +5%, near noise. The existing +25–27% claims in the docs were likely
+   measured under the buffer-absorption artifact and should be re-run.
+7. **The "8× slower than raw quinn" framing was overstated.** That compared
+   Felix's *payload* throughput (73 MB/s) against the probe's *best-config*
+   one-directional throughput. At fanout 1 Felix moves ~146 MB/s of wire traffic
+   (publish in + delivery out), against the probe's 506–628 MB/s at the same MTU
+   setting and a similar core count. **The honest gap is ~3.5× on wire bytes.**
+
+## Current best understanding
+
+The publisher blocks in `client_send_await` (p50 3.8 ms at 4 KiB) while every
+instrumented broker operation stays in the microseconds — `broker_decode` 27 µs,
+`broker_publish_append` 1 µs, `broker_quic_write` 2 µs, `broker_sub_write` 2 µs.
+The machine is 90% kernel time and 12+ cores idle. So the cost is not in any
+single operation and not in CPU-bound work; it is in how many kernel operations
+Felix performs per byte, and in the handoffs between the tasks that perform them.
+
+The leading suspicion — **not yet verified** — is that Felix's effective
+datagram size is far below the MTU quinn negotiates. The probe sent ~15,267
+bytes per packet (2,096 packets for 32 MB at upper 16384); Felix's netstat-derived
+average is ~1,835 bytes. If real, that is ~8× more syscalls per byte and would
+directly explain a 90%-sys workload running 3.5× slow. Possible reasons, all
+unexamined: small writes reaching the socket before coalescing, per-frame
+`write_all` splitting header from payload (`transport/quic/codec.rs` issues two
+`write_all` calls), ACK-heavy traffic from many concurrent streams, or MTU
+discovery not completing within a short run.
+
+## Round 2: the transport is healthy, and the cost is synchronization
+
+Added `FELIX_CONN_STATS_MS` to the broker (`transport/quic/conn.rs`) to log
+`quinn::ConnectionStats` for a *live* connection, and tracing init to the demo so
+it surfaces. Felix's busiest connection under load:
+
+```
+mtu=16354  sent_packets=15108  lost_packets=0  congestion_events=0  black_holes=0
+udp_tx_datagrams=15106  udp_tx_bytes=236417567  udp_tx_ios=15106
+```
+
+**15,650 bytes per datagram, zero loss, zero congestion events.** Path MTU
+discovery works perfectly. The netstat-derived "~1,835 B/datagram" from round 1
+was wrong — it is diluted by ACKs, idle connections and system-wide traffic.
+`udp_tx_ios == udp_tx_datagrams` confirms no GSO on macOS, one syscall per
+datagram, as expected.
+
+### The raw-quinn baseline, corrected twice
+
+Round 1's "628–819 MB/s" figures were **32 MB runs — inside the 64 MiB send
+window**, so the probe had the same measurement flaw as the harness. Sweeping
+run size properly:
+
+| Run | MB/s | MTU | B/datagram | Lost |
+|---|---:|---|---:|---:|
+| 16 MB | 12279.0 | 16354 | 16186 | 0 | ← buffer-absorbed, meaningless |
+| 32 MB | 573.6 | 16354 | 16237 | 0 | ← buffer-absorbed |
+| 64 MB | 638.6 | 16324 | 16189 | 0 | ← buffer-absorbed |
+| 128 MB | 745.8 | 16354 | 16278 | 0 | |
+| 256 MB | 752.2 | 16354 | 16331 | 0 | |
+| 512 MB | 788.0 | 16354 | 16340 | 0 | |
+
+**Raw quinn sustains ~750–800 MB/s.** One intermediate run reported 80.3 MB/s
+with MTU collapsed to 1200 and 649 lost packets; it has not reproduced across
+six subsequent runs and is treated as an anomaly, but it shows MTU discovery
+*can* come undone under sustained single-stream load.
+
+### Nothing in the pipeline is saturated
+
+Queue sweep at a valid run size (234 MB) — all flat:
+
+| Config | MB/s |
+|---|---:|
+| baseline | 72.4 |
+| `SUB_QUEUE_CAPACITY=4096` (broker core queue) | 73.3 |
+| `SUB_QUEUE_BOUND=1024` (writer lane queue) | 72.3 |
+| both raised | 73.7 |
+| `PUBLISH_INFLIGHT_BYTES=32MiB` | 71.6 |
+| all three | 77.5 |
+
+Note this also retracts round 1's "+34% from `PUBLISH_INFLIGHT_BYTES`" — that was
+measured on a buffer-absorbed run. At a valid size it does nothing.
+
+Instrumentation overhead is likewise minor: timings on 17,430 / timings off
+18,293 / non-telemetry build 17,577 msg/s.
+
+Per-thread CPU during a fanout-1 run (`ps -M`): **no thread is saturated.**
+Eight threads sit at 37–49%, and every busy thread shows roughly **11:1 system
+to user time** (e.g. 1.52 s STIME against 0.14 s UTIME).
+
+### The ceiling is per-byte, and it is kernel time that is not I/O
+
+| | Felix | Raw quinn |
+|---|---:|---:|
+| Throughput | 73 MB/s payload (~146 MB/s wire) | 798 MB/s |
+| user | 1.63 s | 0.30 s |
+| sys | 15.60 s | 1.50 s |
+| **sys per MB** | **23.8 ms** | **2.93 ms** |
+| Cores busy | 3.4 of 16 | 1.7 |
+| Involuntary ctx switches | 361,126 | 32,837 |
+
+**Felix spends ~8× more kernel time per byte than raw quinn** — and the weighted
+self-time profile shows `__sendmsg` is only 2.3% of samples. So that kernel time
+is not I/O. It is thread scheduling, futex and condvar traffic.
+
+Corrected self-time profile (the round-1 "symbol occurrence counts" were
+meaningless — they ignored both sample weights and tree structure):
+
+```
+ 5.2%  tracing Instrumented::poll
+ 4.5%  tokio blocking task poll
+ 2.9%  quinn_proto Connection::poll_transmit
+ 2.6%  clock_gettime_nsec_np      \
+ 2.4%  std Timespec::now           |  ~9.8% total in clock reads
+ 2.4%  clock_gettime               |
+ 2.4%  mach_absolute_time         /
+ 2.4%  __psynch_mutexwait          \
+ 2.4%  pthread_mutex_firstfit_lock_slow  |  ~10% in lock/condvar
+ 2.4%  pthread_mutex_firstfit_lock_wait  |
+ 1.6%  __psynch_cvsignal / pthread_cond_signal  /
+ 2.3%  __sendmsg
+ 2.1%  _platform_memmove
+ 1.7%  broker::transport::quic::codec::read_frame_limited_into
+```
+
+### Delivery scales with fanout; a single subscriber does not
+
+| Fanout | Delivered | Publish side |
+|---|---:|---:|
+| 1 | 74.8 MB/s | 74.8 MB/s |
+| 2 | 127.3 MB/s | 63.6 MB/s |
+| 4 | 213.3 MB/s | 53.3 MB/s |
+| 8 | 294.4 MB/s | 36.8 MB/s |
+
+Aggregate capacity is not capped at 73 MB/s — it reaches 294 MB/s across eight
+independent subscriber chains. **One subscriber's chain caps at ~75 MB/s**,
+against raw quinn's 750 MB/s on a single stream.
+
+## Diagnosis
+
+Every fact now points one way. The transport is healthy (full MTU, zero loss,
+zero congestion). No thread, queue, lock or buffer is saturated. The ceiling is
+per-byte rather than per-message or per-frame (1 KiB and 4 KiB both land at
+~73 MB/s despite a 4× difference in message *and* frame rate). Kernel time per
+byte is ~8× raw quinn's while actual I/O syscalls are ~2% of the profile. Adding
+independent chains (fanout) scales; adding parallelism within a chain
+(`pub_stream_count`, `core_shards`, deeper queues) does not.
+
+That is a **latency-bound dependency chain, not a throughput-bound resource**:
+each stage blocks handing off to the next, and the cost is a kernel round trip
+per handoff. The reason it presents as a *byte* rate is that wakeups scale with
+**datagram count** — `read_exact` on a 256 KiB frame is woken once per ~16 KB
+datagram arrival — and datagram count is bytes divided by MTU. This also explains
+the MTU sensitivity measured in round 1 (upper 1452 → 36.3 MB/s vs upper 16384 →
+75.7 MB/s): fewer, larger datagrams mean proportionally fewer wakeups.
+
+**Unverified.** The wakeup-per-datagram mechanism is inferred from converging
+evidence, not directly counted. Counting wakeups per byte — via the existing
+`felix_perf_publish_worker_wakeups_total` / `..._jobs_total` counters under the
+`perf_debug` feature, or `dtrace` on context switches — is the step that would
+confirm or kill it, and should happen before any large change.
+
+## Round 3: the architecture is not the problem
+
+The one-hop blast is an unfair target — Felix does two QUIC hops and twice the
+wire traffic by construction. So: a minimal **store-and-forward relay**
+(publisher → relay → subscriber), where the relay parses length-prefixed frames
+and forwards each one. This is the smallest thing that does the broker's job,
+and it establishes what Felix's *architecture* is worth on this box.
+
+512 MB per run, past the send window:
+
+| Relay read strategy | Frame | Delivered |
+|---|---:|---:|
+| `read_exact` (what Felix does) | 256 KiB | **541.2 MB/s** |
+| `read_chunk` (zero-copy) | 256 KiB | 523.8 MB/s |
+| `read_exact` | 64 KiB | 532.1 MB/s |
+| `read_chunk` | 64 KiB | 541.5 MB/s |
+
+Two conclusions, one of which kills the leading candidate fix:
+
+1. **Store-and-forward over two QUIC hops is worth ~540 MB/s.** Felix gets
+   73 MB/s — **13% of what its own architecture allows.** The gap is Felix's
+   code, not QUIC, not the extra hop, not macOS loopback.
+2. **`read_exact` vs `read_chunk` makes no measurable difference.** Candidate fix
+   #1 below is dead. Good: it was the most invasive of the three and would have
+   been implemented on a hunch.
+
+CPU per byte, all three systems, normalised to wire bytes:
+
+| | sys per MB wire | user | Throughput |
+|---|---:|---:|---:|
+| Raw quinn, one hop | 2.93 ms | 0.30 s | 798 MB/s |
+| Minimal relay, two hops | 2.5 ms | 2.70 s | 541 MB/s |
+| **Felix** | **23.8 ms** | 1.63 s | 73 MB/s |
+
+Felix's **user** time is unremarkable — lower than the relay's, in fact. Its
+**system** time per byte is ~9× the relay's. Since datagram sizes and counts are
+comparable and `__sendmsg` is ~2% of the profile, that kernel time is
+synchronization: futex/condvar traffic from task and thread handoffs. Felix runs
+~19 threads with many hops per batch; the relay runs three tasks.
+
+## Round 4: runtime width matters; frame granularity does not; the pipeline is bimodal
+
+### Tokio worker threads is the only reproducible lever found
+
+Added `FELIX_WORKER_THREADS` to the demo (it previously took tokio's default of
+one worker per CPU). 4 KiB, fanout 1, batch 64, 234 MB run:
+
+| Worker threads | MB/s |
+|---|---:|
+| 1 | 69.0 |
+| **2** | **98.5** |
+| 3 | 90.2 |
+| 4 | 76.3 |
+| 6 | 78.2 |
+| 8 | 78.4 |
+| 16 (default) | 74.2 |
+
+**+33% from reducing parallelism.** A serial dependency chain cannot use extra
+cores; spreading its stages across them only adds cross-core wakeups. Caveat:
+this harness runs broker and clients in one process, so the ideal width here is
+not necessarily the ideal width for a standalone broker.
+
+### The 64 KiB egress granularity is real but is not the cost
+
+Static analysis (correctly) identified that `event_batch_max_bytes` defaults to
+64 KiB (`crates/felix-broker/src/config.rs:115`), that
+`handlers/subscribe/feeder.rs` splits a 256 KiB envelope into four separately
+encoded 64 KiB lane frames, and that `_lane_flush_hints` in `feeder.rs:24-29` is
+a dead binding — `flush_max_items`, `flush_max_delay` and `max_bytes_per_write`
+are captured and never used. **All three verified in the code.**
+
+The prediction was that letting a batch travel as one frame would cut downstream
+scheduling ~4×. Measured (2 reps each):
+
+| Config | MB/s |
+|---|---:|
+| baseline (four 64 KiB frames per batch) | 74.8 / 74.0 |
+| `EVENT_BATCH_MAX_BYTES=1MiB` | 72.6 / 73.6 |
+| `SUB_MAX_BYTES_PER_WRITE=1MiB` | 73.4 / 77.7 |
+| both = 1 MiB (one frame per batch) | 75.9 / 76.5 |
+| both + `WORKER_THREADS=2` | 92.2 / 88.1 |
+
+**No effect.** Only the thread-count lever survives. This is consistent with the
+round-3 relay result: hops, locks and copies are individually free, so reducing
+the number of them does not help either. The chain description is accurate; the
+causal claim attached to it is not.
+
+`_lane_flush_hints` being dead is still a real bug worth fixing — the configured
+flush delay genuinely does nothing — but fixing it will not recover throughput.
+
+### The pipeline is bimodal — the strongest remaining lead
+
+Back-to-back runs of an *identical* configuration
+(`WORKER_THREADS=2`, `DISABLE_TIMINGS=1`, `--sub-delivery-shaping-off`):
+
+```
+repeat 1:  97,475 msg/s  (399 MB/s)
+repeat 2:  23,649 msg/s   (97 MB/s)
+```
+
+and separately `threads=2 + shaping off` alone hit 95,627 msg/s (392 MB/s),
+while `shaping off` by itself on default threads gives 17,224 (71 MB/s).
+
+**Felix intermittently runs 4× faster on identical settings.** Delivery drops
+stay 0 in both modes, so the fast mode is not shedding. This is the single most
+informative unexplained observation: the pipeline can evidently reach ~400 MB/s
+— within striking distance of the 540 MB/s relay ceiling — but usually settles
+into a mode that is 4× slower.
+
+That is the signature of a scheduling/coalescing bistability: in one mode a
+stage accumulates several items per wakeup and amortises the chain; in the other
+it processes one item per wakeup in lockstep. Which one it lands in appears to
+depend on startup timing. **Finding what selects the fast mode, and making it
+the only mode, is the most promising path to closing the gap** — far more so
+than any of the structural changes tested so far.
+
+## Round 5: the direct subscription writer — built, correct, no faster
+
+Implemented the direct egress path: one task owning both the subscription
+receiver and the QUIC `SendStream`, draining, encoding, coalescing up to
+`max_bytes_per_write`, and issuing a single `write_all_chunks`. It skips lane
+registration entirely — no lane channel, no lane task, no connection-writer
+channel or task, no DashMap routing, no `FuturesUnordered`. Behind
+`subscriber_direct_writer` / `FELIX_SUB_DIRECT_WRITER` so it can be A/B'd.
+
+4 KiB, fanout 1, batch 64, 234 MB run, 3 reps:
+
+| Path | msg/s |
+|---|---|
+| lane path (default) | 17,712 / 18,777 / 18,578 |
+| **direct writer** | 18,086 / 18,845 / 17,682 |
+| direct writer + `WORKER_THREADS=2` | 23,106 / 21,169 / 21,460 |
+
+**No difference.** Correctness is clean: `delivery drops 0`, received equals
+published, and fanout 4 still delivers correctly (67,930 msg/s). Only the
+thread-count lever moves anything, exactly as it did on the lane path.
+
+This is the fifth structural hypothesis to fail, and the round-3 relay probe
+predicted it: if 4 added mpsc hops plus a mutex and a copy cost nothing, then
+removing 2 hops cannot recover anything either.
+
+### Why the remaining plan items are also unlikely
+
+- **Making batching real / raising write sizes.** Round 4 already tested the
+  prediction directly: one frame per batch instead of four measured the same.
+- **Batching client dispatch (one channel op per frame instead of 64).** The
+  ceiling is invariant to event rate — 1 KiB delivers 73,126 events/s and 4 KiB
+  delivers 18,250 events/s, both at ~73 MB/s. A per-event cost would cap
+  events/s, not bytes/s. Ruled out by that invariance.
+- **Removing the client publisher round trip.** Same argument: it is per-batch,
+  and batch rate varies 4× across payload sizes with no change in byte rate.
+- **Flow control.** Checked: the client's event stream window is already 64 MiB
+  and its connection window 256 MiB (`crates/felix-client/src/config.rs:27-29`).
+  At 73 MB/s that is 0.86 s of buffering — not window-limited.
+
+## Where this leaves it
+
+Established beyond reasonable doubt:
+
+- The limit is **per-byte**, invariant to event rate, frame rate, frame size, and
+  egress topology.
+- It is **not** the transport (MTU 16354, zero loss, zero congestion events),
+  not CPU (12 of 16 cores idle, user time lower than the relay's), not any
+  queue, lock, copy, or channel hop, and not the number of tasks in the chain.
+- Felix burns **~9× the system time per byte** of an equivalent relay while
+  doing ~2% of its profile in `sendmsg`.
+- A functionally equivalent two-hop relay reaches **540 MB/s**; Felix reaches 73.
+
+The one observation that has not been explained, and the only one that shows the
+gap is closable without redesign, is the **bimodality**: identical configurations
+have produced 97,475 and 23,649 msg/s on back-to-back runs, and ~400 MB/s has
+been observed more than once. Something selects between a coalescing mode and a
+lockstep mode at startup.
+
+**Next step should be instrumentation, not another refactor.** Specifically, a
+per-wakeup item-count histogram at each stage that survives into the fast/slow
+runs, so the mode difference can be attributed. Five topology changes have now
+been tested against this ceiling and none moved it; a sixth without a mechanism
+in hand is not a good bet.
+
+## Round 6: nothing is backpressured, and the byte ceiling is exact
+
+### QUIC flow control is never the constraint
+
+Extended `FELIX_CONN_STATS_MS` to log `frame_tx`/`frame_rx` `data_blocked` and
+`stream_data_blocked` counters. These are the definitive test: an endpoint emits
+`DATA_BLOCKED` / `STREAM_DATA_BLOCKED` precisely when it has bytes to send and
+the peer has denied it credit.
+
+Sampled across a full run, including the connection that pushed 213 MB:
+
+```
+tx=121MB mtu=16354 tx_data_blocked=0 tx_stream_data_blocked=0 rx_data_blocked=0 rx_stream_data_blocked=0
+tx=213MB mtu=16354 tx_data_blocked=0 tx_stream_data_blocked=0 rx_data_blocked=0 rx_stream_data_blocked=0
+```
+
+**Zero, in both directions, on every connection.** Combined with zero lost
+packets and zero congestion events, *nothing in the QUIC layer is ever
+backpressured*. The broker is not credit-starved by a slow client, and the
+publisher is not credit-starved by the broker.
+
+This inverts the reading of `client_send_await p50 = 3.8 ms`. It is not evidence
+of something blocking downstream — if it were, we would see blocked frames. The
+producer side simply is not feeding faster.
+
+### Publisher concurrency does not scale
+
+| `--pub-conns` (×2 streams) | MB/s |
+|---|---:|
+| 1 | 78.3 |
+| 2 | 75.0 |
+| 4 (default) | 74.0 |
+| 8 | 73.2 |
+| 16 | 73.8 |
+
+**One publisher connection reaches the same rate as sixteen.** This rules out the
+client publisher's `mpsc send → oneshot wait` round trip and the benchmark's
+sequential batch awaiting: both are per-batch costs that more concurrency would
+amortise.
+
+### The byte ceiling is exact across a 16× payload range
+
+Every row ~312 MB, so all are past the send window:
+
+| Payload | Total | msg/s | MB/s |
+|---|---:|---:|---:|
+| 2 KiB | 160,000 | 35,707 | **73.1** |
+| 4 KiB | 80,000 | 17,128 | **70.2** |
+| 8 KiB | 40,000 | 8,675 | **71.1** |
+| 16 KiB | 20,000 | 4,382 | **71.8** |
+| 32 KiB | 10,000 | 2,185 | **71.6** |
+
+**A 16× spread in payload size and a 16× spread in message rate produce the same
+70–73 MB/s.** This is the strongest single result in the investigation. It
+definitively eliminates every per-message, per-event, per-batch and per-frame
+explanation — including client dispatch channel operations, publisher round
+trips, encode/decode cost, and framing overhead. Any of those would hold
+*messages* per second constant, not *bytes*.
+
+## Summary of what has been eliminated
+
+Measured and disproven, each with data above:
+
+| Hypothesis | Verdict |
+|---|---|
+| Transport / QUIC / MTU / loss | MTU 16354, 0 lost, 0 congestion events |
+| QUIC flow control | 0 blocked frames, both directions |
+| CPU saturation | 12 of 16 cores idle; user time below the relay's |
+| `Bytes`→`Vec`→`Bytes` copy | 0.2% of a core |
+| Read strategy (`read_exact` vs `read_chunk`) | no difference in relay probe |
+| Replay-ring retention | A/B 0.92×–1.02× |
+| Channel hops / locks / re-encode copies | relay with 4 hops + mutex + copy: no change |
+| Egress topology (lane → direct writer) | no change, 3 reps each |
+| Egress frame granularity (64 KiB → 1 MiB) | no change |
+| Queue depths (core, lane, inflight bytes) | flat 71.6–77.5 MB/s |
+| Publish worker sharding / `pub_stream_count` | more is worse |
+| Publisher connection concurrency | flat 1 → 16 |
+| `core_shards` | +5%, near noise |
+| Per-event/per-batch client costs | byte rate invariant over 16× message rate |
+| Instrumentation overhead | ~5% |
+
+The only lever that moves anything is **tokio worker thread count** (+20–33% at
+2 threads), and the only unexplained observation is the **bimodality** (identical
+config producing 97,475 and 23,649 msg/s; ~400 MB/s seen more than once).
+
+## What the evidence now points to
+
+A ceiling that is:
+
+- exactly proportional to bytes, across 16× payload and message-rate ranges,
+- invariant to every topology, queue, concurrency and batching change tested,
+- not flow-control, congestion, loss, or CPU bound,
+- ~9× more kernel time per byte than an equivalent relay, with ~2% of the
+  profile in `sendmsg`,
+- and occasionally, on identical settings, 4–5× higher,
+
+is characteristic of a **time-quantised stage**: something that moves a bounded
+amount of data per scheduling interval, so the rate is (bytes per cycle) /
+(cycle time) regardless of how those bytes are packaged. That would explain the
+byte-exactness, the immunity to topology, the idle cores, the kernel-heavy
+system time, and the bimodality (two stable cycle patterns).
+
+Concrete suspects not yet eliminated, in order:
+
+1. A timer- or park-driven wakeup cycle in the delivery path — note
+   `71 MB/s ÷ 64 KiB ≈ 1,090 writes/s ≈ 0.92 ms per write`, suspiciously close to
+   a 1 ms timer granularity. Raising `max_bytes_per_write` alone did not move it,
+   which would fit if the *actual* per-cycle payload is bounded elsewhere.
+2. Tokio timer/park interaction on this runtime (`Driver::park_internal` appeared
+   in the profile).
+3. Something in the client receive loop that parks per cycle rather than
+   draining what is available.
+
+The decisive next measurement is a **timestamped trace of one subscriber's write
+cycle** — when each write is issued, how many bytes it carried, and how long the
+task was parked between writes. That directly reads off "bytes per cycle" and
+"cycle time" and would confirm or kill the quantisation theory in one run. The
+`felix_sub_direct_write_frames` / `felix_sub_direct_write_bytes` histograms added
+with the direct writer are the natural place to start.
+
+## Candidate fixes, highest confidence first
+
+1. ~~**Read with `read_chunk` instead of `read_exact`.**~~ **Disproven (round 3)**
+   — the relay probe shows no difference. Do not do this.
+2. ~~**Reduce egress frame granularity.**~~ **Disproven (round 4)** — one frame
+   per batch instead of four measures the same.
+3. ~~**Collapse handoffs in the delivery chain.**~~ **Disproven (round 3)** — a
+   relay with 4 added mpsc hops, a mutex ring append and a re-encode copy runs
+   at 507–534 MB/s, indistinguishable from the 511 MB/s zero-hop baseline. Hops
+   are not the cost, so removing them will not help.
+4. **Investigate the bimodality.** *(now the top item — items 1-3 and the direct
+   writer are all disproven)* The pipeline reaches ~400 MB/s intermittently
+   on unchanged settings. Instrument which stage's batching collapses in the slow
+   mode — a per-wakeup item-count histogram at each stage
+   (`feeder`, `run_writer_lane`, `run_connection_writer`, client dispatch) would
+   show it directly. This is the highest-value next step.
+5. **Set runtime width deliberately.** Worth ~20–33% and already measurable, but
+   validate against a standalone broker before changing any default.
+6. **Fix `_lane_flush_hints`** (`feeder.rs:24-29`) — the configured flush delay
+   is silently ignored. A correctness/config-honesty bug, not a throughput fix,
+   though it may interact with the bimodality above since coalescing is exactly
+   what the dead hints were meant to control.
+
+Not worth doing on this evidence: the `Bytes`→`Vec`→`Bytes` copy, storage/fsync
+work, `io_uring`, anything sendfile-shaped, or `core_shards` as a default.
+
+## Round 7: cwnd/rtt visibility kills the congestion theories — and relocates the problem
+
+Added `cwnd`/`rtt` to the broker's `FELIX_CONN_STATS_MS` logging and a matching
+client-side logger (the client is the sender on the publish path, so its
+congestion state is invisible from broker-side stats).
+
+- **Congestion window is not the cap.** The busy delivery connection grows to
+  cwnd 22–30 MB; the busy publish connection to 13–15 MB. Idle/app-limited
+  connections pin at the 2×MTU minimum (32,708 B), but they carry no load.
+- **Loopback RTT under load is 30–100 ms** — pure queuing delay (~3–8 MB
+  standing in kernel socket buffers). The transport is being fed and drained
+  slower than it can go, and the queue keeps the control loop sluggish.
+- `FELIX_INITIAL_CWND=8MiB` on every endpoint: no change. Confirms cwnd is not
+  binding.
+- **The "backpressured pipeline" framing was wrong for this harness.** The demo
+  sets `subscriber_queue_capacity = 4096`, but that counts *envelopes*: at
+  batch 64 × 4 KiB each envelope is 256 KiB, so the queue absorbs ~1 GiB. In a
+  slow run the publish side finished the whole 1.2 GB run in ~2.5 s
+  (~550 MB/s!) while delivery crawled for another 15 s. **Publish ingest was
+  never the bottleneck; the broker→subscriber delivery chain is the bimodal
+  stage.**
+- In slow mode the delivery connection sends a steady 80 MB/s with zero loss,
+  zero blocked frames and a 22 MB cwnd — the transport is idle; the app side
+  offers one ~52 KB write per ~0.8 ms. In fast mode the same code pushes
+  450–500 MB/s (with some socket-buffer loss, which Cubic absorbs).
+
+## Round 8: the mechanism — driver re-poll latency is the clock
+
+Reading quinn 0.11 internals gave the missing piece:
+
+- The endpoint receive loop does at most ~50 µs of work per poll
+  (`RECV_TIME_BOUND`), the connection driver at most 20 datagrams per poll
+  (`MAX_TRANSMIT_DATAGRAMS`), and both then *reschedule themselves* via
+  `wake_by_ref`. Sustained throughput is therefore
+  `(bounded work per poll) / (re-poll latency)`.
+- On a runtime shared with the application's tasks, re-poll latency grows with
+  app load. The raw-quinn probe (3 tasks) and the relay (7 tasks) re-polled in
+  microseconds and flew; Felix (~50 tasks across 3 runtimes) did not.
+- This also finally explains the per-byte exactness of rounds 1–6: wakeups
+  scale with datagram count, datagrams scale with bytes/MTU, and each wakeup
+  pays a fixed scheduler round trip. Per-message and per-frame costs never
+  mattered because the datagram chain dominates.
+
+**Fix 1 — dedicated I/O runtimes** (`crates/felix-transport`): quinn endpoints
+get a `quinn::Runtime` implementation that spawns all driver tasks onto a pool
+of *single-threaded* tokio runtimes (round-robin per endpoint,
+`FELIX_IO_RUNTIME_THREADS`, default = available parallelism; the demo pins 2 —
+see round 9). Driver self-wakes now re-poll immediately and never migrate
+cores; on macOS the threads are pinned to high QoS. Measured: fast mode
+appears at *default* settings for the first time — 121–137 K msg/s
+(~500–560 MB/s) in most runs.
+
+Verified along the way with a temporarily patched local quinn (raised
+per-poll bounds, pacing off — diagnostic only, **removed**; the shipped fix
+uses official crates exclusively): raising quinn's internal bounds was worth
+only ~+20% once drivers were isolated, and pacing was not the residual
+bottleneck.
+
+## Round 9: the bimodality — batching vs per-datagram lockstep
+
+With drivers isolated, runs are either ~90 MB/s or ~530 MB/s on identical
+settings. What was established:
+
+- Slow mode is a **self-sustaining per-datagram lockstep**: every stage (driver
+  → driver → reader → ACK path back) processes one quantum per wakeup and
+  parks. One cross-thread wakeup chain per ~16 KB datagram at ~200 µs ≈
+  85 MB/s, invariant to write size, ACK frequency, queue depths and payload
+  size — exactly the shape rounds 1–6 measured.
+- Fast mode is the batched equilibrium: some queue depth exists, every poll
+  amortises many datagrams, and the pipeline runs at the machine's real
+  capacity.
+- The equilibrium is selected around startup and is *sticky*, but **any
+  perturbation flips slow → fast permanently** (attaching `sample` to the
+  process reliably did it). It is a scheduling attractor, not a resource limit.
+- Pool-size sweep confirms the mechanism: 1 io thread = never lockstep but
+  serialized (~360 MB/s); 2 = mostly batched; 6–13 = hot drivers fully
+  isolated from each other, lockstep dominates (~90 MB/s). Sharing a thread
+  forces batching. Hence the demo (13 endpoints in one process) pins the pool
+  to 2; a standalone broker has one endpoint and is indifferent.
+- Forced all-E-core execution (`taskpolicy -b`) still reaches 190 MB/s — slow
+  mode is *waiting*, not slow execution.
+
+**Fix 2 — pump colocation** (`QuicConnection::spawn_pump`): the two tasks that
+exchange a wakeup with the transport per datagram/write — the client's
+subscription read task and the broker's per-connection delivery writer — are
+spawned onto the same single-threaded runtime as their connection's drivers,
+making those wakeups same-thread task switches. Worth ~+13% and shrinks the
+lockstep window. The client *publisher* writer must NOT be colocated: it
+blocks in `write_all` against a full send window and starves the drivers it
+waits on (measured 5× loss).
+
+## Round 10: ACK frequency, and levers that did not survive
+
+**Fix 3 — ACK frequency** (`felix-transport`, quinn's ACK-frequency
+extension): `max_ack_delay` 25 ms → 2 ms (a window-limited sender resumes only
+on an ACK, so delayed ACKs stall the pipeline for the full delay) and
+`ack_eliciting_threshold` 1 → 20 (each reverse-path ACK costs a datagram plus
+its wakeup chain; at MTU 16354 the RFC every-other-packet cadence is ~2.5% of
+datagram load and a disproportionate share of wakeups). Worth ~+15% end to
+end. `FELIX_ACK_ELICITING_THRESHOLD` / `FELIX_ACK_FREQ_DISABLE` override.
+
+Measured and rejected:
+
+| Candidate | Verdict |
+|---|---|
+| Huge initial cwnd (`FELIX_INITIAL_CWND` up to 5 GB, which also disables quinn's pacer) | worse — burst loss thrash |
+| Fixed-window congestion controller (official `congestion_controller_factory` API) | worse than Cubic for the same reason; removed |
+| Colocating the client publisher writer | 5× worse; reverted |
+| 1–4 MiB egress writes (`FELIX_SUB_MAX_BYTES_PER_WRITE`) | no change in either mode |
+| Wider io pools for the in-process demo (4–13) | actively harmful (see round 9) |
+| `--sub-shared-thread` | no change |
+| Local quinn patches (per-poll bounds, pacer off) | diagnostic value only; ~+20%/tail-trimming not worth a fork; removed |
+
+## Resolution summary
+
+Root cause, one sentence: **Felix's throughput was clocked by scheduler wakeup
+latency — one cross-thread wakeup chain per QUIC datagram — because quinn's
+bounded-work driver tasks shared runtimes with all application tasks; every
+per-stage measurement was fast because no stage was the problem.**
+
+Shipped changes (official quinn/quinn-proto only):
+
+1. `crates/felix-transport`: dedicated single-threaded I/O runtime pool for
+   quinn drivers (`FELIX_IO_RUNTIME_THREADS`, default = available parallelism,
+   `0` = old behaviour), macOS QoS pinning, `QuicConnection::spawn_pump`,
+   ACK-frequency defaults (2 ms / threshold 20), `close_reason()` passthrough.
+2. `crates/felix-client`: subscription read task colocated via `spawn_pump`;
+   publisher writer deliberately not; client-side `FELIX_CONN_STATS_MS`
+   diagnostics.
+3. `services/broker`: per-connection delivery writer colocated via
+   `spawn_pump`; `FELIX_CONN_STATS_MS` now logs `cwnd`/`rtt`.
+4. `demos/broker/latency_demo.rs`: pins `FELIX_IO_RUNTIME_THREADS=2` for its
+   13-endpoint single-process topology; honours
+   `FELIX_EVENT_BATCH_MAX_BYTES`/`FELIX_SUB_MAX_BYTES_PER_WRITE` overrides.
+5. Removed: the round-5 direct subscription writer (built, measured, no
+   effect — deleted), the `FixedWindow` congestion mode, and every vendored
+   quinn experiment.
+
+Both perf profiles benefit: the throughput profile lands at ~550 MB/s p50 and
+the latency profile measures p50 129 µs / p99 181 µs / p999 256 µs (the ACK
+changes affect only transport acking, not request round trips).
+
+## What remains open
+
+- **The slow mode still occurs in a minority of in-process benchmark runs**
+  (typically 1–2 of 12; ~20 K msg/s when it does). It is the round-9 lockstep
+  attractor: startup-selected, sticky, flipped permanently by any external
+  perturbation. It has never been observed to *degrade* a fast run mid-flight.
+  A standalone broker with remote clients does not share the demo's
+  13-endpoints-in-one-process scheduling surface, so measure there before
+  chasing it further; `FELIX_IO_RUNTIME_THREADS` is the lever to sweep.
+- **A load-sensitive test flake surfaced during this work**:
+  `publish_sharding_preserves_stream_order` intermittently observed a
+  contiguous gap (~100 events) under full-suite parallelism — including in
+  configurations where every queue on the path is `Block`, which should make
+  gaps impossible. It did not reproduce on unmodified `main` (12 runs) nor in
+  the final 14-run verification, and its incidence tracked machine state more
+  than any specific change. The test now collects the full received sequence
+  and asserts at the end, so the next occurrence will show gap vs reorder vs
+  cross-stream contamination directly. Worth its own investigation.
+- `docs-site/.../benchmarks.md` numbers predate all of this (and round 1
+  showed several were buffer-absorption artifacts). The full matrix should be
+  re-run and republished.
+
+## Note on MTU tuning
+
+Round 1 suggested `mtu_discovery_upper_bound` of 8192 beat 16384 by ~30%. That
+comparison came from buffer-absorbed 32 MB probe runs and **does not survive**
+the corrected sweep: at valid run sizes the probe reaches 16354 and sustains
+750–800 MB/s. Treat the 16384 default as fine and unproven-either-way, not as a
+known 30% win. Note the QUIC spec distinction — Felix's
+`initial_mtu` of 1200 is correctly RFC-safe and must stay conservative, since
+RFC 9000 §14 requires PMTUD before exceeding ~1252 bytes on an unknown path.
+The *discovery upper bound* is quinn's DPLPMTUD (RFC 8899) probing, which is
+exactly that mechanism, so tuning it is spec-compliant. `FELIX_INITIAL_MTU` is
+the knob that is genuinely unsafe on an unknown path.
+
+## Reproducing
+
+```sh
+# Sustained (not buffer-absorbed) 4 KiB throughput
+cargo run --release -p broker --bin latency-demo --all-features -- \
+  --binary --warmup 1000 --total 60000 --payload 4096 --fanout 1 --batch 64
+
+# Replay-ring A/B (flag added by this investigation)
+... --log-capacity 1024
+
+# CPU split
+/usr/bin/time -l ./target/release/latency-demo --binary --warmup 1000 \
+  --total 80000 --payload 4096 --fanout 1 --batch 64
+```
+
+Rule of thumb: **a run is only valid if `payload × total` comfortably exceeds
+`send_window` (64 MiB).** Below that the harness reports buffer fill rate.
+
+## Changes in the working tree
+
+The shipped fix is described in "Resolution summary" above. Investigation-era
+artifacts that remain deliberately:
+
+- `demos/broker/latency_demo.rs`: `--log-capacity` / `FELIX_DEMO_LOG_CAPACITY`
+  (defaults to the previous whole-run behaviour), and tracing init when
+  `RUST_LOG` is set so broker/client diagnostics are reachable.
+- `services/broker/src/transport/quic/conn.rs` and
+  `crates/felix-client/src/client/client.rs`: `FELIX_CONN_STATS_MS` logs live
+  `quinn::ConnectionStats` (MTU, cwnd, rtt, loss, blocked-frame counters) on
+  both ends. Off unless the variable is set.
+
+Removed after measuring: the round-5 direct subscription writer and its
+`subscriber_direct_writer` config flag, the `FixedWindow` congestion mode, and
+all vendored quinn/quinn-proto experiments.
+
+Suggested follow-ups not yet done:
+
+- Make `latency-demo` warn (or refuse to report) when run bytes fall below the
+  send window, so the round-1 measurement artifact cannot silently return.
+- Re-run and correct the affected tables in
+  `docs-site/src/content/docs/features/benchmarks.md`, including the
+  `core_shards` claims — the current numbers are both artifact-tainted (round 1)
+  and now far below what the fixed pipeline delivers.
+- Investigate the residual slow-mode tail and the
+  `publish_sharding_preserves_stream_order` gap observation (see "What remains
+  open").
+
+---
+
+## Round 11: four defects in the measurement pipeline
+
+The first full post-fix matrix (2,240 cases, several hours) produced numbers
+that contradicted hand measurement by 5×. None of the causes were in Felix.
+All four are fixed; they are recorded because each one silently produces
+plausible-looking wrong data.
+
+### 1. The raw log is append-only and everything read all of it
+
+`data/raw/latency_demo_runs.jsonl` accumulates every run ever performed.
+`normalize_and_aggregate.py` read the whole file, so the derived CSVs and every
+chart mixed **six code states**: of 5,682 rows, only 2,257 were the new run.
+The rest were commits from three days earlier.
+
+`git_sha` cannot separate them, because the interesting changes are uncommitted
+— several sessions share one sha with `git_dirty: true`. That is what the
+tooling's own warning ("their git_sha does not identify what was measured") was
+telling us.
+
+**Fix.** Each matrix invocation stamps a `session_id`;
+`normalize_and_aggregate.py` derives from the latest session only, and reports
+what it dropped (`--session all` / `--session <prefix>` to override). Applied
+to the existing data: 2,257 kept, 3,425 stale rows excluded, charts fell from
+192 files across 6 commits to 80 from one session.
+
+### 2. Charts held a single bar with everything else "no data"
+
+A direct consequence of (1): old sessions had only ever run a fraction of the
+matrix, so their chart groups were nearly all absent. `make_charts.py` renders
+missing cells as NaN, which is correct, but a figure where *every* bar is
+absent is worse than no figure. It now skips such figures, and with session
+filtering there are no incomplete groups left (448 rows, 0 incomplete).
+
+### 3. Message rate on a linear axis made large payloads look like zero
+
+The throughput charts plotted msg/s across payloads 0–4096 on one linear axis.
+0 B does ~3.7M msg/s and 4 KiB does ~21K, so the 4 KiB bar was 0.6% of the
+tallest and rendered as nothing — reading as "4 KiB has no throughput" when it
+was in fact moving the most *bytes* on the chart.
+
+**Fix.** Log y-axis on message-rate charts, plus a new
+`_delivered_mb_per_s` chart, which is the only cross-payload-comparable
+throughput measure. 0 B is excluded from it rather than drawn as a zero bar.
+
+### 4. The demo's own sweep measured buffer fill
+
+`--all` hardcoded `total = 5000` for every payload — 20 MB at 4 KiB, well
+inside the 64 MiB send window. Sizing is now per payload, with a floor that
+clears the window whenever affordable and a cap on *delivered* messages so a
+20-case sweep stays ~40 s. Only combinations where clearing the window would
+cost millions of deliveries (small payloads at high fanout) still warn.
+
+Two constraints the sizing has to respect: the undersized-run warning must skip
+`payload = 0` (zero volume always trips a byte threshold, which is meaningless
+for empty payloads), and the counts need a wall-clock cap or a 20-case sweep
+becomes a multi-minute benchmark.
+
+### Why this mattered more than it looks
+
+The matrix's throughput half was **unusable**: 45% of `batch=64` cells had
+p90/p10 trial spread above 1.5×, some 7.2×, and the medians mostly landed in
+the degraded mode (~87–114 MB/s — near the *pre-fix* ceiling) while hand
+measurement on an idle machine gave 477–509 MB/s. Publishing those would have
+reported the bug as the product's performance.
+
+**Background CPU load makes the degraded mode much more likely**, so a matrix
+run that overlaps with compilation, a test suite or a docs build is
+contaminated. Run the matrix on an otherwise idle machine.
+
+The latency half of the same matrix was fine — 224 cells, only 15% with
+meaningful spread — and is the basis for the published latency table.
+
+## Round 12: the bimodality is endpoint→I/O-runtime placement (half of it)
+
+### It is not idle waiting
+
+The decisive measurement. Same command, one fast run and one slow, under
+`/usr/bin/time -l`:
+
+| | fast | slow | ratio |
+|---|---:|---:|---:|
+| delivered | 120K msg/s | 20K msg/s | 6× |
+| wall | 0.80 s | 3.39 s | |
+| cores busy | 1.90 | 1.94 | **same** |
+| **sys time per message** | **15.0 µs** | **85.8 µs** | **5.7×** |
+| **context switches per message** | **0.42** | **2.40** | **5.7×** |
+
+Both modes saturate the same ~1.9 cores. The slow mode is not blocked on a
+timer or starved of CPU — it performs **5.7× more kernel work per message**.
+That is the lockstep, quantified: one wakeup chain per item instead of one per
+batch.
+
+### It is client-side, and the broker is innocent
+
+Per-stage timings, fast vs slow (p99):
+
+| stage | fast | slow | ratio |
+|---|---:|---:|---:|
+| `client_sub_read_await` | 672 µs | 13.711 ms | **20.4×** |
+| `client_sub_poll_gap` | 674 µs | 13.713 ms | 20.3× |
+| `client_write` / `client_send_await` | 4.543 ms | 28.138 ms | 6.2× |
+| `broker_sub_write` | 5 µs | 4 µs | 0.8× |
+| `broker_decode` | 69 µs | 79 µs | 1.1× |
+| `broker_publish_append` | 6 µs | 8 µs | 1.3× |
+
+**Every broker stage is unchanged.** The broker writes in 4 µs and the client
+waits 13.7 ms to receive it. Both client directions are affected, which points
+at the client's I/O runtime rather than either data path.
+
+### What selects it: which endpoints share a runtime
+
+Endpoints were assigned to I/O runtimes round-robin. Slow-run rate by pool size,
+8 runs each:
+
+| pool | before grouping | after grouping |
+|---|---|---|
+| 1 | 0/8 (but capped ~345 MB/s — one thread serializes) | — |
+| 2 | 1/8 | 2/8 |
+| 3 | **7/8** | — |
+| 4 | 7/8 | 3/8 |
+| 6 | **8/8** | **1/8** |
+
+Two configurations were *deterministic*, which is what made this tractable:
+`--sub-shared-thread` was 8/8 slow, and pool size 6 was 8/8 slow. Logging the
+assignment showed the difference is not the pattern but which endpoints land
+together:
+
+- **fast** — broker endpoint alone on runtime 0; client publish + client event share runtime 1
+- **slow** — broker endpoint shares runtime 0 with the client's event endpoint
+
+Mechanism: the server endpoint drives every connection in both directions, so
+sharing it with anything starves it; and a client's publish and event endpoints
+carry the two halves of one request/response flow, so splitting *them* makes
+every message pay two cross-thread wakes.
+
+**Fix** (`crates/felix-transport/src/lib.rs`): assignment is by role, with
+disjoint runtime slots that do not depend on creation order.
+
+```rust
+Server => sequence % (pool_len - 1),   // never the last runtime
+Client => pool_len - 1,                // always the last runtime
+```
+
+Reserving the last runtime for clients is what makes the partition stable. A
+history-dependent selection (`seq % pool_len` for servers) alternates them onto
+the client runtime as endpoints accumulate, which matters wherever many
+endpoints are created in one process — see round 14.
+
+Default pool size dropped from available-parallelism to **2** — a bigger pool
+cannot make a single endpoint faster (an endpoint's driver is one task on one
+runtime) and actively splits communicating endpoints. The old default was
+chosen to relieve a parallel-test-suite flake, never for throughput.
+
+This eliminated the pool-size sensitivity — including the 8/8 and 7/8
+deterministic cases — and **raised nothing else**: fast-mode throughput is
+unchanged at ~122K msg/s (500 MB/s) against 123K before.
+
+### Also ruled out this round
+
+| Hypothesis | Result |
+|---|---|
+| Path MTU stuck low | both modes reach 16354 |
+| Packet loss / congestion | 0 lost, 0 congestion events, both modes |
+| Partially-filled datagrams | ~15.6 KB/datagram in both |
+| App runtime width | ~1/8 slow at 1, 2, 4, 8 and 16 worker threads |
+| I/O pool size (after grouping) | 1–3/8 at every size |
+| Event connection pool | 1/8 at pool 1, 2/8 at pool 8 |
+| `cargo run` vs direct binary | no difference (an earlier claim that it *did* was a zsh word-splitting bug in the test harness — see below) |
+
+### Scripting the demo
+
+**zsh does not word-split unquoted parameter expansions.** Passing the demo's
+arguments through a shell variable (`$ARGS`) delivers them as a single string,
+which the parser ignores — the demo then falls back to its full built-in sweep
+and reports a different benchmark entirely. Pass literal arguments, or a shell
+array, when scripting runs.
+
+## Round 13: the residual, and how not to misread a sweep
+
+### The residual bimodality
+
+**~30% of runs land 5–6× slower**, on every configuration tested, measured in
+fresh processes after the round-14 fixes: median 118,011 msg/s (483 MB/s), eight
+runs 116K–122K, four runs 20–23K. Role-based placement removed the
+assignment-dependent component; this is a second, independent cause.
+
+What is known about it:
+
+- costs 5.7× system time and 5.7× context switches per message (round 12)
+- client-side; every broker stage is unaffected
+- sticky for the life of the process, selected at startup
+- much more likely under background CPU load
+- not explained by MTU, loss, datagram fill, runtime width, pool size, or
+  connection pool size
+
+### Test flake, cause not established
+
+`publish_sharding_preserves_stream_order` fails intermittently under full-suite
+parallelism — never in isolation (4/4 passes at every pool setting), and the
+failure is a **2-second timeout, not a data gap**. Rate has ranged from 0/12 to
+2/4 across sessions, correlating with machine load; the last five suite runs
+were clean.
+
+Unresolved concern: the I/O runtime pool is **process-global**, so the whole
+test binary now shares 2 threads where it previously had 16. That is a
+plausible interaction with parallel tests and should be checked before the
+default is committed. Setting a larger pool for the test suite is the obvious
+mitigation if it recurs.
+
+### The single-run trap
+
+The `--all` sweep runs **one trial per case**. With a ~30% slow rate, several
+cases in any sweep will read 5–7× low — two adjacent cases in the log above
+differ 5.7× and 7.1× on identical settings. `--all` is a smoke demo; anything
+quoted must come from `task perf:latency-matrix`, which medians five trials.
+
+Related output fix: the demo printed queueing delay for `batch > 1` runs under
+the same `p50 =` label as real request latency. Those percentiles scale with
+run length by design — lengthening runs to clear the send window made them grow
+from single-digit ms to hundreds of ms, which reads as a catastrophic
+regression and is not one. Batched runs now print under an explicit
+`queueing delay (NOT per-message latency ...)` heading.
+
+## Round 14: benchmark lifecycle — assignment stability and drop accounting
+
+Two defects in the benchmark's lifecycle handling distorted the round-13 sweep:
+endpoint assignment drifted across repeated in-process cases, and subscriber
+timeouts were counted as queue drops. Both are fixed here, and the numbers are
+re-measured afterwards.
+
+### Endpoint assignment must not depend on creation history
+
+The round-12 fix partitioned endpoints by *role* but still chose the slot from
+creation history: `Server => seq % pool_len`. With the default pool of 2 and
+`--all` calling `run_case()` repeatedly in one process, that alternates:
+
+| case | server runtime | clients | result |
+|---|---|---|---|
+| 1 | 0 | 1 | isolated — fast |
+| 2 | **1** | 1 | **server shares with clients — slow** |
+| 3 | 0 | 1 | fast |
+| … | alternating | always 1 | alternating |
+
+So every second case rebuilt precisely the topology round 12 set out to
+eliminate. The verification missed it because it used one endpoint pair per
+process, where the counters never advance far enough to wrap.
+
+**Confirmed against the round-13 sweep log.** Predicting "odd-indexed case is
+slower" from this model alone:
+
+| # | payload | fanout | delivered/s | vs previous |
+|---|---|---|---|---|
+| 10 | 1 KiB | 1 | 396,692 | — |
+| 11 | 1 KiB | 1 | 314,002 | 1.3× slower |
+| 12 | 1 KiB | 10 | 738,852 | — |
+| 13 | 1 KiB | 10 | 129,991 | **5.7× slower** |
+| 14 | 4 KiB | 1 | 108,146 | — |
+| 15 | 4 KiB | 1 | 80,607 | 1.3× slower |
+| 16 | 4 KiB | 10 | 192,867 | — |
+| 17 | 4 KiB | 10 | 26,987 | **7.1× slower** |
+| 18 | 256 B | 1 | 1,298,113 | — |
+| 19 | 256 B | 1 | 977,113 | 1.3× slower |
+
+**5 of 5 pairs**, and the two extremes are the fanout-10 cases where the server
+endpoint does the most work and suffers most from sharing. What round 13 called
+bimodality inside the sweep was deterministic alternation.
+
+**Fix.** Reserve disjoint slots by role, independent of history:
+
+```rust
+Server => sequence % (pool_len - 1),   // never the last runtime
+Client => pool_len - 1,                // always the last runtime
+```
+
+With the default pool of 2 every server is pinned to runtime 0 and every client
+to runtime 1, forever. Verified over a full 20-case sweep: **14 servers → 0,
+126 clients → 1**, no drift. Worst same-config pair ratio fell from 7.1× to
+**1.02×**.
+
+### Subscriber timeouts are not queue drops
+
+`dropped` was `expected_delivered_total - delivered_total`, and drain
+subscribers `break` out of their loop on a 2 s idle timeout, abandoning
+whatever remained. Any slow run therefore reports a large "drop" count that has
+nothing to do with queue policy.
+
+**Fix.** A subscriber that times out, errors, or sees its stream close now
+fails the run with context instead of abandoning events. The field is renamed
+`unaccounted` and documented as a shortfall, not a drop counter — the real
+counters are `metrics` counters with no recorder installed in the demo, so they
+are honestly not collected here. A non-zero value now prints
+`sanity: INVALID RUN ... throughput above is not meaningful`.
+
+Post-fix sweep: **0 of 14 runs invalid**, against two cases previously
+reporting 260K and 134K phantom drops.
+
+### What remains
+
+A genuine residual, in fresh processes where server 0 always lands on runtime 0:
+
+```
+4 KiB, fanout 1, 12 fresh processes
+median 118,011 msg/s (483 MB/s)
+slow: 4/12  ->  20, 20, 21, 23 K msg/s
+```
+
+So ~30% of runs still land 5–6× slow, and this one is not explained by
+endpoint placement. It is the same residual round 13 described; what has
+changed is that it can now be measured without the harness contaminating it,
+and that its supposed "shedding" symptom has evaporated.
+
+Everything round 12 established about its *character* still stands, because
+those measurements were single-case, single-process runs unaffected by the
+alternation bug: same cores busy, 5.7× system time and 5.7× context switches
+per message, client-side, every broker stage unchanged.
+
+### Verifying changes in this area
+
+Two things this class of bug requires:
+
+1. **Exercise repeated cases, not one.** Endpoint assignment is process-global
+   and history-dependent bugs only appear once counters have advanced, so a
+   single endpoint pair per process cannot expose them. Check the assignment
+   log (`RUST_LOG=felix_transport=debug`) over a full sweep.
+2. **Check what a counter measures before drawing conclusions from it.**
+   `unaccounted` is `expected - observed`, not a queue-drop counter; the real
+   drop counters are `metrics` counters and are not collected by the demo.
+
+### Current verified state
+
+| Profile | Result |
+|---|---|
+| Latency, fanout 1 | p50 109–119 µs, p99 138–165 µs |
+| Latency, fanout 10 | p50 236–245 µs, p99 343–356 µs |
+| Throughput 4 KiB fanout 1 | median 118,011 msg/s = **483 MB/s**, ~30% of runs slow |
+| Invalid runs in a 20-case sweep | 0 |
+| Worst same-config pair ratio | 1.02× |
+
+`task lint`, `task test` (twice) and `task demo:check` all pass.
+
+### Next step
+
+One item remains: the ~30% fresh-process slow rate. The standalone-broker
+reproduction is still the right next move — a real broker has one endpoint and
+its clients are separate processes, so if the residual does not reproduce
+there, it is a property of the single-process harness rather than of Felix.
+
+## Everything changed this session
+
+All uncommitted. Grouped by what would make sensible commits.
+
+**Transport (`crates/felix-transport/src/lib.rs`)**
+- `EndpointRole`: server endpoints get a runtime each, client endpoints share
+  one. Replaces round-robin assignment (round 12).
+- Default I/O pool size available-parallelism → **2**.
+- Debug log of endpoint → runtime assignment (`felix_transport=debug`).
+- Round 15: loopback peers connect/accept with `initial_mtu = min_mtu =
+  16336` (skips discovery, makes MTU black-hole verdicts a no-op); initial
+  congestion window scaled per RFC 9002 when the initial MTU exceeds quinn's
+  flat 14,720-byte default (which otherwise deadlocks the handshake);
+  `black_hole_cooldown` 60 s → 2 s with `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`
+  override.
+
+**Client (`crates/felix-client/`)**
+- `client.rs`: `FELIX_CONN_STATS_MS` path-stats logger (client is the sender on
+  the publish path, so its cwnd/rtt is invisible from broker stats).
+- `subscription.rs`: subscription read task colocated via `spawn_pump`.
+- The publisher writer is deliberately *not* colocated — it blocks in
+  `write_all` and starves the drivers it waits on (measured 5× worse).
+- `publisher.rs`/`wire/ack.rs`: acked publishes are pipelined. The writer no
+  longer awaits each broker ack inline (which capped acked throughput per
+  stream at one request per RTT — ~9.4 K msg/s on loopback, ~20/s on a 50 ms
+  WAN); it hands written requests to a per-stream ack-reader task that
+  resolves them in order as acks arrive. Admission permits ride with the
+  pending ack so the in-flight byte budget still reflects unacked data. Ack
+  failure semantics unchanged: timeout, decode error, mismatched or error
+  acks remain fatal for the worker and fail queued requests. Regression test
+  `acked_publishes_pipeline_without_waiting_per_ack` deadlocks (10 s timeout)
+  against the inline-wait implementation and passes in milliseconds with
+  pipelining.
+
+**Broker (`services/broker/`)**
+- `conn.rs`: `FELIX_CONN_STATS_MS` now logs `cwnd` and `rtt`.
+- `subscribe/lane.rs`: per-connection delivery writer colocated via
+  `spawn_pump`.
+- `streams/tests.rs`: `publish_sharding_preserves_stream_order` now pins Block
+  queue policies and collects the full received sequence before asserting, so a
+  failure shows gap vs reorder vs contamination.
+
+**Perf tooling (`scripts/perf/`)**
+- `run_latency_matrix.py`: `session_id` per invocation; `effective_total()`
+  sizes throughput cases past the send window.
+- `normalize_and_aggregate.py`: `select_session()`, latest-session default,
+  reports excluded stale runs.
+- `make_charts.py`: log y-axis for message-rate charts, new
+  `_delivered_mb_per_s` chart, skip all-NaN figures.
+- `presets.yml` / `ci_subset_throughput.yml`: documented `min_run_bytes` /
+  `max_total`.
+
+**Demo (`demos/broker/latency_demo.rs`)**
+- Subscriber timeout, stream error or early close now fails the run with
+  context instead of abandoning remaining events.
+- `dropped` renamed `unaccounted` (`expected - observed`, not a drop counter);
+  a non-zero value prints `sanity: INVALID RUN`.
+- `throughput_total(payload, fanout)`: window floor when affordable, delivered-
+  message cap otherwise.
+- Undersized-run warning, skipped for empty payloads.
+- Batched runs print `queueing delay (NOT per-message latency ...)` instead of
+  a bare `p50 =`.
+- Removed the redundant `FELIX_IO_RUNTIME_THREADS=2` pin (now the default).
+
+**Docs**
+- `benchmarks.md`: post-fix latency table, clean throughput table with the
+  spread column, two latency charts, methodology sections on the send-window
+  rule and session isolation; old cross-platform tables demoted and marked
+  pre-fix.
+- `performance-case-study.md` (new, in the docs site): the narrative version.
+- `internals-concurrency.md`: "The QUIC I/O runtime" section.
+- Animated Mermaid diagrams restored from a stash and extended
+  (`how-felix-works`, `getting-started/overview`, `internals-subscribe`,
+  `performance.md`, durable-storage); `group-commit.svg` wired in.
+- `environment-variables.md`: `FELIX_IO_RUNTIME_THREADS`,
+  `FELIX_ACK_ELICITING_THRESHOLD`, `FELIX_ACK_FREQ_DISABLE`,
+  `FELIX_CONN_STATS_MS`.
+
+**Not done**
+- Cross-page number cleanup. `quic-transport.md` still claims connection
+  throughput "scales nearly linearly" with a table (150K → 3.2M msg/s) that was
+  never measured and that round 6 contradicted pre-fix; `pubsub.md` has an
+  unsourced fanout table including a fanout-1000 row that has never been
+  benchmarked; `system-design.md` says 10k–50k msg/s, two orders of magnitude
+  below every other page; `what-felix-is-for.md` quotes buffer-absorbed figures
+  without the caveat its source page now carries.
+
+## Round 15: the residual is a path-MTU collapse, not scheduling
+
+Reproduced first: 5/16 fresh-process runs at ~21–24 K msg/s against a
+~118–120 K fast mode (4 KiB, fanout 1, batch 64) — the round-13/14 residual,
+alive and well.
+
+### The lockstep theory, tested and killed
+
+The standing theory was a park/wake lockstep between the two I/O runtime
+threads. Tested directly: a bounded busy-wait in `on_thread_park` on the I/O
+runtimes (so a thread about to park stays runnable through the inter-datagram
+gap, turning cross-thread wakes into flag checks). Result: slow-run rate
+unchanged at every spin length (2/12 at 0 µs, ~3/16 at 100 µs, 5/12 at
+500 µs) — and the 100 µs run introduced *new* intermediate modes, because in
+tokio the parked worker is what polls the I/O driver, so spinning before the
+park delays datagram receipt. Wrong theory, and the instrument perturbed the
+system. Removed entirely.
+
+### What a slow run actually looks like
+
+`FELIX_CONN_STATS_MS=250` on a fast and a slow run, busiest connection (the
+client publish connection carrying all traffic), final stats:
+
+| | fast | slow |
+|---|---|---|
+| MTU at end of run | 16354 | **1200** |
+| UDP datagrams for ~230–260 MB | 14,278 | **166,580** |
+| bytes per datagram | 15,744 | **1,549** |
+| lost packets | 0 | 674 (one burst) |
+
+Timeline of the slow run's publish connection:
+
+```
+t=0.25s  mtu=8792   cwnd=17584     rtt=1.9ms   lost=0     (discovery in progress)
+t=0.50s  mtu=16354  cwnd=15.3MB    rtt=13.2ms  lost=0     (discovery SUCCEEDED)
+t=0.75s  mtu=1200   cwnd=9.9MB     rtt=2.9ms   lost=674   (collapse)
+t=1.5s   mtu=1200   ...            ...         lost=674   (stuck; no further loss)
+t=3.0s   mtu=1200   ...            ...         lost=674   (stuck until run ends)
+```
+
+Path-MTU discovery *succeeds*, then a single ~674-packet loss burst drops the
+MTU back to 1200 for the rest of the run. At 1200 instead of 16354 the same
+byte stream costs ~13.6× the datagrams — and each datagram carries a syscall
+and a wakeup chain, which is precisely the 5.7× system time and 5.7× context
+switches per message round 12 measured. Every earlier observation fits:
+client-side (the client is the publish-path sender), broker stages unaffected,
+sticky from "startup" (the collapse lands in the first second, during the
+warmup ramp), and worse under background CPU load (see below). Round 2's
+"80.3 MB/s anomaly with MTU collapsed to 1200 and 649 lost packets" — recorded
+once, not reproduced, set aside — was this defect.
+
+Round 12's "MTU reaches 16354 in both modes" check was made on a delivery
+connection; the collapse hits the *publish* connection carrying the offered
+load. The check was right and looked at the wrong connection.
+
+### Mechanism, in three parts
+
+1. **The loss burst is congestive, not an MTU problem.** The publish path's
+   standing queue (~6.5 MB: 4 MiB payload inflight plus overhead, visible as
+   the 13 ms loopback "RTT") sits within ~1.5 MB of the receiver's 8 MB UDP
+   socket buffer (`kern.ipc.maxsockbuf` caps it there). A scheduling stall of
+   a few ms on the draining side overflows the buffer and the kernel drops a
+   window of packets. Background CPU load makes such stalls — and therefore
+   the collapse — much more likely. If the ramp survives without a burst,
+   steady state is loss-free (fast runs: 0 lost packets), hence bimodal.
+2. **Quinn's black-hole detector cannot tell the difference.** Every dropped
+   packet in the burst is full-MTU (that is what a saturated sender's traffic
+   looks like), which is exactly the "large packets vanish" signature the
+   detector looks for (`BLACK_HOLE_THRESHOLD` = 3 suspicious bursts). Verdict:
+   MTU black hole. The path MTU resets to `initial_mtu` (1200) and MTU
+   discovery enters a 60 s cooldown (`black_hole_cooldown` default).
+3. **Recovery is starved by the load itself.** Quinn only sends an MTU probe
+   when a `poll_transmit` finds nothing else to send
+   (`if buf.is_empty()` in `connection/mod.rs`). A backlogged publisher never
+   has an empty transmit buffer, so after the cooldown no probe is ever sent.
+   Verified: with the cooldown shortened to 2 s (A/B via
+   `FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`), collapsed runs stayed at MTU 1200 for
+   2.7+ s past the collapse with zero probes and zero further losses, and the
+   slow-run rate was unchanged (3/16 at 2 s vs 4/16 at 60 s). The collapse is
+   sticky for the life of the *load*, not the cooldown.
+
+### The fix, in three attempts
+
+The fix took three iterations, each of which taught something about quinn's
+MTU machinery; recorded because every intermediate state *looked* plausible
+and shipped alone would not have worked.
+
+1. **Initial MTU alone is not enough — the handshake deadlocks.** Starting
+   loopback connections at `initial_mtu = 16336` hit a second quinn surprise:
+   the default initial congestion window is a flat 14,720 bytes (RFC 9002's
+   constant, sized for ~1200-byte datagrams, not MTU-scaled) and quinn's send
+   path reserves a full segment per datagram — so an initial MTU larger than
+   the window blocks the very first packet on congestion control, forever.
+   This also means a hand-set `FELIX_INITIAL_MTU=16354` had always been a
+   deadlock. Fixed by scaling the window with RFC 9002's own formula
+   (`clamp(14720, 2×mtu, 10×mtu)` = 32,672 at 16,336) whenever no explicit
+   `FELIX_INITIAL_CWND` is set and the MTU requires it.
+2. **Initial MTU + window is still not enough — the collapse floor is
+   `min_mtu`.** With connections starting and running at 16336, slow runs
+   continued at the same ~30% rate, and the capture showed why: the busy
+   publish connection began at 16336 and a loss burst still dropped it to
+   **1200**. Quinn's black-hole reset target is `TransportConfig::min_mtu`
+   (default 1200), not `initial_mtu`. Raising the start size alone changes
+   nothing about the failure mode.
+3. **The actual fix: guarantee the loopback MTU.** For a loopback peer —
+   the one path where a 16 KiB datagram is guaranteed by construction — the
+   config variant sets both `initial_mtu` *and* `min_mtu` to 16336 (fits
+   IPv4/IPv6 headers within the 16 KiB loopback interface MTU; capped by
+   `FELIX_MTU_UPPER_BOUND`/`FELIX_MAX_UDP_PAYLOAD`). With the floor at
+   16336 a black-hole verdict has nothing to collapse to: congestive loss
+   bursts remain ordinary congestion events and Cubic absorbs them. Applied
+   on both sides: `QuicClient::connect` via `connect_with` and
+   `QuicServer::accept` via `accept_with`, whenever the peer address is
+   loopback. An explicit `FELIX_INITIAL_MTU` disables the special case.
+   `min_mtu` must never be raised for a real network path.
+4. **And pin the discovery bound, or quiet connections starve.** With
+   `initial_mtu = 16336` but the probe bound still at 16384, MTUD probes for
+   sizes that can never fit (16384 minus IP/UDP headers is less than the
+   probe). A probe is full-MTU, bypasses the congestion check when sent, and
+   counts against the window once in flight — so on a *quiet* connection at
+   the two-segment initial window, the doomed probe → loss-detection →
+   retransmit cycle starves every ordinary small send behind it ("blocked by
+   congestion control" for tens of seconds). Busy connections never noticed
+   (Cubic grows the window past caring), which is why the throughput sweeps
+   missed it; a client test with a sparse request/ack exchange hung reliably.
+   The loopback config therefore sets `upper_bound = initial_mtu`: the size
+   is guaranteed, there is nothing to discover, no probe is ever sent.
+
+Additionally, `black_hole_cooldown` drops 60 s → 2 s
+(`FELIX_MTU_BLACK_HOLE_COOLDOWN_MS`) for non-loopback paths. It cannot rescue
+a continuously backlogged sender (probe starvation, above), but for
+intermittent load it turns a spurious collapse into a ≤2 s dent instead of a
+60 s outage, at the cost of one loss-tolerant probe per cooldown on a genuine
+black-hole path.
+
+### Verification
+
+4 KiB × batch 64 × fanout 1, fresh process per run, same binary for both arms
+(the reverted arm disables the loopback guarantee via `FELIX_INITIAL_MTU=1200`
+and restores the stock cooldown):
+
+| Arm | Slow runs | Median | Worst ÷ median |
+|---|---|---:|---:|
+| Baseline (before any of this round) | 5/16 at ~21–24 K | ~118 K msg/s | 5.6× |
+| Fix active | **0/20** | ~122 K msg/s | **1.11×** |
+| Fix reverted via env | 5/16 at ~21–23 K | ~121 K msg/s | 5.7× |
+
+The fix arm's 20 runs span 112.3–125.1 K msg/s. The fast mode itself gained
+~3% from skipping the MTU discovery ramp.
+
+The round-14 open item — reproduce on a standalone broker before chasing
+further — is answered by mechanism: the collapse requires overflowing the
+receiver's UDP socket buffer with full-MTU packets, which any sufficiently
+fast sender can do to any receiver on any high-MTU path; it was never a
+property of the in-process harness. Loopback deployments are now immune by
+construction; non-loopback paths degrade for ≤2 s per spurious verdict when
+their load has idle gaps, and a continuously saturated non-loopback sender
+remains exposed to probe starvation — a quinn behavior worth an upstream
+conversation.

--- a/docs/perf-investigation-throughput.md
+++ b/docs/perf-investigation-throughput.md
@@ -5,10 +5,13 @@ throughput, particularly at larger payload sizes. Records what was measured,
 what was concluded, and — importantly — which hypotheses turned out to be
 wrong.
 
-**Status: resolved. Main ceiling fixed (rounds 7–10); the residual bimodality
-was a path-MTU black-hole collapse (round 15); the Linux CI failure that
-followed was publish-side shedding in an under-configured test, not a
-transport defect (round 16).**
+**Status: resolved for macOS, open for Linux.** Main ceiling fixed (rounds
+7–10); residual bimodality was a path-MTU black-hole collapse (round 15); the
+Linux CI failure was publish-side shedding in an under-configured test (round
+16). Round 17 then established that **the ceiling itself is macOS-specific** —
+Linux is faster at the pre-fix baseline than macOS is after every fix — and
+that the I/O runtime pool must stay off there. Everything measured in rounds
+1–16 is macOS; Linux has never been properly benchmarked.
 The ceiling was scheduling, not any Felix
 stage: quinn's driver tasks do a bounded slice of work per poll and reschedule
 themselves, so sustained throughput is that slice divided by scheduler re-poll
@@ -1388,6 +1391,71 @@ Worth carrying separately: a 400-message unacked burst shedding ~19% at
 default settings on a 4-CPU host is *documented* behaviour, not a bug — but
 it is a sharper edge than the docs' "overload becomes visible" framing
 suggests, and worth revisiting when the ingress queue depth is next tuned.
+
+## Round 17: the ceiling was macOS-specific, and the pool hurts Linux
+
+GitHub was down, so the PR could not be re-tested; running CI's checks locally
+in a Linux container answered a question the whole investigation had left
+open — **all of rounds 1–16 were measured on macOS.**
+
+An A/B of the branch against the merge-base, same container, same configs
+(CI's `ci_subset_*` shapes, 5 trials each):
+
+| Metric | Base | Branch | Delta |
+|---|---:|---:|---:|
+| p50 latency, fanout 1 | 82 µs | 154 µs | **+88%** |
+| p50 latency, fanout 10 | 87 µs | 149 µs | **+71%** |
+| Throughput, fanout 1 | 628 K msg/s | 577 K | −8% |
+| Throughput, fanout 10 | 1.46 M msg/s | 1.09 M | **−25%** |
+
+Distributions are tight on both sides (base 78–85 µs, branch 151–155 µs), so
+this is not noise. It is also what CI's "18 potential performance
+regressions" was reporting — that verdict was correct and was *not* an
+artifact of the round-16 shedding bug.
+
+### Which change, and can it be tuned out
+
+Bisected by environment switch on the branch binary:
+
+| Config | p50 |
+|---|---|
+| default | 151–152 µs |
+| **`FELIX_IO_RUNTIME_THREADS=0`** | **82–86 µs** (= base) |
+| `FELIX_ACK_FREQ_DISABLE=1` | 157–160 µs |
+| both off | 83–85 µs |
+
+The I/O runtime pool accounts for all of it; ACK-frequency tuning and ack
+pipelining are innocent (both remain active in the restored-latency config).
+No variant recovers it — pool sizes 1, 2, 4 and 8 all land at 150–153 µs, and
+disabling pump colocation only partially recovers throughput (1.09 M → 1.19 M
+against the base's 1.48 M) while leaving latency unchanged.
+
+### Why: Linux never had the ceiling
+
+The decisive number is the *base* Linux throughput: 628 K msg/s at 1 KiB is
+**~643 MB/s of payload**, higher than macOS reaches with every fix in this
+branch applied (461 MB/s at 1 KiB). The ~73 MB/s per-byte ceiling that
+started this investigation does not exist on Linux at all.
+
+That reframes the pool. It removes a macOS scheduling pathology — quinn's
+bounded-work drivers re-polling slowly on a shared, loaded runtime. Linux's
+scheduler evidently does not have that pathology, so isolating drivers there
+buys nothing and costs a cross-thread hop per datagram, which is exactly what
+the numbers show.
+
+### Disposition
+
+The pool defaults to `2` on macOS and `0` elsewhere. This is the same code
+shape as the round-16 gate that was reverted — but for the opposite reason,
+and this time with both platforms measured: not "Linux is unvalidated", but
+"Linux is measurably faster without it".
+
+**Open, and now the highest-value perf question:** Linux is the primary
+deployment target and has never been benchmarked properly. Everything
+published in `benchmarks.md` is macOS. Before any further transport tuning,
+the matrix should be run on a real Linux host to establish where its ceiling
+actually is — the optimization targets there are likely entirely different
+from the ones rounds 1–15 chased.
 
 ## Everything changed this session
 

--- a/scripts/perf/ci_subset_throughput.yml
+++ b/scripts/perf/ci_subset_throughput.yml
@@ -3,12 +3,22 @@
     "trials": 5
   },
   "workload": {
-    "fanout": [1, 10],
-    "batch": [64],
-    "payload_bytes": [1024],
+    "fanout": [
+      1,
+      10
+    ],
+    "batch": [
+      64
+    ],
+    "payload_bytes": [
+      1024
+    ],
     "warmup": 500,
     "total": 5000,
-    "binary": true
+    "binary": true,
+    "_comment_total": "total is a floor; scaled so payload*total >= min_run_bytes (see presets.yml).",
+    "min_run_bytes": 134217728,
+    "max_total": 200000
   },
   "profiles": {
     "balanced": {
@@ -27,10 +37,18 @@
   "presets": {
     "P8_hash": {
       "args": [
-        "--pub-conns", "4", "--pub-streams-per-conn", "2", "--pub-sharding", "hash_stream",
-        "--idle-ms", "10000"
+        "--pub-conns",
+        "4",
+        "--pub-streams-per-conn",
+        "2",
+        "--pub-sharding",
+        "hash_stream",
+        "--idle-ms",
+        "10000"
       ]
     }
   },
-  "preset_order": ["P8_hash"]
+  "preset_order": [
+    "P8_hash"
+  ]
 }

--- a/scripts/perf/fast.yml
+++ b/scripts/perf/fast.yml
@@ -1,6 +1,7 @@
 {
+  "_comment": "Fast chart pass: one profile, a representative preset subset, 3 trials. Run via `task perf:fast`, which invokes the matrix twice under one FELIX_PERF_SESSION_ID -- --filter 'batch=1,binary=False' (acked latency, the published headline configuration) and --filter 'batch=64,binary=True' (sustained throughput) -- so both halves aggregate as one session. This covers everything the published charts consume, and none of the cross-checking the full presets.yml matrix exists for (second profile, both encodings per batch shape, extra presets, 5 trials). Use the full matrix for anything surprising: 3 trials is enough to spot an outlier, not to characterize one.",
   "defaults": {
-    "trials": 5
+    "trials": 3
   },
   "workload": {
     "fanout": [
@@ -19,7 +20,6 @@
     ],
     "warmup": 2000,
     "total": 20000,
-    "_comment_binary": "Both encodings, deliberately. latency-demo enables per-message acks only when batch<=1 && !binary, so a binary-only sweep never measures the request-latency configuration the published headline number comes from -- and comparing the two shows a ~2x regression that does not exist.",
     "binary": [
       true,
       false
@@ -37,18 +37,6 @@
         "FELIX_EVENT_SEND_WINDOW": "268435456",
         "FELIX_EVENT_BATCH_MAX_DELAY_US": "250",
         "FELIX_PUBLISH_CHUNK_BYTES": "16384",
-        "FELIX_CACHE_CONN_POOL": "8",
-        "FELIX_CACHE_STREAMS_PER_CONN": "4"
-      }
-    },
-    "high_memory": {
-      "env": {
-        "FELIX_EVENT_CONN_POOL": "8",
-        "FELIX_EVENT_CONN_RECV_WINDOW": "536870912",
-        "FELIX_EVENT_STREAM_RECV_WINDOW": "134217728",
-        "FELIX_EVENT_SEND_WINDOW": "536870912",
-        "FELIX_EVENT_BATCH_MAX_DELAY_US": "250",
-        "FELIX_PUBLISH_CHUNK_BYTES": "32768",
         "FELIX_CACHE_CONN_POOL": "8",
         "FELIX_CACHE_STREAMS_PER_CONN": "4"
       }
@@ -103,18 +91,6 @@
         "hash_stream"
       ]
     },
-    "P8_hash_1stream": {
-      "args": [
-        "--pub-conns",
-        "4",
-        "--pub-streams-per-conn",
-        "2",
-        "--pub-stream-count",
-        "1",
-        "--pub-sharding",
-        "hash_stream"
-      ]
-    },
     "P8_rr": {
       "args": [
         "--pub-conns",
@@ -126,18 +102,6 @@
         "--pub-sharding",
         "rr"
       ]
-    },
-    "P8_rrN": {
-      "args": [
-        "--pub-conns",
-        "4",
-        "--pub-streams-per-conn",
-        "2",
-        "--pub-stream-count",
-        "8",
-        "--pub-sharding",
-        "rr"
-      ]
     }
   },
   "preset_order": [
@@ -145,9 +109,7 @@
     "P2_hash",
     "P4_hash",
     "P8_hash",
-    "P8_hash_1stream",
-    "P8_rr",
-    "P8_rrN"
+    "P8_rr"
   ],
   "chart_outlier_cap_percentile": 0.95
 }

--- a/scripts/perf/make_charts.py
+++ b/scripts/perf/make_charts.py
@@ -127,6 +127,7 @@ def chart_group(
     footer,
     cap_percentile=None,
     scale=None,
+    log_y=False,
 ):
     payload_positions = list(range(len(payloads)))
     group_width = 0.82
@@ -145,7 +146,14 @@ def chart_group(
     if cap_percentile is not None and raw_values:
         cap_value = percentile(raw_values, cap_percentile)
 
+    # A figure where every bar is absent is worse than no figure: it looks like
+    # a measurement of zero, or like the chart is broken. Refuse to emit one.
+    if not raw_values:
+        print(f"  skipping {output_path.name}: no data for {metric_key}")
+        return
+
     fig, ax = plt.subplots(figsize=(10, 5))
+    all_values: list = []
 
     for idx, preset in enumerate(presets):
         heights = []
@@ -175,6 +183,7 @@ def chart_group(
             else:
                 values.append(value / scale if scale else value)
                 clipped.append(False)
+        all_values.extend(v for v in values if v == v)  # drop NaN
         positions = [p + offsets[idx] for p in payload_positions]
         bars = ax.bar(positions, values, width=bar_width * 0.95, label=preset)
 
@@ -206,6 +215,14 @@ def chart_group(
                     rotation=90,
                     color="0.5",
                 )
+
+    # Message rate spans orders of magnitude across payload sizes (a 0 B run
+    # does millions/s, a 16 KiB run tens of thousands), so on a linear axis the
+    # large-payload bars round to nothing and read as "no throughput" when they
+    # are in fact the highest *byte* rates on the chart. Log scale keeps every
+    # bar legible; the MB/s companion chart is what to read for actual capacity.
+    if log_y and all_values and min(all_values) > 0:
+        ax.set_yscale("log")
 
     ax.set_xticks(payload_positions)
     ax.set_xticklabels([str(p) for p in payloads])
@@ -268,6 +285,10 @@ def main():
         profile, fanout, batch, binary, key_git_sha, key_hostname = key
         warmup = unique_or_mixed([r.get("warmup") for r in group_rows])
         total = unique_or_mixed([r.get("total") for r in group_rows])
+        if total == "mixed" and isinstance(batch, int) and batch > 1:
+            # Throughput runs scale message count per payload so run volume
+            # exceeds the QUIC send window (see run_latency_matrix.py).
+            total = "volume-scaled"
         trials = unique_or_mixed([r.get("trial_count") for r in group_rows])
         git_sha = key_git_sha
 
@@ -358,6 +379,31 @@ def main():
                 footer,
                 cap_percentile,
                 scale,
+                log_y=True,
+            )
+
+        # Byte rate, the only cross-payload-comparable throughput number.
+        # Message rate necessarily falls as payloads grow, so a msg/s chart
+        # makes large payloads look like a regression when they are usually
+        # moving the most data. 0 B carries no payload bytes and is excluded
+        # rather than drawn as a zero bar.
+        byte_payloads = [p for p in payloads if p > 0]
+        if byte_payloads:
+            for row in group_rows:
+                delivered = row.get("delivered_throughput_median")
+                payload = row.get("payload_bytes")
+                if delivered is not None and payload:
+                    row["delivered_mb_per_s"] = delivered * payload / 1e6
+            chart_group(
+                group_rows,
+                "delivered_mb_per_s",
+                "delivered payload (MB/s)",
+                f"{title_prefix} - delivered payload byte rate",
+                base_name.with_name(base_name.name + "_delivered_mb_per_s"),
+                presets,
+                byte_payloads,
+                footer,
+                cap_percentile,
             )
 
 

--- a/scripts/perf/normalize_and_aggregate.py
+++ b/scripts/perf/normalize_and_aggregate.py
@@ -46,6 +46,7 @@ def flatten_run(run: dict) -> dict:
     host = run.get("host_info") or {}
     row = {
         "run_id": run.get("run_id"),
+        "session_id": run.get("session_id"),
         "timestamp": run.get("timestamp"),
         "git_sha": run.get("git_sha"),
         "git_dirty": run.get("git_dirty"),
@@ -242,13 +243,80 @@ def write_parquet(rows: list, path: Path):
         print("Skipping parquet write (pyarrow/pandas not available).")
 
 
+def select_session(runs: list, selector: str):
+    """Narrow the append-only raw log to one matrix invocation.
+
+    `data/raw/latency_demo_runs.jsonl` accumulates every run ever performed, so
+    without this the derived CSVs and every chart built from them silently mix
+    unrelated code states. That is not a cosmetic problem: it produced charts
+    holding a single bar with every other payload absent, because an old session
+    had only ever run a subset of the matrix.
+
+    Sessions are keyed by `session_id`. Records written before that field
+    existed fall back to (git_sha, git_dirty, hostname), which is coarser --
+    several dirty-tree sessions on one commit collapse together -- so those are
+    reported as legacy.
+    """
+    def key(run):
+        sid = run.get("session_id")
+        if sid:
+            return ("session", sid)
+        host = (run.get("host_info") or {}).get("hostname")
+        return ("legacy", f"{run.get('git_sha')}|{run.get('git_dirty')}|{host}")
+
+    groups = {}
+    for run in runs:
+        groups.setdefault(key(run), []).append(run)
+    if not groups:
+        return runs, []
+    # Newest first, by the latest timestamp seen in each group.
+    ordered = sorted(
+        groups.items(),
+        key=lambda kv: max(r.get("timestamp") or "" for r in kv[1]),
+        reverse=True,
+    )
+
+    if selector == "all":
+        chosen = ordered
+    elif selector == "latest":
+        chosen = ordered[:1]
+    else:
+        chosen = [(k, v) for k, v in ordered if k[1].startswith(selector)]
+        if not chosen:
+            raise SystemExit(f"no session matches {selector!r}")
+
+    chosen_keys = {k for k, _ in chosen}
+    kept = [r for r in runs if key(r) in chosen_keys]
+    skipped = [(k, len(v)) for k, v in ordered if k not in chosen_keys]
+
+    for kind, ident in (k for k, _ in chosen):
+        label = "session" if kind == "session" else "legacy group"
+        count = len(groups[(kind, ident)])
+        print(f"Using {label} {ident} ({count} runs)")
+    if skipped:
+        total = sum(n for _, n in skipped)
+        print(
+            f"Excluded {total} stale run(s) across {len(skipped)} earlier "
+            f"session(s); pass --session all to include them."
+        )
+    return kept, skipped
+
+
 def main():
     parser = argparse.ArgumentParser(description="Normalize and aggregate latency_demo JSONL.")
     parser.add_argument("--input", default=str(RAW_JSONL))
+    parser.add_argument(
+        "--session",
+        default="latest",
+        help="Which matrix invocation to derive from: 'latest' (default), "
+        "'all', or a session id prefix. The raw log is append-only, so "
+        "'all' mixes code states and is almost never what you want.",
+    )
     args = parser.parse_args()
 
     raw_path = Path(args.input)
     runs = load_runs(raw_path)
+    runs, _ = select_session(runs, args.session)
     rows = [flatten_run(r) for r in runs]
     write_csv(RUNS_CSV, rows)
     write_parquet(rows, RUNS_CSV.with_suffix(".parquet"))

--- a/scripts/perf/requirements.txt
+++ b/scripts/perf/requirements.txt
@@ -7,3 +7,4 @@ matplotlib>=3.8
 # Optional: enables parquet output alongside CSV in normalize_and_aggregate.py.
 # Silently skipped if not installed.
 pandas>=2.2
+pyarrow>=25.0.0

--- a/scripts/perf/run_latency_matrix.py
+++ b/scripts/perf/run_latency_matrix.py
@@ -21,7 +21,10 @@ RAW_JSONL = RAW_DIR / "latency_demo_runs.jsonl"
 DURATION_RE = re.compile(r"^([0-9]*\.?[0-9]+)\s*(us|ms)$")
 RESULTS_RE = re.compile(
     r"Results \(publish n = (?P<publish>\d+), sampled (?P<sampled>\d+), received (?P<received>\d+), "
-    r"(?:dropped|delivery drops) (?P<dropped>\d+)\) payload=(?P<payload>\d+)B "
+    # `unaccounted` is the current name (an expected-minus-observed shortfall,
+    # not a queue-drop counter); `dropped`/`delivery drops` are accepted so the
+    # parser can still read stdout captured before the rename.
+    r"(?:dropped|delivery drops|unaccounted) (?P<dropped>\d+)\) payload=(?P<payload>\d+)B "
     r"fanout=(?P<fanout>\d+) batch=(?P<batch>\d+) "
     r"(?:binary|publish_fastpath)=(?P<binary>true|false):"
 )
@@ -183,6 +186,28 @@ def matches_filter(filters: dict, item: dict) -> bool:
     return True
 
 
+def effective_total(workload: dict, batch: int, payload: int) -> int:
+    """Scale message count so throughput runs measure sustained rate.
+
+    A batch>1 run whose total payload volume fits inside the QUIC connection
+    send window (64 MiB) measures buffer-fill rate, not throughput — the whole
+    run is absorbed before backpressure appears, and the harness stops its
+    clock when the last event arrives. Latency runs (batch<=1, acked) are
+    paced per message and unaffected.
+
+    `min_run_bytes` (default 256 MiB) and `max_total` (default 500k, which
+    caps the blow-up for tiny payloads whose runs are per-message-bound
+    anyway) are configurable per config file.
+    """
+    total = workload["total"]
+    if batch <= 1:
+        return total
+    min_run_bytes = workload.get("min_run_bytes", 256 * 1024 * 1024)
+    max_total = workload.get("max_total", 500_000)
+    needed = -(-min_run_bytes // max(payload, 1))  # ceil div
+    return max(total, min(needed, max_total))
+
+
 def build_matrix(config: dict, trials: int, binary_override=None):
     workload = config["workload"]
     profiles = config["profiles"]
@@ -217,7 +242,7 @@ def build_matrix(config: dict, trials: int, binary_override=None):
                                     "batch": batch,
                                     "payload_bytes": payload,
                                     "warmup": workload["warmup"],
-                                    "total": workload["total"],
+                                    "total": effective_total(workload, batch, payload),
                                     "binary": bool(binary),
                                     "preset": preset_name,
                                     "preset_args": preset.get("args", []),
@@ -225,6 +250,14 @@ def build_matrix(config: dict, trials: int, binary_override=None):
                                 }
                             )
     return matrix
+
+
+# One id per matrix invocation, stamped on every record it writes.
+# FELIX_PERF_SESSION_ID overrides it so several filtered invocations (e.g. the
+# fast pass's latency and throughput halves) land in one session and
+# normalize_and_aggregate.py keeps them together instead of discarding all but
+# the last invocation as stale.
+SESSION_ID = os.environ.get("FELIX_PERF_SESSION_ID") or str(uuid.uuid4())
 
 
 def main():
@@ -410,6 +443,12 @@ def main():
 
                 record = {
                     "run_id": run_id,
+                    # Identifies this matrix invocation. `git_sha` cannot do it:
+                    # the interesting changes are usually uncommitted, so several
+                    # sessions share one sha with `git_dirty: true`. The raw JSONL
+                    # is append-only, so without this the derived data silently
+                    # mixes every run ever performed.
+                    "session_id": SESSION_ID,
                     "timestamp": timestamp,
                     "git_sha": git_sha,
                     "git_dirty": bool(git_dirty),

--- a/services/broker/src/auth.rs
+++ b/services/broker/src/auth.rs
@@ -1,23 +1,16 @@
-//! Broker-side authentication and JWKS caching.
+//! Broker-side authentication: JWKS caching and Felix token verification.
 //!
-//! Fetch and cache tenant JWKS from the control-plane, then verify Felix tokens
-//! using EdDSA (Ed25519) public keys.
+//! Felix tokens are EdDSA (Ed25519); RSA is never accepted here. JWKS fetched
+//! from the control plane carries public key material only, and is treated as
+//! untrusted input -- key shape and length are checked before use. `kid` guides
+//! which key is tried first, but verification still tries all of them, so a
+//! rotation in progress does not reject valid tokens.
 //!
-//! - Felix-issued tokens must be EdDSA; RSA is never accepted for broker auth.
-//! - JWKS data contains only public key material; private keys are never loaded.
-//! - `kid` guides verification order but verification still tries all keys.
-//!
-//! - Attackers may present arbitrary bearer tokens; we validate signature,
-//!   issuer, audience, and tenant ID via `felix_authz`.
-//! - JWKS endpoints are public; we treat the data as untrusted input and validate
-//!   key shape/length before use.
-//! - No tokens or keys are logged to avoid secret leakage.
-//!
-//! - JWKS cache is thread-safe via `DashMap`.
-//! - Key cache invalidation is per-tenant and coordinated with JWKS refresh.
+//! The JWKS cache is a `DashMap`; invalidation is per-tenant and coordinated
+//! with refresh. Nothing here logs a token or a key.
 //!
 //! Construct [`BrokerAuth`] with the control-plane URL and call
-//! [`BrokerAuth::authenticate`] to validate a token and obtain an [`AuthContext`].
+//! [`BrokerAuth::authenticate`] to get an [`AuthContext`].
 //!
 //! # Examples
 //! ```rust,no_run
@@ -25,13 +18,6 @@
 //!
 //! let auth = BrokerAuth::new("http://controlplane".to_string());
 //! ```
-//!
-//! # Common pitfalls
-//! - Forgetting to warm the JWKS cache leads to auth latency on first request.
-//! - Not invalidating cache on JWKS rotation keeps stale public keys in memory.
-//!
-//! # Future work
-//! - Add background JWKS refresh to avoid on-demand fetches under load.
 use anyhow::{Context, Result};
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -59,13 +45,6 @@ use std::time::{Duration, Instant};
 ///
 /// # Concurrency
 /// - Cloning shares the verifier and key store via `Arc`.
-///
-/// # Example
-/// ```rust,no_run
-/// use broker::auth::BrokerAuth;
-///
-/// let auth = BrokerAuth::new("http://controlplane".to_string());
-/// ```
 #[derive(Clone)]
 pub struct BrokerAuth {
     verifier: Arc<FelixTokenVerifier>,
@@ -86,13 +65,6 @@ impl BrokerAuth {
     /// - The verifier is pinned to `iss=felix-auth` and `aud=felix-broker`.
     ///
     /// - Construction is O(1); network IO happens during authentication.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// use broker::auth::BrokerAuth;
-    ///
-    /// let auth = BrokerAuth::new("http://controlplane".to_string());
-    /// ```
     pub fn new(controlplane_url: String) -> Self {
         // We share a key cache between the verifier and JWKS store so that
         // refreshing JWKS invalidates cached decoding keys reliably.

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -296,10 +296,62 @@ pub(crate) async fn handle_connection_with_shutdown(
     // Tracks the per-stream handler tasks so shutdown can wait for in-flight
     // work instead of dropping it.
     let streams = TaskTracker::new();
+
+    // Periodic path stats for a *healthy* connection. The close-path logs below
+    // only fire once the connection is already going away, which is too late to
+    // see how path MTU, loss and congestion evolved under load — the numbers that
+    // decide whether a throughput problem is transport-side or above it.
+    // Off unless `FELIX_CONN_STATS_MS` is set, so it costs nothing in production.
+    // Driven from the accept loop rather than a spawned task so it cannot outlive
+    // the connection it reports on.
+    let stats_interval_ms = std::env::var("FELIX_CONN_STATS_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|ms| *ms > 0);
+    let mut stats_ticker =
+        stats_interval_ms.map(|ms| tokio::time::interval(Duration::from_millis(ms)));
     loop {
         // Accept both bidirectional control streams and uni-directional publish streams.
         tokio::select! {
             biased;
+            // `udp_tx.ios` vs `udp_tx.datagrams` separates syscall count from
+            // datagram count (they diverge only where GSO applies), and
+            // `udp_tx.bytes / udp_tx.datagrams` is the effective datagram size —
+            // which is what tells you whether path MTU is actually being used.
+            _ = async { stats_ticker.as_mut().expect("ticker present").tick().await },
+                if stats_ticker.is_some() =>
+            {
+                let stats = connection.stats();
+                tracing::info!(
+                    conn = connection.info().id.0,
+                    mtu = stats.path.current_mtu,
+                    // A small cwnd here is a send-rate cap no queue or
+                    // topology change can lift.
+                    cwnd = stats.path.cwnd,
+                    rtt_us = stats.path.rtt.as_micros() as u64,
+                    sent_packets = stats.path.sent_packets,
+                    lost_packets = stats.path.lost_packets,
+                    congestion_events = stats.path.congestion_events,
+                    black_holes = stats.path.black_holes_detected,
+                    udp_tx_datagrams = stats.udp_tx.datagrams,
+                    udp_tx_bytes = stats.udp_tx.bytes,
+                    udp_tx_ios = stats.udp_tx.ios,
+                    udp_rx_datagrams = stats.udp_rx.datagrams,
+                    udp_rx_bytes = stats.udp_rx.bytes,
+                    udp_rx_ios = stats.udp_rx.ios,
+                    // Non-zero *_blocked means this endpoint had bytes to send and
+                    // was denied credit by the peer -- i.e. the peer is not
+                    // consuming fast enough. Zero means flow control is not the
+                    // constraint and the sender simply had nothing more to send.
+                    tx_data_blocked = stats.frame_tx.data_blocked,
+                    tx_stream_data_blocked = stats.frame_tx.stream_data_blocked,
+                    rx_data_blocked = stats.frame_rx.data_blocked,
+                    rx_stream_data_blocked = stats.frame_rx.stream_data_blocked,
+                    tx_max_data = stats.frame_tx.max_data,
+                    rx_max_data = stats.frame_rx.max_data,
+                    "quic connection path stats"
+                );
+            }
             _ = shutdown.cancelled() => {
                 tracing::info!(
                     stats = ?connection.stats(),

--- a/services/broker/src/transport/quic/handlers/subscribe/lane.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/lane.rs
@@ -218,17 +218,26 @@ impl WriterLaneManager {
     pub(super) fn ensure_connection_writer(
         &self,
         connection_id: u64,
+        connection: Option<&felix_transport::QuicConnection>,
     ) -> mpsc::Sender<ConnectionCommand> {
         match self.connection_writers.entry(connection_id) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(entry) => {
                 let (tx, rx) = mpsc::channel(self.connection_queue_capacity.max(1));
                 entry.insert(tx.clone());
-                tokio::spawn(run_connection_writer(
-                    connection_id,
-                    rx,
-                    self.max_bytes_per_write,
-                ));
+                let writer = run_connection_writer(connection_id, rx, self.max_bytes_per_write);
+                // Colocate with the connection's transport drivers (`spawn_pump`)
+                // so per-write wakeups stay on-thread. Register always creates
+                // the writer; the `None` arm only covers a delivery racing
+                // ahead of its registration.
+                match connection {
+                    Some(connection) => {
+                        connection.spawn_pump(writer);
+                    }
+                    None => {
+                        tokio::spawn(writer);
+                    }
+                }
                 tx
             }
         }
@@ -239,7 +248,11 @@ impl WriterLaneManager {
         connection_id: u64,
         cmd: ConnectionCommand,
     ) -> std::result::Result<(), ()> {
-        let sender = self.ensure_connection_writer(connection_id);
+        let connection = match &cmd {
+            ConnectionCommand::Register { connection, .. } => Some(connection.clone()),
+            _ => None,
+        };
+        let sender = self.ensure_connection_writer(connection_id, connection.as_ref());
         let conn_label = connection_id.to_string();
         let wait_start = Instant::now();
         let is_control = matches!(

--- a/services/broker/src/transport/quic/handlers/subscribe/tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/tests.rs
@@ -1103,8 +1103,10 @@ async fn run_event_writer_flushes_on_channel_close() -> Result<()> {
     let (server_task, connection) = spawn_event_writer(rx, config).await?;
     tx.send(make_payload(b"closed")).await?;
     drop(tx);
-    drop(connection);
+    // Keep the client connection open until the writer has flushed: dropping it
+    // first races CONNECTION_CLOSE against the flush and fails intermittently.
     server_task.await.context("server join")??;
+    drop(connection);
     Ok(())
 }
 
@@ -1336,7 +1338,7 @@ async fn concurrent_lanes_share_one_connection_writer() {
         let barrier = Arc::clone(&barrier);
         tasks.push(tokio::spawn(async move {
             barrier.wait().await;
-            manager.ensure_connection_writer(42)
+            manager.ensure_connection_writer(42, None)
         }));
     }
 

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -475,6 +475,13 @@ async fn publish_sharding_preserves_stream_order() -> Result<()> {
     let config = BrokerConfig {
         subscriber_queue_policy: felix_broker::SubQueuePolicy::Block,
         subscriber_lane_queue_policy: felix_broker::SubQueuePolicy::Block,
+        // Losslessness needs the *publish* side to block too. Checkpoint 4 (the
+        // per-worker ingress queue, depth 64) defaults to `Drop`, so an unacked
+        // burst that outruns the broker core is shed by design — measured here
+        // as 77 of 400 publishes dropped, which reads as a delivery stall
+        // because the events were never published at all. Blocking pins the
+        // whole path, which is what this test's ordering assertion assumes.
+        pub_ingress_wait: true,
         ..BrokerConfig::default()
     };
     let server_task = tokio::spawn(crate::transport::quic::serve(

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -441,7 +441,20 @@ async fn publish_ack_on_commit_smoke() -> Result<()> {
 #[serial]
 // This test prevents regressions in `publish_sharding_preserves_stream_order` behavior.
 async fn publish_sharding_preserves_stream_order() -> Result<()> {
-    let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+    // Ordering assertion, not a latency assertion. The QUIC I/O runtime pool is
+    // process-global, so under `cargo test` parallelism dozens of concurrent
+    // brokers and clients share it; a tight per-event deadline then fails on
+    // scheduling pressure rather than on a real ordering defect. Generous
+    // enough that only a genuine stall trips it.
+    const EVENT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    // Asserts lossless in-order delivery, so every queue on the path must
+    // Block: the DropNew defaults may legally shed under a loaded test host,
+    // which reads as a gap here.
+    let broker = Arc::new(
+        Broker::new(EphemeralCache::new().into())
+            .with_subscriber_queue_policy(felix_broker::SubQueuePolicy::Block),
+    );
     broker.register_tenant("t1").await?;
     broker.register_namespace("t1", "default").await?;
     broker
@@ -459,7 +472,11 @@ async fn publish_sharding_preserves_stream_order() -> Result<()> {
     )?);
     let addr = server.local_addr()?;
 
-    let config = BrokerConfig::default();
+    let config = BrokerConfig {
+        subscriber_queue_policy: felix_broker::SubQueuePolicy::Block,
+        subscriber_lane_queue_policy: felix_broker::SubQueuePolicy::Block,
+        ..BrokerConfig::default()
+    };
     let server_task = tokio::spawn(crate::transport::quic::serve(
         Arc::clone(&server),
         Arc::clone(&broker),
@@ -467,10 +484,12 @@ async fn publish_sharding_preserves_stream_order() -> Result<()> {
         Arc::clone(&auth.auth),
     ));
 
+    let mut client_config = build_client_config(cert, &auth)?;
+    client_config.client_sub_queue_policy = felix_client::ClientSubQueuePolicy::Block;
     let client = felix_client::Client::connect_with_transport(
         addr,
         "localhost",
-        build_client_config(cert, &auth)?,
+        client_config,
         TransportConfig::default(),
     )
     .await?;
@@ -496,21 +515,26 @@ async fn publish_sharding_preserves_stream_order() -> Result<()> {
             .await?;
     }
 
-    for i in 0..total {
-        let next = timeout(Duration::from_secs(2), sub_alpha.next_event()).await??;
+    let mut alpha_seen = Vec::with_capacity(total as usize);
+    for _ in 0..total {
+        let next = timeout(EVENT_TIMEOUT, sub_alpha.next_event()).await??;
         let event = next.expect("alpha event");
         let mut raw = [0u8; 8];
         raw.copy_from_slice(&event.payload[..8]);
-        assert_eq!(u64::from_be_bytes(raw), i);
+        alpha_seen.push(u64::from_be_bytes(raw));
     }
+    let expected: Vec<u64> = (0..total).collect();
+    assert_eq!(alpha_seen, expected, "alpha sequence diverged");
 
-    for i in 0..total {
-        let next = timeout(Duration::from_secs(2), sub_beta.next_event()).await??;
+    let mut beta_seen = Vec::with_capacity(total as usize);
+    for _ in 0..total {
+        let next = timeout(EVENT_TIMEOUT, sub_beta.next_event()).await??;
         let event = next.expect("beta event");
         let mut raw = [0u8; 8];
         raw.copy_from_slice(&event.payload[..8]);
-        assert_eq!(u64::from_be_bytes(raw), i);
+        beta_seen.push(u64::from_be_bytes(raw));
     }
+    assert_eq!(beta_seen, expected, "beta sequence diverged");
 
     publisher.finish().await?;
     server_task.abort();

--- a/services/controlplane/src/auth/felix_token.rs
+++ b/services/controlplane/src/auth/felix_token.rs
@@ -1,35 +1,21 @@
-//! Felix JWT token minting and verification helpers.
+//! Minting and verification of Felix JWTs -- tenant-scoped access tokens the
+//! broker and control-plane APIs accept.
 //!
-//! Define claim structures and helpers for signing/verifying tenant-scoped
-//! access tokens used by the broker and control-plane APIs.
+//! Felix tokens are **always EdDSA (Ed25519)**, never RSA or HS variants, and
+//! verification rejects anything else outright. That is a deliberate narrowing:
+//! an attacker supplies the token, so accepting a second algorithm means
+//! accepting whichever is weakest. `iss`, `aud` and `tid` are mandatory and
+//! checked before a token is trusted.
 //!
-//! Centralizes Felix token semantics (claims, issuer/audience, EdDSA signing)
-//! and key caching to ensure consistent verification across services.
+//! A signing key is a 32-byte Ed25519 seed with its derived public key and a
+//! `kid` for rotation. `kid` is not a secret; the seed is, and it must not
+//! leave the control-plane trust boundary or reach a log. Public keys are
+//! published via JWKS elsewhere.
 //!
-//! - Token exchange handler mints Felix tokens.
-//! - Broker and control-plane components verify Felix tokens.
-//! - Tests that assert EdDSA-only behavior and key rotation logic.
-//!
-//! - Felix tokens are always EdDSA (Ed25519) and never RSA/HS variants.
-//! - `iss`, `aud`, and `tid` claims are mandatory and validated.
-//! - The private key is a 32-byte Ed25519 seed; the public key must match it.
-//!
-//! Thread-safe key cache protected by `RwLock`; safe for concurrent reads and
-//! rare writes when keys rotate or are first used.
-//!
-//! # Security boundary
-//! This module handles private key material and must only be used within the
-//! control-plane trust boundary. Public keys may be exported via JWKS elsewhere.
-//!
-//! # Security model and threat assumptions
-//! - Attackers may supply arbitrary JWTs; we validate algorithm, issuer,
-//!   audience, and tenant ID before accepting.
-//! - Ed25519 is chosen for constant-time signing and smaller keys to reduce
-//!   side-channel risk compared to RSA.
-//! - Key IDs (`kid`) are used for rotation but are not secrets.
-//!
-//! Use [`mint_token`] to issue a Felix token and [`verify_token`] to validate it
-//! against a tenant's signing keys, including rotation handling.
+//! Verification tries the tenant's current key and then its previous ones, so a
+//! rotation does not invalidate tokens already in flight. The key cache is
+//! behind an `RwLock`: many concurrent reads, writes only on rotation or first
+//! use.
 //!
 //! # Examples
 //! ```rust
@@ -51,13 +37,6 @@
 //! };
 //! let _ = mint_token(&keys, "tenant-a", "principal", vec![], Duration::from_secs(60));
 //! ```
-//!
-//! # Common pitfalls
-//! - Using mismatched issuer/audience values across services.
-//! - Forgetting to validate rotated keys before issuing or verifying tokens.
-//!
-//! # Future work
-//! - Add structured key rotation metadata for safe rollout/rollback.
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use ed25519_dalek::SigningKey as Ed25519SigningKey;
@@ -366,46 +345,14 @@ impl From<jsonwebtoken::errors::Error> for TokenError {
     }
 }
 
-/// Mint a Felix EdDSA token for a tenant and principal.
+/// Mint a Felix EdDSA token for `tenant_id` / `principal_id`, valid for `ttl`.
 ///
-/// Builds Felix claims, enforces key validity, and signs using Ed25519.
-///
-/// - `keys`: Tenant signing keys, including current key for signing.
-/// - `tenant_id`: Tenant identifier to embed in `tid`.
-/// - `principal_id`: Subject identifier to embed in `sub`.
-/// - `perms`: Permission strings granted to the token.
-/// - `ttl`: Time-to-live for the token.
-///
-/// - `Ok(String)` containing the signed JWT.
+/// The algorithm is pinned to EdDSA and the claims always carry `iss`, `aud`
+/// and `tid`. Uses a cached encoding key so repeated mints do not redo the
+/// PKCS8 conversion. Never log the returned token.
 ///
 /// # Errors
-/// - `TokenError::Key` if key validation fails.
-/// - `TokenError::Jwt` if encoding fails.
-/// # Examples
-/// ```rust
-/// use controlplane::auth::felix_token::{mint_token, SigningKey, TenantSigningKeys};
-/// use ed25519_dalek::SigningKey as Ed25519SigningKey;
-/// use jsonwebtoken::Algorithm;
-/// use std::time::Duration;
-///
-/// let seed = [1u8; 32];
-/// let signing_key = Ed25519SigningKey::from_bytes(&seed);
-/// let keys = TenantSigningKeys {
-///     current: SigningKey {
-///         kid: "k1".to_string(),
-///         alg: Algorithm::EdDSA,
-///         private_key: seed,
-///         public_key: signing_key.verifying_key().to_bytes(),
-///     },
-///     previous: vec![],
-/// };
-/// let _ = mint_token(&keys, "tenant-a", "principal", vec![], Duration::from_secs(60));
-/// ```
-///
-/// - The algorithm is pinned to EdDSA and the token includes `iss`, `aud`, `tid`.
-/// - Never log the resulting token in production logs.
-///
-/// - Uses a cached encoding key to avoid repeated PKCS8 conversion.
+/// `TokenError::Key` if key validation fails, `TokenError::Jwt` if encoding does.
 pub fn mint_token(
     keys: &TenantSigningKeys,
     tenant_id: &str,

--- a/services/controlplane/src/auth/keys.rs
+++ b/services/controlplane/src/auth/keys.rs
@@ -1,38 +1,20 @@
-//! Signing key generation helpers for Felix tenant JWTs.
+//! Generation of tenant Ed25519 signing keys for Felix JWTs.
 //!
-//! Produce tenant-scoped Ed25519 signing keys that the control-plane stores and
-//! later exposes (public parts only) via JWKS for broker verification.
+//! Ed25519 only, and it has to stay that way: signing is constant-time by
+//! design, which sidesteps the RSA timing pitfalls, and Felix verification
+//! rejects every other algorithm anyway.
 //!
-//! This module is the single source of truth for Felix tenant signing key
-//! generation. It is invoked by control-plane provisioning and rotation flows
-//! and feeds downstream JWKS publication and broker verification.
+//! The private key is a raw 32-byte seed, *not* PKCS8 DER, and the public key is
+//! derived from that seed rather than stored alongside it -- a stored pair can
+//! drift, a derived one cannot. `kid` is random, used for rotation and cache
+//! lookup, and is not a secret.
 //!
-//! - Control-plane tenant provisioning and rotation logic.
-//! - Tests that need deterministic key material for Felix JWTs.
+//! Generation is pure and stateless, so it is safe to call concurrently. The
+//! private material it returns must never be serialized or logged outside the
+//! control-plane store; only public keys cross the boundary, via JWKS.
 //!
-//! - Keys are always Ed25519 and must remain that way for Felix-issued tokens.
-//! - The private key is a raw 32-byte Ed25519 seed (not PKCS8 DER), and the
-//!   public key is derived from that seed to avoid mismatches.
-//! - Private key material must never be serialized or logged outside storage.
-//!
-//! Pure, stateless key generation with no shared mutable state; safe to call
-//! concurrently from multiple async tasks.
-//!
-//! # Security boundary
-//! This module generates private key material and must only be used inside the
-//! control-plane trust boundary. Public keys may cross the boundary via JWKS,
-//! but private keys must never leave storage.
-//!
-//! # Security model and threat assumptions
-//! - We assume attackers can observe tokens and JWKS but cannot read the
-//!   control-plane's private key storage.
-//! - Ed25519 is used to avoid RSA timing pitfalls and because it is constant-time
-//!   by design for signing, reducing side-channel risk.
-//! - Key IDs (`kid`) are random and used for rotation and cache lookups, not as
-//!   a secret.
-//!
-//! Call [`generate_signing_keys`] during tenant provisioning or key rotation and
-//! persist the returned [`TenantSigningKeys`] in the control-plane store.
+//! Call [`generate_signing_keys`] during provisioning or rotation and persist
+//! the returned [`TenantSigningKeys`].
 use crate::auth::felix_token::{SigningKey, TenantSigningKeys};
 use anyhow::Result;
 use ed25519_dalek::SigningKey as Ed25519SigningKey;

--- a/services/controlplane/src/auth/oidc.rs
+++ b/services/controlplane/src/auth/oidc.rs
@@ -1,37 +1,21 @@
-//! OIDC token validation with cached discovery and JWKS fetching.
+//! Validation of upstream IdP tokens -- the boundary between an external
+//! identity provider and Felix's own authorization.
 //!
-//! Validate inbound IdP bearer tokens against configured issuers using cached
-//! discovery documents and JWKS with TTL-based refresh.
+//! ES256 is the default and only algorithm. RS* and PS* can be enabled by
+//! configuration but are off by default because of the Marvin side-channel
+//! attack, which has no known mitigation in Rust's crypto libraries today; many
+//! IdPs publish RSA keys via JWKS, so the allowlist is opt-in rather than
+//! absent. Felix's own EdDSA tokens are a separate path entirely.
 //!
-//! Provides the IdP boundary for the control-plane: it verifies upstream tokens
-//! (ES256/RS*/PS* based on configured allowlist) before issuing Felix EdDSA tokens elsewhere.
+//! Claims are decoded once *without* verification purely to find the issuer, so
+//! the right JWKS can be fetched. Everything else -- issuer, audience,
+//! signature -- is checked only after that, against configuration.
 //!
-//! - Token exchange endpoint (`/token/exchange`) validates IdP tokens.
-//! - Tests that exercise JWKS caching and issuer validation.
+//! Discovery documents and JWKS are cached with a TTL and refreshed on demand,
+//! in a `DashMap` so concurrent tasks share them without a global lock.
 //!
-//! - Only ES256 is accepted by default.
-//! - RS256/RS384/RS512 and PS256/PS384/PS512 can be enabled via configuration.
-//! - Felix tokens are EdDSA and handled in a separate module.
-//! - RSA/PS algorithms are disabled by default because of the Marvin side-channel attack
-//!   which currently has no known mitigations in Rust's crypto libraries.
-//! - Issuer and audience claims are validated against configuration.
-//! - JWKS and discovery caches are time-bounded and refreshed on demand.
-//!
-//! Shared caches are stored in `DashMap` for concurrent read/write access across
-//! async tasks without global locks.
-//!
-//! # Security boundary
-//! This module is the boundary between external IdP tokens and the internal
-//! authorization system. It must reject unsupported algorithms and issuers.
-//!
-//! # Security model and threat assumptions
-//! - Attackers may craft tokens; we validate issuer, audience, and signature.
-//! - RSA/PS support is opt-in via allowlist because many IdPs publish RSA keys via JWKS.
-//! - We decode claims without verification only to locate the issuer; all other
-//!   validation happens after signature verification.
-//!
-//! Construct an [`UpstreamOidcValidator`] and call [`UpstreamOidcValidator::validate`]
-//! with the bearer token and configured issuers.
+//! Construct an [`UpstreamOidcValidator`] and call
+//! [`UpstreamOidcValidator::validate`].
 use crate::auth::idp_registry::IdpIssuerConfig;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;

--- a/services/controlplane/src/store/postgres.rs
+++ b/services/controlplane/src/store/postgres.rs
@@ -212,16 +212,6 @@ impl PostgresStore {
     ///
     /// - Avoid logging `pg.url` as it may contain credentials.
     /// - Use TLS and least-privilege DB roles in production.
-    ///
-    /// # Example
-    /// ```rust,no_run
-    /// use controlplane::config::PostgresConfig;
-    /// use controlplane::store::{StoreConfig, postgres::PostgresStore};
-    ///
-    /// async fn open(pg: PostgresConfig, cfg: StoreConfig) {
-    ///     let _ = PostgresStore::connect(&pg, cfg).await;
-    /// }
-    /// ```
     pub async fn connect(pg: &PostgresConfig, config: StoreConfig) -> StoreResult<Self> {
         #[cfg(any(test, feature = "pg-tests"))]
         let _ = Self::connect_without_migrations;


### PR DESCRIPTION
Transport (crates/felix-transport):
- Loopback peers connect/accept with a guaranteed MTU (initial_mtu =
  min_mtu = 16336, discovery bound pinned): quinn's black-hole detector
  misread congestive loss bursts as MTU black holes and pinned the path at
  1200 B for the life of the load (~13.6x datagrams/byte, the "one run in
  three is 5-6x slower" bimodality). Recovery probes are starved by any
  backlogged sender, so prevention beats healing on the one path where the
  MTU is knowable. Also: initial congestion window now scales with initial
  MTU per RFC 9002 (quinn's flat 14,720 B otherwise deadlocks the handshake
  above it), and doomed discovery probes no longer starve quiet connections
  at the two-segment window.
- black_hole_cooldown 60s -> 2s for non-loopback paths
  (FELIX_MTU_BLACK_HOLE_COOLDOWN_MS).

Client (crates/felix-client):
- Acked publishes are pipelined: the writer hands written requests to a
  per-stream ack reader instead of awaiting each broker ack inline, lifting
  the 1-request-per-RTT cap per stream for concurrent publishers. Admission
  permits ride with the pending ack so the inflight byte budget bounds
  unacked data. Regression test deadlocks against the inline-wait code.

Benchmarks: 0/20 slow fresh-process runs (was 5/16 at ~21K msg/s), 4 KiB
median ~508 MB/s, worst/median 1.03-1.12x (was 5.9x), 256 B nearly doubled
to 1.4M msg/s. Latency profile unchanged. core_shards re-measured on the
fixed pipeline: +1%, within variance; default stays off.

Tooling: task perf:fast (~15 min chart pass: shared-session filtered matrix
halves via FELIX_PERF_SESSION_ID); matrix parser accepts the round-14
"unaccounted" field rename (every run failed to parse since).

Docs: performance case study rewritten around both defects; benchmarks page
gets post-fix tables, throughput charts (fanout 1 and 10), and the resolved
bimodality note; pubsub/client-config document ack pipelining; env-vars,
internals-concurrency, quic-transport, what-felix-is-for refreshed; full
investigation log in docs/perf-investigation-throughput.md. Site chart SVGs
force-added past the charts/ gitignore so the deployed site renders them.
