### PR TITLE
feat(controlplane): report broker health and expire silent nodes

### DIFF
--- a/demos/cross_tenant_isolation/src/main.rs
+++ b/demos/cross_tenant_isolation/src/main.rs
@@ -434,6 +434,7 @@ async fn spawn_controlplane(store: Arc<PostgresStore>) -> Result<(SocketAddr, Jo
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: true,
         bootstrap_token: Some(BOOTSTRAP_TOKEN.to_string()),
+        node_liveness: Default::default(),
     };
 
     let app = build_router(state.clone()).merge(build_bootstrap_router(state));

--- a/demos/rbac-live/src/main.rs
+++ b/demos/rbac-live/src/main.rs
@@ -307,6 +307,7 @@ async fn spawn_controlplane() -> Result<(SocketAddr, JoinHandle<()>)> {
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: true,
         bootstrap_token: Some(BOOTSTRAP_TOKEN.to_string()),
+        node_liveness: Default::default(),
     };
 
     let app = build_router(state.clone()).merge(build_bootstrap_router(state));

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -42,7 +42,61 @@ On update:
 ## API Sketch (Control Plane)
 - `GetSnapshot()` -> full metadata view + version.
 - `WatchUpdates(from_version)` -> stream of incremental updates.
-- `ReportHealth(node_id, status)` -> node liveness signals.
+- `ReportHealth(node_id, status)` -> node liveness signals. **Implemented** as
+  `POST /v1/nodes/{node_id}/heartbeat`; see [Broker liveness](#broker-liveness).
+
+## Broker liveness
+
+A broker registers on boot and then reports health on an interval. Nothing
+reports that a broker has *stopped*, so silence is the only signal: a periodic
+sweep marks a node `down` once its last heartbeat is older than the timeout.
+
+### `POST /v1/nodes/{node_id}/heartbeat`
+
+Request carries the reporting process's own `incarnation`, from its last
+registration. The response returns the node's lifecycle as the cluster sees it,
+plus the cadence expected of it:
+
+```json
+{ "incarnation": 3 }
+{ "node_id": "broker-1", "lifecycle": "live",
+  "heartbeat_interval_ms": 5000, "expiry_timeout_ms": 15000 }
+```
+
+Four rules, each of which exists for a reason:
+
+- **The recorded time is the control plane's own clock.** A broker that could
+  supply it could postpone its own expiry indefinitely.
+- **An older `incarnation` is rejected with 409.** A heartbeat delayed past a
+  restart belongs to a process the broker has already replaced; counting it
+  would report a dead incarnation as live.
+- **A heartbeat never revives a `down` node.** It proves a process is running,
+  not that it still owns the identity. A broker that reads `"lifecycle": "down"`
+  must register again before it is eligible for placement.
+- **A heartbeat publishes no change.** Heartbeats arrive per node per interval;
+  putting each in the changefeed would evict every real membership change from
+  the retention window. Only the lifecycle move that expiry causes is published.
+
+> **Not yet authenticated.** Any caller that can reach this endpoint can report
+> health for any `node_id`. Authenticating broker identity is tracked in #126;
+> until then it is only safe on a trusted network.
+
+### Configuration
+
+| Setting | Env | Default |
+| --- | --- | --- |
+| `node_liveness.heartbeat_interval_ms` | `FELIX_NODE_HEARTBEAT_INTERVAL_MS` | 5000 |
+| `node_liveness.expiry_timeout_ms` | `FELIX_NODE_EXPIRY_TIMEOUT_MS` | 15000 |
+| `node_liveness.sweep_interval_ms` | `FELIX_NODE_EXPIRY_SWEEP_INTERVAL_MS` | 2000 |
+
+The timeout is three intervals: one lost heartbeat is a hiccup, three is a
+pattern. Startup fails if `expiry_timeout_ms` is not greater than
+`heartbeat_interval_ms` — a timeout at or below the interval expires brokers
+that are heartbeating exactly as told to.
+
+Running several control-plane instances is safe. Each node is claimed by exactly
+one sweep and only that instance publishes the change, so duplicate sweeps cost
+a query and produce no duplicate events.
 
 ## Evolution Plan
 1) Control plane RAFT for membership + placement only.

--- a/services/controlplane/src/api/mod.rs
+++ b/services/controlplane/src/api/mod.rs
@@ -18,6 +18,7 @@ pub mod bootstrap;
 pub mod caches;
 pub mod error;
 pub mod namespaces;
+pub mod nodes;
 pub mod openapi;
 pub mod regions;
 pub mod streams;
@@ -115,6 +116,7 @@ mod tests {
             oidc_validator: crate::auth::oidc::UpstreamOidcValidator::default(),
             bootstrap_enabled: false,
             bootstrap_token: None,
+            node_liveness: Default::default(),
         }
     }
 

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -1,0 +1,84 @@
+//! Broker membership API handlers.
+//!
+//! # Purpose and responsibility
+//! Accepts health reports from brokers and keeps their observed liveness
+//! current.
+//!
+//! # Where it fits in Felix
+//! A broker registers on boot and then reports health on an interval. The
+//! control plane records the last report; a sweep marks silent nodes down.
+//!
+//! # Key invariants and assumptions
+//! - A heartbeat records liveness. It never revives a node the cluster already
+//!   marked down, and never resurrects a superseded incarnation.
+//! - The clock is the control plane's, not the caller's, so a broker cannot
+//!   claim a future heartbeat and outlive its timeout.
+//!
+//! # Security considerations
+//! - **This endpoint is not yet authenticated.** Any caller that can reach it
+//!   can report health for any node_id. Authenticating broker identity is
+//!   tracked in #126; until then this is only safe on a trusted network.
+use crate::api::error::{ApiError, api_conflict, api_internal, api_not_found};
+use crate::api::types::{NodeHeartbeatRequest, NodeHeartbeatResponse};
+use crate::app::AppState;
+use crate::store::StoreError;
+use axum::Json;
+use axum::extract::{Path, State};
+
+#[utoipa::path(
+    post,
+    path = "/v1/nodes/{node_id}/heartbeat",
+    tag = "nodes",
+    params(("node_id" = String, Path, description = "Broker node identifier")),
+    request_body = NodeHeartbeatRequest,
+    responses(
+        (status = 200, description = "Heartbeat recorded", body = NodeHeartbeatResponse),
+        (status = 404, description = "Node is not registered", body = crate::api::types::ErrorResponse),
+        (status = 409, description = "Heartbeat is for a superseded incarnation", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Record that a broker is alive.
+///
+/// Returns the node's current lifecycle and how soon the next heartbeat is
+/// expected. A broker that finds itself `down` here has been expired and must
+/// register again before it is eligible for placement.
+///
+/// # Errors
+/// - 404 when the node is not registered.
+/// - 409 when the reported incarnation is older than the recorded one.
+pub(crate) async fn report_health(
+    State(state): State<AppState>,
+    Path(node_id): Path<String>,
+    Json(request): Json<NodeHeartbeatRequest>,
+) -> Result<Json<NodeHeartbeatResponse>, ApiError> {
+    // The control plane's clock, deliberately: expiry is judged against it, so
+    // letting a caller supply the time would let it postpone its own timeout.
+    let now = now_millis();
+
+    let node = state
+        .store
+        .record_node_heartbeat(&node_id, request.incarnation, now)
+        .await
+        .map_err(|err| match err {
+            StoreError::NotFound(_) => api_not_found("node is not registered"),
+            StoreError::Conflict(ref message) => api_conflict("conflict", message),
+            ref other => api_internal("record node heartbeat", other),
+        })?;
+
+    Ok(Json(NodeHeartbeatResponse {
+        node_id: node.node_id,
+        lifecycle: node.status.lifecycle,
+        heartbeat_interval_ms: state.node_liveness.heartbeat_interval_ms,
+        expiry_timeout_ms: state.node_liveness.expiry_timeout_ms,
+    }))
+}
+
+/// Wall-clock milliseconds since the Unix epoch.
+///
+/// Clamped at zero so a clock behind the epoch cannot panic the handler.
+pub fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/services/controlplane/src/api/openapi.rs
+++ b/services/controlplane/src/api/openapi.rs
@@ -15,14 +15,14 @@
 //! # Security considerations
 //! - Avoid exposing internal-only endpoints in the public schema.
 use crate::api::{
-    caches, namespaces, regions, streams, system, tenants,
+    caches, namespaces, nodes, regions, streams, system, tenants,
     types::{
         CacheChangesResponse, CacheCreateRequest, CacheListResponse, CacheSnapshotResponse,
         ErrorResponse, FeatureFlags, HealthStatus, ListRegionsResponse, NamespaceChangesResponse,
-        NamespaceCreateRequest, NamespaceListResponse, NamespaceSnapshotResponse, Region,
-        StreamChangesResponse, StreamCreateRequest, StreamListResponse, StreamSnapshotResponse,
-        SystemInfo, TenantChangesResponse, TenantCreateRequest, TenantListResponse,
-        TenantSnapshotResponse,
+        NamespaceCreateRequest, NamespaceListResponse, NamespaceSnapshotResponse,
+        NodeHeartbeatRequest, NodeHeartbeatResponse, Region, StreamChangesResponse,
+        StreamCreateRequest, StreamListResponse, StreamSnapshotResponse, SystemInfo,
+        TenantChangesResponse, TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
     },
 };
 use crate::auth::admin;
@@ -86,7 +86,8 @@ use utoipa::OpenApi;
         caches::create_cache,
         caches::get_cache,
         caches::patch_cache,
-        caches::delete_cache
+        caches::delete_cache,
+        nodes::report_health
     ),
     components(schemas(
         FeatureFlags,
@@ -140,6 +141,8 @@ use utoipa::OpenApi;
         NodePatchRequest,
         NodeChange,
         NodeChangeOp,
+        NodeHeartbeatRequest,
+        NodeHeartbeatResponse,
         TokenExchangeRequest,
         TokenExchangeResponse,
         IdpIssuerConfig,
@@ -156,7 +159,8 @@ use utoipa::OpenApi;
         (name = "tenants", description = "Tenant management"),
         (name = "namespaces", description = "Namespace management"),
         (name = "streams", description = "Stream management"),
-        (name = "caches", description = "Cache management")
+        (name = "caches", description = "Cache management"),
+        (name = "nodes", description = "Broker membership")
     )
 )]
 pub struct ApiDoc;

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -5,7 +5,9 @@
 use crate::model::{
     Cache, CacheChange, Namespace, NamespaceChange, Stream, StreamChange, Tenant, TenantChange,
 };
