### PR TITLE
fix(storage): stop an inline rollover parking every Tokio worker

### DIFF
--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -68,6 +68,14 @@ struct LogInner {
     /// write lock serialises appends, which must assign offsets in order
     /// anyway.
     segments: RwLock<SegmentSet>,
+    /// Held shared by appends, exclusively by an inline rollover.
+    ///
+    /// `segments` is synchronous, so a publisher queued on it parks a Tokio
+    /// worker instead of yielding it — for the two device flushes a rollover
+    /// holds it across, that stalls the whole runtime. Waiting on this gate
+    /// instead yields. Layered above `segments` rather than replacing it so
+    /// the uncontended append stays a `try_read`.
+    roll_gate: tokio::sync::RwLock<()>,
     durability: Durability,
     /// `None` unless the fsync policy is `Periodic`. Taken on shutdown.
     syncer: Mutex<Option<PeriodicSyncer>>,
@@ -104,6 +112,12 @@ struct LogInner {
     /// Forces the next seal to fail, so the failure path can be tested.
     #[cfg(test)]
     fail_seal: std::sync::atomic::AtomicBool,
+    /// Milliseconds an inline rollover holds the segment lock, for tests.
+    #[cfg(test)]
+    slow_inline_roll_millis: std::sync::atomic::AtomicU64,
+    /// Set while a stretched inline rollover holds the segment lock.
+    #[cfg(test)]
+    inline_roll_active: std::sync::atomic::AtomicBool,
 }
 
 /// Lifecycle of the background rollover.
@@ -232,6 +246,24 @@ impl LogInner {
             RollState::Preparing | RollState::Sealing
         )
     }
+
+    /// Stretches an inline rollover to the length a real one's flushes take,
+    /// which a temp-dir test does not otherwise reproduce, and marks the window
+    /// so a test can see what the runtime managed to do during it.
+    #[cfg(test)]
+    fn before_inline_roll(&self) {
+        let millis = self.slow_inline_roll_millis.load(Ordering::Acquire);
+        if millis == 0 {
+            return;
+        }
+        self.inline_roll_active.store(true, Ordering::Release);
+        std::thread::sleep(std::time::Duration::from_millis(millis));
+        self.inline_roll_active.store(false, Ordering::Release);
+    }
+
+    #[cfg(not(test))]
+    #[inline]
+    fn before_inline_roll(&self) {}
 
     /// Seal the retired segment, with a hook tests use to force a failure.
     fn seal_retired(&self, retired: &mut crate::segment::SegmentWriter) -> Result<()> {
@@ -426,6 +458,7 @@ impl DiskLog {
             label,
             config: config.clone(),
             segments: RwLock::new(segments),
+            roll_gate: tokio::sync::RwLock::new(()),
             durability: Durability::new(config.fsync_mode, durable_upto),
             syncer: Mutex::new(None),
             retention: Mutex::new(None),
@@ -433,6 +466,10 @@ impl DiskLog {
             roll_failure: Mutex::new(None),
             #[cfg(test)]
             fail_seal: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(test)]
+            slow_inline_roll_millis: std::sync::atomic::AtomicU64::new(0),
+            #[cfg(test)]
+            inline_roll_active: std::sync::atomic::AtomicBool::new(false),
             roll_task: Mutex::new(None),
             pending_seal: Mutex::new(None),
         });
@@ -606,11 +643,22 @@ impl DiskLog {
             return Err(StorageError::InvalidRange);
         }
         inner.check_roll_state()?;
