### PR TITLE
feat(controlplane): persist broker membership in both stores

### DIFF
--- a/services/controlplane/migrations/0005_nodes.sql
+++ b/services/controlplane/migrations/0005_nodes.sql
@@ -1,0 +1,60 @@
+-- Broker membership: a node is a broker process in the cluster.
+--
+-- Spec columns are operator-declared; status columns are heartbeat-derived.
+-- Both live in one row because they describe one node, but only the store
+-- writes the status ones.
+CREATE TABLE IF NOT EXISTS nodes (
+    node_id TEXT PRIMARY KEY,
+    advertise_addr TEXT NOT NULL,
+    region TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+    capacity_max_shards INTEGER NULL,
+    capacity_weight INTEGER NOT NULL DEFAULT 1,
+    lifecycle TEXT NOT NULL,
+    last_heartbeat_at_millis BIGINT NOT NULL,
+    registered_at_millis BIGINT NOT NULL,
+    incarnation BIGINT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Two nodes advertising one address cannot both be reached, so the second is
+-- rejected rather than silently shadowing the first.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_advertise_addr ON nodes(advertise_addr);
+
+-- Placement filters by region, and by which nodes are eligible.
+CREATE INDEX IF NOT EXISTS idx_nodes_region_lifecycle ON nodes(region, lifecycle);
+
+-- Liveness expiry sweeps live nodes ordered by staleness, so the partial index
+-- is over exactly the rows that sweep can act on.
+CREATE INDEX IF NOT EXISTS idx_nodes_heartbeat_expiry
+    ON nodes(last_heartbeat_at_millis)
+    WHERE lifecycle IN ('live', 'draining');
+
+CREATE TABLE IF NOT EXISTS node_changes (
+    seq BIGINT PRIMARY KEY,
+    op TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    payload JSONB,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_node_changes_node ON node_changes(node_id);
+
+-- Why this exists instead of a BIGSERIAL, as the other change tables use:
+--
+-- A sequence hands out numbers in request order, not commit order. Two writers
+-- can take seq 4 and 5, and 5 can commit first. A snapshot taken in between
+-- reads MAX(seq)+1 = 6, so the consumer resumes at 6 and never sees 4 -- a
+-- committed change silently missed.
+--
+-- Allocating from a single locked row instead makes the second writer wait for
+-- the first to commit, so seq order is commit order and `>= next_seq` cannot
+-- skip anything. Membership changes are rare enough for that to cost nothing.
+CREATE TABLE IF NOT EXISTS node_change_seq (
+    only_row BOOLEAN PRIMARY KEY DEFAULT TRUE CONSTRAINT node_change_seq_single CHECK (only_row),
+    next_seq BIGINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO node_change_seq (only_row, next_seq) VALUES (TRUE, 0)
+    ON CONFLICT (only_row) DO NOTHING;

--- a/services/controlplane/src/store/memory.rs
+++ b/services/controlplane/src/store/memory.rs
@@ -38,8 +38,9 @@ use crate::auth::idp_registry::IdpIssuerConfig;
 use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, Namespace, NamespaceChange,
-    NamespaceChangeOp, NamespaceKey, Stream, StreamChange, StreamChangeOp, StreamKey,
-    StreamPatchRequest, Tenant, TenantChange, TenantChangeOp,
+    NamespaceChangeOp, NamespaceKey, Node, NodeChange, NodeChangeOp, NodeLifecycle,
+    NodePatchRequest, Stream, StreamChange, StreamChangeOp, StreamKey, StreamPatchRequest, Tenant,
+    TenantChange, TenantChangeOp,
 };
 use async_trait::async_trait;
 use std::collections::{HashMap, VecDeque};
@@ -88,6 +89,37 @@ impl<T> ChangeLog<T> {
     }
 }
 
+/// A model rejection is the caller's fault, so it surfaces as a conflict
+/// rather than an internal error.
+fn invalid_node(err: crate::model::NodeValidationError) -> StoreError {
+    StoreError::Conflict(err.to_string())
+}
+
+fn invalid_transition(from: NodeLifecycle, to: NodeLifecycle) -> StoreError {
+    invalid_node(crate::model::NodeValidationError::UnsupportedTransition { from, to })
+}
+
+/// Node records and their change log under one lock.
+///
+/// Kept together so a snapshot cannot observe a record set and a `next_seq`
+/// that disagree.
+#[derive(Debug)]
+struct NodeState {
+    records: HashMap<String, Node>,
+    changes: ChangeLog<NodeChange>,
+}
+
+impl NodeState {
+    fn record(&mut self, op: NodeChangeOp, node_id: &str, node: Option<Node>) {
+        self.changes.record(|seq| NodeChange {
+            seq,
+            op,
+            node_id: node_id.to_string(),
+            node,
+        });
+    }
+}
+
 /// In-memory control-plane store.
 ///
 /// ## Data structures
@@ -114,6 +146,12 @@ pub struct InMemoryStore {
     streams: Arc<RwLock<HashMap<StreamKey, Stream>>>,
     /// Authoritative caches keyed by `(tenant_id, namespace, cache)`.
     caches: Arc<RwLock<HashMap<CacheKey, Cache>>>,
+    /// Broker membership keyed by `node_id`, with its change log.
+    ///
+    /// One lock over both, unlike the entities above: a snapshot has to read
+    /// the records and the log position as one value, or a change committed
+    /// between the two reads is missed by every consumer that resumes from it.
+    nodes: Arc<RwLock<NodeState>>,
     /// Bounded change log for tenant changes.
     ///
     /// `next_seq` is per-entity-type (not a global sequence across all entities).
@@ -153,6 +191,10 @@ impl InMemoryStore {
             namespaces: Arc::new(RwLock::new(HashMap::new())),
             streams: Arc::new(RwLock::new(HashMap::new())),
             caches: Arc::new(RwLock::new(HashMap::new())),
+            nodes: Arc::new(RwLock::new(NodeState {
+                records: HashMap::new(),
+                changes: ChangeLog::new(capacity),
+            })),
             tenant_changes: Arc::new(RwLock::new(ChangeLog::new(capacity))),
             namespace_changes: Arc::new(RwLock::new(ChangeLog::new(capacity))),
             stream_changes: Arc::new(RwLock::new(ChangeLog::new(capacity))),
@@ -685,6 +727,172 @@ impl ControlPlaneStore for InMemoryStore {
         })
     }
 
+    async fn register_node(&self, node: Node) -> StoreResult<Node> {
+        node.validate().map_err(invalid_node)?;
+        let mut state = self.nodes.write().await;
+
+        if let Some((holder, _)) = state.records.iter().find(|(id, existing)| {
+            existing.spec.advertise_addr == node.spec.advertise_addr && *id != &node.node_id
+        }) {
+            return Err(StoreError::Conflict(format!(
+                "advertise_addr {} is already registered to node {holder}",
+                node.spec.advertise_addr
+            )));
+        }
+
+        let stored = match state.records.get(&node.node_id) {
+            Some(existing) => {
+                if !existing
+                    .status
+                    .lifecycle
+                    .can_transition_to(node.status.lifecycle)
+                {
+                    return Err(invalid_transition(
+                        existing.status.lifecycle,
+                        node.status.lifecycle,
+                    ));
+                }
+                Node {
+                    status: crate::model::NodeStatus {
+                        // The identity outlives the process, so its first
+                        // registration is what dates it.
+                        registered_at_millis: existing.status.registered_at_millis,
+                        incarnation: existing.status.incarnation + 1,
+                        ..node.status
+                    },
+                    ..node
+                }
+            }
+            None => Node {
+                status: crate::model::NodeStatus {
+                    incarnation: 0,
+                    ..node.status
+                },
+                ..node
+            },
+        };
+
+        state.records.insert(stored.node_id.clone(), stored.clone());
+        state.record(
+            NodeChangeOp::Registered,
+            &stored.node_id,
+            Some(stored.clone()),
+        );
+        metrics::counter!("felix_node_changes_total", "op" => "registered").increment(1);
+        Ok(stored)
+    }
+
+    async fn get_node(&self, node_id: &str) -> StoreResult<Node> {
+        self.nodes
+            .read()
+            .await
+            .records
+            .get(node_id)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound("node".into()))
+    }
+
+    async fn list_nodes(&self) -> StoreResult<Vec<Node>> {
+        let mut items: Vec<Node> = self.nodes.read().await.records.values().cloned().collect();
+        items.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(items)
+    }
+
+    async fn patch_node(&self, node_id: &str, patch: NodePatchRequest) -> StoreResult<Node> {
+        let mut state = self.nodes.write().await;
+        let existing = state
+            .records
+            .get(node_id)
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+        let patched = patch.apply(existing).map_err(invalid_node)?;
+
+        if let Some((holder, _)) = state.records.iter().find(|(id, other)| {
+            other.spec.advertise_addr == patched.spec.advertise_addr && *id != node_id
+        }) {
+            return Err(StoreError::Conflict(format!(
+                "advertise_addr {} is already registered to node {holder}",
+                patched.spec.advertise_addr
+            )));
+        }
+
+        state.records.insert(node_id.to_string(), patched.clone());
+        state.record(NodeChangeOp::Updated, node_id, Some(patched.clone()));
+        metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+        Ok(patched)
+    }
+
+    async fn delete_node(&self, node_id: &str) -> StoreResult<()> {
+        let mut state = self.nodes.write().await;
+        if state.records.remove(node_id).is_none() {
+            return Err(StoreError::NotFound("node".into()));
+        }
+        state.record(NodeChangeOp::Deregistered, node_id, None);
+        metrics::counter!("felix_node_changes_total", "op" => "deregistered").increment(1);
+        Ok(())
+    }
+
+    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()> {
+        let mut state = self.nodes.write().await;
+        let node = state
+            .records
+            .get_mut(node_id)
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+        // Never moves backwards: heartbeats from two connections can arrive out
+        // of order, and the newest observation is the one that matters.
+        node.status.last_heartbeat_at_millis = node.status.last_heartbeat_at_millis.max(at_millis);
+        Ok(())
+    }
+
+    async fn set_node_lifecycle(
+        &self,
+        node_id: &str,
+        lifecycle: NodeLifecycle,
+    ) -> StoreResult<Option<Node>> {
+        let mut state = self.nodes.write().await;
+        let node = state
+            .records
+            .get_mut(node_id)
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+        if node.status.lifecycle == lifecycle {
+            return Ok(None);
+        }
+        if !node.status.lifecycle.can_transition_to(lifecycle) {
+            return Err(invalid_transition(node.status.lifecycle, lifecycle));
+        }
+        node.status.lifecycle = lifecycle;
+        let updated = node.clone();
+        state.record(NodeChangeOp::Updated, node_id, Some(updated.clone()));
+        metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+        Ok(Some(updated))
+    }
+
+    async fn node_snapshot(&self) -> StoreResult<Snapshot<Node>> {
+        // One guard, so `items` and `next_seq` describe the same instant.
+        let state = self.nodes.read().await;
+        let mut items: Vec<Node> = state.records.values().cloned().collect();
+        items.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(Snapshot {
+            items,
+            next_seq: state.changes.next_seq,
+        })
+    }
+
+    async fn node_changes(&self, since: u64) -> StoreResult<ChangeSet<NodeChange>> {
+        let state = self.nodes.read().await;
+        let items = state
+            .changes
+            .items
+            .iter()
+            .filter(|item| item.seq >= since)
+            .take(self.limit())
+            .cloned()
+            .collect();
+        Ok(ChangeSet {
+            items,
+            next_seq: state.changes.next_seq,
+        })
+    }
+
     async fn tenant_exists(&self, tenant_id: &str) -> StoreResult<bool> {
         Ok(self.tenants.read().await.contains_key(tenant_id))
     }