-use crate::model::{ConsistencyLevel, DeliveryGuarantee, RetentionPolicy, StreamKind};
+use crate::model::{
+    ConsistencyLevel, DeliveryGuarantee, NodeLifecycle, RetentionPolicy, StreamKind,
+};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -141,4 +143,28 @@ pub struct CacheSnapshotResponse {
 pub struct CacheChangesResponse {
     pub items: Vec<CacheChange>,
     pub next_seq: u64,
+}
+
+/// A broker's report that it is alive.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeHeartbeatRequest {
+    /// The reporting process's own incarnation, from its last registration.
+    ///
+    /// Carried so a heartbeat that was delayed past a restart is rejected
+    /// rather than counted for the process that replaced it.
+    pub incarnation: u64,
+}
+
+/// What the control plane tells a broker in return.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeHeartbeatResponse {
+    pub node_id: String,
+    /// The node's lifecycle as the cluster sees it. A broker that reads `down`
+    /// here has been expired and must register again.
+    pub lifecycle: NodeLifecycle,
+    /// How soon the next heartbeat is expected, so the interval is configured
+    /// in one place rather than on every broker.
+    pub heartbeat_interval_ms: u64,
+    /// Silence beyond this marks the node down.
+    pub expiry_timeout_ms: u64,
 }

--- a/services/controlplane/src/app.rs
+++ b/services/controlplane/src/app.rs
@@ -9,6 +9,7 @@ use crate::api::openapi::ApiDoc;
 use crate::api::types::{FeatureFlags, Region};
 use crate::auth;
 use crate::auth::oidc::UpstreamOidcValidator;
+use crate::config::NodeLivenessConfig;
 use crate::observability;
 use crate::store::ControlPlaneAuthStore;
 use axum::Router;
@@ -26,6 +27,7 @@ pub struct AppState {
     pub oidc_validator: UpstreamOidcValidator,
     pub bootstrap_enabled: bool,
     pub bootstrap_token: Option<String>,
+    pub node_liveness: NodeLivenessConfig,
 }
 
 pub fn build_router(state: AppState) -> Router {
@@ -98,6 +100,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/v1/tenants/{tenant_id}",
             axum::routing::delete(api::tenants::delete_tenant),
+        )
+        .route(
+            "/v1/nodes/{node_id}/heartbeat",
+            axum::routing::post(api::nodes::report_health),
         )
         .route(
             "/v1/tenants/{tenant_id}/token/exchange",

--- a/services/controlplane/src/auth/exchange.rs
+++ b/services/controlplane/src/auth/exchange.rs
@@ -401,6 +401,7 @@ mod tests {
             oidc_validator: crate::auth::oidc::UpstreamOidcValidator::default(),
             bootstrap_enabled: false,
             bootstrap_token: None,
+            node_liveness: Default::default(),
         }
     }
 

--- a/services/controlplane/src/config.rs
+++ b/services/controlplane/src/config.rs
@@ -17,6 +17,15 @@ pub const DEFAULT_CHANGES_LIMIT: u64 = 1000;
 // it expires, so this leaves headroom to finish the drain and exit before then.
 pub const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS: u64 = 25_000;
 pub const DEFAULT_CHANGE_RETENTION_MAX_ROWS: i64 = 10_000;
+/// How often a healthy broker is expected to report health.
+pub const DEFAULT_NODE_HEARTBEAT_INTERVAL_MS: u64 = 5_000;
+/// How long a node may go unheard before the cluster calls it down.
+///
+/// Three intervals: one lost heartbeat is a hiccup, three is a pattern.
+pub const DEFAULT_NODE_EXPIRY_TIMEOUT_MS: u64 = 15_000;
+/// How often the expiry sweep runs. Finer than the timeout so a node is marked
+/// down close to when it actually expires rather than a whole timeout later.
+pub const DEFAULT_NODE_EXPIRY_SWEEP_INTERVAL_MS: u64 = 2_000;
 const DEFAULT_PG_MAX_CONNECTIONS: u32 = 10;
 const DEFAULT_PG_CONNECT_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_PG_ACQUIRE_TIMEOUT_MS: u64 = 5_000;
@@ -60,6 +69,50 @@ impl Default for PostgresConfig {
     }
 }
 
