### PR TITLE
feat(broker): register, heartbeat, drain, and deregister as a cluster member

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,9 +402,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "axum",
  "base64 0.23.1",
  "bytes",
+ "controlplane",
  "dashmap",
  "ed25519-dalek",
  "felix-authz",

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -81,6 +81,46 @@ Four rules, each of which exists for a reason:
 > health for any `node_id`. Authenticating broker identity is tracked in #126;
 > until then it is only safe on a trusted network.
 
+### Broker-side lifecycle
+
+A broker joins a cluster only when `FELIX_NODE_ID` is set. Membership is opt-in
+because a single-node broker has no cluster to join, and registering one would
+put a node in the catalog that placement would then try to use.
+
+| Env | Required | Meaning |
+| --- | --- | --- |
+| `FELIX_NODE_ID` | opt-in | Stable across restarts. This is the identity, not the process. |
+| `FELIX_NODE_ADVERTISE_ADDR` | with `FELIX_NODE_ID` | `host:port` peers reach this broker on. Not the bind address: a broker bound to `0.0.0.0` has to advertise something routable. |
+| `FELIX_CONTROLPLANE_URL` | with `FELIX_NODE_ID` | Where to register. |
+| `FELIX_REGION_ID` | no | Defaults to `local`. |
+
+Startup fails, rather than defaulting, when `FELIX_NODE_ID` is set without an
+advertised address or a control-plane URL, or when the address does not parse.
+A broker that guessed its own address would register something unreachable, and
+the failure would surface later as peers unable to connect to a node the catalog
+says is live.
+
+The sequence:
+
+1. **Register after the broker can serve.** Advertising a node placement may
+   route to before it can answer is worse than advertising it a moment late, so
+   registration waits for the initial catalog sync when readiness is gated on it.
+2. **Heartbeat** on the interval the control plane returns, with bounded
+   exponential backoff and jitter. A failure is visible
+   (`felix_broker_heartbeat_failures_total`) but never fatal: a control plane
+   that is briefly unreachable must not take down a broker that is serving fine.
+3. **Drain, then deregister** on SIGTERM, before connections are drained, so
+   nothing new is placed here while in-flight work finishes.
+
+A registration refused with a 4xx — a duplicate advertised address, say — stops
+the broker with a clear error instead of retrying. A wrong identity stays wrong,
+and retrying only hides the misconfiguration. An unreachable control plane is
+retried, because it may simply be starting.
+
+This is what separates a graceful shutdown from a crash: a broker that
+deregisters is `left`, and one that simply stops is found `down` by expiry. Both
+remove it from placement, but only the first is intentional.
+
 ### Configuration
 
 | Setting | Env | Default |

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -94,6 +94,10 @@ tempfile = "3"
 serial_test = "3"
 rcgen = "0.14"
 rustls = "0.23"
+# The membership integration test drives the real control-plane router rather
+# than a stub, so a mismatch in the HTTP contract between the two services fails
+# here instead of in a cluster.
+controlplane = { path = "../controlplane" }
 
 [features]
 default = []

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -97,7 +97,7 @@ rustls = "0.23"
 # The membership integration test drives the real control-plane router rather
 # than a stub, so a mismatch in the HTTP contract between the two services fails
 # here instead of in a cluster.
-controlplane = { path = "../controlplane" }
+controlplane = { path = "../controlplane", version = "0.1.1" }
 
 [features]
 default = []

--- a/services/broker/src/config.rs
+++ b/services/broker/src/config.rs
@@ -5,6 +5,21 @@ use std::fs;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 
+/// Identity this broker claims in the cluster.
+///
+/// Present only when `FELIX_NODE_ID` is set. Membership is opt-in because a
+/// single-node broker has no cluster to join, and registering one would put a
+/// node in the catalog that placement would then try to use.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MembershipConfig {
+    /// Stable across restarts. This is the identity, not the process.
+    pub node_id: String,
+    /// `host:port` peers reach this broker on. Not the bind address: a broker
+    /// bound to 0.0.0.0 has to advertise something routable.
+    pub advertise_addr: String,
+    pub region: String,
+}
+
 // Broker service configuration sourced from environment variables.
 #[derive(Debug, Clone)]
 pub struct BrokerConfig {
@@ -16,6 +31,8 @@ pub struct BrokerConfig {
     pub controlplane_url: Option<String>,
     // Poll interval for control-plane changes.
     pub controlplane_sync_interval_ms: u64,
+    // Cluster membership identity, when this broker joins one.
+    pub membership: Option<MembershipConfig>,
     // If true, publish acks are sent after commit.
     pub ack_on_commit: bool,
     // Max frame size accepted on QUIC streams.
@@ -101,6 +118,7 @@ impl Default for BrokerConfig {
             metrics_bind: SocketAddr::from(([0, 0, 0, 0], 8080)),
             controlplane_url: None,
             controlplane_sync_interval_ms: 2000,
+            membership: None,
             ack_on_commit: false,
             max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
             publish_queue_wait_timeout_ms: DEFAULT_PUBLISH_QUEUE_WAIT_TIMEOUT_MS,
@@ -177,6 +195,57 @@ impl SubscriberLaneShard {
             _ => None,
         }
     }
+}
+
+/// Read the cluster identity, or `None` when this broker is not joining one.
+///
+/// Fails rather than defaults on a half-configured identity. A broker that
+/// guessed its own advertised address would register something unreachable, and
+/// the failure would surface later as peers unable to connect to a node the
+/// catalog says is live.
+fn membership_from_env(
+    controlplane_url: &Option<String>,
+) -> std::io::Result<Option<MembershipConfig>> {
+    let Some(node_id) = std::env::var("FELIX_NODE_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let advertise_addr = std::env::var("FELIX_NODE_ADVERTISE_ADDR")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "FELIX_NODE_ID is set but FELIX_NODE_ADVERTISE_ADDR is not; \
+                 a broker cannot advertise an address it has to guess",
+            )
+        })?;
+
+    // Parsed here so a malformed address fails at startup rather than as a
+    // rejected registration once everything else is already running.
+    if advertise_addr.parse::<SocketAddr>().is_err() {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("FELIX_NODE_ADVERTISE_ADDR is not a valid host:port address: {advertise_addr}"),
+        ));
+    }
+
+    if controlplane_url.is_none() {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            "FELIX_NODE_ID is set but FELIX_CONTROLPLANE_URL is not; \
+             there is nowhere to register",
+        ));
+    }
+
+    Ok(Some(MembershipConfig {
+        node_id,
+        advertise_addr,
+        region: std::env::var("FELIX_REGION_ID").unwrap_or_else(|_| "local".to_string()),
+    }))
 }
 
 fn parse_sub_queue_policy(value: &str) -> Option<SubQueuePolicy> {
@@ -281,6 +350,7 @@ impl BrokerConfig {
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             .unwrap_or(2000);
+        let membership = membership_from_env(&controlplane_url)?;
         let ack_on_commit = std::env::var("FELIX_ACK_ON_COMMIT")
             .ok()
             .map(|value| matches!(value.as_str(), "1" | "true" | "yes"))
@@ -450,6 +520,7 @@ impl BrokerConfig {
             metrics_bind,
             controlplane_url,
             controlplane_sync_interval_ms,
+            membership,
             ack_on_commit,
             max_frame_bytes,
             publish_queue_wait_timeout_ms,
@@ -682,6 +753,87 @@ mod tests {
     use std::env;
     use std::fs;
     use tempfile::TempDir;
+
+    /// A broker with no identity is a single node, and registering one would
+    /// put a node in the catalog placement would then try to use.
+    #[serial]
+    #[test]
+    fn membership_is_off_without_a_node_id() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+        }
+        assert!(
+            BrokerConfig::from_env()
+                .expect("config")
+                .membership
+                .is_none()
+        );
+    }
+
+    /// A broker that guessed its advertised address would register something
+    /// unreachable, and the failure would surface later as peers unable to
+    /// connect to a node the catalog says is live.
+    #[serial]
+    #[test]
+    fn a_node_id_without_an_advertise_address_fails_startup() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+        }
+        let err = BrokerConfig::from_env().expect_err("should fail");
+        assert!(
+            err.to_string().contains("FELIX_NODE_ADVERTISE_ADDR"),
+            "{err}"
+        );
+    }
+
+    /// Rejected at startup rather than as a failed registration once everything
+    /// else is already running.
+    #[serial]
+    #[test]
+    fn a_malformed_advertise_address_fails_startup() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "not-an-address");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+        }
+        let err = BrokerConfig::from_env().expect_err("should fail");
+        assert!(err.to_string().contains("valid host:port"), "{err}");
+    }
+
+    #[serial]
+    #[test]
+    fn a_node_id_without_a_control_plane_fails_startup() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
+        }
+        let err = BrokerConfig::from_env().expect_err("should fail");
+        assert!(err.to_string().contains("FELIX_CONTROLPLANE_URL"), "{err}");
+    }
+
+    #[serial]
+    #[test]
+    fn a_complete_identity_is_accepted() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
+            env::set_var("FELIX_REGION_ID", "eu-central-1");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+        }
+        let membership = BrokerConfig::from_env()
+            .expect("config")
+            .membership
+            .expect("membership");
+        assert_eq!(membership.node_id, "broker-a");
+        assert_eq!(membership.advertise_addr, "10.0.0.4:7000");
+        assert_eq!(membership.region, "eu-central-1");
+    }
 
     // Helper to clear all Felix env vars
     fn clear_felix_env() {

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -10,6 +10,7 @@ pub mod config;
 pub mod controlplane;
 pub mod core_shards;
 pub mod durable_config;
+pub mod membership;
 pub mod quic;
 pub mod timings;
 pub mod transport;

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -34,6 +34,7 @@ mod observability;
 mod test_support;
 
 use anyhow::{Context, Result};
+use broker::membership;
 use broker::{auth::BrokerAuth, config, durable_config::DurableStorageConfig, quic};
 use felix_broker::{Broker, DurableStorage};
 use felix_common::lifecycle::{self, DrainBudget, Readiness};
@@ -296,8 +297,49 @@ where
         });
     }
 
