### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,9 +1245,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
h2 accepted and queued empty DATA frames without limit; a stream that is not actively drained could grow memory unboundedly, or panic on length overflow. Low severity, patched upstream in 0.4.16.

Reached only transitively -- hyper -> {axum, hyper-rustls, hyper-timeout} -- so nothing in Felix calls it directly, but the broker and control plane both serve HTTP through axum.

Deliberately a two-line change. `cargo update -p h2`, even with `--precise`, also re-resolves windows-sys across errno, is-terminal, quinn-udp, rustix, rustls-platform-verifier, tempfile and winapi-util -- downgrading 0.61.2 to 0.52.0 and 0.48.0. That is an unrelated change to Windows bindings, and bundling it into a security patch would ship it unreviewed on a platform nothing in CI builds. The lockfile with only h2 bumped passes `cargo metadata --locked`, so cargo agrees it is internally consistent.

Verified: `cargo deny check` reports advisories ok, and `cargo check --workspace --all-features --locked` is clean.