### PR TITLE
feat(controlplane): add the Node/Broker resource model

### DIFF
--- a/services/controlplane/src/api/openapi.rs
+++ b/services/controlplane/src/api/openapi.rs
@@ -33,7 +33,8 @@ use crate::auth::jwks::{self, JwksResponse};
 use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, ConsistencyLevel,
-    DeliveryGuarantee, Namespace, NamespaceChange, NamespaceChangeOp, NamespaceKey,
+    DeliveryGuarantee, Namespace, NamespaceChange, NamespaceChangeOp, NamespaceKey, Node,
+    NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle, NodePatchRequest, NodeSpec, NodeStatus,
     RetentionPolicy, Stream, StreamChange, StreamChangeOp, StreamKey, StreamKind,
     StreamPatchRequest, Tenant, TenantChange, TenantChangeOp,
 };
@@ -131,6 +132,14 @@ use utoipa::OpenApi;
         RetentionPolicy,
         ConsistencyLevel,
         DeliveryGuarantee,
+        Node,
+        NodeSpec,
+        NodeStatus,
+        NodeCapacity,
+        NodeLifecycle,
+        NodePatchRequest,
+        NodeChange,
+        NodeChangeOp,
         TokenExchangeRequest,
         TokenExchangeResponse,
         IdpIssuerConfig,
@@ -151,3 +160,62 @@ use utoipa::OpenApi;
     )
 )]
 pub struct ApiDoc;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A model that is not registered here is absent from the published schema
+    /// and from every generated client, and nothing else would catch it.
+    #[test]
+    fn the_node_model_reaches_the_generated_schema() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).expect("serialize openapi");
+        let schemas = doc["components"]["schemas"]
+            .as_object()
+            .expect("schemas object");
+
+        for name in [
+            "Node",
+            "NodeSpec",
+            "NodeStatus",
+            "NodeCapacity",
+            "NodeLifecycle",
+            "NodePatchRequest",
+            "NodeChange",
+            "NodeChangeOp",
+        ] {
+            assert!(
+                schemas.contains_key(name),
+                "{name} is missing from the schema"
+            );
+        }
+    }
+
+    /// The split only holds on the wire if the patch schema has no observed
+    /// field to send.
+    #[test]
+    fn the_node_patch_schema_exposes_no_observed_field() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).expect("serialize openapi");
+        let properties = doc["components"]["schemas"]["NodePatchRequest"]["properties"]
+            .as_object()
+            .expect("patch properties");
+
+        // Guards against the negative assertions below passing on an empty map.
+        for settable in ["region", "labels", "capacity", "lifecycle"] {
+            assert!(
+                properties.contains_key(settable),
+                "{settable} should be patchable",
+            );
+        }
+        for observed in [
+            "last_heartbeat_at_millis",
+            "registered_at_millis",
+            "incarnation",
+        ] {
+            assert!(
+                !properties.contains_key(observed),
+                "{observed} must not be patchable",
+            );
+        }
+    }
+}

