### PR TITLE
feat(storage): enforce retention on durable logs (#198)

### DIFF
--- a/crates/felix-broker/src/durable.rs
+++ b/crates/felix-broker/src/durable.rs
@@ -153,11 +153,23 @@ impl StreamLog {
     }
 
     /// Replay persisted records from `start`, bounded by `max_bytes`.
+    ///
+    /// A read below the base offset is reported as `CursorTooOld`, not as an
+    /// opaque storage failure: "those records existed and retention discarded
+    /// them" is a resume outcome the caller can act on, and it is the same
+    /// condition `subscribe_from` reports up front. Translating it here is what
+    /// makes a trim landing *mid-replay* surface as well, rather than a short
+    /// history that looks complete.
     pub async fn read_from(&self, start: Offset, max_bytes: usize) -> Result<Vec<LogRecord>> {
         self.log
             .read_range(ReadRange { start, max_bytes })
             .await
-            .map_err(storage_error)
+            .map_err(|err| match err {
+                felix_storage::StorageError::Trimmed { requested, oldest } => {
+                    BrokerError::CursorTooOld { oldest, requested }
+                }
+                other => storage_error(other),
+            })
     }
 
     /// Offset the next published record will take.
@@ -172,6 +184,19 @@ impl StreamLog {
     /// reported rather than silently skipped.
     pub fn base_offset(&self) -> Offset {
         self.log.base_offset()
+    }
+
+    /// Run one retention pass now rather than waiting for the timer.
+    ///
+    /// Returns the number of segments deleted. Retention normally runs on its
+    /// own schedule; this exists so an operator can reclaim space immediately,
+    /// and so tests can observe a trim deterministically.
+    pub async fn enforce_retention_now(&self) -> Result<usize> {
+        self.log
+            .enforce_retention_now()
+            .await
+            .map(|outcome| outcome.segments_deleted)
+            .map_err(storage_error)
     }
 
     /// Exclusive bound on offsets that survive a crash right now.

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -1305,3 +1305,130 @@ async fn backlog_entries_carry_their_own_offsets() {
         assert_eq!(String::from_utf8(payload.to_vec()).expect("utf8"), expected);
     }
 }
+
+// --- Retention -------------------------------------------------------------
+//
+// Retention is what makes `CursorTooOld` reachable on a durable stream. Before
+// it existed, `base_offset` never moved, so every durable resume succeeded and
+// the error path below could not be exercised at all.
+
+fn retention_log_config(retention_bytes: u64) -> LogConfig {
+    LogConfig {
+        retention_bytes: Some(retention_bytes),
+        // The tests drive retention explicitly; the timer must not race them.
+        retention_check_interval: Duration::from_secs(3600),
+        ..log_config(FsyncMode::None)
+    }
+}
+
+/// Publish past the in-memory replay ring, then trim the disk behind it.
+///
+/// Both halves matter. The ring (1024 entries) answers a resume without
+/// touching disk, so a trim is only *observable* to a subscriber once the ring
+/// has evicted the same records — until then the data is genuinely still
+/// available and reporting `CursorTooOld` would be a lie.
+async fn publish_and_trim(broker: &Broker, storage: &DurableStorage, stream: &str) -> u64 {
+    for i in 0..1600 {
+        broker
+            .publish("t1", "default", stream, payload(&format!("v{i:04}")))
+            .await
+            .expect("publish");
+    }
+    let log = storage
+        .open_stream("t1", "default", stream, 0)
+        .expect("stream log");
+    let deleted = log.enforce_retention_now().await.expect("retention");
+    assert!(deleted > 0, "expected retention to delete a segment");
+    log.base_offset()
+}
+
+#[tokio::test]
+async fn resuming_below_the_retained_range_reports_cursor_too_old() {
+    let dir = tempdir().expect("dir");
+    let storage =
+        DurableStorage::open(dir.path(), retention_log_config(8 * 1024)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage.clone());
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+    register(&broker, "orders", true).await;
+
+    let base = publish_and_trim(&broker, &storage, "orders").await;
+    assert!(base > 0, "retention must have advanced the base offset");
+
+    // Offset 0 existed and is gone. That is a different answer from "nothing
+    // there yet", and it is the one a resuming client needs.
+    let err = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Offset(0))
+        .await
+        .expect_err("offset 0 has been trimmed");
+    match err {
+        BrokerError::CursorTooOld { oldest, requested } => {
+            assert_eq!(requested, 0);
+            assert_eq!(oldest, base);
+        }
+        other => panic!("expected CursorTooOld, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn earliest_resumes_from_the_oldest_retained_record() {
+    let dir = tempdir().expect("dir");
+    let storage =
+        DurableStorage::open(dir.path(), retention_log_config(8 * 1024)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage.clone());
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+    register(&broker, "orders", true).await;
+
+    let base = publish_and_trim(&broker, &storage, "orders").await;
+
+    // `earliest` must mean "oldest still retained", not "offset 0" -- otherwise
+    // it is an error for every trimmed stream.
+    let resumed: ResumedSubscription = broker
+        .subscribe_from("t1", "default", "orders", StartPosition::Earliest)
+        .await
+        .expect("earliest still resumes after a trim");
+    if let Some(history) = &resumed.history {
+        assert!(
+            history.from_offset >= base,
+            "earliest resumed at {}, below the retained base {base}",
+            history.from_offset
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_trimmed_read_reports_cursor_too_old_rather_than_a_storage_error() {
+    let dir = tempdir().expect("dir");
+    let storage =
+        DurableStorage::open(dir.path(), retention_log_config(8 * 1024)).expect("storage");
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage.clone());
+    broker.register_tenant("t1").await.expect("tenant");
+    broker
+        .register_namespace("t1", "default")
+        .await
+        .expect("namespace");
+    register(&broker, "orders", true).await;
+
+    let base = publish_and_trim(&broker, &storage, "orders").await;
+
+    // This is the mid-replay case: a paging replay whose next read lands below
+    // a base offset that moved underneath it. Reported, not silently short.
+    let err = broker
+        .read_durable("t1", "default", "orders", 0, 64 * 1024)
+        .await
+        .expect_err("reading trimmed offsets must fail");
+    match err {
+        BrokerError::CursorTooOld { oldest, requested } => {
+            assert_eq!(requested, 0);
+            assert_eq!(oldest, base);
+        }
+        other => panic!("expected CursorTooOld, got {other:?}"),
+    }
+}

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -6,6 +6,7 @@
 // * `segments`  — the segment set: rollover, offset routing, truncation.
 // * `recovery`  — startup discovery, validation and torn-tail repair.
 // * `sync`      — fsync policy and group commit.
+// * `retention` — deleting the oldest segments once a bound is exceeded.
 //
 // This file is the seam between them and the async `AppendOnlyLog` trait.
 //
@@ -30,6 +31,7 @@
 
 pub mod layout;
 pub mod recovery;
+pub mod retention;
 pub mod segments;
 pub mod sync;
 
@@ -69,6 +71,7 @@ struct LogInner {
     durability: Durability,
     /// `None` unless the fsync policy is `Periodic`. Taken on shutdown.
     syncer: Mutex<Option<PeriodicSyncer>>,
+    retention: Mutex<Option<retention::RetentionTask>>,
     /// Where the background rollover is in its lifecycle. At most one runs at
     /// a time, and a failure is terminal for the log.
     roll_state: AtomicU8,
@@ -351,6 +354,21 @@ impl LogInner {
     }
 
     /// Wait until every offset below `target` is durable, flushing if needed.
+    /// One retention pass, on a blocking thread.
+    ///
+    /// Deleting files is a syscall per file and can block on a busy device, so
+    /// it never runs on a reactor worker — the same rule the rollover path
+    /// follows for its flushes.
+    async fn sweep_retention(self: Arc<Self>) -> Result<segments::RetentionOutcome> {
+        let inner = Arc::clone(&self);
+        tokio::task::spawn_blocking(move || {
+            let now = retention::now_micros();
+            inner.segments.write().enforce_retention(now)
+        })
+        .await
+        .map_err(|err| StorageError::Io(std::io::Error::other(err)))?
+    }
+
     async fn ensure_durable(self: &Arc<Self>, target: Offset) -> Result<()> {
         self.durability
             .ensure_durable(target, || Arc::clone(self).flush())
@@ -410,6 +428,7 @@ impl DiskLog {
             segments: RwLock::new(segments),
             durability: Durability::new(config.fsync_mode, durable_upto),
             syncer: Mutex::new(None),
+            retention: Mutex::new(None),
             roll_state: AtomicU8::new(RollState::Idle as u8),
             roll_failure: Mutex::new(None),
             #[cfg(test)]
@@ -432,6 +451,21 @@ impl DiskLog {
                 }
             })?;
             *inner.syncer.lock() = Some(syncer);
+        }
+
+        if config.retention_bytes.is_some() || config.retention_age.is_some() {
+            let weak = Arc::downgrade(&inner);
+            let task =
+                retention::RetentionTask::spawn(config.retention_check_interval, move || {
+                    let weak = weak.clone();
+                    async move {
+                        match weak.upgrade() {
+                            None => Ok(segments::RetentionOutcome::default()),
+                            Some(inner) => inner.sweep_retention().await,
+                        }
+                    }
+                })?;
+            *inner.retention.lock() = Some(task);
         }
 
         Ok(Self { inner })
@@ -497,6 +531,15 @@ impl DiskLog {
     }
 
     /// Force a flush regardless of the configured policy.
+    /// Run one retention pass now, instead of waiting for the timer.
+    ///
+    /// Exists so retention is testable deterministically and so an operator can
+    /// reclaim space without waiting out `retention_check_interval`. Returns
+    /// what the pass reclaimed; a no-op when no bound is configured.
+    pub async fn enforce_retention_now(&self) -> Result<segments::RetentionOutcome> {
+        Arc::clone(&self.inner).sweep_retention().await
+    }
+
     pub async fn sync(&self) -> Result<()> {
         self.inner
             .durability
@@ -511,6 +554,12 @@ impl DiskLog {
     /// mode can lose up to one interval of writes that a clean stop could have
     /// kept.
     pub async fn shutdown(&self) -> Result<()> {
+        // Retention first: it must not start deleting while the rest of
+        // shutdown is flushing, and it has nothing to finish on the way out.
+        let retention = self.inner.retention.lock().take();
+        if let Some(retention) = retention {
+            retention.shutdown().await;
+        }
         let syncer = self.inner.syncer.lock().take();
         if let Some(syncer) = syncer {
             syncer.shutdown().await;

--- a/crates/felix-storage/src/disk_log/retention.rs
+++ b/crates/felix-storage/src/disk_log/retention.rs
@@ -1,0 +1,111 @@
+// Retention: deleting the oldest sealed segments once a bound is exceeded.
+//
+// This runs on its own timer rather than from an append. Retention is bulk file
+// deletion — it unlinks whole segments and their indexes — and putting that on
+// the publish path would trade a bounded disk for an unbounded p999. The
+// rollover work is the cautionary tale: storage work sharing a lock with
+// appends is what makes appends wait on flushes.
+//
+// See `docs/durable-storage.md` for what a trimmed log means to a reader.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Notify;
+
+use crate::disk_log::segments::RetentionOutcome;
+use crate::{Result, StorageError, metrics_names};
+
+/// Background task that enforces retention on a timer.
+///
+/// Holds only a weak reference to the log, so a dropped log stops the work
+/// instead of being kept alive by its own housekeeping.
+#[derive(Debug)]
+pub struct RetentionTask {
+    shutdown: Arc<Notify>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl RetentionTask {
+    /// Run `sweep` every `interval` until shutdown.
+    ///
+    /// A failed sweep is logged and retried on the next tick rather than
+    /// killing the task: a transient I/O error must not silently turn retention
+    /// off for the rest of the process's life, because the symptom of that is a
+    /// full disk hours later.
+    pub fn spawn<F, Fut>(interval: Duration, sweep: F) -> Result<Self>
+    where
+        F: Fn() -> Fut + Send + 'static,
+        Fut: Future<Output = Result<RetentionOutcome>> + Send,
+    {
+        if tokio::runtime::Handle::try_current().is_err() {
+            return Err(StorageError::InvalidConfig(
+                "retention needs a Tokio runtime; open the log from async code or leave retention_bytes and retention_age unset",
+            ));
+        }
+        let shutdown = Arc::new(Notify::new());
+        let signal = Arc::clone(&shutdown);
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // A stall must not queue up a burst of sweeps; one late sweep
+            // reclaims exactly what five would have.
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            // Consume the immediate first tick. A sweep racing `open` would
+            // mean a freshly opened log could delete records before its caller
+            // has read anything, which makes "what can I still read" depend on
+            // scheduling. Callers wanting an immediate pass have
+            // `enforce_retention_now`.
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {
+                        match sweep().await {
+                            Ok(outcome) if outcome.segments_deleted > 0 => {
+                                tracing::info!(
+                                    segments = outcome.segments_deleted,
+                                    bytes = outcome.bytes_reclaimed,
+                                    base_offset = outcome.base_offset,
+                                    "retention deleted segments"
+                                );
+                            }
+                            Ok(_) => {}
+                            Err(err) => {
+                                metrics::counter!(metrics_names::RETENTION_FAILURES_TOTAL)
+                                    .increment(1);
+                                tracing::error!(error = %err, "retention sweep failed");
+                            }
+                        }
+                    }
+                    // No final sweep on shutdown: retention is not a durability
+                    // obligation, and deleting data on the way out is the last
+                    // thing a stopping process should do.
+                    _ = signal.notified() => return,
+                }
+            }
+        });
+        Ok(Self { shutdown, handle })
+    }
+
+    /// Stop the task and wait for it to observe the signal.
+    pub async fn shutdown(self) {
+        self.shutdown.notify_waiters();
+        // `notify_waiters` does not latch, so a task not yet parked on
+        // `notified()` would miss it; nudge until it lands.
+        loop {
+            if self.handle.is_finished() {
+                break;
+            }
+            self.shutdown.notify_waiters();
+            tokio::task::yield_now().await;
+        }
+        let _ = self.handle.await;
+    }
+}
+
+/// Micros since the Unix epoch, matching `AppendRecord::timestamp_micros`.
+pub fn now_micros() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros().min(u128::from(u64::MAX)) as u64)
+        .unwrap_or(0)
+}

--- a/crates/felix-storage/src/disk_log/segments.rs
+++ b/crates/felix-storage/src/disk_log/segments.rs
@@ -96,6 +96,15 @@ impl SealedEntry {
     }
 }
 
+/// What one retention pass reclaimed.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionOutcome {
+    pub segments_deleted: usize,
+    pub bytes_reclaimed: u64,
+    /// Oldest offset still readable after the pass.
+    pub base_offset: Offset,
+}
+
 /// Everything on disk for one shard.
 #[derive(Debug)]
 pub struct SegmentSet {
@@ -445,6 +454,95 @@ impl SegmentSet {
             )?;
         }
         Ok(out)
+    }
+
+    /// Delete whole sealed segments from the head until the configured
+    /// retention bounds are satisfied.
+    ///
+    /// Head-only and whole-segment: partial segments are never rewritten, which
+    /// is what lets recovery keep trusting "valid bytes end at EOF". The active
+    /// segment is never a candidate, so a log always retains at least the
+    /// records written since the last roll.
+    ///
+    /// Advancing `base_offset` is a side effect of removing the head entry, and
+    /// both happen under the caller's write lock — so a reader either sees a
+    /// segment and can read it, or sees a raised base offset and gets
+    /// `Trimmed`. It never sees a descriptor whose file is gone.
+    pub fn enforce_retention(&mut self, now_micros: u64) -> Result<RetentionOutcome> {
+        let max_bytes = self.config.retention_bytes;
+        let max_age_micros = self
+            .config
+            .retention_age
+            .map(|age| age.as_micros().min(u128::from(u64::MAX)) as u64);
+        let mut outcome = RetentionOutcome::default();
+        if max_bytes.is_none() && max_age_micros.is_none() {
+            outcome.base_offset = self.base_offset();
+            return Ok(outcome);
+        }
+
+        let mut total_bytes: u64 = self
+            .sealed
+            .iter()
+            .map(|entry| entry.descriptor.size_bytes)
+            .sum::<u64>()
+            + self.active.size_bytes();
+
+        while let Some(head) = self.sealed.first() {
+            let id = head.descriptor.id;
+            let size = head.descriptor.size_bytes;
+
+            let over_size = max_bytes.is_some_and(|max| total_bytes > max);
+            let too_old = match max_age_micros {
+                // The newest record decides: a segment is only expired once
+                // every record in it is, so nothing younger than the bound goes.
+                Some(max_age) => match self.newest_timestamp(head)? {
+                    Some(newest) => now_micros.saturating_sub(newest) > max_age,
+                    // A sealed segment always holds a record; treat an
+                    // unreadable timestamp as "keep" rather than deleting on
+                    // missing evidence.
+                    None => false,
+                },
+                None => false,
+            };
+            if !over_size && !too_old {
+                break;
+            }
+
+            // Drop the entry first: it owns the reader's descriptor, and
+            // closing before unlinking keeps this correct on platforms that
+            // refuse to remove an open file.
+            self.sealed.remove(0);
+            self.remove_segment_files(id)?;
+            total_bytes = total_bytes.saturating_sub(size);
+            outcome.segments_deleted += 1;
+            outcome.bytes_reclaimed += size;
+        }
+
+        outcome.base_offset = self.base_offset();
+        if outcome.segments_deleted > 0 {
+            metrics::counter!(metrics_names::RETENTION_SEGMENTS_DELETED_TOTAL)
+                .increment(outcome.segments_deleted as u64);
+            metrics::counter!(metrics_names::RETENTION_BYTES_RECLAIMED_TOTAL)
+                .increment(outcome.bytes_reclaimed);
+            metrics::gauge!(metrics_names::SEGMENT_COUNT).set((self.sealed.len() + 1) as f64);
+        }
+        metrics::gauge!(metrics_names::RETENTION_BASE_OFFSET).set(outcome.base_offset as f64);
+        Ok(outcome)
+    }
+
+    /// Timestamp of the newest record in a sealed segment.
+    fn newest_timestamp(&self, entry: &SealedEntry) -> Result<Option<u64>> {
+        let mut out = Vec::new();
+        let mut budget = ReadBudget::new(usize::MAX, 1);
+        entry.reader.read_from(
+            &entry.index,
+            entry.descriptor.last_offset,
+            entry.descriptor.size_bytes,
+            &mut budget,
+            &self.label,
+            &mut out,
+        )?;
+        Ok(out.first().map(|record| record.timestamp_micros))
     }
 
     /// Drop every record at or after `offset`.

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -667,3 +667,248 @@ async fn a_record_larger_than_a_segment_still_round_trips() {
     let values = read_all(&log, 0).await;
     assert_eq!(values, vec!["before".to_string(), big, "after".to_string()]);
 }