+/// Timings for broker liveness.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeLivenessConfig {
+    /// Advertised to brokers in every heartbeat response.
+    pub heartbeat_interval_ms: u64,
+    /// Silence beyond this marks a node down.
+    pub expiry_timeout_ms: u64,
+    /// How often the sweep looks for expired nodes.
+    pub sweep_interval_ms: u64,
+}
+
+impl Default for NodeLivenessConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval_ms: DEFAULT_NODE_HEARTBEAT_INTERVAL_MS,
+            expiry_timeout_ms: DEFAULT_NODE_EXPIRY_TIMEOUT_MS,
+            sweep_interval_ms: DEFAULT_NODE_EXPIRY_SWEEP_INTERVAL_MS,
+        }
+    }
+}
+
+impl NodeLivenessConfig {
+    fn validate(&self) -> Result<()> {
+        if self.heartbeat_interval_ms == 0 {
+            return Err(anyhow!(
+                "node heartbeat_interval_ms must be greater than zero"
+            ));
+        }
+        if self.sweep_interval_ms == 0 {
+            return Err(anyhow!("node sweep_interval_ms must be greater than zero"));
+        }
+        // A timeout at or below the interval expires brokers that are heartbeating
+        // exactly as told to, which takes down a healthy cluster.
+        if self.expiry_timeout_ms <= self.heartbeat_interval_ms {
+            return Err(anyhow!(
+                "node expiry_timeout_ms ({}) must exceed heartbeat_interval_ms ({})",
+                self.expiry_timeout_ms,
+                self.heartbeat_interval_ms
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ControlPlaneConfig {
     pub bind_addr: SocketAddr,
@@ -71,6 +124,7 @@ pub struct ControlPlaneConfig {
     pub change_retention_max_rows: Option<i64>,
     pub oidc_allowed_algorithms: Vec<Algorithm>,
     pub bootstrap: BootstrapConfig,
+    pub node_liveness: NodeLivenessConfig,
     // Total budget for draining in-flight requests after SIGTERM/SIGINT before
     // remaining tasks are force-cancelled.
     pub shutdown_drain_timeout_ms: u64,
@@ -87,7 +141,15 @@ struct ControlPlaneConfigOverride {
     change_retention_max_rows: Option<i64>,
     oidc_allowed_algorithms: Option<Vec<String>>,
     bootstrap: Option<BootstrapOverride>,
+    node_liveness: Option<NodeLivenessOverride>,
     shutdown_drain_timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeLivenessOverride {
+    heartbeat_interval_ms: Option<u64>,
+    expiry_timeout_ms: Option<u64>,
+    sweep_interval_ms: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -138,6 +200,14 @@ impl ControlPlaneConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(DEFAULT_CHANGES_LIMIT);
+        let node_liveness = NodeLivenessConfig {
+            heartbeat_interval_ms: parse_positive_env("FELIX_NODE_HEARTBEAT_INTERVAL_MS")
+                .unwrap_or(DEFAULT_NODE_HEARTBEAT_INTERVAL_MS),
+            expiry_timeout_ms: parse_positive_env("FELIX_NODE_EXPIRY_TIMEOUT_MS")
+                .unwrap_or(DEFAULT_NODE_EXPIRY_TIMEOUT_MS),
+            sweep_interval_ms: parse_positive_env("FELIX_NODE_EXPIRY_SWEEP_INTERVAL_MS")
+                .unwrap_or(DEFAULT_NODE_EXPIRY_SWEEP_INTERVAL_MS),
+        };
         let shutdown_drain_timeout_ms = std::env::var("FELIX_SHUTDOWN_DRAIN_TIMEOUT_MS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -198,6 +268,7 @@ impl ControlPlaneConfig {
                     .with_context(|| "parse FELIX_BOOTSTRAP_BIND_ADDR")?,
                 token: std::env::var("FELIX_BOOTSTRAP_TOKEN").ok(),
             },
+            node_liveness,
             shutdown_drain_timeout_ms,
         };
         config.validate()?;
@@ -226,6 +297,17 @@ impl ControlPlaneConfig {
             }
             if let Some(value) = override_cfg.change_retention_max_rows {
                 config.change_retention_max_rows = Some(value);
+            }
+            if let Some(liveness) = override_cfg.node_liveness {
+                if let Some(value) = liveness.heartbeat_interval_ms {
+                    config.node_liveness.heartbeat_interval_ms = value;
+                }
+                if let Some(value) = liveness.expiry_timeout_ms {
+                    config.node_liveness.expiry_timeout_ms = value;
+                }
+                if let Some(value) = liveness.sweep_interval_ms {
+                    config.node_liveness.sweep_interval_ms = value;
+                }
             }
             if let Some(value) = override_cfg.shutdown_drain_timeout_ms
                 && value > 0
@@ -292,8 +374,19 @@ impl ControlPlaneConfig {
                 "oidc_allowed_algorithms cannot be empty; include at least ES256"
             ));
         }
+        self.node_liveness.validate()?;
         Ok(())
     }
+}
+
+/// Read a positive integer from the environment, ignoring absent, unparsable,
+/// and zero values so a typo falls back to the default rather than disabling a
+/// timer.
+fn parse_positive_env(key: &str) -> Option<u64> {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
 }
 
 fn parse_oidc_allowed_algorithms_csv(value: &str) -> Result<Vec<Algorithm>> {
@@ -397,6 +490,91 @@ mod tests {
                 }
             }
         }
+    }
+
+    /// A timeout at or below the interval expires brokers that are heartbeating
+    /// exactly as configured, which takes the cluster down.
+    #[test]
+    fn a_liveness_timeout_must_outlast_the_heartbeat_interval() {
+        let too_short = NodeLivenessConfig {
+            heartbeat_interval_ms: 5_000,
+            expiry_timeout_ms: 5_000,
+            sweep_interval_ms: 1_000,
+        };
+        let err = too_short.validate().expect_err("equal should be rejected");
+        assert!(err.to_string().contains("must exceed"), "{err}");
+
+        let inverted = NodeLivenessConfig {
+            expiry_timeout_ms: 1_000,
+            ..too_short.clone()
+        };
+        assert!(inverted.validate().is_err());
+
+        let ok = NodeLivenessConfig {
+            expiry_timeout_ms: 5_001,
+            ..too_short
+        };
+        assert!(ok.validate().is_ok());
+    }
+
+    #[test]
+    fn zero_liveness_intervals_are_rejected() {
+        for zeroed in [
+            NodeLivenessConfig {
+                heartbeat_interval_ms: 0,
+                ..NodeLivenessConfig::default()
+            },
+            NodeLivenessConfig {
+                sweep_interval_ms: 0,
+                ..NodeLivenessConfig::default()
+            },
+        ] {
+            assert!(zeroed.validate().is_err(), "{zeroed:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn the_default_liveness_config_is_valid() {
+        assert!(NodeLivenessConfig::default().validate().is_ok());
+    }
+
+    /// An unparsable or zero value falls back to the default rather than
+    /// disabling the timer.
+    #[serial]
+    #[test]
+    fn bad_liveness_env_values_fall_back_to_defaults() {
+        let _env = clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_HEARTBEAT_INTERVAL_MS", "not-a-number");
+            env::set_var("FELIX_NODE_EXPIRY_SWEEP_INTERVAL_MS", "0");
+            env::set_var("FELIX_NODE_EXPIRY_TIMEOUT_MS", "30000");
+        }
+
+        let config = ControlPlaneConfig::from_env().expect("config");
+        assert_eq!(
+            config.node_liveness.heartbeat_interval_ms,
+            DEFAULT_NODE_HEARTBEAT_INTERVAL_MS
+        );
+        assert_eq!(
+            config.node_liveness.sweep_interval_ms,
+            DEFAULT_NODE_EXPIRY_SWEEP_INTERVAL_MS
+        );
+        assert_eq!(config.node_liveness.expiry_timeout_ms, 30_000);
+    }
+
+    /// A config whose liveness timings cannot work must fail at startup, not
+    /// after it has taken the cluster down.
+    #[serial]
+    #[test]
+    fn an_unworkable_liveness_config_fails_startup() {
+        let _env = clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_HEARTBEAT_INTERVAL_MS", "10000");
+            env::set_var("FELIX_NODE_EXPIRY_TIMEOUT_MS", "5000");
+        }
+
+        let err = ControlPlaneConfig::from_env().expect_err("should fail");
+        assert!(err.to_string().contains("must exceed"), "{err}");
     }
 
     #[serial]

--- a/services/controlplane/src/lib.rs
+++ b/services/controlplane/src/lib.rs
@@ -8,6 +8,7 @@ pub mod api;
 pub mod app;
 pub mod auth;
 pub mod config;
+pub mod membership;
 pub mod model;
 pub mod observability;
 pub mod store;

--- a/services/controlplane/src/main.rs
+++ b/services/controlplane/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use controlplane::api::types::{FeatureFlags, Region};
 use controlplane::app::{AppState, build_bootstrap_router, build_router};
 use controlplane::auth::oidc::UpstreamOidcValidator;
-use controlplane::{config, observability, store};
+use controlplane::{config, membership, observability, store};
 use felix_common::lifecycle::{self, DrainBudget, Readiness};
 use std::future::{Future, IntoFuture};
 use std::sync::Arc;
@@ -48,6 +48,14 @@ where
             async move { metrics_shutdown.cancelled().await },
         ))
     };
