### PR TITLE
feat(controlplane): expose broker membership to operators

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -121,6 +121,51 @@ This is what separates a graceful shutdown from a crash: a broker that
 deregisters is `left`, and one that simply stops is found `down` by expiry. Both
 remove it from placement, but only the first is intentional.
 
+### Operator endpoints
+
+`GET /v1/nodes` and `GET /v1/nodes/{node_id}` list registered brokers and
+explain each one's placement standing:
+
+```json
+{ "node": { "node_id": "broker-1", "spec": { ... }, "status": { ... } },
+  "placement": { "eligible": false, "heartbeat_age_ms": 41200,
+                 "reasons": ["last heartbeat was 41200ms ago, past the 15000ms timeout; expiry has not run yet"] } }
+```
+
+`placement.reasons` exists because "this broker is registered but shards are not
+landing on it" is otherwise answered by reading a lifecycle string and doing
+heartbeat arithmetic by hand. It reports a stale heartbeat separately from the
+lifecycle, so the window between a heartbeat lapsing and the sweep noticing —
+where a node still reads `live` — is visible rather than inferred.
+
+Filters intersect, and an absent filter matches everything:
+
+```
+GET /v1/nodes?lifecycle=live&region=us-west-2&label=rack%3Da1&label=tier%3Dhot
+```
+
+Repeating `label` requires all of them. The listing is unpaginated, like the
+other listings in this API: a cluster has brokers in the tens, and a cursor no
+caller needs is a cursor every caller has to handle.
+
+#### Authorization
+
+Both read endpoints require `node.view:cluster:*` in a Felix bearer token. The
+tenant comes from the token's own `tid` claim rather than a path segment,
+because the cluster is not a tenant resource; that claim only selects which
+tenant's signing keys to verify against, exactly as `kid` selects a key without
+conferring one.
+
+`cluster:*` sits outside the tenant hierarchy on purpose. No tenant scope
+contains it, and `validate_new_rule_allowed` admits a policy only when its
+object is already inside the caller's scope — so a tenant admin cannot grant
+themselves cluster access, and nothing in the bootstrap seed grants it either.
+The converse also holds: cluster scope confers nothing inside a tenant, so it is
+not a backdoor into tenant data.
+
+Note that the registration, heartbeat, drain, and deregister endpoints above are
+**not** authenticated yet (#126). Only the operator read endpoints are.
+
 ### Configuration
 
 | Setting | Env | Default |

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -18,15 +18,22 @@
 //! - **This endpoint is not yet authenticated.** Any caller that can reach it
 //!   can report health for any node_id. Authenticating broker identity is
 //!   tracked in #126; until then this is only safe on a trusted network.
-use crate::api::error::{ApiError, api_conflict, api_internal, api_not_found};
+use crate::api::error::{
+    ApiError, api_conflict, api_forbidden, api_internal, api_not_found, api_unauthorized,
+};
 use crate::api::types::{
-    NodeHeartbeatRequest, NodeHeartbeatResponse, NodeRegistrationRequest, NodeRegistrationResponse,
+    NodeHeartbeatRequest, NodeHeartbeatResponse, NodeListResponse, NodePlacement,
+    NodeRegistrationRequest, NodeRegistrationResponse, NodeView,
 };
 use crate::app::AppState;
+use crate::auth::felix_token::verify_token;
+use crate::auth::rbac::authorize::{ACTION_NODE_VIEW, ParsedObject, parse_permission};
 use crate::model::{Node, NodeLifecycle, NodeSpec, NodeStatus};
 use crate::store::StoreError;
 use axum::Json;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
+use axum::http::HeaderMap;
+use std::collections::HashMap;
 
 #[utoipa::path(
     post,
@@ -227,4 +234,285 @@ async fn set_lifecycle(
                 ref other => api_internal("get node", other),
             }),
     }