+    // Cluster membership, when this broker has an identity. Registration waits
+    // for `serving`, because advertising a node placement can route to before
+    // it can answer is worse than advertising it a moment late.
+    let membership_client = reqwest::Client::new();
+    let membership = match (&config.membership, &config.controlplane_url) {
+        (Some(membership_config), Some(base_url)) => {
+            let serving = if gate_readiness_on_sync {
+                seeded.clone()
+            } else {
+                // Nothing to wait for: the accept loop is already running.
+                let now = CancellationToken::new();
+                now.cancel();
+                now
+            };
+            Some(membership::spawn(
+                membership_client.clone(),
+                base_url.clone(),
+                membership_config.clone(),
+                serving,
+                sync_shutdown.clone(),
+            ))
+        }
+        _ => {
+            tracing::info!("cluster membership disabled (FELIX_NODE_ID not set)");
+            None
+        }
+    };
+
     // Block until the shutdown signal resolves so the process stays alive.
-    shutdown.await;
+    // A refused registration ends the process too: a broker that is not a
+    // cluster member should say so and stop, not serve traffic nobody routes.
+    let mut membership_rejected = false;
+    match &membership {
+        Some(task) => {
+            tokio::select! {
+                _ = shutdown => {}
+                _ = task.fatal.cancelled() => {
+                    membership_rejected = true;
+                }
+            }
+        }
+        None => shutdown.await,
+    }
 
     // Step 1: stop advertising readiness. Load balancers and the Kubernetes
     // endpoints controller drop this instance from rotation while it can still
@@ -330,6 +372,37 @@ where
         .await
     {
         accept_task.abort();
+    }
+
+    // Leave the cluster before draining connections, so nothing new is placed
+    // here while in-flight work finishes.
+    if let (Some(membership_config), Some(base_url)) =
+        (&config.membership, &config.controlplane_url)
+        && !membership_rejected
+    {
+        budget
+            .drain("membership_deregister", async {
+                membership::shutdown_membership(
+                    &membership_client,
+                    base_url,
+                    &membership_config.node_id,
+                )
+                .await;
+            })
+            .await;
+    }
+
+    let mut membership = membership;
+    if let Some(task) = &mut membership {
+        sync_shutdown.cancel();
+        if !budget
+            .drain("membership_heartbeat", async {
+                let _ = (&mut task.handle).await;
+            })
+            .await
+        {
+            task.handle.abort();
+        }
     }
 
     let mut controlplane_task = controlplane_task;
@@ -374,6 +447,12 @@ where
     }
 
     budget.report();
+    if membership_rejected {
+        tracing::error!("broker stopped: the control plane refused this node identity");
+        return Err(anyhow::anyhow!(
+            "control plane refused this node identity; check FELIX_NODE_ID and FELIX_NODE_ADVERTISE_ADDR"
+        ));
+    }
     tracing::info!("broker stopped");
     Ok(())
 }