@@ -878,6 +1086,14 @@ impl AuthStore for InMemoryStore {
 mod tests {
     use super::*;
     use crate::model::{ConsistencyLevel, DeliveryGuarantee, RetentionPolicy, StreamKind};
+
+    /// The same suite Postgres runs, so parity is enforced rather than assumed.
+    #[tokio::test]
+    async fn satisfies_the_node_store_contract() {
+        let store = std::sync::Arc::new(store_with_limits(100, 1000));
+        crate::store::node_contract::run_node_contract(store.clone()).await;
+        crate::store::node_contract::run_node_concurrency_contract(store).await;
+    }
 
     fn store_with_limits(changes_limit: u64, retention: i64) -> InMemoryStore {
         InMemoryStore::new(StoreConfig {

--- a/services/controlplane/src/store/mod.rs
+++ b/services/controlplane/src/store/mod.rs
@@ -10,7 +10,8 @@ use crate::auth::idp_registry::IdpIssuerConfig;
 use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::model::{
     Cache, CacheChange, CacheKey, CachePatchRequest, Namespace, NamespaceChange, NamespaceKey,
-    Stream, StreamChange, StreamKey, StreamPatchRequest, Tenant, TenantChange,
+    Node, NodeChange, NodePatchRequest, Stream, StreamChange, StreamKey, StreamPatchRequest,
+    Tenant, TenantChange,
 };
 use async_trait::async_trait;
 use thiserror::Error;
@@ -18,6 +19,8 @@ use thiserror::Error;
 pub mod memory;
 pub mod postgres;
 
+#[cfg(test)]
+mod node_contract;
 #[cfg(test)]
 mod postgres_tests;
 
@@ -108,6 +111,42 @@ pub trait ControlPlaneStore: Send + Sync {
     async fn delete_cache(&self, key: &CacheKey) -> StoreResult<()>;
     async fn cache_snapshot(&self) -> StoreResult<Snapshot<Cache>>;
     async fn cache_changes(&self, since: u64) -> StoreResult<ChangeSet<CacheChange>>;
+
+    /// Register a node, or revive the record a restarting node already has.
+    ///
+    /// `node_id` identifies a broker across restarts, so registering an id that
+    /// already exists updates its spec and bumps `incarnation` rather than
+    /// conflicting. `registered_at_millis` is preserved from the first
+    /// registration; the caller's value is used only for a new node.
+    ///
+    /// Conflicts only when `advertise_addr` belongs to a different node.
+    async fn register_node(&self, node: Node) -> StoreResult<Node>;
+    async fn get_node(&self, node_id: &str) -> StoreResult<Node>;
+    async fn list_nodes(&self) -> StoreResult<Vec<Node>>;
+    /// Apply an operator patch. Rejects a lifecycle transition the model
+    /// disallows, and never touches heartbeat-derived fields.
+    async fn patch_node(&self, node_id: &str, patch: NodePatchRequest) -> StoreResult<Node>;
+    async fn delete_node(&self, node_id: &str) -> StoreResult<()>;
+    /// Record liveness without emitting a change.
+    ///
+    /// Heartbeats arrive per node per interval; putting each one in the
+    /// changefeed would evict every real membership change from the retention
+    /// window. Only a lifecycle move a heartbeat causes is worth publishing,
+    /// and that is [`ControlPlaneStore::set_node_lifecycle`].
+    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()>;
+    /// Move a node's lifecycle from an observed signal rather than an operator.
+    ///
+    /// Unlike [`ControlPlaneStore::patch_node`] this may drive transitions an
+    /// operator cannot, because liveness expiry and graceful shutdown are not
+    /// admin actions. Returns `Ok(None)` when the node is already there, so a
+    /// repeated sweep does not publish a change per pass.
+    async fn set_node_lifecycle(
+        &self,
+        node_id: &str,
+        lifecycle: crate::model::NodeLifecycle,
+    ) -> StoreResult<Option<Node>>;
+    async fn node_snapshot(&self) -> StoreResult<Snapshot<Node>>;
+    async fn node_changes(&self, since: u64) -> StoreResult<ChangeSet<NodeChange>>;
 
     async fn tenant_exists(&self, tenant_id: &str) -> StoreResult<bool>;
     async fn namespace_exists(&self, key: &NamespaceKey) -> StoreResult<bool>;

--- a/services/controlplane/src/store/node_contract.rs
+++ b/services/controlplane/src/store/node_contract.rs
@@ -1,0 +1,451 @@
+//! Node store behaviour that both backends must satisfy.
+//!
+//! One body, two callers: the memory store runs it in `memory::tests`, Postgres
+//! in `postgres_tests`. Parity is the point -- a rule that holds only in memory
+//! is a rule the deployed system does not have.
+use super::{ControlPlaneStore, StoreError};
+use crate::model::{Node, NodeCapacity, NodeLifecycle, NodePatchRequest, NodeSpec, NodeStatus};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+pub(crate) fn node(node_id: &str, port: u16) -> Node {
+    Node {
+        node_id: node_id.to_string(),
+        spec: NodeSpec {
+            advertise_addr: format!("10.0.0.4:{port}"),
+            region: "us-west-2".to_string(),
+            labels: BTreeMap::from([("rack".to_string(), "a1".to_string())]),
+            capacity: NodeCapacity {
+                max_shards: Some(64),
+                weight: 2,
+            },
+        },
+        status: NodeStatus {
+            lifecycle: NodeLifecycle::Live,
+            last_heartbeat_at_millis: 1_700_000_000_000,
+            registered_at_millis: 1_699_000_000_000,
+            incarnation: 0,
+        },
+    }
+}
+
+/// Run every node contract case against `store`.
+///
+/// Takes a store the caller has already emptied of nodes.
+pub(crate) async fn run_node_contract(store: Arc<dyn ControlPlaneStore>) {
+    let store: &dyn ControlPlaneStore = store.as_ref();
+    register_is_readable(store).await;
+    register_rejects_an_address_another_node_holds(store).await;
+    reregistering_preserves_identity_and_bumps_incarnation(store).await;
+    an_invalid_node_is_rejected(store).await;
+    patch_updates_the_spec_and_leaves_observed_status_alone(store).await;
+    patch_rejects_an_unsupported_transition(store).await;
+    a_heartbeat_never_moves_backwards(store).await;
+    a_heartbeat_publishes_no_change(store).await;
+    set_lifecycle_is_idempotent(store).await;
+    missing_nodes_report_not_found(store).await;
+    delete_removes_and_publishes(store).await;
+    a_snapshot_and_the_changes_after_it_lose_nothing(store).await;
+    changes_are_ordered_and_monotonic(store).await;
+}
+
+/// Run the cases that need to share the store across tasks.
+///
+/// Separate from [`run_node_contract`] only because these need an owned handle.
+pub(crate) async fn run_node_concurrency_contract(store: Arc<dyn ControlPlaneStore>) {
+    a_snapshot_taken_under_concurrent_writes_loses_nothing(store).await;
+}
+
+/// The reason `node_changes.seq` is allocated from a locked row rather than a
+/// sequence.
+///
+/// A sequence hands out numbers in request order, not commit order, so a
+/// snapshot taken while writer 4 is still in flight and writer 5 has committed
+/// reads `next_seq = 6` and never sees 4. Reconstructing from that snapshot
+/// then comes up short, which is what this asserts cannot happen.
+async fn a_snapshot_taken_under_concurrent_writes_loses_nothing(store: Arc<dyn ControlPlaneStore>) {
+    const WRITERS: u16 = 24;
+
+    clear(store.as_ref()).await;
+
+    let writers: Vec<_> = (0..WRITERS)
+        .map(|i| {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                store
+                    .register_node(node(&format!("broker-{i:03}"), 7200 + i))
+                    .await
+                    .expect("register");
+            })
+        })
+        .collect();
+
+    // Taken while the writers are still going, which is the whole point.
+    let mut snapshots = Vec::new();
+    for _ in 0..WRITERS {
+        snapshots.push(store.node_snapshot().await.expect("snapshot"));
+        tokio::task::yield_now().await;
+    }
+
+    for writer in writers {
+        writer.await.expect("writer");
+    }
+
+    let final_state: BTreeMap<String, Node> = store
+        .list_nodes()
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|n| (n.node_id.clone(), n))
+        .collect();
+    assert_eq!(final_state.len(), WRITERS as usize);
+
+    for snapshot in snapshots {
+        let since = snapshot.next_seq;
+        let mut reconstructed: BTreeMap<String, Node> = snapshot
+            .items
+            .into_iter()
+            .map(|n| (n.node_id.clone(), n))
+            .collect();
+        for change in store.node_changes(since).await.expect("changes").items {
+            match change.node {
+                Some(node) => {
+                    reconstructed.insert(change.node_id, node);
+                }
+                None => {
+                    reconstructed.remove(&change.node_id);
+                }
+            }
+        }
+        assert_eq!(
+            reconstructed.keys().collect::<Vec<_>>(),
+            final_state.keys().collect::<Vec<_>>(),
+            "a snapshot at next_seq={since} plus the changes after it lost a node",
+        );
+    }
+}
+
+async fn clear(store: &dyn ControlPlaneStore) {
+    for node in store.list_nodes().await.expect("list") {
+        store.delete_node(&node.node_id).await.expect("delete");
+    }
+}
+
+async fn register_is_readable(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let stored = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    assert_eq!(stored.node_id, "broker-a");
+    assert_eq!(stored.status.incarnation, 0);
+
+    let fetched = store.get_node("broker-a").await.expect("get");
+    assert_eq!(fetched, stored);
+    assert_eq!(store.list_nodes().await.expect("list"), vec![stored]);
+}
+
+async fn register_rejects_an_address_another_node_holds(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+
+    let mut clash = node("broker-b", 7001);
+    clash.spec.advertise_addr = node("broker-a", 7001).spec.advertise_addr;
+    let err = store
+        .register_node(clash)
+        .await
+        .expect_err("should conflict");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+
+    // The clash must not have half-registered the second node.
+    assert!(store.get_node("broker-b").await.is_err());
+}
+
+async fn reregistering_preserves_identity_and_bumps_incarnation(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let first = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+
+    let mut restarted = node("broker-a", 7001);
+    restarted.spec.region = "eu-central-1".to_string();
+    // A restarting broker does not know when its identity was first seen.
+    restarted.status.registered_at_millis = 0;
+    restarted.status.last_heartbeat_at_millis = first.status.last_heartbeat_at_millis + 5_000;
+
+    let second = store.register_node(restarted).await.expect("re-register");
+    assert_eq!(second.status.incarnation, 1);
+    assert_eq!(
+        second.status.registered_at_millis, first.status.registered_at_millis,
+        "the identity keeps its original registration time",
+    );
+    assert_eq!(second.spec.region, "eu-central-1");
+}
+
+async fn an_invalid_node_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let mut bad = node("broker-a", 7001);
+    bad.spec.advertise_addr = "not-an-address".to_string();
+    let err = store.register_node(bad).await.expect_err("should reject");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+    assert!(store.list_nodes().await.expect("list").is_empty());
+}
+
+async fn patch_updates_the_spec_and_leaves_observed_status_alone(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let before = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+
+    let after = store
+        .patch_node(
+            "broker-a",
+            NodePatchRequest {
+                region: Some("eu-central-1".to_string()),
+                ..NodePatchRequest::default()
+            },
+        )
+        .await
+        .expect("patch");
+
+    assert_eq!(after.spec.region, "eu-central-1");
+    assert_eq!(after.status, before.status);
+}
+
+async fn patch_rejects_an_unsupported_transition(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Down)
+        .await
+        .expect("set down");
+
+    let err = store
+        .patch_node(
+            "broker-a",
+            NodePatchRequest {
+                lifecycle: Some(NodeLifecycle::Draining),
+                ..NodePatchRequest::default()
+            },
+        )
+        .await
+        .expect_err("should reject");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+
+    let unchanged = store.get_node("broker-a").await.expect("get");
+    assert_eq!(unchanged.status.lifecycle, NodeLifecycle::Down);
+}
+
+async fn a_heartbeat_never_moves_backwards(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let registered = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    let at = registered.status.last_heartbeat_at_millis;
+
+    store
+        .record_node_heartbeat("broker-a", at + 1_000)
+        .await
+        .expect("beat");
+    store
+        .record_node_heartbeat("broker-a", at - 1_000)
+        .await
+        .expect("late beat");
+
+    let seen = store.get_node("broker-a").await.expect("get");
+    assert_eq!(seen.status.last_heartbeat_at_millis, at + 1_000);
+}
+
+async fn a_heartbeat_publishes_no_change(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    let before = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    store
+        .record_node_heartbeat("broker-a", 1_800_000_000_000)
+        .await
+        .expect("beat");
+
+    let after = store.node_snapshot().await.expect("snapshot").next_seq;
+    assert_eq!(
+        before, after,
+        "a heartbeat would evict real membership changes from the window",
+    );
+}
+
+async fn set_lifecycle_is_idempotent(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+
+    let moved = store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Down)
+        .await
+        .expect("set down");
+    assert!(moved.is_some());
+    let after_first = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    let repeat = store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Down)
+        .await
+        .expect("set down again");
+    assert!(repeat.is_none(), "a repeated sweep should publish nothing");
+    assert_eq!(
+        after_first,
+        store.node_snapshot().await.expect("snapshot").next_seq
+    );
+}
+
+async fn missing_nodes_report_not_found(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    assert!(matches!(
+        store.get_node("absent").await.expect_err("get"),
+        StoreError::NotFound(_)
+    ));
+    assert!(matches!(
+        store.delete_node("absent").await.expect_err("delete"),
+        StoreError::NotFound(_)
+    ));
+    assert!(matches!(
+        store
+            .record_node_heartbeat("absent", 1)
+            .await
+            .expect_err("beat"),
+        StoreError::NotFound(_)
+    ));
+    assert!(matches!(
+        store
+            .patch_node("absent", NodePatchRequest::default())
+            .await
+            .expect_err("patch"),
+        StoreError::NotFound(_)
+    ));
+    assert!(matches!(
+        store
+            .set_node_lifecycle("absent", NodeLifecycle::Down)
+            .await
+            .expect_err("lifecycle"),
+        StoreError::NotFound(_)
+    ));
+}
+
+async fn delete_removes_and_publishes(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    store.delete_node("broker-a").await.expect("delete");
+
+    assert!(store.get_node("broker-a").await.is_err());
+    let changes = store.node_changes(since).await.expect("changes");
+    assert_eq!(changes.items.len(), 1);
+    assert_eq!(changes.items[0].node_id, "broker-a");
+    assert!(
+        changes.items[0].node.is_none(),
+        "a deregistration carries no body",
+    );
+}
+
+/// The bootstrap contract: take a snapshot, poll from its `next_seq`, and the
+/// two together describe every node exactly once.
+async fn a_snapshot_and_the_changes_after_it_lose_nothing(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+
+    let snapshot = store.node_snapshot().await.expect("snapshot");
+    assert_eq!(snapshot.items.len(), 1);
+
+    store
+        .register_node(node("broker-b", 7002))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-b", NodeLifecycle::Draining)
+        .await
+        .expect("drain");
+
+    let changes = store
+        .node_changes(snapshot.next_seq)
+        .await
+        .expect("changes");
+    assert!(
+        changes.items.iter().all(|c| c.seq >= snapshot.next_seq),
+        "a change already in the snapshot must not be replayed",
+    );
+    assert!(
+        changes.items.iter().any(|c| c.node_id == "broker-b"),
+        "a change committed after the snapshot must be visible from its next_seq",
+    );
+
+    // Applying the snapshot then the changes reproduces the store exactly.
+    let mut reconstructed: BTreeMap<String, Node> = snapshot
+        .items
+        .into_iter()
+        .map(|n| (n.node_id.clone(), n))
+        .collect();
+    for change in changes.items {
+        match change.node {
+            Some(node) => {
+                reconstructed.insert(change.node_id, node);
+            }
+            None => {
+                reconstructed.remove(&change.node_id);
+            }
+        }
+    }
+    let actual: BTreeMap<String, Node> = store
+        .list_nodes()
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|n| (n.node_id.clone(), n))
+        .collect();
+    assert_eq!(reconstructed, actual);
+}
+
+async fn changes_are_ordered_and_monotonic(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    for i in 0..5u16 {
+        store
+            .register_node(node(&format!("broker-{i}"), 7100 + i))
+            .await
+            .expect("register");
+    }
+
+    let changes = store.node_changes(since).await.expect("changes");
+    assert_eq!(changes.items.len(), 5);
+    for pair in changes.items.windows(2) {
+        assert!(
+            pair[0].seq < pair[1].seq,
+            "seq must be strictly increasing: {} then {}",
+            pair[0].seq,
+            pair[1].seq,
+        );
+    }
+    assert!(
+        changes.next_seq > changes.items.last().expect("last").seq,
+        "next_seq must be past the last change returned",
+    );
+}