+}
+
+/// Filters accepted by the node listing.
+///
+/// Every filter is an intersection, and an absent filter matches everything.
+#[derive(Debug, Default)]
+struct NodeFilters {
+    lifecycle: Option<String>,
+    region: Option<String>,
+    /// `key=value` pairs a node must carry all of.
+    labels: Vec<(String, String)>,
+}
+
+impl NodeFilters {
+    /// `?lifecycle=live&region=us-west-2&label=rack%3Da1&label=tier%3Dhot`
+    ///
+    /// Repeating `label` intersects rather than replaces, which is what makes
+    /// "the hot racks in this region" expressible.
+    fn from_query(query: &HashMap<String, String>, raw: &str) -> Self {
+        let labels = raw
+            .split('&')
+            .filter_map(|pair| pair.strip_prefix("label="))
+            .filter_map(|value| {
+                let decoded = percent_decode(value);
+                decoded
+                    .split_once('=')
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+            })
+            .collect();
+        Self {
+            lifecycle: query.get("lifecycle").cloned(),
+            region: query.get("region").cloned(),
+            labels,
+        }
+    }
+
+    fn matches(&self, node: &crate::model::Node) -> bool {
+        if let Some(lifecycle) = &self.lifecycle
+            && !lifecycle_matches(node.status.lifecycle, lifecycle)
+        {
+            return false;
+        }
+        if let Some(region) = &self.region
+            && &node.spec.region != region
+        {
+            return false;
+        }
+        self.labels
+            .iter()
+            .all(|(key, value)| node.spec.labels.get(key) == Some(value))
+    }
+}
+
+/// Minimal `%XX` decoding for label values, which routinely contain `=` and `/`.
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => match u8::from_str_radix(&value[i + 1..i + 3], 16) {
+                Ok(byte) => {
+                    out.push(byte);
+                    i += 3;
+                }
+                Err(_) => {
+                    out.push(bytes[i]);
+                    i += 1;
+                }
+            },
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            byte => {
+                out.push(byte);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).unwrap_or_else(|_| value.to_string())
+}
+
+fn lifecycle_matches(lifecycle: NodeLifecycle, wanted: &str) -> bool {
+    let name = match lifecycle {
+        NodeLifecycle::Live => "live",
+        NodeLifecycle::Draining => "draining",
+        NodeLifecycle::Down => "down",
+        NodeLifecycle::Left => "left",
+    };
+    name.eq_ignore_ascii_case(wanted)
+}
+
+/// Explain this node's placement standing at `now`.
+fn placement_for(node: &Node, now_millis: u64, expiry_timeout_ms: u64) -> NodePlacement {
+    // Saturating: a heartbeat recorded a moment ahead of this read (two control
+    // plane instances, slightly different clocks) is an age of zero, not a
+    // wrapped enormous one.
+    let heartbeat_age_ms = now_millis.saturating_sub(node.status.last_heartbeat_at_millis);
+    let mut reasons = Vec::new();
+
+    match node.status.lifecycle {
+        NodeLifecycle::Live => {}
+        NodeLifecycle::Draining => {
+            reasons.push("node is draining and takes no new placement".into())
+        }
+        NodeLifecycle::Down => reasons.push("node missed its heartbeat window".into()),
+        NodeLifecycle::Left => reasons.push("node deregistered and left the cluster".into()),
+    }
+
+    // Reported separately from the lifecycle: between a heartbeat lapsing and
+    // the sweep noticing, a node still reads `live` while already being past
+    // its window, and that gap is exactly what an operator is trying to see.
+    if heartbeat_age_ms > expiry_timeout_ms
+        && matches!(
+            node.status.lifecycle,
+            NodeLifecycle::Live | NodeLifecycle::Draining
+        )
+    {
+        reasons.push(format!(
+            "last heartbeat was {heartbeat_age_ms}ms ago, past the {expiry_timeout_ms}ms timeout; expiry has not run yet"
+        ));
+    }
+
+    if node.spec.capacity.max_shards == Some(0) {
+        reasons.push("capacity hint max_shards is zero".into());
+    }
+    if node.spec.capacity.weight == 0 {
+        reasons.push("capacity hint weight is zero, so placement never selects it".into());
+    }
+
+    NodePlacement {
+        eligible: reasons.is_empty(),
+        reasons,
+        heartbeat_age_ms,
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/nodes",
+    tag = "nodes",
+    params(
+        ("lifecycle" = Option<String>, Query, description = "live, draining, down, or left"),
+        ("region" = Option<String>, Query, description = "Exact region match"),
+        ("label" = Option<String>, Query, description = "key=value; repeat to require several")
+    ),
+    responses((status = 200, description = "List registered nodes", body = NodeListResponse))
+)]
+/// List every registered broker and why each is, or is not, placeable.
+///
+/// Unpaginated, like the other listings in this API: a cluster has brokers in
+/// the tens, and a cursor no caller needs is a cursor every caller has to handle.
+///
+/// # Errors
+/// - 500 when the store cannot be read.
+pub(crate) async fn list_nodes(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+    raw_query: axum::extract::RawQuery,
+) -> Result<Json<NodeListResponse>, ApiError> {
+    require_cluster_node_view(&state, &headers).await?;
+    let filters = NodeFilters::from_query(&query, raw_query.0.as_deref().unwrap_or_default());
+    let now = now_millis();
+    let expiry = state.node_liveness.expiry_timeout_ms;
+
+    let items = state
+        .store
+        .list_nodes()
+        .await
+        .map_err(|ref err| api_internal("failed to list nodes", err))?
+        .into_iter()
+        .filter(|node| filters.matches(node))
+        .map(|node| NodeView {
+            placement: placement_for(&node, now, expiry),
+            node,
+        })
+        .collect();
+
+    Ok(Json(NodeListResponse { items }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/nodes/{node_id}",
+    tag = "nodes",
+    params(("node_id" = String, Path, description = "Broker node identifier")),
+    responses(
+        (status = 200, description = "Node detail", body = NodeView),
+        (status = 404, description = "Node is not registered", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Fetch one broker, with the same placement explanation the listing gives.
+///
+/// # Errors
+/// - 404 when the node is not registered.
+pub(crate) async fn get_node(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(node_id): Path<String>,
+) -> Result<Json<NodeView>, ApiError> {
+    require_cluster_node_view(&state, &headers).await?;
+    let node = state
+        .store
+        .get_node(&node_id)
+        .await
+        .map_err(|err| match err {
+            StoreError::NotFound(_) => api_not_found("node is not registered"),
+            ref other => api_internal("get node", other),
+        })?;
+
+    let placement = placement_for(&node, now_millis(), state.node_liveness.expiry_timeout_ms);
+    Ok(Json(NodeView { node, placement }))
+}
+
+/// Require cluster-scoped `node.view` from a Felix bearer token.
+///
+/// The tenant comes from the token's own `tid` claim rather than the path,
+/// because `/v1/nodes` is not a tenant resource. That claim only selects which
+/// tenant's signing keys to check against — the signature is what grants trust,
+/// exactly as `kid` selects a key without conferring one.
+///
+/// Naming a tenant confers nothing here: the permission this requires is
+/// `node.view:cluster:*`, and no tenant scope contains a cluster object, so a
+/// tenant admin cannot write that rule for themselves.
+async fn require_cluster_node_view(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| api_unauthorized("missing bearer token"))?;
+
+    let tenant_id = unverified_tenant(bearer)?;
+    let keys = state
+        .store
+        .get_tenant_signing_keys(&tenant_id)
+        .await
+        .map_err(|ref err| api_internal("failed to load signing keys", err))?;
+    let claims = verify_token(&keys, &tenant_id, bearer, 5)
+        .map_err(|_| api_unauthorized("invalid token"))?;
+
+    let allowed = claims.perms.iter().any(|perm| {
+        // Parsed against the token's own tenant; a cluster object ignores it.
+        // Unparsable entries are skipped rather than trusted, so a malformed
+        // permission can never widen access.
+        matches!(
+            parse_permission(perm, &tenant_id),
+            Ok(parsed) if parsed.action == ACTION_NODE_VIEW && parsed.object == ParsedObject::Cluster
+        )
+    });
+
+    if allowed {
+        Ok(())
+    } else {
+        Err(api_forbidden("missing node.view:cluster:* permission"))
+    }
+}
+
+/// Read `tid` from an unverified token, only to choose a verification key.
+fn unverified_tenant(token: &str) -> Result<String, ApiError> {
+    use base64::Engine as _;
+
+    let payload = token
+        .split('.')
+        .nth(1)
+        .ok_or_else(|| api_unauthorized("malformed token"))?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .map_err(|_| api_unauthorized("malformed token"))?;
+    let claims: serde_json::Value =
+        serde_json::from_slice(&decoded).map_err(|_| api_unauthorized("malformed token"))?;
+
+    claims
+        .get("tid")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| api_unauthorized("token has no tenant claim"))
 }

--- a/services/controlplane/src/api/openapi.rs
+++ b/services/controlplane/src/api/openapi.rs
@@ -20,10 +20,10 @@ use crate::api::{
         CacheChangesResponse, CacheCreateRequest, CacheListResponse, CacheSnapshotResponse,
         ErrorResponse, FeatureFlags, HealthStatus, ListRegionsResponse, NamespaceChangesResponse,
         NamespaceCreateRequest, NamespaceListResponse, NamespaceSnapshotResponse,
-        NodeHeartbeatRequest, NodeHeartbeatResponse, NodeRegistrationRequest,
-        NodeRegistrationResponse, Region, StreamChangesResponse, StreamCreateRequest,
-        StreamListResponse, StreamSnapshotResponse, SystemInfo, TenantChangesResponse,
-        TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
+        NodeHeartbeatRequest, NodeHeartbeatResponse, NodeListResponse, NodePlacement,
+        NodeRegistrationRequest, NodeRegistrationResponse, NodeView, Region, StreamChangesResponse,
+        StreamCreateRequest, StreamListResponse, StreamSnapshotResponse, SystemInfo,
+        TenantChangesResponse, TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
     },
 };
 use crate::auth::admin;
@@ -91,7 +91,9 @@ use utoipa::OpenApi;
         nodes::report_health,
         nodes::register_node,
         nodes::drain_node,
-        nodes::deregister_node
+        nodes::deregister_node,
+        nodes::list_nodes,
+        nodes::get_node
     ),
     components(schemas(
         FeatureFlags,
@@ -149,6 +151,9 @@ use utoipa::OpenApi;
         NodeHeartbeatResponse,
         NodeRegistrationRequest,
         NodeRegistrationResponse,
+        NodeView,
+        NodePlacement,
+        NodeListResponse,
         TokenExchangeRequest,
         TokenExchangeResponse,
         IdpIssuerConfig,
@@ -193,10 +198,43 @@ mod tests {
             "NodePatchRequest",
             "NodeChange",
             "NodeChangeOp",
+            "NodeView",
+            "NodePlacement",
+            "NodeListResponse",
+            "NodeRegistrationRequest",
+            "NodeRegistrationResponse",
+            "NodeHeartbeatRequest",
+            "NodeHeartbeatResponse",
         ] {
             assert!(
                 schemas.contains_key(name),
                 "{name} is missing from the schema"
+            );
+        }
+    }
+
+    /// A route the document does not describe is a route no generated client
+    /// can call, and nothing else in the build would notice.
+    #[test]
+    fn every_node_route_is_described() {
+        let doc = serde_json::to_value(ApiDoc::openapi()).expect("serialize openapi");
+        let paths = doc["paths"].as_object().expect("paths object");
+
+        for (path, method) in [
+            ("/v1/nodes", "get"),
+            ("/v1/nodes", "post"),
+            ("/v1/nodes/{node_id}", "get"),
+            ("/v1/nodes/{node_id}/heartbeat", "post"),
+            ("/v1/nodes/{node_id}/drain", "post"),
+            ("/v1/nodes/{node_id}/deregister", "post"),
+        ] {
+            let described = paths
+                .get(path)
+                .and_then(|entry| entry.get(method))
+                .is_some();
+            assert!(
+                described,
+                "{method} {path} is missing from the OpenAPI document"
             );
         }
     }

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -193,3 +193,30 @@ pub struct NodeRegistrationResponse {
     pub heartbeat_interval_ms: u64,
     pub expiry_timeout_ms: u64,
 }
+
+/// Why a node is or is not a placement candidate.
+///
+/// The point of the endpoint: "this broker is registered but shards are not
+/// landing on it" is otherwise answered by reading a lifecycle string and doing
+/// heartbeat arithmetic by hand.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodePlacement {
+    pub eligible: bool,
+    /// Empty when eligible. One entry per reason it is not.
+    pub reasons: Vec<String>,
+    /// How long since the last accepted heartbeat, against the control plane's
+    /// clock at the time of the request.
+    pub heartbeat_age_ms: u64,
+}
+
+/// A node as an operator sees it: the record, plus what it means.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct NodeView {
+    pub node: crate::model::Node,
+    pub placement: NodePlacement,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct NodeListResponse {
+    pub items: Vec<NodeView>,
+}

--- a/services/controlplane/src/app.rs
+++ b/services/controlplane/src/app.rs
@@ -101,7 +101,14 @@ pub fn build_router(state: AppState) -> Router {
             "/v1/tenants/{tenant_id}",
             axum::routing::delete(api::tenants::delete_tenant),
         )
-        .route("/v1/nodes", axum::routing::post(api::nodes::register_node))
+        .route(
+            "/v1/nodes",
+            axum::routing::get(api::nodes::list_nodes).post(api::nodes::register_node),
+        )
+        .route(
+            "/v1/nodes/{node_id}",
+            axum::routing::get(api::nodes::get_node),
+        )
         .route(
             "/v1/nodes/{node_id}/heartbeat",
             axum::routing::post(api::nodes::report_health),

--- a/services/controlplane/src/auth/rbac/authorize.rs
+++ b/services/controlplane/src/auth/rbac/authorize.rs
@@ -16,6 +16,9 @@ pub const ACTION_STREAM_PUBLISH: &str = "stream.publish";
 pub const ACTION_STREAM_SUBSCRIBE: &str = "stream.subscribe";
 pub const ACTION_CACHE_READ: &str = "cache.read";
 pub const ACTION_CACHE_WRITE: &str = "cache.write";
+/// Read cluster membership. Cluster-scoped, so it is never reachable from a
+/// tenant scope -- see [`ParsedObject::Cluster`].
+pub const ACTION_NODE_VIEW: &str = "node.view";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Segment {
@@ -25,6 +28,14 @@ pub enum Segment {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParsedObject {
+    /// The cluster itself: brokers, their liveness, their placement standing.
+    ///
+    /// Deliberately outside the tenant hierarchy. No tenant scope contains it,
+    /// so a tenant admin cannot grant it to themselves through
+    /// [`validate_new_rule_allowed`], which only admits rules already inside the
+    /// caller's scope. It reaches a token only when an operator who already has
+    /// cluster scope writes the rule.
+    Cluster,
     Tenant {
         tenant_id: String,
     },
@@ -64,6 +75,7 @@ pub fn canonical_action(action: &str) -> Option<&'static str> {
         ACTION_STREAM_SUBSCRIBE => Some(ACTION_STREAM_SUBSCRIBE),
         ACTION_CACHE_READ => Some(ACTION_CACHE_READ),
         ACTION_CACHE_WRITE => Some(ACTION_CACHE_WRITE),
+        ACTION_NODE_VIEW => Some(ACTION_NODE_VIEW),
         _ => None,
     }
 }
@@ -82,6 +94,7 @@ pub fn parse_permission(raw: &str, tenant_id: &str) -> Result<ParsedPermission, 
 /// Parse an RBAC object string into a typed structure.
 ///
 /// Canonical grammar:
+/// - `cluster:*`
 /// - `tenant:{tenant_id}`
 /// - `namespace:{tenant_id}/{namespace}`
 /// - `stream:{tenant_id}/{namespace}/{stream}`
@@ -89,6 +102,15 @@ pub fn parse_permission(raw: &str, tenant_id: &str) -> Result<ParsedPermission, 
 pub fn parse_object(raw: &str, tenant_id: &str) -> Result<ParsedObject, String> {
     if raw == "tenant:*" {
         return Err("tenant:* is not allowed".to_string());
+    }
+
+    // Checked before the tenant-scoped forms, and without consulting
+    // `tenant_id`: the cluster belongs to no tenant.
+    if raw == "cluster:*" {
+        return Ok(ParsedObject::Cluster);
+    }
+    if raw.starts_with("cluster:") {
+        return Err("the only cluster object is cluster:*".to_string());
     }
 
     if let Some(rest) = raw.strip_prefix("tenant:") {
@@ -141,6 +163,12 @@ pub fn parse_object(raw: &str, tenant_id: &str) -> Result<ParsedObject, String> 
 
 pub fn object_within_scope(scope: &ParsedObject, target: &ParsedObject) -> bool {
     match (scope, target) {
+        // Cluster scope is its own island in both directions. A tenant scope
+        // does not reach it, which is what stops a tenant admin granting
+        // themselves cluster access; and cluster scope confers nothing inside a
+        // tenant, so it cannot be used to read tenant data either.
+        (ParsedObject::Cluster, ParsedObject::Cluster) => true,
+        (ParsedObject::Cluster, _) | (_, ParsedObject::Cluster) => false,
         (ParsedObject::Tenant { tenant_id: s }, ParsedObject::Tenant { tenant_id: t }) => s == t,
         (ParsedObject::Tenant { tenant_id: s }, ParsedObject::Namespace { tenant_id: t, .. }) => {
             s == t
@@ -306,6 +334,88 @@ fn split3(input: &str) -> Result<(&str, &str, &str), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_cluster_object_parses_independently_of_any_tenant() {
+        // Same object, whatever tenant the token belongs to.
+        assert_eq!(parse_object("cluster:*", "t1"), Ok(ParsedObject::Cluster));
+        assert_eq!(parse_object("cluster:*", "t2"), Ok(ParsedObject::Cluster));
+        // One spelling only, so a typo is rejected rather than silently scoped.
+        assert!(parse_object("cluster:nodes", "t1").is_err());
+        assert!(parse_object("cluster:", "t1").is_err());
+    }
+
+    #[test]
+    fn node_view_is_a_recognised_action() {
+        let parsed = parse_permission("node.view:cluster:*", "t1").expect("parse");
+        assert_eq!(parsed.action, ACTION_NODE_VIEW);
+        assert_eq!(parsed.object, ParsedObject::Cluster);
+    }
+
+    /// The property the whole cluster scope rests on. `validate_new_rule_allowed`
+    /// admits a rule only if its object is inside the caller's existing scope,
+    /// so if a tenant scope never contains the cluster, no tenant admin can
+    /// write themselves a cluster permission.
+    #[test]
+    fn a_tenant_scope_never_reaches_the_cluster() {
+        let tenant_scopes = [
+            ParsedObject::Tenant {
+                tenant_id: "t1".to_string(),
+            },
+            parse_object("namespace:t1/*", "t1").expect("namespace"),
+            parse_object("stream:t1/payments/*", "t1").expect("stream"),
+        ];
+
+        for scope in &tenant_scopes {
+            assert!(
+                !object_within_scope(scope, &ParsedObject::Cluster),
+                "{scope:?} must not contain the cluster",
+            );
+        }
+
+        let rule = PolicyRule {
+            subject: "role:tenant-admin".to_string(),
+            object: "cluster:*".to_string(),
+            action: ACTION_NODE_VIEW.to_string(),
+        };
+        assert!(
+            validate_new_rule_allowed(&tenant_scopes, "t1", &rule).is_err(),
+            "a tenant admin must not be able to grant cluster access",
+        );
+    }
+
+    /// And the converse: cluster scope is not a backdoor into tenant data.
+    #[test]
+    fn cluster_scope_confers_nothing_inside_a_tenant() {
+        let cluster = [ParsedObject::Cluster];
+        for target in [
+            "tenant:t1",
+            "namespace:t1/payments",
+            "stream:t1/payments/orders",
+            "cache:t1/payments/sessions",
+        ] {
+            let parsed = parse_object(target, "t1").expect("parse");
+            assert!(
+                !object_within_scope(&ParsedObject::Cluster, &parsed),
+                "cluster scope must not reach {target}",
+            );
+        }
+
+        let rule = PolicyRule {
+            subject: "role:ops".to_string(),
+            object: "stream:t1/payments/orders".to_string(),
+            action: ACTION_STREAM_MANAGE.to_string(),
+        };
+        assert!(validate_new_rule_allowed(&cluster, "t1", &rule).is_err());
+    }
+
+    #[test]
+    fn cluster_scope_contains_the_cluster() {
+        assert!(object_within_scope(
+            &ParsedObject::Cluster,
+            &ParsedObject::Cluster
+        ));
+    }
 
     #[test]
     fn strict_object_validation_accepts_canonical_forms() {

--- a/services/controlplane/tests/node_admin_api.rs
+++ b/services/controlplane/tests/node_admin_api.rs
@@ -1,0 +1,336 @@
+//! Operator-facing node listing and detail.
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use common::read_json;
+use controlplane::api::types::{FeatureFlags, Region};
+use controlplane::app::{AppState, build_router};
+use controlplane::auth::felix_token::{TenantSigningKeys, mint_token};
+use controlplane::auth::keys::generate_signing_keys;
+use controlplane::config::NodeLivenessConfig;
+use controlplane::model::{Node, NodeCapacity, NodeLifecycle, NodeSpec, NodeStatus};
+use controlplane::store::memory::InMemoryStore;
+use controlplane::store::{AuthStore, ControlPlaneAuthStore, ControlPlaneStore, StoreConfig};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
+    heartbeat_interval_ms: 5_000,
+    expiry_timeout_ms: 15_000,
+    sweep_interval_ms: 2_000,
+};
+
+type App = axum::routing::RouterIntoService<Body, ()>;
+
+async fn setup() -> (App, Arc<InMemoryStore>, TenantSigningKeys) {
+    let store = Arc::new(InMemoryStore::new(StoreConfig {
+        changes_limit: 1000,
+        change_retention_max_rows: Some(1000),
+    }));
+    let keys = generate_signing_keys().expect("keys");
+    store
+        .set_tenant_signing_keys("t1", keys.clone())
+        .await
+        .expect("set keys");
+
+    let state = AppState {
+        region: Region {
+            region_id: "local".to_string(),
+            display_name: "Local".to_string(),
+        },
+        api_version: "v1".to_string(),
+        features: FeatureFlags {
+            durable_storage: store.is_durable(),
+            tiered_storage: false,
+            bridges: false,
+        },
+        store: Arc::clone(&store) as Arc<dyn ControlPlaneAuthStore + Send + Sync>,
+        oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
+        bootstrap_enabled: false,
+        bootstrap_token: None,
+        node_liveness: LIVENESS,
+    };
+    (build_router(state).into_service(), store, keys)
+}
+
+fn token(keys: &TenantSigningKeys, perms: Vec<&str>) -> String {
+    mint_token(
+        keys,
+        "t1",
+        "p:ops",
+        perms.into_iter().map(str::to_string).collect(),
+        Duration::from_secs(900),
+    )
+    .expect("token")
+}
+
+fn get(path: &str, bearer: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("GET").uri(path);
+    if let Some(bearer) = bearer {
+        builder = builder.header("authorization", format!("Bearer {bearer}"));
+    }
+    builder.body(Body::empty()).expect("request")
+}
+
+fn node(node_id: &str, port: u16, region: &str, rack: &str) -> Node {
+    Node {
+        node_id: node_id.to_string(),
+        spec: NodeSpec {
+            advertise_addr: format!("10.0.0.4:{port}"),
+            region: region.to_string(),
+            labels: BTreeMap::from([("rack".to_string(), rack.to_string())]),
+            capacity: NodeCapacity::default(),
+        },
+        status: NodeStatus {
+            lifecycle: NodeLifecycle::Live,
+            last_heartbeat_at_millis: controlplane::api::nodes::now_millis(),
+            registered_at_millis: 1,
+            incarnation: 0,
+        },
+    }
+}
+
+#[tokio::test]
+async fn listing_requires_a_token() {
+    let (app, _store, _keys) = setup().await;
+    let response = app.oneshot(get("/v1/nodes", None)).await.expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A tenant admin's own scope must not open the cluster listing. This is the
+/// HTTP half of the property `authorize.rs` proves about the object grammar.
+#[tokio::test]
+async fn tenant_scoped_permissions_do_not_grant_the_cluster() {
+    let (app, _store, keys) = setup().await;
+    for perm in [
+        "tenant.manage:tenant:t1",
+        "ns.manage:namespace:t1/*",
+        "rbac.policy.manage:tenant:t1",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(get("/v1/nodes", Some(&token(&keys, vec![perm]))))
+            .await
+            .expect("request");
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{perm} must not grant node.view",
+        );
+    }
+}
+
+#[tokio::test]
+async fn an_invalid_token_is_rejected() {
+    let (app, _store, _keys) = setup().await;
+    let response = app
+        .oneshot(get("/v1/nodes", Some("not.a.token")))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A token signed by a different tenant's keys must not pass, even carrying the
+/// right permission string.
+#[tokio::test]
+async fn a_token_signed_by_another_key_is_rejected() {
+    let (app, _store, _keys) = setup().await;
+    let foreign = generate_signing_keys().expect("keys");
+    let bearer = mint_token(
+        &foreign,
+        "t1",
+        "p:attacker",
+        vec!["node.view:cluster:*".to_string()],
+        Duration::from_secs(900),
+    )
+    .expect("token");
+
+    let response = app
+        .oneshot(get("/v1/nodes", Some(&bearer)))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn cluster_node_view_lists_every_broker() {
+    let (app, store, keys) = setup().await;
+    store
+        .register_node(node("broker-a", 7001, "us-west-2", "a1"))
+        .await
+        .expect("register");
+    store
+        .register_node(node("broker-b", 7002, "eu-central-1", "b2"))
+        .await
+        .expect("register");
+
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+    let response = app
+        .oneshot(get("/v1/nodes", Some(&bearer)))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = read_json(response).await;
+    let items = body["items"].as_array().expect("items");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0]["node"]["node_id"], "broker-a");
+    assert_eq!(items[0]["placement"]["eligible"], true);
+    // The advertised address is what an operator needs to check reachability.
+    assert_eq!(items[0]["node"]["spec"]["advertise_addr"], "10.0.0.4:7001");
+}
+
+#[tokio::test]
+async fn filters_intersect() {
+    let (app, store, keys) = setup().await;
+    store
+        .register_node(node("broker-a", 7001, "us-west-2", "a1"))
+        .await
+        .expect("register");
+    store
+        .register_node(node("broker-b", 7002, "us-west-2", "b2"))
+        .await
+        .expect("register");
+    store
+        .register_node(node("broker-c", 7003, "eu-central-1", "a1"))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-b", NodeLifecycle::Draining)
+        .await
+        .expect("drain");
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+
+    for (query, expected) in [
+        ("?region=us-west-2", vec!["broker-a", "broker-b"]),
+        ("?lifecycle=live", vec!["broker-a", "broker-c"]),
+        ("?lifecycle=draining", vec!["broker-b"]),
+        ("?label=rack%3Da1", vec!["broker-a", "broker-c"]),
+        ("?region=us-west-2&label=rack%3Da1", vec!["broker-a"]),
+        ("?region=us-west-2&lifecycle=live", vec!["broker-a"]),
+        ("?region=nowhere", vec![]),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(get(&format!("/v1/nodes{query}"), Some(&bearer)))
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::OK, "{query}");
+        let body: serde_json::Value = read_json(response).await;
+        let ids: Vec<String> = body["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .map(|item| {
+                item["node"]["node_id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(ids, expected, "{query}");
+    }
+}
+
+#[tokio::test]
+async fn a_missing_node_is_not_found() {
+    let (app, _store, keys) = setup().await;
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+    let response = app
+        .oneshot(get("/v1/nodes/absent", Some(&bearer)))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// The acceptance criterion: the output has to say *why* a node is not a
+/// placement candidate, not just that it is not one.
+#[tokio::test]
+async fn placement_explains_each_exclusion() {
+    let (app, store, keys) = setup().await;
+    store
+        .register_node(node("broker-down", 7001, "us-west-2", "a1"))
+        .await
+        .expect("register");
+    store
+        .set_node_lifecycle("broker-down", NodeLifecycle::Down)
+        .await
+        .expect("down");
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+
+    let response = app
+        .clone()
+        .oneshot(get("/v1/nodes/broker-down", Some(&bearer)))
+        .await
+        .expect("request");
+    let body: serde_json::Value = read_json(response).await;
+    assert_eq!(body["placement"]["eligible"], false);
+    let reasons = body["placement"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons
+            .iter()
+            .any(|r| r.as_str().unwrap_or_default().contains("heartbeat window")),
+        "{reasons:?}",
+    );
+}
+
+/// The window between a heartbeat lapsing and the sweep noticing: the node
+/// still reads `live`, and that gap is exactly what an operator is chasing.
+#[tokio::test]
+async fn a_stale_heartbeat_is_reported_before_expiry_runs() {
+    let (app, store, keys) = setup().await;
+    let mut stale = node("broker-stale", 7001, "us-west-2", "a1");
+    stale.status.last_heartbeat_at_millis =
+        controlplane::api::nodes::now_millis() - LIVENESS.expiry_timeout_ms * 3;
+    store.register_node(stale).await.expect("register");
+
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+    let response = app
+        .oneshot(get("/v1/nodes/broker-stale", Some(&bearer)))
+        .await
+        .expect("request");
+    let body: serde_json::Value = read_json(response).await;
+
+    assert_eq!(
+        body["node"]["status"]["lifecycle"], "live",
+        "expiry has not run"
+    );
+    assert_eq!(body["placement"]["eligible"], false);
+    let reasons = body["placement"]["reasons"].as_array().expect("reasons");
+    assert!(
+        reasons
+            .iter()
+            .any(|r| r.as_str().unwrap_or_default().contains("past the")),
+        "a stale heartbeat should be called out even while the node reads live: {reasons:?}",
+    );
+    assert!(
+        body["placement"]["heartbeat_age_ms"].as_u64().unwrap_or(0) > LIVENESS.expiry_timeout_ms
+    );
+}
+
+/// Nothing in the operator view should carry key material or tokens.
+#[tokio::test]
+async fn the_node_view_exposes_no_secrets() {
+    let (app, store, keys) = setup().await;
+    store
+        .register_node(node("broker-a", 7001, "us-west-2", "a1"))
+        .await
+        .expect("register");
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+
+    let response = app
+        .oneshot(get("/v1/nodes", Some(&bearer)))
+        .await
+        .expect("request");
+    let body: serde_json::Value = read_json(response).await;
+    let rendered = body.to_string().to_lowercase();
+    for forbidden in ["secret", "private", "token", "signing", "password"] {
+        assert!(
+            !rendered.contains(forbidden),
+            "{forbidden} leaked: {rendered}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #96. Fifth slice of **M2**.

> **Stacked on #221**, which is green but unmerged, because both touch `api/nodes.rs`, `app.rs`, and `openapi.rs`. Targets that branch so the diff is only this slice; I'll retarget to `main` once #221 lands.

## What's here

`GET /v1/nodes` and `GET /v1/nodes/{node_id}`, filtered by lifecycle, region, and labels, each explaining why a node is or is not a placement candidate.

`placement.reasons` is the point of the endpoint. "This broker is registered but shards are not landing on it" is otherwise answered by reading a lifecycle string and doing heartbeat arithmetic by hand. A **stale heartbeat is reported separately from the lifecycle**, so the window between a heartbeat lapsing and the sweep noticing — where the node still reads `live` — is visible rather than inferred.

Filters intersect; repeating `label` requires all of them. Unpaginated, matching every other listing here: a cluster has brokers in the tens, and a cursor no caller needs is a cursor every caller has to handle.

## A correction worth your attention

The issue asks for authorization "consistent with tenant/stream administration". **Those endpoints enforce nothing** — `streams.rs`, `tenants.rs`, `namespaces.rs`, and `caches.rs` have no auth at all; only the RBAC/IdP admin, token exchange, and bootstrap paths do. Read literally, the criterion would have meant shipping another open endpoint. You chose to build the cluster-scoped model properly instead, so that's what this does.

## The security design

Every existing RBAC object is tenant-scoped, and the cluster belongs to no tenant. So `ParsedObject::Cluster` (`cluster:*`) is its own island **in both directions**:

- **No tenant scope contains it.** `validate_new_rule_allowed` admits a policy only when its object is already inside the caller's scope, so a tenant admin cannot write themselves a cluster permission. Nothing in the bootstrap seed grants it either — I checked.
- **It contains no tenant object.** Cluster scope is not a backdoor into tenant data.

Both directions are asserted, in the grammar (`authorize.rs`) and over HTTP (`tenant_scoped_permissions_do_not_grant_the_cluster` tries `tenant.manage`, `ns.manage`, and `rbac.policy.manage` and expects 403 from each).

The tenant comes from the token's own `tid` claim rather than a path segment, since the cluster is not a tenant resource. **That claim only selects which signing keys to verify against** — the signature is what grants trust, exactly as `kid` selects a key without conferring one. `a_token_signed_by_another_key_is_rejected` covers the obvious attack: a correctly-shaped token carrying `node.view:cluster:*`, signed by the wrong key.

## Tests

10 HTTP tests: unauthorized, invalid token, foreign signing key, tenant-scoped-perms-are-not-enough, list, filter intersection, missing node, placement reasons, stale-heartbeat-before-expiry, and a check that nothing in the operator view carries secrets.

The OpenAPI test now asserts **routes**, not just schemas — a route the document doesn't describe is a route no generated client can call, and nothing else in the build would notice.

## Verification

`task lint`, `task test` (65 suites), `task deny`, `task demo:check`, `node scripts/check-mermaid.mjs`, and the pg suite against real Postgres 16 — all clean. `task deny` is now in my pre-push list after it caught me last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)