--- a/services/broker/src/membership.rs
+++ b/services/broker/src/membership.rs
@@ -1,0 +1,421 @@
+//! Broker-side cluster membership.
+//!
+//! The broker claims a stable identity on boot, reports health on an interval,
+//! and says goodbye on the way out. The control plane turns that into the
+//! catalog placement reads.
+//!
+//! The distinction this module exists to preserve: a broker that deregisters is
+//! `left`, and one that simply stops is found `down` by heartbeat expiry. Both
+//! remove it from placement, but only the first is intentional, so only the
+//! first should be silent in the logs.
+//!
+//! Registration happens *after* the broker can serve. Registering earlier
+//! advertises a node that placement may immediately use and that cannot yet
+//! answer.
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
+
+use crate::config::MembershipConfig;
+
+/// Ceiling on heartbeat retry backoff.
+///
+/// Bounded so a broker that was unreachable for an hour resumes reporting
+/// within one ceiling of the control plane coming back, rather than after a
+/// doubling interval measured in hours.
+const MAX_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Fraction of a delay that jitter may add.
+///
+/// Restarting a cluster puts every broker on the same schedule; without jitter
+/// they heartbeat in lockstep and the control plane sees the whole fleet at
+/// once, every interval.
+const JITTER_FRACTION: f64 = 0.2;
+
+#[derive(Debug, Serialize)]
+struct RegistrationRequest<'a> {
+    node_id: &'a str,
+    advertise_addr: &'a str,
+    region: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegistrationResponse {
+    node: NodeView,
+    heartbeat_interval_ms: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeView {
+    status: NodeStatusView,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeStatusView {
+    incarnation: u64,
+    lifecycle: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HeartbeatRequest {
+    incarnation: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct HeartbeatResponse {
+    lifecycle: String,
+    heartbeat_interval_ms: u64,
+}
+
+/// A registered identity, and what the control plane told us about it.
+#[derive(Debug, Clone)]
+pub struct Registration {
+    pub node_id: String,
+    /// This process's incarnation. Sent with every heartbeat so one delayed
+    /// past a restart is rejected instead of counted for its successor.
+    pub incarnation: u64,
+    pub heartbeat_interval_ms: u64,
+}
+
+/// Why a registration attempt did not produce an identity.
+///
+/// The split is what decides whether to retry. A control plane that is still
+/// starting will accept the same request in a moment; one that rejected the
+/// identity will reject it forever, and retrying only hides the misconfiguration.
+#[derive(Debug)]
+pub enum RegisterError {
+    /// The control plane refused this identity or address. Terminal.
+    Rejected(String),
+    /// The control plane could not be reached, or failed internally.
+    Unavailable(anyhow::Error),
+}
+
+impl std::fmt::Display for RegisterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Rejected(message) => write!(f, "{message}"),
+            Self::Unavailable(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+/// Claim this broker's identity.
+///
+/// Fails loudly. A broker that cannot register is not a cluster member, and
+/// carrying on as if it were means publishing to a node no one will route to.
+pub async fn register(
+    client: &reqwest::Client,
+    base_url: &str,
+    config: &MembershipConfig,
+) -> std::result::Result<Registration, RegisterError> {
+    let response = client
+        .post(format!("{}/v1/nodes", base_url.trim_end_matches('/')))
+        .json(&RegistrationRequest {
+            node_id: &config.node_id,
+            advertise_addr: &config.advertise_addr,
+            region: &config.region,
+        })
+        .send()
+        .await
+        .with_context(|| format!("register node {} with {base_url}", config.node_id))
+        .map_err(RegisterError::Unavailable)?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let message = format!(
+            "control plane rejected registration of {} ({status}): {body}",
+            config.node_id
+        );
+        // A 4xx says this identity or address is wrong, and it will be wrong
+        // next time too. Anything else may just be a control plane still coming
+        // up, which is worth waiting for.
+        return Err(if status.is_client_error() {
+            RegisterError::Rejected(message)
+        } else {
+            RegisterError::Unavailable(anyhow!(message))
+        });
+    }
+
+    let registered: RegistrationResponse = response
+        .json()
+        .await
+        .context("decode node registration response")
+        .map_err(RegisterError::Unavailable)?;
+
+    metrics::counter!("felix_broker_membership_registrations_total").increment(1);
+    tracing::info!(
+        node_id = %config.node_id,
+        advertise_addr = %config.advertise_addr,
+        incarnation = registered.node.status.incarnation,
+        lifecycle = %registered.node.status.lifecycle,
+        "registered with the control plane",
+    );
+
+    Ok(Registration {
+        node_id: config.node_id.clone(),
+        incarnation: registered.node.status.incarnation,
+        heartbeat_interval_ms: registered.heartbeat_interval_ms,
+    })
+}
+
+/// Report health until `shutdown` fires.
+///
+/// A failed heartbeat is retried with bounded exponential backoff. It is never
+/// fatal: the control plane being briefly unreachable must not take down a
+/// broker that is otherwise serving fine. If it stays unreachable past the
+/// expiry timeout the control plane marks this node down on its own, which is
+/// the correct outcome and needs no help from here.
+pub async fn run_heartbeat(
+    client: reqwest::Client,
+    base_url: String,
+    registration: Registration,
+    shutdown: CancellationToken,
+    consecutive_failures: Arc<AtomicU64>,
+) {
+    let base_url = base_url.trim_end_matches('/').to_string();
+    let url = format!("{base_url}/v1/nodes/{}/heartbeat", registration.node_id);
+    let mut interval = Duration::from_millis(registration.heartbeat_interval_ms.max(1));
+
+    loop {
+        let failures = consecutive_failures.load(Ordering::Acquire);
+        let delay = if failures == 0 {
+            interval
+        } else {
+            backoff(interval, failures)
+        };
+
+        tokio::select! {
+            _ = shutdown.cancelled() => return,
+            _ = tokio::time::sleep(jittered(delay)) => {}
+        }
+
+        match send_heartbeat(&client, &url, registration.incarnation).await {
+            Ok(response) => {
+                consecutive_failures.store(0, Ordering::Release);
+                metrics::counter!("felix_broker_heartbeats_total").increment(1);
+                // The control plane owns the cadence, so a change to it takes
+                // effect without touching broker configuration.
+                interval = Duration::from_millis(response.heartbeat_interval_ms.max(1));
+
+                // Being told we are down means expiry already removed this node
+                // from placement. Registering again is the broker's job, not
+                // this loop's, so make the state visible and keep reporting.
+                if response.lifecycle != "live" && response.lifecycle != "draining" {
+                    metrics::counter!("felix_broker_heartbeat_rejected_total").increment(1);
+                    tracing::warn!(
+                        node_id = %registration.node_id,
+                        lifecycle = %response.lifecycle,
+                        "the control plane no longer considers this broker live",
+                    );
+                }
+            }
+            Err(err) => {
+                let failures = consecutive_failures.fetch_add(1, Ordering::AcqRel) + 1;
+                metrics::counter!("felix_broker_heartbeat_failures_total").increment(1);
+                tracing::warn!(
+                    node_id = %registration.node_id,
+                    consecutive_failures = failures,
+                    error = %err,
+                    "heartbeat failed; retrying with backoff",
+                );
+            }
+        }
+    }
+}
+
+async fn send_heartbeat(
+    client: &reqwest::Client,
+    url: &str,
+    incarnation: u64,
+) -> Result<HeartbeatResponse> {
+    let response = client
+        .post(url)
+        .json(&HeartbeatRequest { incarnation })
+        .send()
+        .await
+        .context("send heartbeat")?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("heartbeat rejected ({status}): {body}"));
+    }
+    response.json().await.context("decode heartbeat response")
+}
+
+/// Stop receiving new placement, without stopping service.
+pub async fn drain(client: &reqwest::Client, base_url: &str, node_id: &str) -> Result<()> {
+    post_lifecycle(client, base_url, node_id, "drain").await
+}
+
+/// Leave the cluster on purpose, so this is not mistaken for a crash.
+pub async fn deregister(client: &reqwest::Client, base_url: &str, node_id: &str) -> Result<()> {
+    post_lifecycle(client, base_url, node_id, "deregister").await
+}
+
+async fn post_lifecycle(
+    client: &reqwest::Client,
+    base_url: &str,
+    node_id: &str,
+    action: &str,
+) -> Result<()> {
+    let response = client
+        .post(format!(
+            "{}/v1/nodes/{node_id}/{action}",
+            base_url.trim_end_matches('/')
+        ))
+        .send()
+        .await
+        .with_context(|| format!("{action} node {node_id}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("{action} rejected ({status}): {body}"));
+    }
+    Ok(())
+}
+
+/// Exponential backoff, capped.
+///
+/// `failures` is the count so far, so the first retry waits one interval rather
+/// than doubling immediately.
+fn backoff(interval: Duration, failures: u64) -> Duration {
+    let shift = failures.saturating_sub(1).min(16) as u32;
+    interval
+        .saturating_mul(2u32.saturating_pow(shift))
+        .min(MAX_RETRY_BACKOFF)
+}
+
+/// Spread a delay so a restarted fleet does not report in lockstep.
+fn jittered(delay: Duration) -> Duration {
+    let spread = delay.as_secs_f64() * JITTER_FRACTION;
+    if spread <= 0.0 {
+        return delay;
+    }
+    // Cheap and adequate: this only needs to decorrelate brokers, not resist
+    // prediction, so it avoids pulling in an RNG on the shutdown path.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let fraction = f64::from(nanos) / f64::from(u32::MAX);
+    delay + Duration::from_secs_f64(spread * fraction)
+}
+
+/// Everything the broker needs to keep its membership current.
+pub struct MembershipTask {
+    /// Ends when the broker stops.
+    pub handle: tokio::task::JoinHandle<()>,
+    /// Cancelled when registration was refused outright, so the process can
+    /// exit with the reason rather than run on as a non-member.
+    pub fatal: CancellationToken,
+    /// Consecutive heartbeat failures, exposed so shutdown and metrics can see
+    /// whether membership is currently healthy.
+    pub consecutive_failures: Arc<AtomicU64>,
+}
+
+/// Register once the broker can serve, then report health until shutdown.
+///
+/// `serving` gates registration: advertising a node before it can answer means
+/// placement may route to it and get nothing. A registration refused with a 4xx
+/// cancels `fatal` instead of retrying, because a wrong identity stays wrong.
+pub fn spawn(
+    client: reqwest::Client,
+    base_url: String,
+    config: MembershipConfig,
+    serving: CancellationToken,
+    shutdown: CancellationToken,
+) -> MembershipTask {
+    let fatal = CancellationToken::new();
+    let consecutive_failures = Arc::new(AtomicU64::new(0));
+
+    let handle = tokio::spawn({
+        let fatal = fatal.clone();
+        let consecutive_failures = Arc::clone(&consecutive_failures);
+        async move {
+            tokio::select! {
+                _ = shutdown.cancelled() => return,
+                _ = serving.cancelled() => {}
+            }
+
+            let mut attempt = 0u64;
+            let registration = loop {
+                match register(&client, &base_url, &config).await {
+                    Ok(registration) => break registration,
+                    Err(RegisterError::Rejected(message)) => {
+                        metrics::counter!("felix_broker_membership_rejections_total").increment(1);
+                        tracing::error!(
+                            node_id = %config.node_id,
+                            error = %message,
+                            "the control plane refused this identity; the broker is not a cluster member",
+                        );
+                        fatal.cancel();
+                        return;
+                    }
+                    Err(RegisterError::Unavailable(err)) => {
+                        attempt += 1;
+                        metrics::counter!("felix_broker_membership_registration_failures_total")
+                            .increment(1);
+                        tracing::warn!(
+                            node_id = %config.node_id,
+                            attempt,
+                            error = %err,
+                            "could not reach the control plane to register; retrying",
+                        );
+                        let delay = jittered(backoff(Duration::from_millis(500), attempt));
+                        tokio::select! {
+                            _ = shutdown.cancelled() => return,
+                            _ = tokio::time::sleep(delay) => {}
+                        }
+                    }
+                }
+            };
+
+            run_heartbeat(
+                client,
+                base_url,
+                registration,
+                shutdown,
+                consecutive_failures,
+            )
+            .await;
+        }
+    });
+
+    MembershipTask {
+        handle,
+        fatal,
+        consecutive_failures,
+    }
+}
+
+/// Leave the cluster on the way out.
+///
+/// Drain first so nothing new is placed here while in-flight work finishes,
+/// then deregister so this reads as intentional rather than as a crash.
+/// Neither failure is worth aborting a shutdown over: if the control plane
+/// cannot be told, heartbeat expiry reaches the same conclusion a timeout later.
+pub async fn shutdown_membership(client: &reqwest::Client, base_url: &str, node_id: &str) {
+    if let Err(err) = drain(client, base_url, node_id).await {
+        tracing::warn!(node_id, error = %err, "could not mark this broker draining");
+    }
+    if let Err(err) = deregister(client, base_url, node_id).await {
+        tracing::warn!(
+            node_id,
+            error = %err,
+            "could not deregister; the control plane will expire this node instead",
+        );
+    } else {
+        tracing::info!(node_id, "deregistered from the control plane");
+    }
+}
+
+#[cfg(test)]
+#[path = "membership_tests.rs"]
+mod tests;

--- a/services/broker/src/membership_tests.rs
+++ b/services/broker/src/membership_tests.rs
@@ -1,0 +1,297 @@
+//! Membership client behaviour against a stub control plane.
+use super::*;
+use crate::test_support::http_test::{
+    build_test_client, spawn_axum_with_shutdown, wait_for_listen,
+};
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::routing::post;
+use serde_json::json;
+use std::sync::Mutex;
+
+/// Records what the broker sent, so a test can assert on the calls rather than
+/// on the client's own bookkeeping.
+#[derive(Default)]
+struct Calls {
+    registrations: Vec<serde_json::Value>,
+    heartbeats: Vec<u64>,
+    drained: Vec<String>,
+    deregistered: Vec<String>,
+    /// Heartbeats to reject before succeeding, so backoff can be exercised.
+    fail_heartbeats: usize,
+}
+
+type Shared = Arc<Mutex<Calls>>;
+
+fn stub_control_plane(state: Shared) -> axum::Router {
+    axum::Router::new()
+        .route(
+            "/v1/nodes",
+            post(
+                |State(state): State<Shared>, Json(body): Json<serde_json::Value>| async move {
+                    let incarnation = {
+                        let mut calls = state.lock().expect("lock");
+                        calls.registrations.push(body);
+                        calls.registrations.len() as u64 - 1
+                    };
+                    Json(json!({
+                        "node": { "status": { "incarnation": incarnation, "lifecycle": "live" } },
+                        "heartbeat_interval_ms": 20,
+                        "expiry_timeout_ms": 60,
+                    }))
+                },
+            ),
+        )
+        .route(
+            "/v1/nodes/{node_id}/heartbeat",
+            post(
+                |State(state): State<Shared>,
+                 Path(_): Path<String>,
+                 Json(body): Json<serde_json::Value>| async move {
+                    let mut calls = state.lock().expect("lock");
+                    if calls.fail_heartbeats > 0 {
+                        calls.fail_heartbeats -= 1;
+                        return Err(axum::http::StatusCode::SERVICE_UNAVAILABLE);
+                    }
+                    calls
+                        .heartbeats
+                        .push(body["incarnation"].as_u64().unwrap_or_default());
+                    Ok(Json(
+                        json!({ "lifecycle": "live", "heartbeat_interval_ms": 20 }),
+                    ))
+                },
+            ),
+        )
+        .route(
+            "/v1/nodes/{node_id}/drain",
+            post(
+                |State(state): State<Shared>, Path(id): Path<String>| async move {
+                    state.lock().expect("lock").drained.push(id);
+                    Json(json!({}))
+                },
+            ),
+        )
+        .route(
+            "/v1/nodes/{node_id}/deregister",
+            post(
+                |State(state): State<Shared>, Path(id): Path<String>| async move {
+                    state.lock().expect("lock").deregistered.push(id);
+                    Json(json!({}))
+                },
+            ),
+        )
+        .with_state(state)
+}
+
+async fn serve(
+    state: Shared,
+) -> (
+    String,
+    tokio::sync::oneshot::Sender<()>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (stop, handle) = spawn_axum_with_shutdown(listener, stub_control_plane(state));
+    wait_for_listen(addr).await.expect("listen");
+    (format!("http://{addr}"), stop, handle)
+}
+
+fn config() -> MembershipConfig {
+    MembershipConfig {
+        node_id: "broker-a".to_string(),
+        advertise_addr: "10.0.0.4:7000".to_string(),
+        region: "us-west-2".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn registration_sends_the_identity_and_returns_the_incarnation() {
+    let calls: Shared = Arc::default();
+    let (base_url, stop, handle) = serve(Arc::clone(&calls)).await;
+    let client = build_test_client().expect("client");
+
+    let registration = register(&client, &base_url, &config())
+        .await
+        .expect("register");
+    assert_eq!(registration.node_id, "broker-a");
+    assert_eq!(registration.incarnation, 0);
+    assert_eq!(registration.heartbeat_interval_ms, 20);
+
+    let sent = calls.lock().expect("lock").registrations[0].clone();
+    assert_eq!(sent["node_id"], "broker-a");
+    assert_eq!(sent["advertise_addr"], "10.0.0.4:7000");
+    assert_eq!(sent["region"], "us-west-2");
+    // Observed status is the control plane's to set.
+    assert!(sent.get("status").is_none());
+
+    let _ = stop.send(());
+    let _ = handle.await;
+}
+
+/// A broker that cannot register is not a cluster member, so this must not be
+/// swallowed into "carry on and hope".
+#[tokio::test]
+async fn a_rejected_registration_is_an_error() {
+    let app = axum::Router::new().route(
+        "/v1/nodes",
+        post(|| async { (axum::http::StatusCode::CONFLICT, "address in use") }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (stop, handle) = spawn_axum_with_shutdown(listener, app);
+    wait_for_listen(addr).await.expect("listen");
+
+    let client = build_test_client().expect("client");
+    let err = register(&client, &format!("http://{addr}"), &config())
+        .await
+        .expect_err("should fail");
+    assert!(err.to_string().contains("rejected registration"), "{err}");
+
+    let _ = stop.send(());
+    let _ = handle.await;
+}
+
+/// Every heartbeat carries this process's incarnation, so one delayed past a
+/// restart is rejected rather than counted for its successor.
+#[tokio::test]
+async fn heartbeats_carry_the_registered_incarnation() {
+    let calls: Shared = Arc::default();
+    let (base_url, stop, handle) = serve(Arc::clone(&calls)).await;
+    let client = build_test_client().expect("client");
+
+    let mut registration = register(&client, &base_url, &config())
+        .await
+        .expect("register");
+    registration.incarnation = 7;
+
+    let shutdown = CancellationToken::new();
+    let failures = Arc::new(AtomicU64::new(0));
+    let beating = tokio::spawn(run_heartbeat(
+        client,
+        base_url,
+        registration,
+        shutdown.clone(),
+        Arc::clone(&failures),
+    ));
+
+    // Wait for a few beats rather than a fixed sleep.
+    for _ in 0..200 {
+        if calls.lock().expect("lock").heartbeats.len() >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    shutdown.cancel();
+    beating.await.expect("heartbeat task");
+
+    let sent = calls.lock().expect("lock").heartbeats.clone();
+    assert!(
+        sent.len() >= 2,
+        "expected repeated heartbeats, got {sent:?}"
+    );
+    assert!(sent.iter().all(|i| *i == 7), "{sent:?}");
+    assert_eq!(failures.load(Ordering::Acquire), 0);
+
+    let _ = stop.send(());
+    let _ = handle.await;
+}
+
+/// The control plane being briefly unreachable must not stop a broker that is
+/// otherwise serving. The failure has to be visible, not fatal.
+#[tokio::test]
+async fn heartbeat_failures_are_counted_and_then_recovered_from() {
+    let calls: Shared = Arc::new(Mutex::new(Calls {
+        fail_heartbeats: 3,
+        ..Calls::default()
+    }));
+    let (base_url, stop, handle) = serve(Arc::clone(&calls)).await;
+    let client = build_test_client().expect("client");
+
+    let registration = register(&client, &base_url, &config())
+        .await
+        .expect("register");
+    let shutdown = CancellationToken::new();
+    let failures = Arc::new(AtomicU64::new(0));
+    let beating = tokio::spawn(run_heartbeat(
+        client,
+        base_url,
+        registration,
+        shutdown.clone(),
+        Arc::clone(&failures),
+    ));
+
+    for _ in 0..400 {
+        if !calls.lock().expect("lock").heartbeats.is_empty() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    shutdown.cancel();
+    beating.await.expect("heartbeat task");
+
+    assert!(
+        !calls.lock().expect("lock").heartbeats.is_empty(),
+        "the loop should recover once the control plane does",
+    );
+    // Reset on success, so the counter reads "currently failing", not "ever failed".
+    assert_eq!(failures.load(Ordering::Acquire), 0);
+
+    let _ = stop.send(());
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn draining_and_deregistering_hit_the_right_endpoints() {
+    let calls: Shared = Arc::default();
+    let (base_url, stop, handle) = serve(Arc::clone(&calls)).await;
+    let client = build_test_client().expect("client");
+
+    drain(&client, &base_url, "broker-a").await.expect("drain");
+    deregister(&client, &base_url, "broker-a")
+        .await
+        .expect("deregister");
+
+    {
+        let calls = calls.lock().expect("lock");
+        assert_eq!(calls.drained, vec!["broker-a".to_string()]);
+        assert_eq!(calls.deregistered, vec!["broker-a".to_string()]);
+    }
+
+    let _ = stop.send(());
+    let _ = handle.await;
+}
+
+#[test]
+fn backoff_grows_and_then_stops_growing() {
+    let interval = Duration::from_millis(100);
+    assert_eq!(backoff(interval, 1), interval);
+    assert_eq!(backoff(interval, 2), interval * 2);
+    assert_eq!(backoff(interval, 3), interval * 4);
+    // Capped, so a long outage does not turn into an hours-long retry gap.
+    assert_eq!(backoff(interval, 60), MAX_RETRY_BACKOFF);
+    assert_eq!(backoff(Duration::from_secs(120), 1), MAX_RETRY_BACKOFF);
+}
+
+/// Jitter only ever delays, and only within the documented fraction: a
+/// heartbeat pulled earlier would tighten the cadence the control plane sized
+/// its expiry window against.
+#[test]
+fn jitter_delays_within_its_bound() {
+    let delay = Duration::from_millis(1000);
+    for _ in 0..50 {
+        let jittered = jittered(delay);
+        assert!(
+            jittered >= delay,
+            "{jittered:?} moved earlier than {delay:?}"
+        );
+        assert!(
+            jittered <= delay.mul_f64(1.0 + JITTER_FRACTION),
+            "{jittered:?} exceeded the jitter bound",
+        );
+    }
+}

--- a/services/broker/src/transport/mod.rs
+++ b/services/broker/src/transport/mod.rs
@@ -23,6 +23,7 @@ mod tests {
             metrics_bind: "0.0.0.0:8080".parse::<SocketAddr>().unwrap(),
             controlplane_url: None,
             controlplane_sync_interval_ms: 2000,
+            membership: None,
             ack_on_commit: false,
             max_frame_bytes: 16 * 1024 * 1024,
             publish_queue_wait_timeout_ms: 2000,

--- a/services/broker/src/transport/quic/handlers/subscribe/tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/tests.rs
@@ -41,6 +41,7 @@ fn test_config() -> crate::config::BrokerConfig {
         metrics_bind: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
         controlplane_url: None,
         controlplane_sync_interval_ms: 2000,
+        membership: None,
         ack_on_commit: false,
         max_frame_bytes: 16 * 1024 * 1024,
         publish_queue_wait_timeout_ms: 2000,

--- a/services/broker/tests/membership_lifecycle.rs
+++ b/services/broker/tests/membership_lifecycle.rs
@@ -1,0 +1,276 @@
+//! Broker membership end to end, against the real control-plane router.
+//!
+//! A stub would let the two services drift: the broker could send a field the
+//! control plane ignores, or read one it never sends, and every test would still
+//! pass. Running the real router means the HTTP contract is under test too.
+//!
+//! Run with `cargo test -p broker --test membership_lifecycle`.
+use broker::config::MembershipConfig;
+use broker::membership::{self, RegisterError};
+use controlplane::api::types::{FeatureFlags, Region};
+use controlplane::app::{AppState, build_router};
+use controlplane::config::NodeLivenessConfig;
+use controlplane::model::NodeLifecycle;
+use controlplane::store::memory::InMemoryStore;
+use controlplane::store::{ControlPlaneStore, StoreConfig};
+use reqwest::{Client, redirect::Policy};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
+    heartbeat_interval_ms: 20,
+    expiry_timeout_ms: 60,
+    sweep_interval_ms: 10,
+};
+
+struct Cluster {
+    base_url: String,
+    store: Arc<InMemoryStore>,
+    client: Client,
+    stop: tokio::sync::oneshot::Sender<()>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Cluster {
+    async fn start() -> Self {
+        let store = Arc::new(InMemoryStore::new(StoreConfig {
+            changes_limit: 1000,
+            change_retention_max_rows: Some(1000),
+        }));
+        let state = AppState {
+            region: Region {
+                region_id: "us-west-2".to_string(),
+                display_name: "Test".to_string(),
+            },
+            api_version: "v1".to_string(),
+            features: FeatureFlags {
+                durable_storage: store.is_durable(),
+                tiered_storage: false,
+                bridges: false,
+            },
+            store: Arc::clone(&store)
+                as Arc<dyn controlplane::store::ControlPlaneAuthStore + Send + Sync>,
+            oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
+            bootstrap_enabled: false,
+            bootstrap_token: None,
+            node_liveness: LIVENESS,
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (stop, stop_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, build_router(state).into_make_service())
+                .with_graceful_shutdown(async move {
+                    let _ = stop_rx.await;
+                })
+                .await;
+        });
+
+        Self {
+            base_url: format!("http://{addr}"),
+            store,
+            client: Client::builder()
+                .timeout(Duration::from_secs(2))
+                .no_proxy()
+                .redirect(Policy::none())
+                .build()
+                .expect("client"),
+            stop,
+            server,
+        }
+    }
+
+    async fn lifecycle(&self, node_id: &str) -> NodeLifecycle {
+        self.store
+            .get_node(node_id)
+            .await
+            .expect("node should be registered")
+            .status
+            .lifecycle
+    }
+
+    async fn shutdown(self) {
+        let _ = self.stop.send(());
+        let _ = self.server.await;
+    }
+}
+
+fn config(node_id: &str, port: u16) -> MembershipConfig {
+    MembershipConfig {
+        node_id: node_id.to_string(),
+        advertise_addr: format!("10.0.0.4:{port}"),
+        region: "us-west-2".to_string(),
+    }
+}
+
+/// Boot must leave exactly one live record, and a restart must reuse the same
+/// identity rather than adding a second one.
+#[tokio::test]
+async fn boot_produces_one_live_record_and_a_restart_reuses_it() {
+    let cluster = Cluster::start().await;
+
+    let first = membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001),
+    )
+    .await
+    .expect("register");
+    assert_eq!(first.incarnation, 0);
+    assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Live);
+
+    // Same identity, new process.
+    let second = membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001),
+    )
+    .await
+    .expect("re-register");
+    assert_eq!(
+        second.incarnation, 1,
+        "a restart takes the next incarnation"
+    );
+
+    let nodes = cluster.store.list_nodes().await.expect("list");
+    assert_eq!(
+        nodes.len(),
+        1,
+        "a restart must not create a second identity"
+    );
+
+    cluster.shutdown().await;
+}
+
+/// Graceful shutdown has to be distinguishable from a crash, or placement
+/// cannot tell "this broker meant to go" from "this broker vanished".
+#[tokio::test]
+async fn graceful_shutdown_leaves_rather_than_expiring() {
+    let cluster = Cluster::start().await;
+    membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001),
+    )
+    .await
+    .expect("register");
+
+    membership::shutdown_membership(&cluster.client, &cluster.base_url, "broker-a").await;
+
+    assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Left);
+    cluster.shutdown().await;
+}
+
+/// A broker that is killed never says anything, so silence is the only signal.
+#[tokio::test]
+async fn an_abrupt_stop_is_detected_by_expiry() {
+    let cluster = Cluster::start().await;
+    let registered = membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001),
+    )
+    .await
+    .expect("register");
+    assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Live);
+
+    // The process is gone; nothing more arrives. Drive the sweep at a time past
+    // the timeout instead of waiting for one.
+    let registered_at = cluster
+        .store
+        .get_node("broker-a")
+        .await
+        .expect("get")
+        .status
+        .last_heartbeat_at_millis;
+    let expired = controlplane::membership::expire_once(
+        cluster.store.as_ref(),
+        &LIVENESS,
+        registered_at + LIVENESS.expiry_timeout_ms + 1,
+    )
+    .await;
+
+    assert_eq!(expired, 1);
+    assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Down);
+    assert_eq!(registered.incarnation, 0);
+
+    cluster.shutdown().await;
+}
+
+/// Two brokers cannot both be reachable at one address, so the second must be
+/// refused rather than silently shadowing the first.
+#[tokio::test]
+async fn a_duplicate_advertised_address_is_refused_terminally() {
+    let cluster = Cluster::start().await;
+    membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001),
+    )
+    .await
+    .expect("register");
+
+    let err = membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-b", 7001),
+    )
+    .await
+    .expect_err("should be refused");
+    assert!(
+        matches!(err, RegisterError::Rejected(_)),
+        "a wrong address stays wrong, so this must not be retried: {err:?}",
+    );
+
+    cluster.shutdown().await;
+}
+
+/// The whole loop: register, heartbeat, and stay live across several expiry
+/// windows without anything else intervening.
+#[tokio::test]
+async fn heartbeats_keep_a_broker_live_past_its_expiry_window() {
+    let cluster = Cluster::start().await;
+    let serving = CancellationToken::new();
+    serving.cancel();
+    let shutdown = CancellationToken::new();
+
+    let task = membership::spawn(
+        cluster.client.clone(),
+        cluster.base_url.clone(),
+        config("broker-a", 7001),
+        serving,
+        shutdown.clone(),
+    );
+
+    // Wait for registration to land.
+    for _ in 0..200 {
+        if cluster.store.get_node("broker-a").await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Sweep repeatedly across more than one expiry window. A live broker must
+    // survive every pass.
+    for _ in 0..12 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        controlplane::membership::expire_once(
+            cluster.store.as_ref(),
+            &LIVENESS,
+            controlplane::api::nodes::now_millis(),
+        )
+        .await;
+    }
+
+    assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Live);
+    assert_eq!(task.consecutive_failures.load(Ordering::Acquire), 0);
+
+    shutdown.cancel();
+    let _ = task.handle.await;
+    cluster.shutdown().await;
+}

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -19,8 +19,11 @@
 //!   can report health for any node_id. Authenticating broker identity is
 //!   tracked in #126; until then this is only safe on a trusted network.
 use crate::api::error::{ApiError, api_conflict, api_internal, api_not_found};