+
+    // Liveness expiry runs on the API token: it stops admitting work at the same
+    // point the listener does, before anything drains.
+    let expiry_task = membership::spawn_expiry_sweep(
+        Arc::clone(&state.store) as Arc<dyn store::ControlPlaneStore + Send + Sync>,
+        state.node_liveness.clone(),
+        api_shutdown.clone(),
+    );
 
     let app = build_router(state.clone());
 
@@ -127,6 +135,16 @@ where
         api_task.abort();
     }
 
+    let mut expiry_task = expiry_task;
+    if !budget
+        .drain("node_expiry_sweep", async {
+            let _ = (&mut expiry_task).await;
+        })
+        .await
+    {
+        expiry_task.abort();
+    }
+
     let mut bootstrap_task = bootstrap_task;
     if let Some(task) = &mut bootstrap_task
         && !budget
@@ -192,6 +210,7 @@ async fn build_state(config: config::ControlPlaneConfig) -> anyhow::Result<AppSt
         ),
         bootstrap_enabled: config.bootstrap.enabled,
         bootstrap_token: config.bootstrap.token,
+        node_liveness: config.node_liveness,
     })
 }
 
@@ -216,6 +235,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            node_liveness: config::NodeLivenessConfig::default(),
             shutdown_drain_timeout_ms: 25_000,
         };
         let state = build_state(config).await.expect("state");
@@ -239,6 +259,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            node_liveness: config::NodeLivenessConfig::default(),
             shutdown_drain_timeout_ms: 25_000,
         };
         let err = build_state(config).await.err().expect("missing postgres");
@@ -266,6 +287,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: Some("bootstrap-token".to_string()),
             },
+            node_liveness: config::NodeLivenessConfig::default(),
             shutdown_drain_timeout_ms: 25_000,
         };
         let err = build_state(config)
@@ -293,6 +315,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: None,
             },
+            node_liveness: config::NodeLivenessConfig::default(),
             shutdown_drain_timeout_ms: 25_000,
         };
         run_with_shutdown(config, async {
@@ -319,6 +342,7 @@ mod tests {
                 bind_addr: "127.0.0.1:0".parse().expect("bootstrap"),
                 token: Some("bootstrap-token".to_string()),
             },
+            node_liveness: config::NodeLivenessConfig::default(),
             shutdown_drain_timeout_ms: 25_000,
         };
         run_with_shutdown(config, async {

--- a/services/controlplane/src/membership.rs
+++ b/services/controlplane/src/membership.rs
@@ -1,0 +1,78 @@
+//! Broker liveness expiry.
+//!
+//! A broker reports health on an interval. Nothing reports that a broker has
+//! *stopped*, so silence is the only signal, and something has to notice it.
+//! This is that something: a periodic sweep that marks nodes down once their
+//! last heartbeat is older than the configured timeout.
+//!
+//! Running several control-plane instances is fine. The store moves each node
+//! exactly once and only the instance that moved it publishes the change, so
+//! duplicate sweeps cost a query and produce no duplicate events.
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::config::NodeLivenessConfig;
+use crate::store::ControlPlaneStore;
+
+/// Run one expiry pass against `now_millis`.
+///
+/// Separate from the loop so tests can drive it at an exact time instead of
+/// waiting for a timer.
+pub async fn expire_once(
+    store: &dyn ControlPlaneStore,
+    liveness: &NodeLivenessConfig,
+    now_millis: u64,
+) -> usize {
+    // Saturating: before the timeout has elapsed since the epoch nothing can be
+    // stale, and wrapping would expire the whole cluster.
+    let expiry_before = now_millis.saturating_sub(liveness.expiry_timeout_ms);
+
+    match store.expire_stale_nodes(expiry_before).await {
+        Ok(expired) => {
+            for node in &expired {
+                tracing::warn!(
+                    node_id = %node.node_id,
+                    last_heartbeat_at_millis = node.status.last_heartbeat_at_millis,
+                    "broker missed its heartbeat window and was marked down",
+                );
+            }
+            metrics::counter!("felix_node_expiry_total").increment(expired.len() as u64);
+            expired.len()
+        }
+        Err(err) => {
+            // Logged and retried on the next tick. A transient database error
+            // must not leave liveness frozen for the rest of the process's life.
+            tracing::error!(error = %err, "node expiry sweep failed");
+            metrics::counter!("felix_node_expiry_failures_total").increment(1);
+            0
+        }
+    }
+}
+
+/// Sweep for expired nodes until `shutdown` fires.
+pub fn spawn_expiry_sweep(
+    store: Arc<dyn ControlPlaneStore + Send + Sync>,
+    liveness: NodeLivenessConfig,
+    shutdown: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(Duration::from_millis(liveness.sweep_interval_ms));
+        // A sweep that overruns its interval must not then run back-to-back
+        // trying to catch up; the next tick is soon enough.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => return,
+                _ = ticker.tick() => {
+                    expire_once(store.as_ref(), &liveness, crate::api::nodes::now_millis()).await;
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+#[path = "membership_tests.rs"]
+mod tests;

--- a/services/controlplane/src/membership_tests.rs
+++ b/services/controlplane/src/membership_tests.rs
@@ -1,0 +1,193 @@
+//! Expiry behaviour, driven at exact times rather than by waiting on a timer.
+use super::*;
+use crate::config::NodeLivenessConfig;
+use crate::model::NodeLifecycle;
+use crate::store::memory::InMemoryStore;
+use crate::store::node_contract::node;
+use crate::store::{ControlPlaneStore, StoreConfig};
+
+const INTERVAL_MS: u64 = 1_000;
+const TIMEOUT_MS: u64 = 3_000;
+const T0: u64 = 1_700_000_000_000;
+
+fn liveness() -> NodeLivenessConfig {
+    NodeLivenessConfig {
+        heartbeat_interval_ms: INTERVAL_MS,
+        expiry_timeout_ms: TIMEOUT_MS,
+        sweep_interval_ms: 500,
+    }
+}
+
+async fn store_with_node() -> InMemoryStore {
+    let store = InMemoryStore::new(StoreConfig {
+        changes_limit: 100,
+        change_retention_max_rows: Some(1_000),
+    });
+    let mut broker = node("broker-a", 7001);
+    broker.status.last_heartbeat_at_millis = T0;
+    store.register_node(broker).await.expect("register");
+    store
+}
+
+#[tokio::test]
+async fn a_broker_heartbeating_inside_the_window_stays_live() {
+    let store = store_with_node().await;
+
+    // Four intervals of healthy reporting, sweeping after each one.
+    for beat in 1..=4 {
+        let now = T0 + beat * INTERVAL_MS;
+        store
+            .record_node_heartbeat("broker-a", 0, now)
+            .await
+            .expect("beat");
+        assert_eq!(expire_once(&store, &liveness(), now).await, 0);
+    }
+
+    let node = store.get_node("broker-a").await.expect("get");
+    assert_eq!(node.status.lifecycle, NodeLifecycle::Live);
+}
+
+#[tokio::test]
+async fn a_silent_broker_goes_down_once_the_timeout_elapses() {
+    let store = store_with_node().await;
+
+    // Exactly at the timeout is still inside the window.
+    assert_eq!(expire_once(&store, &liveness(), T0 + TIMEOUT_MS).await, 0);
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Live,
+    );
+
+    assert_eq!(
+        expire_once(&store, &liveness(), T0 + TIMEOUT_MS + 1).await,
+        1
+    );
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Down,
+    );
+}
+
+/// Marking a node down is what placement watches for, so it has to reach the
+/// changefeed like any other membership change.
+#[tokio::test]
+async fn expiry_publishes_a_change() {
+    let store = store_with_node().await;
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    expire_once(&store, &liveness(), T0 + TIMEOUT_MS + 1).await;
+
+    let changes = store.node_changes(since).await.expect("changes");
+    assert_eq!(changes.items.len(), 1);
+    let published = changes.items[0].node.as_ref().expect("body");
+    assert_eq!(published.node_id, "broker-a");
+    assert_eq!(published.status.lifecycle, NodeLifecycle::Down);
+}
+
+/// Two control-plane instances sweep the same database. Between them a node
+/// must be marked down once and published once.
+#[tokio::test]
+async fn a_repeated_sweep_expires_a_node_once() {
+    let store = store_with_node().await;
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+    let now = T0 + TIMEOUT_MS + 1;
+
+    assert_eq!(expire_once(&store, &liveness(), now).await, 1);
+    for _ in 0..3 {
+        assert_eq!(expire_once(&store, &liveness(), now).await, 0);
+    }
+
+    assert_eq!(
+        store
+            .node_changes(since)
+            .await
+            .expect("changes")
+            .items
+            .len(),
+        1
+    );
+}
+
+/// A draining broker is still serving, so losing it matters as much as losing a
+/// live one.
+#[tokio::test]
+async fn a_draining_broker_also_expires() {
+    let store = store_with_node().await;
+    store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Draining)
+        .await
+        .expect("drain");
+
+    assert_eq!(
+        expire_once(&store, &liveness(), T0 + TIMEOUT_MS + 1).await,
+        1
+    );
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Down,
+    );
+}
+
+/// A node already down is not swept again, so a permanently dead broker does
+/// not publish a change on every tick forever.
+#[tokio::test]
+async fn a_departed_node_is_not_swept() {
+    let store = store_with_node().await;
+    store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Left)
+        .await
+        .expect("leave");
+
+    assert_eq!(
+        expire_once(&store, &liveness(), T0 + TIMEOUT_MS * 100).await,
+        0
+    );
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Left,
+    );
+}
+
+/// Before `expiry_timeout_ms` has elapsed since the epoch, subtracting it would
+/// wrap and expire every node in the cluster.
+#[tokio::test]
+async fn a_clock_near_the_epoch_expires_nothing() {
+    let store = InMemoryStore::new(StoreConfig {
+        changes_limit: 100,
+        change_retention_max_rows: Some(1_000),
+    });
+    let mut broker = node("broker-a", 7001);
+    broker.status.last_heartbeat_at_millis = 0;
+    store.register_node(broker).await.expect("register");
+
+    assert_eq!(expire_once(&store, &liveness(), 1).await, 0);
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Live,
+    );
+}