--- a/services/controlplane/src/config.rs
+++ b/services/controlplane/src/config.rs
@@ -344,11 +344,56 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    fn clear_felix_env() {
-        for (key, _) in env::vars() {
+    /// Names the pg-test harness uses to find its database.
+    ///
+    /// `FELIX_CONTROLPLANE_POSTGRES_URL` and `DATABASE_URL` are also real
+    /// configuration, so they are cleared like anything else and restored on
+    /// drop. `FELIX_TEST_DATABASE_URL` is only ever harness plumbing, so
+    /// clearing it would be wrong even momentarily.
+    const HARNESS_ONLY_ENV: &str = "FELIX_TEST_DATABASE_URL";
+
+    /// Clears the config environment for the life of the returned guard.
+    ///
+    /// Restoring matters beyond tidiness: these tests share a process with the
+    /// pg-test helpers, which read `FELIX_TEST_DATABASE_URL` and friends to find
+    /// their database. Clearing without restoring left every pg test that
+    /// happened to run afterwards silently falling back to spawning a Docker
+    /// container -- flaky, and it leaked the container.
+    #[must_use]
+    fn clear_felix_env() -> EnvRestore {
+        let mut cleared = Vec::new();
+        for (key, value) in env::vars() {
+            if key == HARNESS_ONLY_ENV {
+                continue;
+            }
             if key.starts_with("FELIX_") || key == "DATABASE_URL" {
                 unsafe {
-                    env::remove_var(key);
+                    env::remove_var(&key);
+                }
+                cleared.push((key, value));
+            }
+        }
+        EnvRestore { cleared }
+    }
+
+    /// Puts back everything [`clear_felix_env`] removed, and anything the test
+    /// set afterwards is removed for the same reason.
+    struct EnvRestore {
+        cleared: Vec<(String, String)>,
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            for (key, _) in env::vars() {
+                if key != HARNESS_ONLY_ENV && (key.starts_with("FELIX_") || key == "DATABASE_URL") {
+                    unsafe {
+                        env::remove_var(&key);
+                    }
+                }
+            }
+            for (key, value) in &self.cleared {
+                unsafe {
+                    env::set_var(key, value);
                 }
             }
         }
@@ -357,7 +402,7 @@ mod tests {
     #[serial]
     #[test]
     fn from_env_uses_defaults() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let config = ControlPlaneConfig::from_env().expect("from_env");
         assert_eq!(config.bind_addr.to_string(), "0.0.0.0:8443");
         assert_eq!(config.metrics_bind.to_string(), "0.0.0.0:8080");
@@ -365,13 +410,13 @@ mod tests {
         assert_eq!(config.changes_limit, DEFAULT_CHANGES_LIMIT);
         assert_eq!(config.oidc_allowed_algorithms, vec![Algorithm::ES256]);
         assert!(matches!(config.storage, StorageBackend::Memory));
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_respects_env_vars() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         unsafe {
             env::set_var("FELIX_CONTROLPLANE_BIND", "127.0.0.1:9443");
             env::set_var("FELIX_CONTROLPLANE_METRICS_BIND", "127.0.0.1:9090");
@@ -393,25 +438,25 @@ mod tests {
             vec![Algorithm::ES256, Algorithm::RS256, Algorithm::PS256]
         );
 
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_rejects_invalid_socket_addr() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         unsafe {
             env::set_var("FELIX_CONTROLPLANE_BIND", "not-a-valid-address");
         }
         let result = ControlPlaneConfig::from_env();
         assert!(result.is_err());
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_activates_postgres_when_url_present() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         unsafe {
             env::set_var(
                 "FELIX_CONTROLPLANE_POSTGRES_URL",
@@ -421,23 +466,23 @@ mod tests {
         let config = ControlPlaneConfig::from_env().expect("from_env");
         assert!(matches!(config.storage, StorageBackend::Postgres));
         assert!(config.postgres.is_some());
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_or_yaml_no_file_uses_defaults() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let config = ControlPlaneConfig::from_env_or_yaml().expect("from_env_or_yaml");
         assert_eq!(config.bind_addr.to_string(), "0.0.0.0:8443");
         assert_eq!(config.region_id, "local");
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_or_yaml_file_not_found_fails() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let tmpdir = TempDir::new().unwrap();
         let nonexistent = tmpdir.path().join("nonexistent.yml");
         unsafe {
@@ -445,13 +490,13 @@ mod tests {
         }
         let result = ControlPlaneConfig::from_env_or_yaml();
         assert!(result.is_err());
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_or_yaml_overrides_with_valid_yaml() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let tmpdir = TempDir::new().unwrap();
         let config_path = tmpdir.path().join("config.yml");
         fs::write(
@@ -481,13 +526,13 @@ storage:
             vec![Algorithm::ES256, Algorithm::RS384, Algorithm::PS512]
         );
 
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_or_yaml_invalid_yaml_fails() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let tmpdir = TempDir::new().unwrap();
         let config_path = tmpdir.path().join("bad.yml");
         fs::write(&config_path, "this is not: valid: yaml:").unwrap();
@@ -498,13 +543,13 @@ storage:
         let result = ControlPlaneConfig::from_env_or_yaml();
         assert!(result.is_err());
 
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_or_yaml_invalid_socket_in_yaml_fails() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         let tmpdir = TempDir::new().unwrap();
         let config_path = tmpdir.path().join("config.yml");
         fs::write(&config_path, "bind_addr: \"not-a-socket\"").unwrap();
@@ -515,13 +560,13 @@ storage:
         let result = ControlPlaneConfig::from_env_or_yaml();
         assert!(result.is_err());
 
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 
     #[serial]
     #[test]
     fn from_env_rejects_invalid_oidc_algorithm() {
-        clear_felix_env();
+        let _env = clear_felix_env();
         unsafe {
             env::set_var(
                 "FELIX_CONTROLPLANE_OIDC_ALLOWED_ALGORITHMS",
@@ -530,6 +575,6 @@ storage:
         }
         let result = ControlPlaneConfig::from_env();
         assert!(result.is_err());
-        clear_felix_env();
+        let _env = clear_felix_env();
     }
 }

--- a/services/controlplane/src/main.rs
+++ b/services/controlplane/src/main.rs
@@ -4,18 +4,11 @@
 //! the main API server and (optionally) the bootstrap server.
 //!
 //! The `build_state` helper keeps wiring testable and minimizes main setup logic.
-mod api;
-mod app;
-mod auth;
-mod config;
-mod model;
-mod observability;
-mod store;
-
 use anyhow::Context;
-use api::types::{FeatureFlags, Region};
-use app::{AppState, build_bootstrap_router, build_router};
-use auth::oidc::UpstreamOidcValidator;
+use controlplane::api::types::{FeatureFlags, Region};
+use controlplane::app::{AppState, build_bootstrap_router, build_router};
+use controlplane::auth::oidc::UpstreamOidcValidator;
+use controlplane::{config, observability, store};
 use felix_common::lifecycle::{self, DrainBudget, Readiness};
 use std::future::{Future, IntoFuture};
 use std::sync::Arc;

--- a/services/controlplane/src/model/mod.rs
+++ b/services/controlplane/src/model/mod.rs
@@ -1,14 +1,19 @@
 //! Control-plane data model module.
 //!
-//! Re-exports the core tenant/namespace/stream/cache models and change payloads
-//! used by the API and store layers.
+//! Re-exports the core tenant/namespace/stream/cache/node models and change
+//! payloads used by the API and store layers.
 mod cache;
 mod namespace;
+mod node;
 mod stream;
 mod tenant;
 
 pub use cache::{Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest};
 pub use namespace::{Namespace, NamespaceChange, NamespaceChangeOp, NamespaceKey};
+pub use node::{
+    Node, NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle, NodePatchRequest, NodeSpec,
+    NodeStatus, NodeValidationError,
+};
 pub use stream::{
     ConsistencyLevel, DeliveryGuarantee, RetentionPolicy, Stream, StreamChange, StreamChangeOp,
     StreamKey, StreamKind, StreamPatchRequest,

--- a/services/controlplane/src/model/node.rs
+++ b/services/controlplane/src/model/node.rs
@@ -1,0 +1,293 @@
+//! Broker node model, patch payloads, and change-log events.
+//!
+//! A node is a broker process in the cluster. The record is split in two: a
+//! `NodeSpec` an operator sets, and a `NodeStatus` the cluster observes. Only
+//! the spec is reachable through [`NodePatchRequest`], so an admin call can
+//! never claim a broker is alive.
+//!
+//! Shard placement reads this model but is not part of it: a node says where it
+//! is and how much it can hold, never what it currently holds.
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use utoipa::ToSchema;
+
+/// Longest accepted node identity, label key, or label value.
+const MAX_IDENTIFIER_LEN: usize = 253;
+
+/// Why a node record was rejected.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum NodeValidationError {
+    #[error("node_id must not be empty")]
+    EmptyNodeId,
+    #[error("node_id must be at most {MAX_IDENTIFIER_LEN} characters")]
+    NodeIdTooLong,
+    #[error(
+        "node_id must contain only lowercase alphanumerics, '-', '.', or '_': {0:?} is not allowed"
+    )]
+    NodeIdCharacter(char),
+    #[error("region must not be empty")]
+    EmptyRegion,
+    #[error("advertise_addr {0:?} is not a valid host:port address")]
+    InvalidAdvertiseAddr(String),
+    #[error("advertise_addr must specify a non-zero port")]
+    ZeroAdvertisePort,
+    #[error("label keys must not be empty")]
+    EmptyLabelKey,
+    #[error("label key {0:?} must be at most {MAX_IDENTIFIER_LEN} characters")]
+    LabelKeyTooLong(String),
+    #[error("label value for {0:?} must be at most {MAX_IDENTIFIER_LEN} characters")]
+    LabelValueTooLong(String),
+    #[error("capacity hint max_shards must be greater than zero when set")]
+    ZeroMaxShards,
+    #[error("cannot move a node from {from:?} to {to:?}")]
+    UnsupportedTransition {
+        from: NodeLifecycle,
+        to: NodeLifecycle,
+    },
+}
+
+/// Where a node is in its membership lifecycle.
+///
+/// No state is terminal: a broker keeps its identity across restarts, so a
+/// record that reached `Left` or `Down` is revived by the same node
+/// re-registering rather than replaced by a new one.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum NodeLifecycle {
+    /// Registered and heartbeating. Eligible for new shard placement.
+    Live,
+    /// Still serving, but should not receive new placement. Operator-driven.
+    Draining,
+    /// Heartbeat expired. The process may or may not still be running.
+    Down,
+    /// Deregistered through a graceful shutdown.
+    Left,
+}
+
+impl NodeLifecycle {
+    /// Whether `self` may move to `next`.
+    ///
+    /// Two rules produce the whole table. A node that is not currently serving
+    /// cannot begin draining, because there is nothing to drain. Everything
+    /// else is reachable, including revival from `Down` or `Left`, which is
+    /// what a broker restart looks like.
+    pub fn can_transition_to(self, next: NodeLifecycle) -> bool {
+        use NodeLifecycle::*;
+        match (self, next) {
+            (from, to) if from == to => true,
+            (Down | Left, Draining) => false,
+            _ => true,
+        }
+    }
+}
+
+/// Capacity hints an operator provides for placement.
+///
+/// Hints, not limits: placement is free to weigh them against live signals.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct NodeCapacity {
+    /// Upper bound on shards this node should hold. `None` means unbounded.
+    pub max_shards: Option<u32>,
+    /// Relative share of shards against other nodes. Larger takes more.
+    #[serde(default = "default_weight")]
+    pub weight: u32,
+}
+
+/// Hand-written so an omitted `capacity` and an omitted `weight` agree. A
+/// derived `Default` would give weight 0, which is no share of placement at all.
+impl Default for NodeCapacity {
+    fn default() -> Self {
+        Self {
+            max_shards: None,
+            weight: default_weight(),
+        }
+    }
+}
+
+fn default_weight() -> u32 {
+    1
+}
+
+/// What an operator declares about a node.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct NodeSpec {
+    /// `host:port` the node's broker-internal QUIC listener is reachable on.
+    ///
+    /// Unique across the cluster: two nodes advertising one address cannot both
+    /// be reached, and the store rejects the second.
+    pub advertise_addr: String,
+    pub region: String,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
+    #[serde(default)]
+    pub capacity: NodeCapacity,
+}
+
+/// What the cluster has observed about a node.
+///
+/// Every field here is derived from registration and heartbeats. None of it is
+/// settable through [`NodePatchRequest`], except `lifecycle`, and then only for
+/// the transitions an operator is allowed to drive.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct NodeStatus {
+    pub lifecycle: NodeLifecycle,
+    /// Milliseconds since the Unix epoch at the last accepted heartbeat.
+    pub last_heartbeat_at_millis: u64,
+    /// Milliseconds since the Unix epoch at the node's first registration.
+    ///
+    /// Preserved across restarts, so it dates the identity rather than the
+    /// current process.
+    pub registered_at_millis: u64,
+    /// Increments on every registration, so a restart is distinguishable from a
+    /// node that never went away.
+    #[serde(default)]
+    pub incarnation: u64,
+}
+
+/// A broker process in the cluster.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct Node {
+    pub node_id: String,
+    pub spec: NodeSpec,
+    pub status: NodeStatus,
+}
+
+impl Node {
+    /// Check identity, address, labels, and capacity hints.
+    ///
+    /// Does not check cluster-wide uniqueness of `node_id` or
+    /// `spec.advertise_addr`; only a store sees enough to do that.
+    pub fn validate(&self) -> Result<(), NodeValidationError> {
+        validate_node_id(&self.node_id)?;
+        self.spec.validate()
+    }
+}
+
+impl NodeSpec {
+    pub fn validate(&self) -> Result<(), NodeValidationError> {
+        if self.region.trim().is_empty() {
+            return Err(NodeValidationError::EmptyRegion);
+        }
+        validate_advertise_addr(&self.advertise_addr)?;
+        validate_labels(&self.labels)?;
+        self.capacity.validate()
+    }
+}
+
+impl NodeCapacity {
+    pub fn validate(&self) -> Result<(), NodeValidationError> {
+        if self.max_shards == Some(0) {
+            return Err(NodeValidationError::ZeroMaxShards);
+        }
+        Ok(())
+    }
+}
+
+/// Operator-settable changes to a node.
+///
+/// Deliberately has no field for `last_heartbeat_at_millis`,
+/// `registered_at_millis`, or `incarnation`: liveness is observed, and an admin
+/// call that could write it would let a dead broker be reported live.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Default)]
+pub struct NodePatchRequest {
+    pub region: Option<String>,
+    pub labels: Option<BTreeMap<String, String>>,
+    pub capacity: Option<NodeCapacity>,
+    /// The only status field an operator may drive, and only into a lifecycle
+    /// [`NodeLifecycle::can_transition_to`] allows from the current one.
+    pub lifecycle: Option<NodeLifecycle>,
+}
+
+impl NodePatchRequest {
+    /// Apply this patch to `node`, leaving it untouched if anything is invalid.
+    pub fn apply(&self, node: &Node) -> Result<Node, NodeValidationError> {
+        let mut patched = node.clone();
+        if let Some(region) = &self.region {
+            patched.spec.region = region.clone();
+        }
+        if let Some(labels) = &self.labels {
+            patched.spec.labels = labels.clone();
+        }
+        if let Some(capacity) = &self.capacity {
+            patched.spec.capacity = capacity.clone();
+        }
+        if let Some(lifecycle) = self.lifecycle {
+            if !node.status.lifecycle.can_transition_to(lifecycle) {
+                return Err(NodeValidationError::UnsupportedTransition {
+                    from: node.status.lifecycle,
+                    to: lifecycle,
+                });
+            }
+            patched.status.lifecycle = lifecycle;
+        }
+        patched.validate()?;
+        Ok(patched)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeChange {
+    pub seq: u64,
+    pub op: NodeChangeOp,
+    pub node_id: String,
+    pub node: Option<Node>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum NodeChangeOp {
+    Registered,
+    Updated,
+    Deregistered,
+}
+
+fn validate_node_id(node_id: &str) -> Result<(), NodeValidationError> {
+    if node_id.is_empty() {
+        return Err(NodeValidationError::EmptyNodeId);
+    }
+    if node_id.len() > MAX_IDENTIFIER_LEN {
+        return Err(NodeValidationError::NodeIdTooLong);
+    }
+    // Constrained because a node_id reaches directory names, metric labels, and
+    // log lines; anything needing quoting there is a problem later.
+    if let Some(bad) = node_id
+        .chars()
+        .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '.' | '_')))
+    {
+        return Err(NodeValidationError::NodeIdCharacter(bad));
+    }
+    Ok(())
+}
+
+fn validate_advertise_addr(addr: &str) -> Result<(), NodeValidationError> {
+    let parsed: SocketAddr = addr
+        .parse()
+        .map_err(|_| NodeValidationError::InvalidAdvertiseAddr(addr.to_string()))?;
+    // Port 0 means "any port" to a listener, so it can never be dialled.
+    if parsed.port() == 0 {
+        return Err(NodeValidationError::ZeroAdvertisePort);
+    }
+    Ok(())
+}
+
+fn validate_labels(labels: &BTreeMap<String, String>) -> Result<(), NodeValidationError> {
+    for (key, value) in labels {
+        if key.is_empty() {
+            return Err(NodeValidationError::EmptyLabelKey);
+        }
+        if key.len() > MAX_IDENTIFIER_LEN {
+            return Err(NodeValidationError::LabelKeyTooLong(key.clone()));
+        }
+        if value.len() > MAX_IDENTIFIER_LEN {
+            return Err(NodeValidationError::LabelValueTooLong(key.clone()));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "node_tests.rs"]
+mod tests;

--- a/services/controlplane/src/model/node_tests.rs
+++ b/services/controlplane/src/model/node_tests.rs
@@ -1,0 +1,322 @@
+//! Unit tests for the node model: validation, patching, and serialization.
+use super::*;
+
+fn node() -> Node {
+    Node {
+        node_id: "broker-1".to_string(),
+        spec: NodeSpec {
+            advertise_addr: "10.0.0.4:7000".to_string(),
+            region: "us-west-2".to_string(),
+            labels: BTreeMap::from([("rack".to_string(), "a1".to_string())]),
+            capacity: NodeCapacity {
+                max_shards: Some(64),
+                weight: 2,
+            },
+        },
+        status: NodeStatus {
+            lifecycle: NodeLifecycle::Live,
+            last_heartbeat_at_millis: 1_700_000_000_000,
+            registered_at_millis: 1_699_000_000_000,
+            incarnation: 3,
+        },
+    }
+}
+
+#[test]
+fn a_well_formed_node_validates() {
+    assert_eq!(node().validate(), Ok(()));
+}
+
+#[test]
+fn an_empty_node_id_is_rejected() {
+    let mut node = node();
+    node.node_id = String::new();
+    assert_eq!(node.validate(), Err(NodeValidationError::EmptyNodeId));
+}
+
+#[test]
+fn a_node_id_needing_quoting_elsewhere_is_rejected() {
+    for (id, bad) in [("Broker-1", 'B'), ("broker 1", ' '), ("broker/1", '/')] {
+        let mut node = node();
+        node.node_id = id.to_string();
+        assert_eq!(
+            node.validate(),
+            Err(NodeValidationError::NodeIdCharacter(bad)),
+            "{id} should be rejected",
+        );
+    }
+}
+
+#[test]
+fn an_over_long_node_id_is_rejected() {
+    let mut node = node();
+    node.node_id = "a".repeat(MAX_IDENTIFIER_LEN + 1);
+    assert_eq!(node.validate(), Err(NodeValidationError::NodeIdTooLong));
+
+    node.node_id = "a".repeat(MAX_IDENTIFIER_LEN);
+    assert_eq!(node.validate(), Ok(()));
+}
+
+#[test]
+fn an_unusable_advertise_address_is_rejected() {
+    for addr in ["", "10.0.0.4", "not-an-address:7000", "10.0.0.4:port"] {
+        let mut node = node();
+        node.spec.advertise_addr = addr.to_string();
+        assert_eq!(
+            node.validate(),
+            Err(NodeValidationError::InvalidAdvertiseAddr(addr.to_string())),
+            "{addr} should be rejected",
+        );
+    }
+}
+
+/// Port 0 parses, but a listener reads it as "any port", so it is never dialable.
+#[test]
+fn a_zero_advertise_port_is_rejected() {
+    let mut node = node();
+    node.spec.advertise_addr = "10.0.0.4:0".to_string();
+    assert_eq!(node.validate(), Err(NodeValidationError::ZeroAdvertisePort));
+}
+
+#[test]
+fn an_ipv6_advertise_address_is_accepted() {
+    let mut node = node();
+    node.spec.advertise_addr = "[2001:db8::1]:7000".to_string();
+    assert_eq!(node.validate(), Ok(()));
+}
+
+#[test]
+fn an_empty_region_is_rejected() {
+    let mut node = node();
+    node.spec.region = "   ".to_string();
+    assert_eq!(node.validate(), Err(NodeValidationError::EmptyRegion));
+}
+
+#[test]
+fn malformed_labels_are_rejected() {
+    let mut node = node();
+    node.spec.labels = BTreeMap::from([(String::new(), "a".to_string())]);
+    assert_eq!(node.validate(), Err(NodeValidationError::EmptyLabelKey));
+
+    let long = "a".repeat(MAX_IDENTIFIER_LEN + 1);
+    node.spec.labels = BTreeMap::from([(long.clone(), "a".to_string())]);
+    assert_eq!(
+        node.validate(),
+        Err(NodeValidationError::LabelKeyTooLong(long))
+    );
+
+    node.spec.labels = BTreeMap::from([("rack".to_string(), "a".repeat(MAX_IDENTIFIER_LEN + 1))]);
+    assert_eq!(
+        node.validate(),
+        Err(NodeValidationError::LabelValueTooLong("rack".to_string()))
+    );
+}
+
+#[test]
+fn a_zero_max_shards_hint_is_rejected() {
+    let mut node = node();
+    node.spec.capacity.max_shards = Some(0);
+    assert_eq!(node.validate(), Err(NodeValidationError::ZeroMaxShards));
+
+    node.spec.capacity.max_shards = None;
+    assert_eq!(node.validate(), Ok(()));
+}
+
+#[test]
+fn a_node_that_is_not_serving_cannot_start_draining() {
+    for from in [NodeLifecycle::Down, NodeLifecycle::Left] {
+        assert!(
+            !from.can_transition_to(NodeLifecycle::Draining),
+            "{from:?} should not be drainable",
+        );
+    }
+}
+
+/// A broker keeps its identity across a restart, so re-registering has to be
+/// able to revive a record that reached `Down` or `Left`.
+#[test]
+fn a_restart_revives_a_down_or_departed_node() {
+    for from in [NodeLifecycle::Down, NodeLifecycle::Left] {
+        assert!(from.can_transition_to(NodeLifecycle::Live));
+    }
+}
+
+#[test]
+fn every_lifecycle_can_stay_where_it_is() {
+    for state in [
+        NodeLifecycle::Live,
+        NodeLifecycle::Draining,
+        NodeLifecycle::Down,
+        NodeLifecycle::Left,
+    ] {
+        assert!(state.can_transition_to(state), "{state:?} should be stable");
+    }
+}
+
+#[test]
+fn a_patch_updates_only_the_fields_it_names() {
+    let before = node();
+    let patch = NodePatchRequest {
+        region: Some("eu-central-1".to_string()),
+        ..NodePatchRequest::default()
+    };
+
+    let after = patch.apply(&before).expect("patch");
+    assert_eq!(after.spec.region, "eu-central-1");
+    assert_eq!(after.spec.labels, before.spec.labels);
+    assert_eq!(after.spec.capacity, before.spec.capacity);
+    assert_eq!(after.status, before.status);
+}
+
+#[test]
+fn a_patch_can_drive_an_allowed_lifecycle_transition() {
+    let before = node();
+    let patch = NodePatchRequest {
+        lifecycle: Some(NodeLifecycle::Draining),
+        ..NodePatchRequest::default()
+    };
+
+    let after = patch.apply(&before).expect("patch");
+    assert_eq!(after.status.lifecycle, NodeLifecycle::Draining);
+    assert_eq!(
+        after.status.last_heartbeat_at_millis,
+        before.status.last_heartbeat_at_millis
+    );
+}
+
+#[test]
+fn a_patch_cannot_drive_an_unsupported_lifecycle_transition() {
+    let mut before = node();
+    before.status.lifecycle = NodeLifecycle::Down;
+    let patch = NodePatchRequest {
+        lifecycle: Some(NodeLifecycle::Draining),
+        ..NodePatchRequest::default()
+    };
+
+    assert_eq!(
+        patch.apply(&before),
+        Err(NodeValidationError::UnsupportedTransition {
+            from: NodeLifecycle::Down,
+            to: NodeLifecycle::Draining,
+        }),
+    );
+}
+
+#[test]
+fn a_rejected_patch_leaves_the_node_untouched() {
+    let before = node();
+    let patch = NodePatchRequest {
+        region: Some(String::new()),
+        ..NodePatchRequest::default()
+    };
+
+    assert_eq!(patch.apply(&before), Err(NodeValidationError::EmptyRegion));
+    assert_eq!(before, node());
+}
+
+/// The whole point of splitting spec from status: an admin patch has no field
+/// that could claim a broker is alive.
+#[test]
+fn a_patch_cannot_forge_observed_liveness() {
+    let before = node();
+    let json = serde_json::json!({
+        "region": "eu-central-1",
+        "lastHeartbeatAtMillis": 9_999_999_999_999u64,
+        "last_heartbeat_at_millis": 9_999_999_999_999u64,
+        "incarnation": 99,
+        "registered_at_millis": 0,
+    });
+
+    let patch: NodePatchRequest = serde_json::from_value(json).expect("deserialize");
+    let after = patch.apply(&before).expect("patch");
+    assert_eq!(after.status, before.status);
+}
+
+#[test]
+fn a_node_round_trips_through_json() {
+    let before = node();
+    let encoded = serde_json::to_string(&before).expect("serialize");
+    let after: Node = serde_json::from_str(&encoded).expect("deserialize");
+    assert_eq!(after, before);
+}
+
+/// Labels sit in a `BTreeMap` so a change payload for the same node is byte
+/// identical however the map was built.
+#[test]
+fn label_order_does_not_change_the_encoding() {
+    let mut ascending = node();
+    ascending.spec.labels = BTreeMap::from([
+        ("a".to_string(), "1".to_string()),
+        ("z".to_string(), "2".to_string()),
+    ]);
+    let mut descending = node();
+    descending.spec.labels = BTreeMap::from([
+        ("z".to_string(), "2".to_string()),
+        ("a".to_string(), "1".to_string()),
+    ]);
+
+    assert_eq!(
+        serde_json::to_string(&ascending).expect("serialize"),
+        serde_json::to_string(&descending).expect("serialize"),
+    );
+}
+
+#[test]
+fn optional_spec_fields_default_when_absent() {
+    let json = serde_json::json!({
+        "advertise_addr": "10.0.0.4:7000",
+        "region": "us-west-2",
+    });
+
+    let spec: NodeSpec = serde_json::from_value(json).expect("deserialize");
+    assert!(spec.labels.is_empty());
+    assert_eq!(spec.capacity, NodeCapacity::default());
+    assert_eq!(spec.validate(), Ok(()));
+}
+
+/// `weight` defaults to 1 rather than 0, so a spec that omits it is not silently
+/// given zero share of placement.
+#[test]
+fn an_omitted_capacity_weight_defaults_to_one() {
+    let capacity: NodeCapacity =
+        serde_json::from_value(serde_json::json!({})).expect("deserialize");
+    assert_eq!(capacity.weight, 1);
+    assert_eq!(NodeCapacity::default().weight, 1);
+}
+
+#[test]
+fn change_ops_serialize_as_camel_case() {
+    for (op, expected) in [
+        (NodeChangeOp::Registered, "\"registered\""),
+        (NodeChangeOp::Updated, "\"updated\""),
+        (NodeChangeOp::Deregistered, "\"deregistered\""),
+    ] {
+        assert_eq!(serde_json::to_string(&op).expect("serialize"), expected);
+    }
+}
+
+/// A deregistration carries no node body, matching the other change feeds.
+#[test]
+fn a_change_round_trips_with_and_without_a_body() {
+    for change in [
+        NodeChange {
+            seq: 7,
+            op: NodeChangeOp::Registered,
+            node_id: "broker-1".to_string(),
+            node: Some(node()),
+        },
+        NodeChange {
+            seq: 8,
+            op: NodeChangeOp::Deregistered,
+            node_id: "broker-1".to_string(),
+            node: None,
+        },
+    ] {
+        let encoded = serde_json::to_string(&change).expect("serialize");
+        let decoded: NodeChange = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded.seq, change.seq);
+        assert_eq!(decoded.op, change.op);
+        assert_eq!(decoded.node_id, change.node_id);
+        assert_eq!(decoded.node, change.node);
+    }
+}


### PR DESCRIPTION
Closes #92. First slice of **M2 — Cluster membership & broker identity**. Model only: persistence is #93, heartbeat and liveness expiry are #94, the admin API is #96.

## The model

A node is a broker process. The record splits in two, which is the whole design:

- **`NodeSpec`** — what an operator declares: `advertise_addr`, `region`, `labels`, `capacity`.
- **`NodeStatus`** — what the cluster observes: `lifecycle`, `last_heartbeat_at_millis`, `registered_at_millis`, `incarnation`.

`NodePatchRequest` reaches only the spec, plus the lifecycle transitions an operator may drive. It has **no field** for a heartbeat, a registration time, or an incarnation — so the ordinary admin path cannot forge liveness. That is asserted against the *generated OpenAPI schema*, not just the Rust type, since the wire contract is what an operator actually talks to.

**Lifecycle**: `Live`, `Draining`, `Down`, `Left`, with one rule — a node that is not serving cannot begin draining. Nothing is terminal: a broker keeps its identity across a restart, so re-registering has to revive a record that reached `Down` or `Left`. `incarnation` is what distinguishes a restart from a node that never left.

Uniqueness of `node_id` and `advertise_addr` is documented on the model but enforced by the store — only a store sees enough to check it. No shard state here: a node says where it is and how much it can hold, never what it currently holds.

**A bug the tests caught:** `#[derive(Default)]` on `NodeCapacity` gives `weight: 0` while the serde default gives `1`, so a spec omitting `capacity` entirely would have been silently given no share of placement. `Default` is now hand-written so both paths agree.

## Two fixes that came out of the work

Both are in their own commits.

### `clear_felix_env` was leaking Docker containers

`config.rs`'s test helper removed every `FELIX_*` var from the process and never put them back. `FELIX_TEST_DATABASE_URL` is one of them, so **any pg test ordered after a config test found no URL and fell back to spawning a Docker container** — which then failed on `does not expose port 5432`, and leaked, because the helper leaks its testcontainers client so nothing tears it down.

Measured over 12 runs of the pg-test lib suite, verified in both directions:

| | test failures | leaked containers |
| --- | --- | --- |
| before | 1 / 12 | **11** |
| after | 0 / 12 | 0 |

It now restores what it cleared and never touches `FELIX_TEST_DATABASE_URL`, which is only ever harness plumbing. `FELIX_CONTROLPLANE_POSTGRES_URL` and `DATABASE_URL` are real configuration, so those are still cleared — and now restored.

This also means any local run claiming to have tested against a configured Postgres may have quietly used a throwaway container instead.

### The binary recompiled the whole crate

`main.rs` re-declared every module, so `controlplane` compiled twice and any public item the binary did not call was reported dead there — which is what surfaced it, since the node model is not wired into a handler until #96. `main.rs` only ever used the public API, so importing from `controlplane::` is enough.

## Tests

24 model tests plus 2 OpenAPI tests, covering the schema, validation, serialization, patch, and changefeed cases the issue asks for. The OpenAPI tests guard the acceptance criterion directly — nothing else would catch a model registered in `model/mod.rs` but forgotten in `components(schemas(...))`. The patch-schema test asserts the settable fields are present too, so its negative assertions cannot pass on an empty map.

## Verification

`task lint`, `task test` (62 suites), `task demo:check`, and the pg-test suite against a real Postgres 16 via `task pg:up` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)