-use crate::api::types::{NodeHeartbeatRequest, NodeHeartbeatResponse};
+use crate::api::types::{
+    NodeHeartbeatRequest, NodeHeartbeatResponse, NodeRegistrationRequest, NodeRegistrationResponse,
+};
 use crate::app::AppState;
+use crate::model::{Node, NodeLifecycle, NodeSpec, NodeStatus};
 use crate::store::StoreError;
 use axum::Json;
 use axum::extract::{Path, State};
@@ -81,4 +84,147 @@ pub fn now_millis() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/nodes",
+    tag = "nodes",
+    request_body = NodeRegistrationRequest,
+    responses(
+        (status = 200, description = "Node registered", body = NodeRegistrationResponse),
+        (status = 409, description = "Identity or address rejected", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Claim a broker identity.
+///
+/// Idempotent per `node_id`: a broker that restarts re-registers under the same
+/// identity, keeping its original registration time and taking the next
+/// incarnation. That is what lets a restart be told apart from a new node.
+///
+/// # Errors
+/// - 409 when the identity or advertised address is invalid, or the address
+///   already belongs to another node.
+pub(crate) async fn register_node(
+    State(state): State<AppState>,
+    Json(request): Json<NodeRegistrationRequest>,
+) -> Result<Json<NodeRegistrationResponse>, ApiError> {
+    let now = now_millis();
+    let node = Node {
+        node_id: request.node_id,
+        spec: NodeSpec {
+            advertise_addr: request.advertise_addr,
+            region: request.region,
+            labels: request.labels,
+            capacity: request.capacity,
+        },
+        // The control plane's to set, not the caller's. `register_node`
+        // preserves the original `registered_at_millis` and owns `incarnation`.
+        status: NodeStatus {
+            lifecycle: NodeLifecycle::Live,
+            last_heartbeat_at_millis: now,
+            registered_at_millis: now,
+            incarnation: 0,
+        },
+    };
+
+    let node = state
+        .store
+        .register_node(node)
+        .await
+        .map_err(|err| match err {
+            StoreError::Conflict(ref message) => api_conflict("conflict", message),
+            ref other => api_internal("register node", other),
+        })?;
+
+    Ok(Json(NodeRegistrationResponse {
+        node,
+        heartbeat_interval_ms: state.node_liveness.heartbeat_interval_ms,
+        expiry_timeout_ms: state.node_liveness.expiry_timeout_ms,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/nodes/{node_id}/drain",
+    tag = "nodes",
+    params(("node_id" = String, Path, description = "Broker node identifier")),
+    responses(
+        (status = 200, description = "Node is draining", body = crate::model::Node),
+        (status = 404, description = "Node is not registered", body = crate::api::types::ErrorResponse),
+        (status = 409, description = "Node cannot drain from its current lifecycle", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Stop new placement without stopping service.
+///
+/// Called by a broker at the start of its own shutdown, so nothing new is
+/// assigned to it while it finishes what it has.
+///
+/// # Errors
+/// - 404 when the node is not registered.
+/// - 409 when the node is not currently serving, since there is nothing to drain.
+pub(crate) async fn drain_node(
+    State(state): State<AppState>,
+    Path(node_id): Path<String>,
+) -> Result<Json<Node>, ApiError> {
+    set_lifecycle(&state, &node_id, NodeLifecycle::Draining).await
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/nodes/{node_id}/deregister",
+    tag = "nodes",
+    params(("node_id" = String, Path, description = "Broker node identifier")),
+    responses(
+        (status = 200, description = "Node has left", body = crate::model::Node),
+        (status = 404, description = "Node is not registered", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Leave the cluster on purpose.
+///
+/// This is what distinguishes a graceful shutdown from a crash: a node that
+/// deregisters is `left`, while one that simply stops is found `down` by expiry.
+/// The record is kept either way, so the identity and its incarnation survive
+/// for the next boot.
+///
+/// # Errors
+/// - 404 when the node is not registered.
+pub(crate) async fn deregister_node(
+    State(state): State<AppState>,
+    Path(node_id): Path<String>,
+) -> Result<Json<Node>, ApiError> {
+    set_lifecycle(&state, &node_id, NodeLifecycle::Left).await
+}
+
+/// Drive a lifecycle move, treating "already there" as success.
+///
+/// A retried drain or deregistration must not fail: a broker that shuts down
+/// twice for the same reason is not an error condition.
+async fn set_lifecycle(
+    state: &AppState,
+    node_id: &str,
+    lifecycle: NodeLifecycle,
+) -> Result<Json<Node>, ApiError> {
+    let moved = state
+        .store
+        .set_node_lifecycle(node_id, lifecycle)
+        .await
+        .map_err(|err| match err {
+            StoreError::NotFound(_) => api_not_found("node is not registered"),
+            StoreError::Conflict(ref message) => api_conflict("conflict", message),
+            ref other => api_internal("set node lifecycle", other),
+        })?;
+
+    match moved {
+        Some(node) => Ok(Json(node)),
+        None => state
+            .store
+            .get_node(node_id)
+            .await
+            .map(Json)
+            .map_err(|err| match err {
+                StoreError::NotFound(_) => api_not_found("node is not registered"),
+                ref other => api_internal("get node", other),
+            }),
+    }
 }

--- a/services/controlplane/src/api/openapi.rs
+++ b/services/controlplane/src/api/openapi.rs
@@ -20,9 +20,10 @@ use crate::api::{
         CacheChangesResponse, CacheCreateRequest, CacheListResponse, CacheSnapshotResponse,
         ErrorResponse, FeatureFlags, HealthStatus, ListRegionsResponse, NamespaceChangesResponse,
         NamespaceCreateRequest, NamespaceListResponse, NamespaceSnapshotResponse,
-        NodeHeartbeatRequest, NodeHeartbeatResponse, Region, StreamChangesResponse,
-        StreamCreateRequest, StreamListResponse, StreamSnapshotResponse, SystemInfo,
-        TenantChangesResponse, TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
+        NodeHeartbeatRequest, NodeHeartbeatResponse, NodeRegistrationRequest,
+        NodeRegistrationResponse, Region, StreamChangesResponse, StreamCreateRequest,
+        StreamListResponse, StreamSnapshotResponse, SystemInfo, TenantChangesResponse,
+        TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
     },
 };
 use crate::auth::admin;
@@ -87,7 +88,10 @@ use utoipa::OpenApi;
         caches::get_cache,
         caches::patch_cache,
         caches::delete_cache,
-        nodes::report_health
+        nodes::report_health,
+        nodes::register_node,
+        nodes::drain_node,
+        nodes::deregister_node
     ),
     components(schemas(
         FeatureFlags,
@@ -143,6 +147,8 @@ use utoipa::OpenApi;
         NodeChangeOp,
         NodeHeartbeatRequest,
         NodeHeartbeatResponse,
+        NodeRegistrationRequest,
+        NodeRegistrationResponse,
         TokenExchangeRequest,
         TokenExchangeResponse,
         IdpIssuerConfig,

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -168,3 +168,28 @@ pub struct NodeHeartbeatResponse {
     /// Silence beyond this marks the node down.
     pub expiry_timeout_ms: u64,
 }
+
+/// A broker claiming its identity on boot.
+///
+/// Carries only spec fields. Observed status is the control plane's to set: a
+/// broker that could declare itself live could outlive its own expiry.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeRegistrationRequest {
+    pub node_id: String,
+    /// `host:port` the broker-internal QUIC listener is reachable on.
+    pub advertise_addr: String,
+    pub region: String,
+    #[serde(default)]
+    pub labels: std::collections::BTreeMap<String, String>,
+    #[serde(default)]
+    pub capacity: crate::model::NodeCapacity,
+}
+
+/// What a broker learns from registering.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeRegistrationResponse {
+    pub node: crate::model::Node,
+    /// The cadence expected of this broker, so it is configured in one place.
+    pub heartbeat_interval_ms: u64,
+    pub expiry_timeout_ms: u64,
+}

--- a/services/controlplane/src/app.rs
+++ b/services/controlplane/src/app.rs
@@ -101,9 +101,18 @@ pub fn build_router(state: AppState) -> Router {
             "/v1/tenants/{tenant_id}",
             axum::routing::delete(api::tenants::delete_tenant),
         )
+        .route("/v1/nodes", axum::routing::post(api::nodes::register_node))
         .route(
             "/v1/nodes/{node_id}/heartbeat",
             axum::routing::post(api::nodes::report_health),
+        )
+        .route(
+            "/v1/nodes/{node_id}/drain",
+            axum::routing::post(api::nodes::drain_node),
+        )
+        .route(
+            "/v1/nodes/{node_id}/deregister",
+            axum::routing::post(api::nodes::deregister_node),
         )
         .route(
             "/v1/tenants/{tenant_id}/token/exchange",


### PR DESCRIPTION
Closes #95. Fourth slice of **M2**, and the one that makes the milestone's completion signal real: N brokers register on boot, appear live, and transition to down within the heartbeat timeout after process failure.

## What's here

The control plane had no registration endpoint — #94 only added the heartbeat — so this adds `POST /v1/nodes`, `/drain`, and `/deregister`, plus the broker-side client that drives them.

**Membership is opt-in on `FELIX_NODE_ID`.** A single-node broker has no cluster to join, and registering one would put a node in the catalog that placement would then try to use.

## The decisions worth reviewing

**Registration waits until the broker can serve.** Advertising a node placement may route to before it can answer is worse than advertising it a moment late, so it waits on the same `seeded` gate readiness uses.

**A 4xx registration is terminal; anything else is retried.** A duplicate advertised address will be a duplicate next time too, so the broker stops with the reason rather than retrying forever and hiding the misconfiguration. An unreachable control plane is retried with bounded backoff, because it may simply be starting. `RegisterError` makes that split explicit rather than leaving it to a status-code check at the call site.

**Startup fails on a half-configured identity** — a node id with no advertised address, no control-plane URL, or an address that doesn't parse. A broker that guessed its own address would register something unreachable, and that surfaces later as peers unable to connect to a node the catalog calls live.

**Heartbeat failures are visible but never fatal.** A briefly unreachable control plane must not take down a broker that is serving fine. If it stays unreachable, expiry reaches the correct conclusion on its own.

**Shutdown drains then deregisters *before* connections drain**, so nothing new is placed here while in-flight work finishes. That ordering is what separates a graceful stop (`left`) from a crash (`down`).

## Testing against the real control plane, not a stub

`membership_lifecycle.rs` runs the **actual control-plane router** in-process. A stub would let the two services drift — the broker could send a field the control plane ignores, or read one it never sends, and every test would still pass. This required adding `controlplane` as a broker dev-dependency; the comment in `Cargo.toml` says why.

Five cases, one per acceptance criterion:

| | |
|---|---|
| boot → one live record, restart reuses it | not a second identity; incarnation goes 0 → 1 |
| graceful shutdown | → `left` |
| abrupt stop | → `down` via expiry, driven at an exact time |
| duplicate advertised address | → `Rejected`, terminal |
| heartbeats across several expiry windows | stays `live`, zero failures |

Plus 7 unit tests against a stub for the retry and jitter behaviour that a real control plane won't produce on demand — including that **jitter only ever delays**, since pulling a heartbeat earlier would tighten the cadence the expiry window was sized against.

## Not authenticated

Same as #94: any caller can register or deregister any `node_id`. #126 (M8) owns this and explicitly covers "prevent one broker from reporting health or claiming identity for another". The docs say so rather than leaving it implicit.

## Noticed, not fixed

`services/broker/src/config.rs` has the same `clear_felix_env` helper I fixed in the control plane last week — it clears every `FELIX_*` var without restoring. It causes no container leak here because the broker tests don't use `FELIX_TEST_DATABASE_URL`, but it's the same latent cross-test hazard. Left alone rather than expanding this PR; happy to file it.

## Verification

`task lint`, `task test` (64 suites), `task demo:check`, `node scripts/check-mermaid.mjs`, and the pg suite against real Postgres 16 — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)