--- a/services/controlplane/src/store/memory.rs
+++ b/services/controlplane/src/store/memory.rs
@@ -831,16 +831,54 @@ impl ControlPlaneStore for InMemoryStore {
         Ok(())
     }
 
-    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()> {
+    async fn record_node_heartbeat(
+        &self,
+        node_id: &str,
+        incarnation: u64,
+        at_millis: u64,
+    ) -> StoreResult<Node> {
         let mut state = self.nodes.write().await;
         let node = state
             .records
             .get_mut(node_id)
             .ok_or_else(|| StoreError::NotFound("node".into()))?;
+        if incarnation < node.status.incarnation {
+            return Err(StoreError::Conflict(format!(
+                "heartbeat for incarnation {incarnation} of {node_id}, which is now at {}",
+                node.status.incarnation
+            )));
+        }
         // Never moves backwards: heartbeats from two connections can arrive out
         // of order, and the newest observation is the one that matters.
         node.status.last_heartbeat_at_millis = node.status.last_heartbeat_at_millis.max(at_millis);
-        Ok(())
+        Ok(node.clone())
+    }
+
+    async fn expire_stale_nodes(&self, expiry_before_millis: u64) -> StoreResult<Vec<Node>> {
+        let mut state = self.nodes.write().await;
+        let stale: Vec<String> = state
+            .records
+            .values()
+            .filter(|node| {
+                matches!(
+                    node.status.lifecycle,
+                    NodeLifecycle::Live | NodeLifecycle::Draining
+                ) && node.status.last_heartbeat_at_millis < expiry_before_millis
+            })
+            .map(|node| node.node_id.clone())
+            .collect();
+
+        let mut expired = Vec::with_capacity(stale.len());
+        for node_id in stale {
+            let node = state.records.get_mut(&node_id).expect("just listed");
+            node.status.lifecycle = NodeLifecycle::Down;
+            let moved = node.clone();
+            state.record(NodeChangeOp::Updated, &node_id, Some(moved.clone()));
+            metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+            expired.push(moved);
+        }
+        expired.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(expired)
     }
 
     async fn set_node_lifecycle(

--- a/services/controlplane/src/store/mod.rs
+++ b/services/controlplane/src/store/mod.rs
@@ -20,7 +20,7 @@ pub mod memory;
 pub mod postgres;
 
 #[cfg(test)]
-mod node_contract;
+pub(crate) mod node_contract;
 #[cfg(test)]
 mod postgres_tests;
 
@@ -133,7 +133,29 @@ pub trait ControlPlaneStore: Send + Sync {
     /// changefeed would evict every real membership change from the retention
     /// window. Only a lifecycle move a heartbeat causes is worth publishing,
     /// and that is [`ControlPlaneStore::set_node_lifecycle`].
-    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()>;
+    ///
+    /// `incarnation` is the caller's own, and one older than the stored value
+    /// is rejected: it comes from a process the broker has already replaced,
+    /// and honouring it would report a dead incarnation as live.
+    ///
+    /// Never revives. A node the cluster marked `Down` stays down until it
+    /// registers again, because a heartbeat proves a process is running, not
+    /// that it still owns the identity.
+    ///
+    /// `at_millis` never moves the stored value backwards, so a delayed
+    /// heartbeat is a no-op rather than a regression.
+    async fn record_node_heartbeat(
+        &self,
+        node_id: &str,
+        incarnation: u64,
+        at_millis: u64,
+    ) -> StoreResult<Node>;
+    /// Mark every node whose last heartbeat predates `expiry_before_millis` as
+    /// down, and return the ones this call moved.
+    ///
+    /// Safe to run from several control-plane instances at once: each node is
+    /// moved by exactly one of them, and only that one publishes the change.
+    async fn expire_stale_nodes(&self, expiry_before_millis: u64) -> StoreResult<Vec<Node>>;
     /// Move a node's lifecycle from an observed signal rather than an operator.
     ///
     /// Unlike [`ControlPlaneStore::patch_node`] this may drive transitions an

--- a/services/controlplane/src/store/node_contract.rs
+++ b/services/controlplane/src/store/node_contract.rs
@@ -42,6 +42,10 @@ pub(crate) async fn run_node_contract(store: Arc<dyn ControlPlaneStore>) {
     patch_rejects_an_unsupported_transition(store).await;
     a_heartbeat_never_moves_backwards(store).await;
     a_heartbeat_publishes_no_change(store).await;
+    a_heartbeat_from_a_superseded_incarnation_is_rejected(store).await;
+    a_heartbeat_does_not_revive_a_down_node(store).await;
+    expiry_moves_only_stale_serving_nodes(store).await;
+    expiry_is_idempotent_across_instances(store).await;
     set_lifecycle_is_idempotent(store).await;
     missing_nodes_report_not_found(store).await;
     delete_removes_and_publishes(store).await;
@@ -53,7 +57,56 @@ pub(crate) async fn run_node_contract(store: Arc<dyn ControlPlaneStore>) {
 ///
 /// Separate from [`run_node_contract`] only because these need an owned handle.
 pub(crate) async fn run_node_concurrency_contract(store: Arc<dyn ControlPlaneStore>) {
-    a_snapshot_taken_under_concurrent_writes_loses_nothing(store).await;
+    a_snapshot_taken_under_concurrent_writes_loses_nothing(Arc::clone(&store)).await;
+    concurrent_sweeps_expire_a_node_exactly_once(store).await;
+}
+
+/// The multi-instance case for real: several sweeps racing on one store, as
+/// several control-plane replicas would. Exactly one may claim each node, and
+/// the changefeed must show one event per node, not one per sweep.
+async fn concurrent_sweeps_expire_a_node_exactly_once(store: Arc<dyn ControlPlaneStore>) {
+    const NODES: u16 = 12;
+    const SWEEPERS: usize = 6;
+
+    clear(store.as_ref()).await;
+    let mut cutoff = 0;
+    for i in 0..NODES {
+        let registered = store
+            .register_node(node(&format!("broker-{i:03}"), 7400 + i))
+            .await
+            .expect("register");
+        cutoff = cutoff.max(registered.status.last_heartbeat_at_millis + 1);
+    }
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    let sweepers: Vec<_> = (0..SWEEPERS)
+        .map(|_| {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                store
+                    .expire_stale_nodes(cutoff)
+                    .await
+                    .expect("expire")
+                    .len()
+            })
+        })
+        .collect();
+
+    let mut claimed = 0;
+    for sweeper in sweepers {
+        claimed += sweeper.await.expect("sweeper");
+    }
+    assert_eq!(
+        claimed, NODES as usize,
+        "every node must be claimed exactly once across all sweeps",
+    );
+
+    let changes = store.node_changes(since).await.expect("changes");
+    assert_eq!(
+        changes.items.len(),
+        NODES as usize,
+        "one change per node, not one per sweep",
+    );
 }
 
 /// The reason `node_changes.seq` is allocated from a locked row rather than a
@@ -253,11 +306,11 @@ async fn a_heartbeat_never_moves_backwards(store: &dyn ControlPlaneStore) {
     let at = registered.status.last_heartbeat_at_millis;
 
     store
-        .record_node_heartbeat("broker-a", at + 1_000)
+        .record_node_heartbeat("broker-a", 0, at + 1_000)
         .await
         .expect("beat");
     store
-        .record_node_heartbeat("broker-a", at - 1_000)
+        .record_node_heartbeat("broker-a", 0, at - 1_000)
         .await
         .expect("late beat");
 
@@ -274,7 +327,7 @@ async fn a_heartbeat_publishes_no_change(store: &dyn ControlPlaneStore) {
     let before = store.node_snapshot().await.expect("snapshot").next_seq;
 
     store
-        .record_node_heartbeat("broker-a", 1_800_000_000_000)
+        .record_node_heartbeat("broker-a", 0, 1_800_000_000_000)
         .await
         .expect("beat");
 
@@ -322,7 +375,7 @@ async fn missing_nodes_report_not_found(store: &dyn ControlPlaneStore) {
     ));
     assert!(matches!(
         store
-            .record_node_heartbeat("absent", 1)
+            .record_node_heartbeat("absent", 0, 1)
             .await
             .expect_err("beat"),
         StoreError::NotFound(_)
@@ -447,5 +500,152 @@ async fn changes_are_ordered_and_monotonic(store: &dyn ControlPlaneStore) {
     assert!(
         changes.next_seq > changes.items.last().expect("last").seq,
         "next_seq must be past the last change returned",
+    );
+}
+
+/// A heartbeat delayed past a restart belongs to a process the broker has
+/// already replaced. Counting it would report a dead incarnation as live.
+async fn a_heartbeat_from_a_superseded_incarnation_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    let restarted = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("re-register");
+    assert_eq!(restarted.status.incarnation, 1);
+
+    let err = store
+        .record_node_heartbeat("broker-a", 0, 1_800_000_000_000)
+        .await
+        .expect_err("stale incarnation should be rejected");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+
+    // The current incarnation still works, and a future one is accepted too:
+    // the broker may have re-registered against another control-plane instance.
+    store
+        .record_node_heartbeat("broker-a", 1, 1_800_000_000_000)
+        .await
+        .expect("current incarnation");
+    store
+        .record_node_heartbeat("broker-a", 2, 1_800_000_000_001)
+        .await
+        .expect("newer incarnation");
+}
+
+/// A heartbeat proves a process is running, not that it still owns the
+/// identity. Reviving here would let a broker the cluster already replaced keep
+/// receiving placement.
+async fn a_heartbeat_does_not_revive_a_down_node(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Down)
+        .await
+        .expect("down");
+
+    let after = store
+        .record_node_heartbeat("broker-a", 0, 1_900_000_000_000)
+        .await
+        .expect("beat");
+    assert_eq!(after.status.lifecycle, NodeLifecycle::Down);
+    assert_eq!(
+        after.status.last_heartbeat_at_millis, 1_900_000_000_000,
+        "liveness is still recorded, so a later registration is judged fairly",
+    );
+}
+
+async fn expiry_moves_only_stale_serving_nodes(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let base = node("broker-fresh", 7301).status.last_heartbeat_at_millis;
+
+    store
+        .register_node(node("broker-stale", 7300))
+        .await
+        .expect("register");
+    let mut fresh = node("broker-fresh", 7301);
+    fresh.status.last_heartbeat_at_millis = base + 10_000;
+    store.register_node(fresh).await.expect("register");
+    store
+        .register_node(node("broker-left", 7302))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-left", NodeLifecycle::Left)
+        .await
+        .expect("leave");
+
+    let expired = store.expire_stale_nodes(base + 1).await.expect("expire");
+    assert_eq!(
+        expired
+            .iter()
+            .map(|n| n.node_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["broker-stale"],
+        "only a stale, still-serving node should move",
+    );
+    assert_eq!(
+        store
+            .get_node("broker-fresh")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Live,
+    );
+    assert_eq!(
+        store
+            .get_node("broker-left")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Left,
+    );
+}
+
+/// Several control-plane instances run this sweep against one database. A node
+/// must be claimed by exactly one of them, and published once.
+async fn expiry_is_idempotent_across_instances(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let registered = store
+        .register_node(node("broker-a", 7001))
+        .await
+        .expect("register");
+    let cutoff = registered.status.last_heartbeat_at_millis + 1;
+    let since = store.node_snapshot().await.expect("snapshot").next_seq;
+
+    assert_eq!(
+        store
+            .expire_stale_nodes(cutoff)
+            .await
+            .expect("expire")
+            .len(),
+        1
+    );
+    for _ in 0..3 {
+        assert!(
+            store
+                .expire_stale_nodes(cutoff)
+                .await
+                .expect("expire")
+                .is_empty()
+        );
+    }
+
+    assert_eq!(
+        store
+            .node_changes(since)
+            .await
+            .expect("changes")
+            .items
+            .len(),
+        1,
+        "a repeated sweep must not publish a change per pass",
     );
 }

--- a/services/controlplane/src/store/postgres.rs
+++ b/services/controlplane/src/store/postgres.rs
@@ -1455,11 +1455,32 @@ impl ControlPlaneStore for PostgresStore {
         Ok(())
     }
 
-    async fn record_node_heartbeat(&self, node_id: &str, at_millis: u64) -> StoreResult<()> {
+    async fn record_node_heartbeat(
+        &self,
+        node_id: &str,
+        incarnation: u64,
+        at_millis: u64,
+    ) -> StoreResult<Node> {
+        let mut tx = self.pool.begin().await?;
+        let existing = sqlx::query_as::<_, DbNode>(NODE_SELECT_BY_ID_FOR_UPDATE)
+            .bind(node_id)
+            .fetch_optional(&mut *tx)
+            .await?
+            .map(node_from_db)
+            .transpose()?
+            .ok_or_else(|| StoreError::NotFound("node".into()))?;
+
+        if incarnation < existing.status.incarnation {
+            return Err(StoreError::Conflict(format!(
+                "heartbeat for incarnation {incarnation} of {node_id}, which is now at {}",
+                existing.status.incarnation
+            )));
+        }
+
         // GREATEST, not assignment: heartbeats from two connections can arrive
         // out of order, and the newest observation is the one that matters.
         // No change is emitted -- see the trait for why.
-        let updated = sqlx::query(
+        sqlx::query(
             r#"UPDATE nodes
                SET last_heartbeat_at_millis = GREATEST(last_heartbeat_at_millis, $2),
                    updated_at = now()
@@ -1467,12 +1488,44 @@ impl ControlPlaneStore for PostgresStore {
         )
         .bind(node_id)
         .bind(at_millis as i64)
-        .execute(&self.pool)
+        .execute(&mut *tx)
         .await?;
-        if updated.rows_affected() == 0 {
-            return Err(StoreError::NotFound("node".into()));
+
+        let mut updated = existing;
+        updated.status.last_heartbeat_at_millis =
+            updated.status.last_heartbeat_at_millis.max(at_millis);
+        tx.commit().await?;
+        Ok(updated)
+    }
+
+    async fn expire_stale_nodes(&self, expiry_before_millis: u64) -> StoreResult<Vec<Node>> {
+        let mut tx = self.pool.begin().await?;
+
+        // The UPDATE both selects and claims: it takes a row lock and re-checks
+        // the predicate, so a second control-plane instance running the same
+        // sweep concurrently matches zero rows and publishes nothing.
+        let rows = sqlx::query_as::<_, DbNode>(
+            r#"UPDATE nodes SET lifecycle = 'down', updated_at = now()
+               WHERE lifecycle IN ('live', 'draining') AND last_heartbeat_at_millis < $1
+               RETURNING node_id, advertise_addr, region, labels, capacity_max_shards, capacity_weight, lifecycle, last_heartbeat_at_millis, registered_at_millis, incarnation"#,
+        )
+        .bind(expiry_before_millis as i64)
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let mut expired = Vec::with_capacity(rows.len());
+        for row in rows {
+            let node = node_from_db(row)?;
+            record_node_change(&mut tx, NodeChangeOp::Updated, &node.node_id, Some(&node)).await?;
+            expired.push(node);
         }
-        Ok(())
+        tx.commit().await?;
+
+        for _ in &expired {
+            metrics::counter!("felix_node_changes_total", "op" => "updated").increment(1);
+        }
+        expired.sort_by(|a, b| a.node_id.cmp(&b.node_id));
+        Ok(expired)
     }
 
     async fn set_node_lifecycle(

--- a/services/controlplane/src/store/postgres_tests.rs
+++ b/services/controlplane/src/store/postgres_tests.rs
@@ -247,7 +247,7 @@ async fn a_reconnected_store_still_sees_registered_nodes() -> anyhow::Result<()>
             .register_node(crate::store::node_contract::node("broker-a", 7001))
             .await?;
         store
-            .record_node_heartbeat("broker-a", 1_800_000_000_000)
+            .record_node_heartbeat("broker-a", 0, 1_800_000_000_000)
             .await?;
         store.node_snapshot().await?;
         drop(store);

--- a/services/controlplane/tests/api_coverage.rs
+++ b/services/controlplane/tests/api_coverage.rs
@@ -32,6 +32,7 @@ fn app_with_state() -> axum::routing::RouterIntoService<Body, ()> {
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     build_router(state).into_service()
 }

--- a/services/controlplane/tests/auth_admin.rs
+++ b/services/controlplane/tests/auth_admin.rs
@@ -34,6 +34,7 @@ fn build_state(store: Arc<InMemoryStore>) -> AppState {
         oidc_validator: UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     }
 }
 

--- a/services/controlplane/tests/auth_bootstrap.rs
+++ b/services/controlplane/tests/auth_bootstrap.rs
@@ -35,6 +35,7 @@ fn bootstrap_state(enabled: bool, token: Option<String>) -> (Arc<InMemoryStore>,
         oidc_validator: UpstreamOidcValidator::default(),
         bootstrap_enabled: enabled,
         bootstrap_token: token,
+        node_liveness: Default::default(),
     };
     (store, state)
 }

--- a/services/controlplane/tests/auth_exchange.rs
+++ b/services/controlplane/tests/auth_exchange.rs
@@ -221,6 +221,7 @@ async fn exchange_returns_tenant_scoped_token() {
         ),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -329,6 +330,7 @@ async fn exchange_forbidden_without_policies() {
         ),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -447,6 +449,7 @@ async fn exchange_supports_group_claim_based_rbac() {
         ),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -582,6 +585,7 @@ async fn exchange_group_claim_rbac_requires_groups_claim_mapping() {
         ),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -697,6 +701,7 @@ async fn exchange_supports_group_claim_values_with_group_prefix() {
         ),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();

--- a/services/controlplane/tests/auth_jwks.rs
+++ b/services/controlplane/tests/auth_jwks.rs
@@ -61,6 +61,7 @@ async fn jwks_endpoint_returns_keys_for_tenant() {
         oidc_validator: UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app = build_router(state).into_service();
 
@@ -108,6 +109,7 @@ async fn jwks_endpoint_missing_tenant_returns_404() {
         oidc_validator: UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app = build_router(state).into_service();
 

--- a/services/controlplane/tests/http_smoke.rs
+++ b/services/controlplane/tests/http_smoke.rs
@@ -42,6 +42,7 @@ fn app_with_region_id(region_id: &str) -> axum::routing::RouterIntoService<axum:
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     build_router(state).into_service()
 }
@@ -958,7 +959,16 @@ impl ControlPlaneStore for FailingStore {
         Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
     }
 
-    async fn record_node_heartbeat(&self, _node_id: &str, _at_millis: u64) -> StoreResult<()> {
+    async fn record_node_heartbeat(
+        &self,
+        _node_id: &str,
+        _incarnation: u64,
+        _at_millis: u64,
+    ) -> StoreResult<Node> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn expire_stale_nodes(&self, _expiry_before_millis: u64) -> StoreResult<Vec<Node>> {
         Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
     }
 
@@ -1093,6 +1103,7 @@ async fn system_health_reports_internal_error_on_store_failure() {
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1122,6 +1133,7 @@ async fn tenant_endpoints_report_internal_error_on_store_failure() {
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1184,6 +1196,7 @@ async fn stream_and_cache_endpoints_report_internal_error_after_scope_checks() {
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1299,6 +1312,7 @@ async fn stream_and_cache_create_report_not_found_when_store_reports_missing_nam
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: false,
         bootstrap_token: None,
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1360,6 +1374,7 @@ async fn bootstrap_initialize_reports_internal_error_when_signing_key_ensure_fai
         oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
         bootstrap_enabled: true,
         bootstrap_token: Some("secret".to_string()),
+        node_liveness: Default::default(),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_bootstrap_router(state).into_service();

--- a/services/controlplane/tests/node_heartbeat.rs
+++ b/services/controlplane/tests/node_heartbeat.rs
@@ -1,0 +1,200 @@
+//! HTTP behaviour of the broker heartbeat endpoint.
+mod common;
+mod http_helpers;
+
+use axum::body::Body;
+use axum::http::StatusCode;
+use common::read_json;
+use controlplane::api::types::FeatureFlags;
+use controlplane::app::{AppState, build_router};
+use controlplane::config::NodeLivenessConfig;
+use controlplane::model::{Node, NodeCapacity, NodeLifecycle, NodeSpec, NodeStatus};
+use controlplane::store::memory::InMemoryStore;
+use controlplane::store::{ControlPlaneStore, StoreConfig};
+use http_helpers::json_request;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tower::ServiceExt;
+
+const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
+    heartbeat_interval_ms: 2_000,
+    expiry_timeout_ms: 6_000,
+    sweep_interval_ms: 500,
+};
+
+fn node(node_id: &str) -> Node {
+    Node {
+        node_id: node_id.to_string(),
+        spec: NodeSpec {
+            advertise_addr: "10.0.0.4:7000".to_string(),
+            region: "us-west-2".to_string(),
+            labels: BTreeMap::new(),
+            capacity: NodeCapacity::default(),
+        },
+        status: NodeStatus {
+            lifecycle: NodeLifecycle::Live,
+            last_heartbeat_at_millis: 1,
+            registered_at_millis: 1,
+            incarnation: 0,
+        },
+    }
+}
+
+async fn app_with(store: Arc<InMemoryStore>) -> axum::routing::RouterIntoService<Body, ()> {
+    let state = AppState {
+        region: controlplane::api::types::Region {
+            region_id: "local".to_string(),
+            display_name: "Local Region".to_string(),
+        },
+        api_version: "v1".to_string(),
+        features: FeatureFlags {
+            durable_storage: store.is_durable(),
+            tiered_storage: false,
+            bridges: false,
+        },
+        store,
+        oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
+        bootstrap_enabled: false,
+        bootstrap_token: None,
+        node_liveness: LIVENESS,
+    };
+    build_router(state).into_service()
+}
+
+fn store() -> Arc<InMemoryStore> {
+    Arc::new(InMemoryStore::new(StoreConfig {
+        changes_limit: controlplane::config::DEFAULT_CHANGES_LIMIT,
+        change_retention_max_rows: Some(1_000),
+    }))
+}
+
+#[tokio::test]
+async fn a_heartbeat_returns_the_lifecycle_and_the_expected_cadence() {
+    let store = store();
+    store
+        .register_node(node("broker-a"))
+        .await
+        .expect("register");
+    let app = app_with(Arc::clone(&store)).await;
+
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/nodes/broker-a/heartbeat",
+            serde_json::json!({ "incarnation": 0 }),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = read_json(response).await;
+    assert_eq!(body["node_id"], "broker-a");
+    assert_eq!(body["lifecycle"], "live");
+    // The cadence comes from the control plane, so it is configured in one place.
+    assert_eq!(
+        body["heartbeat_interval_ms"],
+        LIVENESS.heartbeat_interval_ms
+    );
+    assert_eq!(body["expiry_timeout_ms"], LIVENESS.expiry_timeout_ms);
+}
+
+/// The recorded time is the control plane's own. A broker that could supply it
+/// could postpone its own expiry indefinitely.
+#[tokio::test]
+async fn a_heartbeat_records_the_control_planes_clock() {
+    let store = store();
+    store
+        .register_node(node("broker-a"))
+        .await
+        .expect("register");
+    let before = controlplane::api::nodes::now_millis();
+
+    let app = app_with(Arc::clone(&store)).await;
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/nodes/broker-a/heartbeat",
+            serde_json::json!({ "incarnation": 0, "last_heartbeat_at_millis": 99_999_999_999_999u64 }),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let recorded = store
+        .get_node("broker-a")
+        .await
+        .expect("get")
+        .status
+        .last_heartbeat_at_millis;
+    assert!(
+        recorded >= before && recorded < 99_999_999_999_999,
+        "recorded {recorded} should be the server clock, not the caller's",
+    );
+}
+
+#[tokio::test]
+async fn a_heartbeat_for_an_unregistered_node_is_not_found() {
+    let app = app_with(store()).await;
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/nodes/absent/heartbeat",
+            serde_json::json!({ "incarnation": 0 }),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn a_heartbeat_for_a_superseded_incarnation_conflicts() {
+    let store = store();
+    store
+        .register_node(node("broker-a"))
+        .await
+        .expect("register");
+    store
+        .register_node(node("broker-a"))
+        .await
+        .expect("restart");
+
+    let app = app_with(Arc::clone(&store)).await;
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/nodes/broker-a/heartbeat",
+            serde_json::json!({ "incarnation": 0 }),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+/// A broker that reads `down` here knows it was expired and must register again
+/// rather than carry on as if it were still a cluster member.
+#[tokio::test]
+async fn an_expired_broker_is_told_it_is_down() {
+    let store = store();
+    store
+        .register_node(node("broker-a"))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-a", NodeLifecycle::Down)
+        .await
+        .expect("down");
+
+    let app = app_with(Arc::clone(&store)).await;
+    let response = app
+        .oneshot(json_request(
+            "POST",
+            "/v1/nodes/broker-a/heartbeat",
+            serde_json::json!({ "incarnation": 0 }),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = read_json(response).await;
+    assert_eq!(body["lifecycle"], "down");
+}

--- a/services/controlplane/tests/pg_store_e2e.rs
+++ b/services/controlplane/tests/pg_store_e2e.rs
@@ -1766,6 +1766,7 @@ async fn pg_bootstrap_initialize_and_jwks_includes_previous_keys() -> Result<()>
         oidc_validator: UpstreamOidcValidator::default(),
         bootstrap_enabled: true,
         bootstrap_token: Some("token".to_string()),
+        node_liveness: Default::default(),
     };
     let bootstrap_app = app::build_bootstrap_router(state.clone());
     let body = json!({


### PR DESCRIPTION
Closes #94. Third slice of **M2**.

## What's here

`POST /v1/nodes/{node_id}/heartbeat`, a configurable expiry sweep, and the store primitives behind both.

Nothing reports that a broker has *stopped*, so silence is the only signal. A sweep marks a node `down` once its last heartbeat is older than `expiry_timeout_ms` — three intervals by default, because one lost heartbeat is a hiccup and three is a pattern. **Startup fails** if the timeout does not exceed the interval; that config expires brokers heartbeating exactly as told to.

## Four rules, each tested

- **The recorded time is the control plane's clock.** A broker that could supply it could postpone its own expiry indefinitely. `a_heartbeat_records_the_control_planes_clock` sends a far-future timestamp in the body and asserts it is ignored.
- **An older `incarnation` is rejected with 409.** A heartbeat delayed past a restart belongs to a process the broker has already replaced; counting it would report a dead incarnation as live.
- **A heartbeat never revives a `down` node.** It proves a process is running, not that it still owns the identity. The broker reads `"lifecycle": "down"` and must register again. Liveness is still *recorded*, so a later registration is judged fairly.
- **A heartbeat publishes no change.** Per-node per-interval events would evict every real membership change from the retention window. Only the lifecycle move expiry causes is published.

## Multi-instance safety

The acceptance criterion is that several control-plane instances do not produce conflicting liveness state. The Postgres sweep is a single `UPDATE ... RETURNING` that claims rows under lock and re-checks its predicate, so a concurrent sweep matches zero rows and publishes nothing.

`concurrent_sweeps_expire_a_node_exactly_once` runs **six racing sweepers over twelve nodes** against real Postgres and asserts the claims sum to exactly twelve and the changefeed holds twelve events — not one per sweep.

## Testing time without waiting on it

`expire_once` takes `now_millis` explicitly, so the seven expiry tests drive exact instants rather than sleeping. That covers the boundary in both directions (at the timeout is still live; one millisecond past is down), draining nodes expiring, departed nodes not being swept, and a clock near the epoch — where `now - timeout` would wrap and expire the entire cluster.

The heartbeat rules live in the shared `node_contract` suite, so **both stores** prove them.

## Not authenticated

Any caller that can reach this endpoint can report health for any `node_id`. That is deliberate scope: #126 (M8) owns authenticating broker identity and explicitly includes auditing which M2 paths are unauthenticated. The module doc, the handler, and `docs/control-plane.md` all say so rather than leaving it implicit.

## Also

`task demo:check` caught `demo-rbac-live` and `demo_cross_tenant_isolation` breaking on the new `AppState` field — the out-of-workspace trap from CLAUDE.md. Both fixed.

`docs/control-plane.md` gains a Broker liveness section, and the `ReportHealth` API sketch is marked implemented with a pointer to it.

## Verification

`task lint`, `task test` (63 suites), `task demo:check`, `node scripts/check-mermaid.mjs`, and the pg suite (113 lib tests) against real Postgres 16 — all clean, re-run after rebasing onto merged `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)