+        // Shared with the rollover re-check, which runs on a blocking thread;
+        // cloning it there would copy the batch once per retry.
+        let records = Arc::new(records);
 
         // The hard-limit fallback. A background roll normally replaces the
         // segment well before this, so reaching here means the log filled
         // faster than a replacement could be built — rare, and still correct.
         for attempt in 0..MAX_ROLL_ATTEMPTS {
+            // Taken before anything touches `segments`, the read below
+            // included: a rollover holds the synchronous lock, so a publisher
+            // that reaches it at all parks a worker either way.
+            let mut gate = match inner.roll_gate.try_read() {
+                Ok(gate) => gate,
+                Err(_) => inner.roll_gate.read().await,
+            };
+
             // While a background rollover is building the replacement, the
             // segment is allowed to grow past its configured size rather than
             // blocking here. That headroom is what gives the preparation time
@@ -621,26 +669,37 @@ impl DiskLog {
                 .read()
                 .would_roll_within(&records, roll_pending)
             {
+                drop(gate);
+                // Exclusive, so no append can be queued on `segments` while
+                // the rollover flushes.
+                let exclusive = inner.roll_gate.write().await;
                 let roller = Arc::clone(&inner);
-                let batch = records.clone();
+                let batch = Arc::clone(&records);
                 tokio::task::spawn_blocking(move || {
                     let mut segments = roller.segments.write();
                     // Re-checked under the write lock: another publisher may
                     // have rolled already, and rolling twice leaves an empty
                     // segment behind.
                     if segments.would_roll_within(&batch, roller.roll_pending()) {
+                        roller.before_inline_roll();
                         segments.roll()?;
                     }
                     Ok::<(), StorageError>(())
                 })
                 .await
                 .map_err(|err| StorageError::Io(std::io::Error::other(err)))??;
+                // Downgraded rather than released: the gate is fair, so
+                // releasing it would let every publisher queued behind this
+                // rollover refill the segment before the one that paid for it
+                // appends, which the retry budget does not cover.
+                gate = exclusive.downgrade();
             }
 
             let mut segments = inner.segments.write();
             if segments.would_roll_within(&records, inner.roll_pending()) {
                 // Filled again in the gap. Drop the lock and roll off-thread.
                 drop(segments);
+                drop(gate);
                 debug_assert!(attempt + 1 < MAX_ROLL_ATTEMPTS, "rollover retry starved");
                 continue;
             }
@@ -648,6 +707,7 @@ impl DiskLog {
             let durable_target = segments.tail_offset();
             let prepare_roll = segments.should_prepare_roll();
             drop(segments);
+            drop(gate);
 
             // Start the replacement while the current segment still has room,
             // so the flushes it costs never land on an append. `Idle ->

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -912,3 +912,85 @@ async fn zero_retention_bounds_are_rejected_at_open() {
         .is_err()
     );
 }
+
+/// An inline rollover must not park every Tokio worker in the runtime.
+///
+/// The publisher that rolls is on a blocking thread; the ones behind it queue
+/// on `segments`, which is synchronous. Once as many are queued as there are
+/// workers, nothing else in the runtime can run until the rollover finishes.
+/// The longest stall an unrelated task sees is what measures that.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_inline_rollover_does_not_park_every_worker() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::time::Instant;
+
+    const ROLL_MILLIS: u64 = 500;
+    const WORKERS: usize = 2;
+
+    let dir = tempdir().expect("dir");
+    // The 100 default for `rollover_threshold_percent` keeps the background
+    // rollover out of this; the inline hard-limit path is under test.
+    let log = Arc::new(open(&dir, FsyncMode::None));
+
+    // Fill the segment so the next appends are the ones that must roll.
+    for i in 0..8 {
+        log.append(&records(&[&format!("fill-{i}")]))
+            .await
+            .expect("fill");
+    }
+
+    log.inner
+        .slow_inline_roll_millis
+        .store(ROLL_MILLIS, Ordering::Release);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let max_stall_micros = Arc::new(AtomicU64::new(0));
+
+    // Touches nothing the log owns; it only needs a worker to run on.
+    let ticker = tokio::spawn({
+        let stop = Arc::clone(&stop);
+        let max_stall_micros = Arc::clone(&max_stall_micros);
+        async move {
+            let mut last = Instant::now();
+            while !stop.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+                let now = Instant::now();
+                max_stall_micros.fetch_max((now - last).as_micros() as u64, Ordering::Release);
+                last = now;
+            }
+        }
+    });
+
+    // Several times the worker count: one publisher is inside the rollover on
+    // a blocking thread, and it takes only two of the rest arriving together to
+    // park both workers. Oversubscribing makes that certain rather than likely.
+    let publishers: Vec<_> = (0..WORKERS * 4)
+        .map(|p| {
+            let log = Arc::clone(&log);
+            tokio::spawn(async move {
+                for i in 0..4 {
+                    log.append(&records(&[&format!("p{p}-{i}")]))
+                        .await
+                        .expect("append");
+                }
+            })
+        })
+        .collect();
+
+    for publisher in publishers {
+        publisher.await.expect("publisher");
+    }
+    stop.store(true, Ordering::Release);
+    ticker.await.expect("ticker");
+
+    // A fifth of one rollover: far above the scheduling noise a yielding task
+    // sees even on a loaded box, and far below the full-length stall that
+    // parking every worker produces.
+    let stall = Duration::from_micros(max_stall_micros.load(Ordering::Acquire));
+    assert!(
+        stall < Duration::from_millis(ROLL_MILLIS / 5),
+        "an unrelated task stalled for {stall:?} during a {ROLL_MILLIS}ms rollover: \
+         appends parked their workers on the synchronous segment lock",
+    );
+}

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -207,7 +207,6 @@ ship rather than being marked off here.
 | Log-backed cache (one core log, many semantics) | 🎯 Target | Cache is a separate storage handle, not a projection over the stream log |
 | Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` takes an offset, so *changes since a known point* is gap-free. The missing half is the snapshot: there is no way to ask for current state and subsequent changes in one call |
 | Queue semantics (consumer groups, acks, redelivery) | 🎯 Target | Explicitly post-MVP; not started |
-| Retention and log trimming | 🎯 Target | Nothing deletes segments on age or size, so a durable stream grows without bound |
 | Tiered / cold storage | 🎯 Target | `TieredStore` trait declared, no implementation |
 | Multi-node clustering and replication | 🎯 Target | Not started |
 | Raft consensus for cluster metadata | 🎯 Target | `felix-consensus` is a configuration struct with no protocol implementation |

--- a/docs/storage-performance.md
+++ b/docs/storage-performance.md
@@ -198,6 +198,26 @@ tail latency is dominated by rollover flushes rather than by appends. Prefer the
 default unless restart time is genuinely the binding constraint, and if it is,
 measure the tail rather than assuming recovery is the only thing that moved.
 
+#### What a rollover no longer costs
+
+Those numbers are the flushes themselves, and they are irreducible. Two things
+that used to ride along with them are not:
+
+* **A rollover no longer stalls the runtime.** The segment set is behind a
+  synchronous lock, so a publisher queued on it parked a Tokio worker rather
+  than yielding it. Held across a rollover's two device flushes, that stalled
+  everything else on the runtime — other shards, subscriber fanout, the accept
+  loop — once as many publishers were queued as there were workers. Appends now
+  wait on an async gate and yield.
+* **Rollover contention no longer rejects appends.** An append that lost the
+  race for the new segment `MAX_ROLL_ATTEMPTS` times returned `Unsupported`.
+  With 128 KiB segments, 16 publishers on one shard and 4 workers, that was
+  6 runs in 20. It is 0 in 20 now: the gate admits one rollover at a time, and
+  the publisher that rolls appends under the same gate rather than re-entering
+  the race it just won.
+
+Neither makes a rollover cheaper, so the table above still stands.
+
 ### Rolling segments in the background does not help
 
 The obvious fix for the table above is to stop doing rollover work on the append


### PR DESCRIPTION
Closes #195.

## The change

`segments` is a `parking_lot` lock, so a publisher queued on it parks its Tokio worker rather than yielding. An append holds it for microseconds, which is fine; an inline rollover holds it across two device flushes, which is not. Once as many publishers are queued as the runtime has workers, nothing else runs until the rollover finishes — including work that never touches this log.

This is option 1 from the issue: an async coordination primitive for the segment set. `roll_gate` is a `tokio::sync::RwLock` layered *above* `segments` — appends hold it shared, an inline rollover holds it exclusively. A publisher arriving during a rollover awaits and yields its worker.

Two details that are load-bearing:

- **The gate is taken before the `would_roll_within` pre-check**, not just before the write. That pre-check takes `segments.read()`, which parks a worker just as the write lock does. My first version missed this and the regression test caught it.
- **The rolling publisher downgrades rather than releases.** The gate is fair, so releasing it would let every publisher queued behind the rollover refill the segment before the one that paid for it appends — and `MAX_ROLL_ATTEMPTS` does not cover that. This surfaced as `rollover retry starved` in `concurrent_appends_across_a_rollover_stay_contiguous`.

The uncontended path is a `try_read`, so it never touches the wait queue.

## What this does and does not buy

It does **not** make a rollover cheaper. The flushes are unchanged and an append that needs the new segment still waits for it, so the segment-size table in `docs/storage-performance.md` still stands. What it removes is the cost being charged to the whole runtime.

It also fixes a failure mode I did not expect to find: under rollover contention, appends were being **rejected outright** once the retry budget was exhausted (`Unsupported("append could not secure segment capacity; rollover kept losing the race")`).

| 128 KiB segments, 16 publishers on one shard, 4 workers | main | this branch |
| --- | --- | --- |
| runs that rejected an append | **6 / 20** | **0 / 20** |

Uncontended append path, 256 MiB segments, 16 publishers, 3 trials — unchanged within noise:

| | p50 | p99 | p999 | throughput |
| --- | --- | --- | --- | --- |
| main | 2.7–3.0µs | 103–109µs | 171–194µs | 284–299k/s |
| this branch | 3.0–3.2µs | 104–105µs | 174–180µs | 277–286k/s |

Both measured with a throwaway `DiskLog`-level harness, built from each branch before running so nothing compiled mid-run. Not committed.

## Regression test

`an_inline_rollover_does_not_park_every_worker` — two workers, oversubscribed publishers racing one rollover stretched by a test hook, and an unrelated task whose longest stall is the measurement.

Verified in both directions rather than assumed:

- **without the fix: 12/12 fail** (stalls of 530ms–1.07s against a 500ms rollover)
- **with the fix: 12/12 pass**

An earlier version of the test passed without the fix; it is only in this shape because that was checked.

## Also

Drops the `Retention and log trimming | 🎯 Target | Nothing deletes segments on age or size` row from `what-felix-is-for.md`. #198 shipped retention, and the row contradicted the paragraph above it on the same page.

## Verification

`task lint`, `task test`, `task demo:check`, and `node scripts/check-mermaid.mjs` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)