--- a/services/controlplane/src/store/postgres.rs
+++ b/services/controlplane/src/store/postgres.rs
@@ -32,8 +32,10 @@ use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::config::PostgresConfig;
 use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, Namespace, NamespaceChange,
-    NamespaceChangeOp, NamespaceKey, RetentionPolicy, Stream, StreamChange, StreamChangeOp,
-    StreamKey, StreamKind, StreamPatchRequest, Tenant, TenantChange, TenantChangeOp,
+    NamespaceChangeOp, NamespaceKey, Node, NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle,
+    NodePatchRequest, NodeSpec, NodeStatus, NodeValidationError, RetentionPolicy, Stream,
+    StreamChange, StreamChangeOp, StreamKey, StreamKind, StreamPatchRequest, Tenant, TenantChange,
+    TenantChangeOp,
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -1304,6 +1306,265 @@ impl ControlPlaneStore for PostgresStore {
         Ok(ChangeSet { items, next_seq })
     }
 
+    async fn register_node(&self, node: Node) -> StoreResult<Node> {
+        node.validate().map_err(invalid_node)?;
+        let mut tx = self.pool.begin().await?;
+
+        let existing = sqlx::query_as::<_, DbNode>(NODE_SELECT_BY_ID_FOR_UPDATE)
+            .bind(&node.node_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(node_from_db)
+            .transpose()?;
+
+        let stored = match existing {
+            Some(existing) => {
+                if !existing
+                    .status
+                    .lifecycle
+                    .can_transition_to(node.status.lifecycle)
+                {
+                    return Err(invalid_node_transition(
+                        existing.status.lifecycle,
+                        node.status.lifecycle,
+                    ));
+                }
+                Node {
+                    status: NodeStatus {
+                        // The identity outlives the process, so its first
+                        // registration is what dates it.
+                        registered_at_millis: existing.status.registered_at_millis,
+                        incarnation: existing.status.incarnation + 1,
+                        ..node.status
+                    },
+                    ..node
+                }
+            }
+            None => Node {
+                status: NodeStatus {
+                    incarnation: 0,
+                    ..node.status
+                },
+                ..node
+            },
+        };
+
+        let upsert = sqlx::query(
+            r#"INSERT INTO nodes (node_id, advertise_addr, region, labels, capacity_max_shards, capacity_weight, lifecycle, last_heartbeat_at_millis, registered_at_millis, incarnation)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+               ON CONFLICT (node_id) DO UPDATE SET
+                 advertise_addr = EXCLUDED.advertise_addr,
+                 region = EXCLUDED.region,
+                 labels = EXCLUDED.labels,
+                 capacity_max_shards = EXCLUDED.capacity_max_shards,
+                 capacity_weight = EXCLUDED.capacity_weight,
+                 lifecycle = EXCLUDED.lifecycle,
+                 last_heartbeat_at_millis = EXCLUDED.last_heartbeat_at_millis,
+                 registered_at_millis = EXCLUDED.registered_at_millis,
+                 incarnation = EXCLUDED.incarnation,
+                 updated_at = now()"#,
+        );
+        let upsert = bind_node(upsert, &stored).execute(&mut *tx).await;
+        if let Err(err) = upsert {
+            if is_unique_violation(&err) {
+                return Err(StoreError::Conflict(format!(
+                    "advertise_addr {} is already registered to another node",
+                    stored.spec.advertise_addr
+                )));
+            }
+            return Err(StoreError::Unexpected(err.into()));
+        }
+
+        record_node_change(
+            &mut tx,
+            NodeChangeOp::Registered,
+            &stored.node_id,
+            Some(&stored),
+        )
+        .await?;
+        tx.commit().await?;
+        metrics::counter!("felix_node_changes_total", "op" => "registered").increment(1);
+        Ok(stored)
+    }
+
+    async fn get_node(&self, node_id: &str) -> StoreResult<Node> {
+        sqlx::query_as::<_, DbNode>(NODE_SELECT_BY_ID)
+            .bind(node_id)
+            .fetch_optional(&self.pool)
+            .await?
+            .map(node_from_db)
+            .transpose()?
+            .ok_or_else(|| StoreError::NotFound("node".into()))
+    }
+
+    async fn list_nodes(&self) -> StoreResult<Vec<Node>> {
+        let rows = sqlx::query_as::<_, DbNode>(NODE_SELECT_ALL)
+            .fetch_all(&self.pool)
+            .await?;
+        rows.into_iter().map(node_from_db).collect()
+    }
+
+    async fn patch_node(&self, node_id: &str, patch: NodePatchRequest) -> StoreResult<Node> {
+        let mut tx = self.pool.begin().await?;
+        let existing = sqlx::query_as::<_, DbNode>(NODE_SELECT_BY_ID_FOR_UPDATE)
+            .bind(node_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(node_from_db)
+            .transpose()?
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+
+        let patched = patch.apply(&existing).map_err(invalid_node)?;
+
+        let update = sqlx::query(
+            r#"UPDATE nodes SET advertise_addr = $2, region = $3, labels = $4,
+                 capacity_max_shards = $5, capacity_weight = $6, lifecycle = $7,
+                 last_heartbeat_at_millis = $8, registered_at_millis = $9, incarnation = $10,
+                 updated_at = now()
+               WHERE node_id = $1"#,
+        );
+        let update = bind_node(update, &patched).execute(&mut *tx).await;
+        if let Err(err) = update {
+            if is_unique_violation(&err) {
+                return Err(StoreError::Conflict(format!(
+                    "advertise_addr {} is already registered to another node",
+                    patched.spec.advertise_addr
+                )));
+            }
+            return Err(StoreError::Unexpected(err.into()));
+        }
+
+        record_node_change(&mut tx, NodeChangeOp::Updated, node_id, Some(&patched)).await?;
+        tx.commit().await?;
+        metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+        Ok(patched)
+    }
+
+    async fn delete_node(&self, node_id: &str) -> StoreResult<()> {
+        let mut tx = self.pool.begin().await?;
+        let deleted = sqlx::query("DELETE FROM nodes WHERE node_id = $1")
+            .bind(node_id)
+            .execute(&mut *tx)
+            .await?;
+        if deleted.rows_affected() == 0 {
+            return Err(StoreError::NotFound("node".into()));
+        }
+        record_node_change(&mut tx, NodeChangeOp::Deregistered, node_id, None).await?;
+        tx.commit().await?;
+        metrics::counter!("felix_node_changes_total", "op" => "deregistered").increment(1);
+        Ok(())
+    }
+
+    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()> {
+        // GREATEST, not assignment: heartbeats from two connections can arrive
+        // out of order, and the newest observation is the one that matters.
+        // No change is emitted -- see the trait for why.
+        let updated = sqlx::query(
+            r#"UPDATE nodes
+               SET last_heartbeat_at_millis = GREATEST(last_heartbeat_at_millis, $2),
+                   updated_at = now()
+               WHERE node_id = $1"#,
+        )
+        .bind(node_id)
+        .bind(at_millis as i64)
+        .execute(&self.pool)
+        .await?;
+        if updated.rows_affected() == 0 {
+            return Err(StoreError::NotFound("node".into()));
+        }
+        Ok(())
+    }
+
+    async fn set_node_lifecycle(
+        &self,
+        node_id: &str,
+        lifecycle: NodeLifecycle,
+    ) -> StoreResult<Option<Node>> {
+        let mut tx = self.pool.begin().await?;
+        let existing = sqlx::query_as::<_, DbNode>(NODE_SELECT_BY_ID_FOR_UPDATE)
+            .bind(node_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(node_from_db)
+            .transpose()?
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+
+        if existing.status.lifecycle == lifecycle {
+            return Ok(None);
+        }
+        if !existing.status.lifecycle.can_transition_to(lifecycle) {
+            return Err(invalid_node_transition(
+                existing.status.lifecycle,
+                lifecycle,
+            ));
+        }
+
+        let mut updated = existing;
+        updated.status.lifecycle = lifecycle;
+        sqlx::query("UPDATE nodes SET lifecycle = $2, updated_at = now() WHERE node_id = $1")
+            .bind(node_id)
+            .bind(node_lifecycle_to_str(lifecycle))
+            .execute(&mut *tx)
+            .await?;
+
+        record_node_change(&mut tx, NodeChangeOp::Updated, node_id, Some(&updated)).await?;
+        tx.commit().await?;
+        metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+        Ok(Some(updated))
+    }
+
+    async fn node_snapshot(&self) -> StoreResult<Snapshot<Node>> {
+        // REPEATABLE READ, not just one transaction: under the default READ
+        // COMMITTED the two statements below see different snapshots, so a node
+        // committed between them is absent from `items` while its seq is
+        // already counted in `next_seq` -- lost to every consumer that resumes
+        // there. Together with seq being handed out in commit order (see
+        // 0005_nodes.sql), this makes snapshot-then-poll exactly-once.
+        let mut tx = self.pool.begin().await?;
+        begin_consistent_read(&mut tx).await?;
+        let rows = sqlx::query_as::<_, DbNode>(NODE_SELECT_ALL)
+            .fetch_all(&mut *tx)
+            .await?;
+        let items = rows
+            .into_iter()
+            .map(node_from_db)
+            .collect::<StoreResult<Vec<_>>>()?;
+        let next_seq = sqlx::query_scalar::<_, i64>("SELECT next_seq FROM node_change_seq")
+            .fetch_one(&mut *tx)
+            .await? as u64;
+        tx.commit().await?;
+        Ok(Snapshot { items, next_seq })
+    }
+
+    async fn node_changes(&self, since: u64) -> StoreResult<ChangeSet<NodeChange>> {
+        // Consistent for the same reason as `node_snapshot`: the rows and
+        // `next_seq` have to describe one instant.
+        let mut tx = self.pool.begin().await?;
+        begin_consistent_read(&mut tx).await?;
+        let rows = sqlx::query_as::<_, NodeChangeRow>(
+            r#"SELECT seq, op, node_id, payload FROM node_changes WHERE seq >= $1 ORDER BY seq ASC LIMIT $2"#,
+        )
+        .bind(since as i64)
+        .bind(self.limit())
+        .fetch_all(&mut *tx)
+        .await?;
+        let next_seq = sqlx::query_scalar::<_, i64>("SELECT next_seq FROM node_change_seq")
+            .fetch_one(&mut *tx)
+            .await? as u64;
+        tx.commit().await?;
+
+        let mut items = Vec::with_capacity(rows.len());
+        for row in rows {
+            items.push(NodeChange {
+                seq: row.seq as u64,
+                op: parse_node_change_op(&row.op)?,
+                node_id: row.node_id,
+                node: row.payload.map(serde_json::from_value).transpose()?,
+            });
+        }
+        Ok(ChangeSet { items, next_seq })
+    }
+
     async fn tenant_exists(&self, tenant_id: &str) -> StoreResult<bool> {
         let exists: bool =
             sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM tenants WHERE tenant_id = $1)")
@@ -1336,6 +1597,161 @@ impl ControlPlaneStore for PostgresStore {
     fn backend_name(&self) -> &'static str {
         "postgres"
     }
+}
+
+const NODE_SELECT_ALL: &str = r#"SELECT node_id, advertise_addr, region, labels, capacity_max_shards, capacity_weight, lifecycle, last_heartbeat_at_millis, registered_at_millis, incarnation FROM nodes ORDER BY node_id"#;
+const NODE_SELECT_BY_ID: &str = r#"SELECT node_id, advertise_addr, region, labels, capacity_max_shards, capacity_weight, lifecycle, last_heartbeat_at_millis, registered_at_millis, incarnation FROM nodes WHERE node_id = $1"#;
+/// `FOR UPDATE` so a concurrent register or patch of the same node waits rather
+/// than reading the row this transaction is about to replace.
+const NODE_SELECT_BY_ID_FOR_UPDATE: &str = r#"SELECT node_id, advertise_addr, region, labels, capacity_max_shards, capacity_weight, lifecycle, last_heartbeat_at_millis, registered_at_millis, incarnation FROM nodes WHERE node_id = $1 FOR UPDATE"#;
+
+/// Bind a node in the column order the insert and the update both use.
+fn bind_node<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments>,
+    node: &'q Node,
+) -> sqlx::query::Query<'q, sqlx::Postgres, sqlx::postgres::PgArguments> {
+    query
+        .bind(&node.node_id)
+        .bind(&node.spec.advertise_addr)
+        .bind(&node.spec.region)
+        .bind(serde_json::to_value(&node.spec.labels).unwrap_or_default())
+        .bind(node.spec.capacity.max_shards.map(|v| v as i32))
+        .bind(node.spec.capacity.weight as i32)
+        .bind(node_lifecycle_to_str(node.status.lifecycle))
+        .bind(node.status.last_heartbeat_at_millis as i64)
+        .bind(node.status.registered_at_millis as i64)
+        .bind(node.status.incarnation as i64)
+}
+
+/// Make the rest of the transaction read one consistent snapshot of the
+/// database, rather than re-reading between statements.
+async fn begin_consistent_read(tx: &mut sqlx::Transaction<'_, sqlx::Postgres>) -> StoreResult<()> {
+    sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Append a change, taking its `seq` from the locked counter.
+///
+/// The `UPDATE ... RETURNING` holds a row lock until this transaction commits,
+/// so a concurrent writer blocks and takes the next number only afterwards.
+/// That is what makes `seq` order equal commit order, which is what lets a
+/// consumer resume at `next_seq` without missing anything. See 0005_nodes.sql.
+async fn record_node_change(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    op: NodeChangeOp,
+    node_id: &str,
+    node: Option<&Node>,
+) -> StoreResult<()> {
+    let seq = sqlx::query_scalar::<_, i64>(
+        "UPDATE node_change_seq SET next_seq = next_seq + 1 RETURNING next_seq - 1",
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    sqlx::query("INSERT INTO node_changes (seq, op, node_id, payload) VALUES ($1, $2, $3, $4)")
+        .bind(seq)
+        .bind(node_change_op_to_str(&op))
+        .bind(node_id)
+        .bind(node.map(serde_json::to_value).transpose()?)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Row shape for the `nodes` table.
+#[derive(Debug, Clone, FromRow)]
+struct DbNode {
+    node_id: String,
+    advertise_addr: String,
+    region: String,
+    labels: serde_json::Value,
+    capacity_max_shards: Option<i32>,
+    capacity_weight: i32,
+    lifecycle: String,
+    last_heartbeat_at_millis: i64,
+    registered_at_millis: i64,
+    incarnation: i64,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct NodeChangeRow {
+    seq: i64,
+    op: String,
+    node_id: String,
+    payload: Option<serde_json::Value>,
+}
+
+fn node_from_db(row: DbNode) -> StoreResult<Node> {
+    Ok(Node {
+        node_id: row.node_id,
+        spec: NodeSpec {
+            advertise_addr: row.advertise_addr,
+            region: row.region,
+            labels: serde_json::from_value(row.labels)?,
+            capacity: NodeCapacity {
+                max_shards: row.capacity_max_shards.map(|v| v as u32),
+                weight: row.capacity_weight as u32,
+            },
+        },
+        status: NodeStatus {
+            lifecycle: parse_node_lifecycle(&row.lifecycle)?,
+            last_heartbeat_at_millis: row.last_heartbeat_at_millis as u64,
+            registered_at_millis: row.registered_at_millis as u64,
+            incarnation: row.incarnation as u64,
+        },
+    })
+}
+
+fn node_lifecycle_to_str(lifecycle: NodeLifecycle) -> &'static str {
+    match lifecycle {
+        NodeLifecycle::Live => "live",
+        NodeLifecycle::Draining => "draining",
+        NodeLifecycle::Down => "down",
+        NodeLifecycle::Left => "left",
+    }
+}
+
+fn parse_node_lifecycle(value: &str) -> StoreResult<NodeLifecycle> {
+    match value {
+        "live" => Ok(NodeLifecycle::Live),
+        "draining" => Ok(NodeLifecycle::Draining),
+        "down" => Ok(NodeLifecycle::Down),
+        "left" => Ok(NodeLifecycle::Left),
+        other => Err(StoreError::Unexpected(anyhow!(
+            "unknown node lifecycle: {other}"
+        ))),
+    }
+}
+
+fn node_change_op_to_str(op: &NodeChangeOp) -> &'static str {
+    match op {
+        NodeChangeOp::Registered => "Registered",
+        NodeChangeOp::Updated => "Updated",
+        NodeChangeOp::Deregistered => "Deregistered",
+    }
+}
+
+fn parse_node_change_op(value: &str) -> StoreResult<NodeChangeOp> {
+    match value {
+        "Registered" => Ok(NodeChangeOp::Registered),
+        "Updated" => Ok(NodeChangeOp::Updated),
+        "Deregistered" => Ok(NodeChangeOp::Deregistered),
+        other => Err(StoreError::Unexpected(anyhow!(
+            "unknown node change op: {other}"
+        ))),
+    }
+}
+
+/// A model rejection is the caller's fault, so it surfaces as a conflict rather
+/// than an internal error.
+fn invalid_node(err: NodeValidationError) -> StoreError {
+    StoreError::Conflict(err.to_string())
+}
+
+fn invalid_node_transition(from: NodeLifecycle, to: NodeLifecycle) -> StoreError {
+    invalid_node(NodeValidationError::UnsupportedTransition { from, to })
 }
 
 fn is_unique_violation(err: &sqlx::Error) -> bool {

--- a/services/controlplane/src/store/postgres_tests.rs
+++ b/services/controlplane/src/store/postgres_tests.rs
@@ -204,7 +204,8 @@ async fn reset_db(url: &str, schema: &str) -> Result<(), sqlx::Error> {
          {schema_ident}.stream_changes, {schema_ident}.cache_changes, {schema_ident}.streams, \
          {schema_ident}.caches, {schema_ident}.namespaces, {schema_ident}.idp_issuers, \
          {schema_ident}.rbac_policies, {schema_ident}.rbac_groupings, \
-         {schema_ident}.tenant_signing_keys, {schema_ident}.tenants RESTART IDENTITY CASCADE",
+         {schema_ident}.tenant_signing_keys, {schema_ident}.nodes, \
+         {schema_ident}.node_changes, {schema_ident}.tenants RESTART IDENTITY CASCADE",
     );
     // Same as `ensure_schema`: the interpolated identifier is our own generated schema name,
     // which cannot be passed as a bind parameter.
@@ -212,6 +213,170 @@ async fn reset_db(url: &str, schema: &str) -> Result<(), sqlx::Error> {
         .execute(&pool)
         .await
         .map(|_| ())
+}
+
+/// Node records are authoritative state, so a new store over the same database
+/// must find them exactly as they were -- including the observed status a
+/// restarting broker cannot reconstruct for itself.
+#[tokio::test]
+#[serial]
+async fn a_reconnected_store_still_sees_registered_nodes() -> anyhow::Result<()> {
+    let Some(url) = pg_url().await else {
+        return Ok(());
+    };
+    let schema = ensure_schema(&url).await?;
+    let url = url_with_schema(&url, &schema);
+    run_migrations_once(&url).await?;
+    reset_db(&url, &schema).await?;
+
+    let pg_cfg = config::PostgresConfig {
+        url: url.clone(),
+        max_connections: 5,
+        connect_timeout_ms: 10_000,
+        acquire_timeout_ms: 10_000,
+    };
+    let store_config = StoreConfig {
+        changes_limit: config::DEFAULT_CHANGES_LIMIT,
+        change_retention_max_rows: None,
+    };
+
+    let before = {
+        let store =
+            PostgresStore::connect_without_migrations(&pg_cfg, store_config.clone()).await?;
+        let node = store
+            .register_node(crate::store::node_contract::node("broker-a", 7001))
+            .await?;
+        store
+            .record_node_heartbeat("broker-a", 1_800_000_000_000)
+            .await?;
+        store.node_snapshot().await?;
+        drop(store);
+        node
+    };
+
+    // A different store handle over the same database, which is what a restart
+    // of the control plane looks like from here.
+    let store = PostgresStore::connect_without_migrations(&pg_cfg, store_config).await?;
+    let after = store.get_node("broker-a").await?;
+
+    assert_eq!(after.node_id, before.node_id);
+    assert_eq!(after.spec, before.spec);
+    assert_eq!(
+        after.status.registered_at_millis,
+        before.status.registered_at_millis
+    );
+    assert_eq!(after.status.incarnation, before.status.incarnation);
+    assert_eq!(
+        after.status.last_heartbeat_at_millis, 1_800_000_000_000,
+        "the last observed heartbeat survives, so expiry can judge staleness",
+    );
+
+    // The changefeed survives too, so a client resuming after the restart is
+    // not forced to re-bootstrap.
+    let changes = store.node_changes(0).await?;
+    assert!(changes.items.iter().any(|c| c.node_id == "broker-a"));
+    Ok(())
+}
+
+/// The property `node_change_seq` exists to provide: a second writer cannot take
+/// a seq until the first has committed.
+///
+/// Without it -- with the `BIGSERIAL` the other change tables use -- writer 2
+/// takes seq 1 and commits while writer 1 still holds seq 0 uncommitted. A
+/// snapshot in that window reads `MAX(seq) + 1 = 2`, so when writer 1 finally
+/// commits, seq 0 is below every consumer's resume point and is never
+/// delivered. Serialising the allocation is what removes that window, and this
+/// asserts the serialisation rather than trusting it.
+#[tokio::test]
+#[serial]
+async fn a_node_change_seq_is_not_handed_out_until_the_holder_commits() -> anyhow::Result<()> {
+    let Some(url) = pg_url().await else {
+        return Ok(());
+    };
+    let schema = ensure_schema(&url).await?;
+    let url = url_with_schema(&url, &schema);
+    run_migrations_once(&url).await?;
+    reset_db(&url, &schema).await?;
+
+    const ALLOCATE: &str =
+        "UPDATE node_change_seq SET next_seq = next_seq + 1 RETURNING next_seq - 1";
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(&url)
+        .await?;
+
+    let mut holder = pool.begin().await?;
+    let first: i64 = sqlx::query_scalar(ALLOCATE).fetch_one(&mut *holder).await?;
+
+    // Spawned rather than timed out in place: dropping a sqlx future does not
+    // cancel the statement the server is already running, so the contender has
+    // to be the same attempt that eventually succeeds.
+    let mut contender = tokio::spawn({
+        let pool = pool.clone();
+        async move {
+            let mut tx = pool.begin().await?;
+            let seq: i64 = sqlx::query_scalar(ALLOCATE).fetch_one(&mut *tx).await?;
+            tx.commit().await?;
+            Ok::<i64, sqlx::Error>(seq)
+        }
+    });
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(750), &mut contender)
+            .await
+            .is_err(),
+        "a second writer took a seq while {first} was still uncommitted",
+    );
+
+    holder.commit().await?;
+
+    let second = tokio::time::timeout(Duration::from_secs(5), contender)
+        .await
+        .expect("the second writer should proceed once the first commits")??;
+
+    assert_eq!(
+        second,
+        first + 1,
+        "seq order must follow commit order with no gap",
+    );
+    pool.close().await;
+    Ok(())
+}
+
+/// The same suite the memory store runs, so parity is enforced rather than
+/// assumed. Skips silently when no database is configured, like every other
+/// test in this file.
+#[tokio::test]
+#[serial]
+async fn satisfies_the_node_store_contract() -> anyhow::Result<()> {
+    let Some(url) = pg_url().await else {
+        return Ok(());
+    };
+    let schema = ensure_schema(&url).await?;
+    let url = url_with_schema(&url, &schema);
+    run_migrations_once(&url).await?;
+    reset_db(&url, &schema).await?;
+
+    let store = PostgresStore::connect_without_migrations(
+        &config::PostgresConfig {
+            url,
+            max_connections: 5,
+            connect_timeout_ms: 10_000,
+            acquire_timeout_ms: 10_000,
+        },
+        StoreConfig {
+            changes_limit: config::DEFAULT_CHANGES_LIMIT,
+            change_retention_max_rows: None,
+        },
+    )
+    .await?;
+
+    let store = std::sync::Arc::new(store);
+    crate::store::node_contract::run_node_contract(store.clone()).await;
+    crate::store::node_contract::run_node_concurrency_contract(store).await;
+    Ok(())
 }
 
 #[tokio::test]

--- a/services/controlplane/tests/http_smoke.rs
+++ b/services/controlplane/tests/http_smoke.rs
@@ -12,7 +12,8 @@ use controlplane::auth::idp_registry::IdpIssuerConfig;
 use controlplane::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use controlplane::model::{
     Cache, CacheChange, CacheKey, CachePatchRequest, Namespace, NamespaceChange, NamespaceKey,
-    Stream, StreamChange, StreamKey, StreamPatchRequest, Tenant, TenantChange,
+    Node, NodeChange, NodeLifecycle, NodePatchRequest, Stream, StreamChange, StreamKey,
+    StreamPatchRequest, Tenant, TenantChange,
 };
 use controlplane::store::{
     AuthStore, ChangeSet, ControlPlaneStore, Snapshot, StoreError, StoreResult,
@@ -934,6 +935,46 @@ impl ControlPlaneStore for FailingStore {
     }
 
     async fn cache_changes(&self, _since: u64) -> StoreResult<ChangeSet<CacheChange>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn register_node(&self, _node: Node) -> StoreResult<Node> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn get_node(&self, _node_id: &str) -> StoreResult<Node> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn list_nodes(&self) -> StoreResult<Vec<Node>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn patch_node(&self, _node_id: &str, _patch: NodePatchRequest) -> StoreResult<Node> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn delete_node(&self, _node_id: &str) -> StoreResult<()> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn record_node_heartbeat(&self, _node_id: &str, _at_millis: u64) -> StoreResult<()> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn set_node_lifecycle(
+        &self,
+        _node_id: &str,
+        _lifecycle: NodeLifecycle,
+    ) -> StoreResult<Option<Node>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn node_snapshot(&self) -> StoreResult<Snapshot<Node>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn node_changes(&self, _since: u64) -> StoreResult<ChangeSet<NodeChange>> {
         Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
     }
 


### PR DESCRIPTION
Closes #93. Second slice of **M2**. Store layer only — heartbeat timing and liveness expiry are #94, the admin API is #96.

## What's here

Node CRUD, snapshots, and an ordered changefeed on `ControlPlaneStore`, implemented in Postgres and memory, plus migration `0005_nodes.sql`.

**Registration is create-or-revive.** A `node_id` identifies a broker across restarts, so re-registering keeps the original `registered_at_millis`, bumps `incarnation`, and takes the new spec. An `advertise_addr` another node holds is a conflict.

**Heartbeats publish no change.** They arrive per node per interval, and putting each in the changefeed would evict every real membership change from the retention window. `set_node_lifecycle` is the observed-signal path — idempotent, so a repeated expiry sweep publishes nothing.

## Making snapshot-then-poll exactly-once

The acceptance criterion is that a snapshot plus subsequent polling *cannot miss or duplicate a committed change*. Two things are needed, and I tested both rather than assuming them.

**1. `node_changes.seq` comes from a locked counter row, not `BIGSERIAL`.** A sequence hands out numbers in request order, not commit order: writer 4 can still be in flight when writer 5 commits, so a snapshot in that window reads `MAX(seq)+1 = 6` and never delivers 4. Allocating from a locked row makes the second writer wait for the first to commit.

`a_node_change_seq_is_not_handed_out_until_the_holder_commits` asserts that serialisation directly, and I verified it **fails** when the table is switched to `BIGSERIAL`.

**2. The snapshot reads at `REPEATABLE READ`.** Under the default `READ COMMITTED` the two statements in `node_snapshot` see *different* views, so a node committing between them is absent from `items` while already counted in `next_seq` — lost to every consumer resuming there.

**The concurrency test caught this in my own first implementation.** It was not theoretical:

```
a snapshot at next_seq=58 plus the changes after it lost a node
  left:  [... "broker-022"]
  right: [... "broker-022", "broker-023"]
```

The memory store has the equivalent hazard, so node records and their change log live under **one** lock there.

## Two pre-existing issues I did not fix

Both are the same bugs, in the entities that already existed. I left them alone rather than doing a silent drive-by, and they deserve their own issue — say the word and I'll file it:

- `tenant_changes`, `namespace_changes`, `stream_changes`, and `cache_changes` all use `BIGSERIAL` with `MAX(seq)+1`, so they have the commit-order gap described above.
- `tenant_snapshot` and friends read `items` and `next_seq` under **separate** locks in the memory store, and in separate `READ COMMITTED` statements in Postgres — the same missed-change window.

## Tests

`node_contract.rs` is one suite both stores run — 13 behavioural cases plus a concurrency case. Parity is the point: a rule that holds only in memory is a rule the deployed system does not have.

Postgres-only, since memory is explicitly not durable:
- `a_reconnected_store_still_sees_registered_nodes` — a new store handle over the same database finds records, observed status, and changefeed intact.
- `a_node_change_seq_is_not_handed_out_until_the_holder_commits` — the sequencing property above.

Indexes: unique on `advertise_addr`, `(region, lifecycle)` for placement, and a partial index on `last_heartbeat_at_millis` restricted to `live`/`draining` — the rows an expiry sweep can act on. The sweep query itself lands in #94.

## Verification

`task lint`, `task test` (62 suites), `task demo:check`, and the full pg suite (100 lib tests) against real Postgres 16 via `task pg:up` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)