+
+// --- Retention -------------------------------------------------------------
+//
+// Retention is the only thing that ever raises `base_offset`, which makes it the
+// only thing that can make `Trimmed` reachable. Every test here therefore
+// asserts the *observable* consequence — a read that now fails, a base offset
+// that moved — rather than just counting files.
+
+fn retention_config(retention_bytes: Option<u64>, retention_age: Option<Duration>) -> LogConfig {
+    LogConfig {
+        retention_bytes,
+        retention_age,
+        // Long enough that the background task never fires mid-test; these
+        // tests drive retention explicitly via `enforce_retention_now`.
+        retention_check_interval: Duration::from_secs(3600),
+        ..config(FsyncMode::None)
+    }
+}
+
+/// A record with an explicit timestamp, for age-based retention.
+fn aged_record(payload: &str, timestamp_micros: u64) -> AppendRecord {
+    AppendRecord {
+        payload: Bytes::copy_from_slice(payload.as_bytes()),
+        timestamp_micros,
+    }
+}
+
+#[tokio::test]
+async fn retention_is_off_by_default() {
+    let dir = tempdir().expect("dir");
+    let log = open(&dir, FsyncMode::None);
+    for payload in ["a", "b", "c", "d", "e", "f"] {
+        log.append(&records(&[payload])).await.expect("append");
+    }
+
+    let outcome = log.enforce_retention_now().await.expect("retention");
+    assert_eq!(outcome.segments_deleted, 0);
+    assert_eq!(log.base_offset(), 0);
+    assert_eq!(read_all(&log, 0).await.len(), 6);
+}
+
+#[tokio::test]
+async fn size_retention_deletes_oldest_segments_and_raises_base_offset() {
+    let dir = tempdir().expect("dir");
+    // One segment holds ~2 of these records, so this keeps roughly one sealed
+    // segment plus the active one.
+    let log = DiskLog::open(
+        dir.path(),
+        "t/ns/s/0",
+        retention_config(Some(crate::segment::SEGMENT_HEADER_LEN + 120), None),
+    )
+    .expect("open");
+
+    for payload in ["a", "b", "c", "d", "e", "f", "g", "h"] {
+        log.append(&records(&[payload])).await.expect("append");
+    }
+    assert_eq!(log.base_offset(), 0, "nothing trimmed before a sweep");
+
+    let outcome = log.enforce_retention_now().await.expect("retention");
+    assert!(outcome.segments_deleted > 0, "expected a trim");
+    assert!(outcome.bytes_reclaimed > 0);
+    let base = log.base_offset();
+    assert!(
+        base > 0,
+        "base offset must advance past the deleted records"
+    );
+    assert_eq!(outcome.base_offset, base);
+
+    // The surviving records still read back, contiguously, from the new base.
+    let surviving = read_all(&log, base).await;
+    assert!(!surviving.is_empty());
+    assert_eq!(surviving.last().map(String::as_str), Some("h"));
+}
+
+#[tokio::test]
+async fn retention_makes_a_below_base_read_report_trimmed() {
+    let dir = tempdir().expect("dir");
+    let log = DiskLog::open(
+        dir.path(),
+        "t/ns/s/0",
+        retention_config(Some(crate::segment::SEGMENT_HEADER_LEN + 120), None),
+    )
+    .expect("open");
+    for payload in ["a", "b", "c", "d", "e", "f", "g", "h"] {
+        log.append(&records(&[payload])).await.expect("append");
+    }
+    log.enforce_retention_now().await.expect("retention");
+    let base = log.base_offset();
+    assert!(base > 0);
+
+    // This is the assertion the whole feature exists to make possible: before
+    // retention, `Trimmed` could not fire on a durable log at all.
+    let err = log
+        .read_range(ReadRange {
+            start: 0,
+            max_bytes: usize::MAX,
+        })
+        .await
+        .expect_err("offset 0 is gone");
+    match err {
+        StorageError::Trimmed { requested, oldest } => {
+            assert_eq!(requested, 0);
+            assert_eq!(oldest, base);
+        }
+        other => panic!("expected Trimmed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn retention_never_deletes_the_active_segment() {
+    let dir = tempdir().expect("dir");
+    // A bound far below one segment: retention still cannot empty the log,
+    // because the active segment is not a candidate.
+    let log = DiskLog::open(dir.path(), "t/ns/s/0", retention_config(Some(1), None)).expect("open");
+    for payload in ["a", "b", "c", "d", "e", "f"] {
+        log.append(&records(&[payload])).await.expect("append");
+    }
+
+    log.enforce_retention_now().await.expect("retention");
+    let base = log.base_offset();
+    let tail = log.tail_offset().await.expect("tail");
+    assert!(base < tail, "the active segment's records must survive");
+    assert!(!read_all(&log, base).await.is_empty());
+}
+
+#[tokio::test]
+async fn age_retention_uses_the_newest_record_in_a_segment() {
+    let dir = tempdir().expect("dir");
+    let log = DiskLog::open(
+        dir.path(),
+        "t/ns/s/0",
+        retention_config(None, Some(Duration::from_secs(60))),
+    )
+    .expect("open");
+
+    let now = crate::disk_log::retention::now_micros();
+    let old = now - Duration::from_secs(3600).as_micros() as u64;
+    // Enough expired records to fill whole segments: a segment is only a
+    // candidate once *every* record in it has expired, so a handful sharing a
+    // segment with fresh ones would (correctly) survive.
+    for i in 0..12 {
+        log.append(&[aged_record(&format!("old{i:02}"), old)])
+            .await
+            .expect("append");
+    }
+    for i in 0..12 {
+        log.append(&[aged_record(&format!("new{i:02}"), now)])
+            .await
+            .expect("append");
+    }
+
+    let outcome = log.enforce_retention_now().await.expect("retention");
+    assert!(outcome.segments_deleted > 0, "expired segments should go");
+    let surviving = read_all(&log, log.base_offset()).await;
+    assert!(
+        !surviving.contains(&"old00".to_string()),
+        "the oldest expired record should be gone, got {surviving:?}"
+    );
+    assert!(
+        (0..12).all(|i| surviving.contains(&format!("new{i:02}"))),
+        "every fresh record must survive, got {surviving:?}"
+    );
+}
+
+#[tokio::test]
+async fn age_retention_keeps_a_segment_whose_newest_record_is_fresh() {
+    let dir = tempdir().expect("dir");
+    let log = DiskLog::open(
+        dir.path(),
+        "t/ns/s/0",
+        retention_config(None, Some(Duration::from_secs(60))),
+    )
+    .expect("open");
+
+    let now = crate::disk_log::retention::now_micros();
+    let old = now - Duration::from_secs(3600).as_micros() as u64;
+    // An old record and a fresh one land in the same segment. The newest
+    // decides, so nothing is deleted -- the conservative direction.
+    log.append(&[aged_record("old", old)])
+        .await
+        .expect("append");
+    log.append(&[aged_record("new", now)])
+        .await
+        .expect("append");
+    for payload in ["x", "y", "z"] {
+        log.append(&[aged_record(payload, now)])
+            .await
+            .expect("append");
+    }
+
+    let outcome = log.enforce_retention_now().await.expect("retention");
+    assert_eq!(
+        outcome.segments_deleted, 0,
+        "a segment holding one fresh record must survive"
+    );
+    assert_eq!(log.base_offset(), 0);
+}
+
+#[tokio::test]
+async fn a_trimmed_log_reopens_from_its_surviving_base_offset() {
+    let dir = tempdir().expect("dir");
+    let cfg = retention_config(Some(crate::segment::SEGMENT_HEADER_LEN + 120), None);
+    let base = {
+        let log = DiskLog::open(dir.path(), "t/ns/s/0", cfg.clone()).expect("open");
+        for payload in ["a", "b", "c", "d", "e", "f", "g", "h"] {
+            log.append(&records(&[payload])).await.expect("append");
+        }
+        log.enforce_retention_now().await.expect("retention");
+        let base = log.base_offset();
+        log.shutdown().await.expect("shutdown");
+        base
+    };
+    assert!(base > 0, "the trim must have removed segment 0");
+
+    // Recovery has to derive the base from the lowest *surviving* segment, not
+    // assume the directory starts at offset 0.
+    let reopened = DiskLog::open(dir.path(), "t/ns/s/0", cfg).expect("reopen");
+    assert_eq!(reopened.base_offset(), base);
+    assert_eq!(
+        read_all(&reopened, base).await.last().map(String::as_str),
+        Some("h")
+    );
+    let err = reopened
+        .read_range(ReadRange {
+            start: 0,
+            max_bytes: usize::MAX,
+        })
+        .await
+        .expect_err("trimmed offsets stay trimmed across a restart");
+    assert!(matches!(err, StorageError::Trimmed { .. }));
+}
+
+#[tokio::test]
+async fn zero_retention_bounds_are_rejected_at_open() {
+    let dir = tempdir().expect("dir");
+    assert!(DiskLog::open(dir.path(), "t/ns/s/0", retention_config(Some(0), None)).is_err());
+    assert!(
+        DiskLog::open(
+            dir.path(),
+            "t/ns/s/0",
+            retention_config(None, Some(Duration::ZERO))
+        )
+        .is_err()
+    );
+}

--- a/crates/felix-storage/src/log.rs
+++ b/crates/felix-storage/src/log.rs
@@ -117,6 +117,27 @@ pub struct LogConfig {
     /// an 8ms preparation overshoots by about 1%. Small segments are the case
     /// this cannot rescue — see the note on `segment_size_bytes`.
     pub max_overshoot_percent: u8,
+    /// Delete whole sealed segments from the head once the log exceeds this
+    /// many bytes. `None` (the default) never deletes anything.
+    ///
+    /// The active segment is never deleted, so a log settles at roughly
+    /// `retention_bytes` and never below `segment_size_bytes` regardless of how
+    /// small this is set.
+    pub retention_bytes: Option<u64>,
+    /// Delete whole sealed segments whose newest record is older than this.
+    /// `None` (the default) never deletes anything.
+    ///
+    /// Age comes from the records' own `timestamp_micros`, not file mtime, so a
+    /// restore or a copy does not reset it. The *newest* record in a segment
+    /// decides, which is the conservative end: nothing younger than the bound
+    /// is ever deleted.
+    pub retention_age: Option<Duration>,
+    /// How often retention is evaluated. Ignored unless a retention bound is
+    /// set.
+    ///
+    /// Retention is bulk file deletion and must not land on a publish, so it
+    /// runs on its own timer rather than being triggered by an append.
+    pub retention_check_interval: Duration,
     /// Checksum every record of every segment at open time.
     ///
     /// Off by default: startup would otherwise cost one full pass over all data
@@ -141,6 +162,9 @@ impl Default for LogConfig {
             max_overshoot_percent: 100,
             repair_checksum_tail: false,
             verify_all_on_open: false,
+            retention_bytes: None,
+            retention_age: None,
+            retention_check_interval: Duration::from_secs(60),
         }
     }
 }
@@ -167,6 +191,25 @@ impl LogConfig {
         if self.max_records_per_read == 0 {
             return Err(StorageError::InvalidConfig(
                 "max_records_per_read must be greater than zero",
+            ));
+        }
+        // Zero is not "retain nothing" — the active segment is never deleted, so
+        // it would be a bound the log can never satisfy, re-evaluated forever.
+        if self.retention_bytes == Some(0) {
+            return Err(StorageError::InvalidConfig(
+                "retention_bytes must be greater than zero; omit it to disable retention",
+            ));
+        }
+        if self.retention_age == Some(Duration::ZERO) {
+            return Err(StorageError::InvalidConfig(
+                "retention_age must be greater than zero; omit it to disable retention",
+            ));
+        }
+        if (self.retention_bytes.is_some() || self.retention_age.is_some())
+            && self.retention_check_interval.is_zero()
+        {
+            return Err(StorageError::InvalidConfig(
+                "retention_check_interval must be greater than zero",
             ));
         }
         if let FsyncMode::Periodic { interval } = self.fsync_mode

--- a/crates/felix-storage/src/metrics_names.rs
+++ b/crates/felix-storage/src/metrics_names.rs
@@ -53,6 +53,17 @@ pub const SEGMENT_ROLL_DISCARDED_TOTAL: &str = "felix_storage_segment_roll_disca
 /// Segments currently on disk for a shard.
 pub const SEGMENT_COUNT: &str = "felix_storage_segment_count";
 
+/// Sealed segments deleted by retention.
+pub const RETENTION_SEGMENTS_DELETED_TOTAL: &str = "felix_storage_retention_segments_deleted_total";
+/// Bytes reclaimed by retention.
+pub const RETENTION_BYTES_RECLAIMED_TOTAL: &str = "felix_storage_retention_bytes_reclaimed_total";
+/// Oldest offset still readable. Rises only when retention deletes a segment,
+/// and is what `Trimmed` and `CursorTooOld` report as `oldest`.
+pub const RETENTION_BASE_OFFSET: &str = "felix_storage_retention_base_offset";
+/// Retention passes that failed. Non-fatal — the next pass retries — but a
+/// persistently non-zero value means the log is growing unbounded.
+pub const RETENTION_FAILURES_TOTAL: &str = "felix_storage_retention_failures_total";
+
 /// Records returned by range reads.
 pub const READ_RECORDS_TOTAL: &str = "felix_storage_read_records_total";
 /// Payload bytes returned by range reads.

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -141,7 +141,7 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Control plane metadata service | ✅ Today | REST + OpenAPI, tenant/namespace/stream/cache CRUD, snapshot and changes feeds, in-memory or Postgres backing |
 | Prometheus metrics, health endpoints | ✅ Today | Plus opt-in `telemetry` feature for per-stage timings |
 | Durable streams | ✅ Today | Opt-in per stream via `durable: true`, and only when the broker runs with `FELIX_DURABLE_STORAGE_DIR`. Segmented crash-safe log: CRC-verified records, torn-tail recovery, group commit, three fsync policies. Single node, and nothing trims it |
-| Resumable subscriptions | ✅ Today | `Subscribe` takes `latest` / `earliest` / an offset; every delivered event carries its offset (`Event.offset`) so an application can checkpoint and resume at `offset + 1`. Stored history joins live delivery with no gap, backfilling from disk if the live queue overflowed. Durable streams only; unbounded until retention exists |
+| Resumable subscriptions | ✅ Today | `Subscribe` takes `latest` / `earliest` / an offset; every delivered event carries its offset (`Event.offset`) so an application can checkpoint and resume at `offset + 1`. Stored history joins live delivery with no gap, backfilling from disk if the live queue overflowed. Durable streams only; bounded by retention when it is configured, unbounded otherwise |
 | Graceful shutdown | 🚧 Partial | Readiness flip, bounded drain, and accept-loop cancellation done; per-subsystem cancellation still open |
 | Sharding | 🚧 Partial | Streams carry a shard count; ops are not yet directed to a shard leader |
 
@@ -188,9 +188,11 @@ for behavior at thousands of subscribers or across a network.
   was registered with `durable: true`, which persists each record before
   acknowledging it and replays it afterwards. Durable storage is opt-in per
   stream and off unless the broker is started with `FELIX_DURABLE_STORAGE_DIR`.
-  Retention and tiering are not implemented, so a durable stream grows without
-  bound today — which also means a resume never fails for having been trimmed
-  yet.
+  Retention is available but off by default (`FELIX_DURABLE_RETENTION_BYTES` /
+  `FELIX_DURABLE_RETENTION_SECONDS`): unset, a durable stream grows without
+  bound; set, the oldest records are discarded and a resume below them fails
+  with a typed error naming the oldest retained offset. Tiering is not
+  implemented.
 
 ---
 

--- a/docs-site/src/content/docs/reference/environment-variables.md
+++ b/docs-site/src/content/docs/reference/environment-variables.md
@@ -1160,6 +1160,63 @@ export FELIX_DURABLE_SEGMENT_BYTES="67108864"  # 64 MiB
 **Trade-off**: Smaller segments bound recovery time (only the active segment is
 fully scanned at startup) at the cost of more files and more rollovers.
 
+### `FELIX_DURABLE_RETENTION_BYTES`
+
+**Description**: Delete the oldest sealed segments once a stream's log exceeds
+this size. Unset means the log grows without bound, which is the default and the
+pre-retention behaviour.
+
+**Type**: Positive integer (bytes)
+
+**Default**: unset (no size bound)
+
+**Example**:
+```bash
+export FELIX_DURABLE_RETENTION_BYTES="10737418240"  # 10 GiB per stream shard
+```
+
+**Note**: The active segment is never deleted, so a log settles at roughly this
+size and never below `FELIX_DURABLE_SEGMENT_BYTES` regardless of how small this
+is set. Records below the retained range report `CursorTooOld` to a resuming
+subscriber, naming the oldest offset still available.
+
+### `FELIX_DURABLE_RETENTION_SECONDS`
+
+**Description**: Delete sealed segments whose newest record is older than this.
+Combines with `FELIX_DURABLE_RETENTION_BYTES`; either bound alone is enough to
+trigger a deletion.
+
+**Type**: Positive integer (seconds)
+
+**Default**: unset (no age bound)
+
+**Example**:
+```bash
+export FELIX_DURABLE_RETENTION_SECONDS="604800"  # 7 days
+```
+
+**Note**: Age comes from the records' own timestamps rather than file mtime, so
+restoring a backup does not reset it. A segment survives until its *newest*
+record has expired, so nothing younger than the bound is ever deleted.
+
+### `FELIX_DURABLE_RETENTION_INTERVAL_SECONDS`
+
+**Description**: How often retention is evaluated. Ignored unless a retention
+bound is set.
+
+**Type**: Positive integer (seconds)
+
+**Default**: `60`
+
+**Example**:
+```bash
+export FELIX_DURABLE_RETENTION_INTERVAL_SECONDS="300"
+```
+
+**Trade-off**: Retention is bulk file deletion and runs on its own timer so it
+never lands on a publish. A longer interval means disk usage overshoots the
+bound for longer between passes.
+
 ### `FELIX_DURABLE_INDEX_SPACING_BYTES`
 
 **Description**: Bytes of segment data between sparse index entries. A read

--- a/docs/durable-storage.md
+++ b/docs/durable-storage.md
@@ -485,11 +485,12 @@ fail rather than print the wrong numbers.
 
 - **One log per stream.** `StreamMetadata::shards` is carried through to the
   shard key but the data path is not yet sharded, so every stream uses shard 0.
-- **No retention.** `truncate` exists for replication's benefit; nothing deletes
-  segments on age or size yet. So a durable stream grows without bound, and
-  `CursorTooOld` is currently only reachable for an in-memory stream whose replay
-  ring has evicted — the durable path will start returning it once retention
-  lands.
+- **Retention is off unless configured.** `retention_bytes` and `retention_age`
+  are both unset by default, so an existing deployment keeps growing without
+  bound exactly as before. Setting either bounds the log: whole sealed segments
+  are deleted from the head, `base_offset` rises, and offsets below it report
+  `Trimmed` (storage) or `CursorTooOld` (broker) rather than a short read. See
+  [Retention](#retention) below.
 - **No tiered storage.** [`tiered.rs`](../crates/felix-storage/src/tiered.rs) is
   still trait scaffolding — `TieredStore`, `OffloadedSegment`, `ColdCacheConfig`
   and `RetentionPolicy` are declared, and nothing implements them. There is no
@@ -498,6 +499,46 @@ fail rather than print the wrong numbers.
   below for what this milestone deliberately left in place for it.
 - **Single node.** Replication (M5) is what `seal`'s checksum and `read_range`'s
   bounded paging exist to serve.
+
+## Retention
+
+A durable log grows until something deletes from it. Two bounds, both optional
+and both off by default:
+
+| setting | meaning |
+| --- | --- |
+| `retention_bytes` | delete oldest sealed segments once the log exceeds this size |
+| `retention_age` | delete sealed segments whose newest record is older than this |
+| `retention_check_interval` | how often the bounds are evaluated (default 60s) |
+
+Four properties are worth knowing, because each rules out a class of surprise:
+
+- **Whole segments, from the head only.** Records are never rewritten, which is
+  what lets recovery keep trusting "valid bytes end at EOF". A partial segment is
+  never trimmed.
+- **The active segment is never deleted.** A log therefore retains at least the
+  records written since its last roll, no matter how small the bound. Setting
+  `retention_bytes` below `segment_size_bytes` does not empty the log; it just
+  cannot be satisfied.
+- **Age comes from the records, not the filesystem.** `timestamp_micros` on the
+  newest record in a segment decides, so restoring or copying a directory does
+  not reset the clock. The *newest* record is the one that counts, which is the
+  conservative end — a segment survives until everything in it has expired.
+- **It runs on its own timer, never on an append.** Retention is bulk file
+  deletion; putting it on the publish path would trade a bounded disk for an
+  unbounded p999.
+
+What a reader sees after a trim is the point of the feature. `read_range` below
+`base_offset` returns `StorageError::Trimmed { requested, oldest }`, which the
+broker translates to `BrokerError::CursorTooOld`. That distinction — "those
+records existed and are gone" versus "nothing here yet" — is what lets a
+resuming subscriber tell a real gap from an empty tail. A trim landing
+*mid-replay* surfaces the same way rather than silently ending the history
+early. `earliest` means the oldest record still retained, so it keeps working on
+a trimmed stream instead of becoming an error.
+
+An operator can force a pass with `StreamLog::enforce_retention_now` instead of
+waiting out the interval.
 
 ## Tiered storage: what M1 set up for it
 

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -36,9 +36,13 @@ durability, clustering, or advanced observability.
 - [X] Connection info + stream helpers (bi/uni)
 - [X] Graceful shutdown hooks (drain connections on SIGTERM) — see
       [Graceful Shutdown](../docs-site/src/content/docs/deployment/graceful-shutdown.md).
-      Readiness flip, bounded drain, and accept-loop cancellation are done; per-subsystem
-      cancellation (publish workers, ack waiters, subscription writers) and process-level
-      SIGTERM tests remain open under #139.
+      Readiness flip, accept-loop cancellation, and a bounded per-connection drain
+      (`TaskTracker` grace window, then the connection is closed) are done. Cancelling
+      each subsystem individually was deliberately *not* the design: publish and
+      subscribe streams are long-lived by construction, so waiting on them would hang
+      exactly as long as waiting on the connection. What is still untested is a real
+      signal: `run_with_shutdown` is driven by a synthetic future in tests, and nothing
+      sends an actual SIGTERM to a running process.
 - [ ] Backpressure defaults (caps per connection/subscription)
 
 ## Broker core (`felix-broker`)
@@ -90,6 +94,9 @@ durability, clustering, or advanced observability.
 - [X] Handle crash/recover of broker data-plane nodes (torn-tail repair on
       startup; loud failure on interior corruption). Control-plane recovery and
       re-sync from a new leader remain open.
+- [X] Enforce retention — sealed segments are deleted on age or size, `base_offset`
+      advances, and offsets below it report `Trimmed` / `CursorTooOld`. Off by
+      default. See [Durable Storage](durable-storage.md#retention).
 - [ ] Define requirements for tiered storage (hot/cold path, LCU?) — tracked as
       [#172](https://github.com/gabloe/felix/issues/172)
 - [ ] Implement tiered storage primitives. `TieredStore` and friends are declared
@@ -108,9 +115,10 @@ durability, clustering, or advanced observability.
    verified on every read and during recovery. See
    [the format spec](storage-format.md).
 2. ~~How should data file segmentation and garbage collection work to honor per-segment size caps? What is a sane segment cap? 512MB?~~
-   **Partly answered:** segments roll at `segment_size_bytes`, default 256 MiB —
-   chosen so a full scan of the active segment at startup stays under a second.
-   Garbage collection (retention) is still open.
+   **Answered:** segments roll at `segment_size_bytes`, default 256 MiB — chosen
+   so a full scan of the active segment at startup stays under a second.
+   Collection is whole-segment retention by age or size, off by default; see
+   [Durable Storage](durable-storage.md#retention).
 3. What is the delete policy? Should we retain the last *N* versions per key for rollbacks, or can we drop them immediately?
 4. ~~What crash recovery guarantees do we need? We can’t mark an entry as committed until the payload bytes are actually persisted.~~
    **Answered:** three policies with explicit windows — `OnCommit` acknowledges

--- a/services/broker/src/durable_config.rs
+++ b/services/broker/src/durable_config.rs
@@ -56,6 +56,13 @@ impl DurableStorageConfig {
                 .unwrap_or(LogConfig::default().rollover_threshold_percent),
             max_overshoot_percent: parse_env("FELIX_DURABLE_MAX_OVERSHOOT_PERCENT")?
                 .unwrap_or(LogConfig::default().max_overshoot_percent),
+            // Unset means unbounded growth
+            retention_bytes: parse_env("FELIX_DURABLE_RETENTION_BYTES")?,
+            retention_age: parse_env::<u64>("FELIX_DURABLE_RETENTION_SECONDS")?
+                .map(Duration::from_secs),
+            retention_check_interval: parse_env::<u64>("FELIX_DURABLE_RETENTION_INTERVAL_SECONDS")?
+                .map(Duration::from_secs)
+                .unwrap_or(LogConfig::default().retention_check_interval),
         };
         // Fail at startup rather than at the first durable publish.
         log.validate()
@@ -76,8 +83,21 @@ impl DurableStorageConfig {
             }
             FsyncMode::OnCommit => "fsync before every acknowledgement".to_string(),
         };
+        let retention = match (self.log.retention_bytes, self.log.retention_age) {
+            (None, None) => " retention=off (log grows unbounded)".to_string(),
+            (bytes, age) => {
+                let mut parts = Vec::new();
+                if let Some(bytes) = bytes {
+                    parts.push(format!("{bytes}B"));
+                }
+                if let Some(age) = age {
+                    parts.push(format!("{}s", age.as_secs()));
+                }
+                format!(" retention={}", parts.join("/"))
+            }
+        };
         format!(
-            "root={} segment={}B index_spacing={}B {durability}",
+            "root={} segment={}B index_spacing={}B {durability}{retention}",
             self.root.display(),
             self.log.segment_size_bytes,
             self.log.index_spacing_bytes,

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -158,9 +158,6 @@ async fn write_replay(
                 .read_durable(tenant_id, namespace, stream, at, HISTORY_PAGE_BYTES)
                 .await?;
             if records.is_empty() {
-                // The range is closed and was on disk when it was computed, so
-                // this only happens if retention trimmed underneath us. Stop
-                // rather than spin; the backlog still joins on cleanly.
                 break;
             }
             let mut batch = ReplayBatch::new(max_events, max_bytes);


### PR DESCRIPTION
Closes #198 

A durable stream grew without bound: nothing ever deleted a segment. `truncate` removes a *suffix* for replication's benefit, so it drops the newest records rather than the oldest.

The consequence was larger than disk. `CursorTooOld` and `StorageError::Trimmed` both read `base_offset`, and `base_offset` only rises when segments are deleted -- so on a durable stream every resume succeeded and neither error could fire. Two documented contracts were unreachable code.

Storage:
- `LogConfig::retention_bytes` / `retention_age`, both optional and unset by default, so an existing deployment is unchanged.
- `SegmentSet::enforce_retention` deletes whole sealed segments from the head. Never the active segment, so a log always retains at least what was written since its last roll. Removing the head entry advances `base_offset` under the same write lock, so a reader either reads a segment or gets `Trimmed` -- never a descriptor whose file is gone.
- Age comes from the records' own `timestamp_micros`, not file mtime, and the *newest* record in a segment decides: nothing younger than the bound is ever deleted.
- Runs on its own timer (`retention_check_interval`, default 60s) on a blocking thread. Retention is bulk file deletion and must not land on a publish. The first tick is consumed so a sweep cannot race `open`.
- Metrics: segments deleted, bytes reclaimed, base offset, failures.

Broker:
- `StreamLog::read_from` maps `Trimmed` to `CursorTooOld` instead of an opaque `Storage(String)`. This is what makes a trim landing *mid-replay* surface, rather than a paging loop ending early and delivering a short history that looks complete.
- `StreamLog::enforce_retention_now` for an operator (and for tests).
- `FELIX_DURABLE_RETENTION_BYTES` / `_SECONDS` / `_INTERVAL_SECONDS`.

Tests: size and age retention, the active segment surviving an unsatisfiable bound, a segment kept because one record in it is fresh, reopening a trimmed directory whose first segment is not segment 0, and at broker level `CursorTooOld` on both subscribe and mid-replay read. The mid-replay test fails against the old mapping
(`Storage("offset 0 is no longer available...")`) and passes with it.

Also corrects the graceful-shutdown entry in todos.md: it claimed per-subsystem cancellation was still open under #139, which is closed. That approach was deliberately not taken -- publish and subscribe streams are long-lived, so the drain waits on a `TaskTracker` with a grace window and then closes the connection. What genuinely remains untested is a real SIGTERM against a running process.

Closes #198.