### PR TITLE
chore(release): 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,13 +70,22 @@ jobs:
             dist/SHA256SUMS
           if-no-files-found: error
 
+      # The changelog entry, not auto-generated notes. A release spanning months
+      # generates a list that is mostly dependency bumps: accurate about commits,
+      # poor about what changed. Fails closed if the entry is missing.
+      - name: Extract release notes from CHANGELOG.md
+        run: |
+          python3 scripts/changelog_section.py "${RELEASE_TAG}" > release-notes.md
+          echo "--- release notes ---"
+          cat release-notes.md
+
       - name: Publish GitHub prerelease
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: Felix ${{ env.RELEASE_TAG }}
           prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
-          generate_release_notes: true
+          body_path: release-notes.md
           files: |
             dist/*.tar.gz
             dist/SHA256SUMS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,139 @@ for what the current release actually guarantees.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-09-07
+
+Durable streams. A stream registered with `durable: true` now persists every
+record before acknowledging it, replays it after a restart, and lets a
+subscriber resume from an exact offset.
+
+**No wire-protocol break.** `felix-wire` `VERSION` remains `1`. The new
+capabilities are negotiated flag bits, so a 0.1.1 client and a 0.2.0 broker
+still interoperate — they simply agree on the original flag set. That is the
+whole point of negotiating capabilities rather than bumping a version.
+
+**Durable storage is opt-in and off by default.** Nothing persists unless the
+broker is started with `FELIX_DURABLE_STORAGE_DIR` *and* the stream is
+registered durable. The on-disk format is version 2; there is no version 1 to
+migrate from, because durable storage did not exist in 0.1.1.
+
+**Clustering is not in this release.** It contains broker membership plumbing —
+brokers can register, heartbeat, and appear in a control-plane listing — but
+nothing routes across brokers. A client still talks to one broker and gets
+exactly what it got in 0.1.1. See *Known limitations* below.
+
+### Added
+
+- **Durable single-node log.** A log-structured segment store behind the broker:
+  records are never rewritten, a torn tail is repaired on startup while interior
+  corruption refuses to start, and indexes are derived rather than trusted.
+  Group commit means one device flush serves many appends. Configured with
+  `FELIX_DURABLE_STORAGE_DIR`, `FELIX_DURABLE_SEGMENT_BYTES`, and the fsync
+  policy (`none`, `periodic`, `on_commit`). (#173, #174)
+- **Resumable subscriptions over the wire.** `Subscribe` carries an optional
+  `start` — `latest` (the default, and what every older client sends),
+  `earliest`, or an exact offset — and every delivered event carries its offset.
+  History read from disk joins live delivery with no gap and no duplicate.
+  Asking for an offset retention has discarded is a typed error, not a silent
+  restart at the tail. (#197)
+- **Retention on durable logs.** `FELIX_DURABLE_RETENTION_BYTES` and
+  `FELIX_DURABLE_RETENTION_SECONDS` bound a stream's growth by deleting the
+  oldest sealed segments. Unset means unbounded, which remains the default. (#203)
+- **Capability negotiation for stream authentication.** A client offers
+  `Auth.client_flags` and the broker answers `AuthOk.server_flags`. A peer that
+  predates negotiation exchanges a plain `Ok`, and the only safe reading of that
+  silence is the original flag set. (#170)
+- **Binary publish acknowledgements**, so an acked publish no longer pays for a
+  JSON round trip. (#167)
+- **Broker cluster membership** (control plane only, see *Known limitations*):
+  a Node resource model, membership persisted in both stores with an ordered
+  changefeed, heartbeat and liveness expiry, broker-side registration and
+  graceful deregistration, an operator listing at `GET /v1/nodes`, and
+  Prometheus metrics for the fleet. (#218, #219, #220, #221, #222, #223)
+- **Documentation site** migrated from MkDocs to Astro Starlight, with the
+  durable segment format, storage performance, and delivery semantics written
+  up. (#165, #166, #169, #174)
+- Demos for lossy and lossless state settlement and for slow-consumer
+  isolation. (#163)
+
+### Fixed
+
+- **Lossless publishing was not lossless end to end.** (#171)
+- **The backlog-to-live handoff dropped records.** Reading history before
+  registering a subscriber loses any publish landing in between; the handoff is
+  now ordered so it cannot. (#191)
+- **A failed rollover is now terminal.** A rollover fails on a failed fsync or a
+  failed file creation, and both mean the log can no longer honour what it has
+  already acknowledged. It rejects further appends rather than continuing
+  quietly. (#196)
+- **An inline rollover no longer parks every Tokio worker.** The segment set is
+  behind a synchronous lock; held across a rollover's device flushes it stalled
+  everything else on the runtime. It also stopped appends being rejected outright
+  under rollover contention — six runs in twenty became zero in twenty. (#217)
+- **Record header checksums (format v2)**, plus cancellation, startup, and
+  hydration defects found in review. (#178)
+- **MTU black-hole collapse on Linux**, where a path MTU below the probed size
+  silently destroyed throughput. Acked publishes are now pipelined. (#200, #202)
+- Durability, ordering, and recovery defects from successive reviews of the
+  durable log. (#176, #179, #180)
+- Cursor identity is pinned to disk offsets, and the broker proves its catalog
+  seeded before reporting ready. (#180)
+
+### Changed
+
+- **An fsync was cut from the rollover path** — a freshly created and therefore
+  empty index file was being flushed. Median p999 on the default inline path
+  improved from 5.12ms to 3.98ms (−22%), and max from 61.8ms to 47.0ms (−24%).
+  Background rollover was added alongside it and ships **disabled**, because it
+  measured worse: `F_FULLFSYNC` does not overlap with concurrent writes, so
+  moving a rollover's flushes off the append lock stops confining them rather
+  than hiding them. (#192)
+- Performance is now measured on a Linux 16 vCPU VM in addition to macOS, since
+  the two platforms' fsync semantics differ enough to invert a result. (#201)
+
 ### Dependencies
 
 - `opentelemetry` 0.31.0 → 0.32.0, `opentelemetry-otlp` 0.31.1 → 0.32.0,
   `opentelemetry_sdk` 0.31.0 → 0.32.1, `tracing-opentelemetry` 0.32.1 → 0.33.0.
   These four are version-locked to each other and have to move together.
+- `sqlx` 0.8.6 → 0.9.0. Its `SqlSafeStr` bound means `sqlx::query` now takes
+  only `&'static str`, so dynamic statements need `AssertSqlSafe` and a reason.
+- `base64` 0.22 → 0.23, `bytes` 1.11 → 1.12, `dashmap` 6.1 → 6.2,
+  `uuid` 1.21 → 1.24, `socket2` 0.6.2 → 0.6.5, `rcgen` 0.14.7 → 0.14.9,
+  `metrics` 0.24.3 → 0.24.6, `serde_json` 1.0.149 → 1.0.151.
+- `h2` → 0.4.16 for RUSTSEC-2026-0258.
+
+### Known limitations
+
+- **No clustering.** The membership endpoints added here are a registry. No
+  traffic crosses a broker, brokers do not talk to each other, and there is no
+  sharding, replication, or failover. Placement lands in M3, cross-broker
+  forwarding in M4.
+- **The membership endpoints are not authenticated.** Registration, heartbeat,
+  drain, and deregister accept any caller that can reach them; only the operator
+  read endpoints require a token. Safe on a trusted network, not on an open one.
+  Tracked in #126.
+- **At-most-once delivery.** Slow subscribers drop under the default policy.
+  Durable streams make the *record* recoverable — a subscriber can resume from
+  an offset — but nothing redelivers automatically.
+- Single-region, single control-plane instance.
+
+### Upgrading from 0.1.1
+
+No code changes are required, and no configuration becomes mandatory. Every
+addition above is opt-in.
+
+- 0.1.1 clients work against a 0.2.0 broker unchanged. Capabilities are
+  negotiated, so an older client simply does not offer the new flags.
+- Durable storage stays off until `FELIX_DURABLE_STORAGE_DIR` is set. Setting it
+  is not sufficient on its own: a stream must also be registered `durable: true`.
+- If you do enable durable storage, decide the fsync policy deliberately.
+  `periodic` (the default) bounds loss to one interval; `on_commit` loses
+  nothing acknowledged and costs milliseconds per publish.
+- `segment_size_bytes` is a latency knob as well as a recovery knob. Below a few
+  MiB, tail latency is dominated by rollover flushes. Prefer the 256 MiB default
+  unless restart time is genuinely the binding constraint, and measure the tail
+  if you change it.
 
 ## [0.1.1] - 2026-08-09
 
@@ -102,6 +230,7 @@ isolation, ephemeral cache, tenant/namespace/stream registries, RBAC and Felix
 token authorization, a control plane with a Postgres-backed store, a Rust client
 SDK, and a protocol conformance runner.
 
-[Unreleased]: https://github.com/gabloe/felix/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/gabloe/felix/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/gabloe/felix/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/gabloe/felix/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/gabloe/felix/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "ahash"
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "controlplane"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -934,7 +934,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "felix-authz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "casbin",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "felix-broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -967,7 +967,7 @@ dependencies = [
 
 [[package]]
 name = "felix-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "felix-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -1004,7 +1004,7 @@ dependencies = [
 
 [[package]]
 name = "felix-conformance"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -1026,29 +1026,29 @@ dependencies = [
 
 [[package]]
 name = "felix-consensus"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "felix-crypto"
-version = "0.1.1"
+version = "0.2.0"
 
 [[package]]
 name = "felix-metadata"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "felix-router"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "felix-common",
 ]
 
 [[package]]
 name = "felix-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "felix-transport"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1077,7 +1077,7 @@ dependencies = [
 
 [[package]]
 name = "felix-wire"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,9 +54,12 @@ codegen-units = 1
 [workspace.package]
 edition = "2024"
 # Single source of truth for member crate versions. Members opt in with
-# `version.workspace = true`; bumping a release means editing this line only.
-# Non-member demos under demos/ keep their own literal version.
-version = "0.1.1"
+# `version.workspace = true`.
+#
+# This line is not the whole bump: intra-workspace path dependencies also pin a
+# `version`, which Cargo requires to match, so they move with it. The standalone
+# demos under demos/ keep their own literal version and are independent.
+version = "0.2.0"
 # Fail-closed default: a new crate inherits the *restrictive* licence unless it
 # deliberately opts into Apache-2.0. The permissive crates (felix-wire,
 # felix-common, felix-transport, felix-client, felix-conformance) set

--- a/crates/felix-broker/Cargo.toml
+++ b/crates/felix-broker/Cargo.toml
@@ -16,8 +16,8 @@ bytes = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 metrics = "0.24"
-felix-storage = { path = "../felix-storage", version = "0.1.1" }
-felix-wire = { path = "../felix-wire", version = "0.1.1" }
+felix-storage = { path = "../felix-storage", version = "0.2.0" }
+felix-wire = { path = "../felix-wire", version = "0.2.0" }
 arc-swap = "1.8"
 ahash = "0.8"
 hashbrown = { version = "0.16", features = ["equivalent"] }

--- a/crates/felix-client/Cargo.toml
+++ b/crates/felix-client/Cargo.toml
@@ -27,10 +27,10 @@ serde_yaml_ng = { workspace = true }
 # unlike the rest of this crate's dependency graph (Apache-2.0) — keeping them optional and
 # off by default means the default felix-client build has zero Elastic-2.0 transitive
 # dependencies. See LICENSING.md at the repo root.
-felix-broker = { path = "../felix-broker", version = "0.1.1", optional = true }
-felix-storage = { path = "../felix-storage", version = "0.1.1", optional = true }
-felix-transport = { path = "../felix-transport", version = "0.1.1" }
-felix-wire = { path = "../felix-wire", version = "0.1.1" }
+felix-broker = { path = "../felix-broker", version = "0.2.0", optional = true }
+felix-storage = { path = "../felix-storage", version = "0.2.0", optional = true }
+felix-transport = { path = "../felix-transport", version = "0.2.0" }
+felix-wire = { path = "../felix-wire", version = "0.2.0" }
 quinn = "0.11"
 
 [features]

--- a/crates/felix-conformance/Cargo.toml
+++ b/crates/felix-conformance/Cargo.toml
@@ -17,15 +17,15 @@ publish = false
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
-broker = { path = "../../services/broker", version = "0.1.1" }
+broker = { path = "../../services/broker", version = "0.2.0" }
 base64 = "0.23"
 ed25519-dalek = { version = "2", features = ["pkcs8"] }
-felix-authz = { path = "../felix-authz", version = "0.1.1" }
-felix-broker = { path = "../felix-broker", version = "0.1.1" }
-felix-client = { path = "../felix-client", version = "0.1.1" }
-felix-storage = { path = "../felix-storage", version = "0.1.1" }
-felix-transport = { path = "../felix-transport", version = "0.1.1" }
-felix-wire = { path = "../felix-wire", version = "0.1.1" }
+felix-authz = { path = "../felix-authz", version = "0.2.0" }
+felix-broker = { path = "../felix-broker", version = "0.2.0" }
+felix-client = { path = "../felix-client", version = "0.2.0" }
+felix-storage = { path = "../felix-storage", version = "0.2.0" }
+felix-transport = { path = "../felix-transport", version = "0.2.0" }
+felix-wire = { path = "../felix-wire", version = "0.2.0" }
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs"] }
 quinn = "0.11"
 rcgen = "0.14"

--- a/crates/felix-router/Cargo.toml
+++ b/crates/felix-router/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["felix", "routing"]
 categories = ["network-programming"]
 
 [dependencies]
-felix-common = { path = "../felix-common", version = "0.1.1" }
+felix-common = { path = "../felix-common", version = "0.2.0" }

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "controlplane"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "felix-authz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "casbin",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "felix-broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "felix-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "felix-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "felix-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "felix-transport"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "felix-wire"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "controlplane"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -897,7 +897,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "felix-authz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "casbin",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "felix-broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "felix-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "felix-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -958,7 +958,7 @@ dependencies = [
 
 [[package]]
 name = "felix-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "felix-transport"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "felix-wire"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -922,7 +922,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "felix-authz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "casbin",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "felix-broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "felix-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "felix-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "felix-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "felix-transport"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "felix-wire"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -922,7 +922,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "felix-authz"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "casbin",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "felix-broker"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "felix-client"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "felix-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "felix-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "felix-transport"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "felix-wire"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",

--- a/scripts/changelog_section.py
+++ b/scripts/changelog_section.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Print one version's section from CHANGELOG.md.
+
+The release workflow uses this as the GitHub release body. Without it the body
+is auto-generated from merged pull requests, which for a release spanning months
+is mostly dependency bumps -- an accurate list of commits and a poor description
+of what changed.
+
+Exits non-zero when the section is missing, so a tag whose changelog entry was
+forgotten fails the release rather than publishing an empty one.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def section(changelog: str, version: str) -> str | None:
+    # Headings look like `## [0.2.0] - 2026-09-07`; capture until the next `## `.
+    pattern = rf"^## \[{re.escape(version)}\][^\n]*\n(.*?)(?=^## |\Z)"
+    found = re.search(pattern, changelog, re.MULTILINE | re.DOTALL)
+    return found.group(1).strip() if found else None
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: changelog_section.py <version>", file=sys.stderr)
+        return 2
+
+    version = sys.argv[1].removeprefix("v")
+    changelog = Path("CHANGELOG.md").read_text(encoding="utf-8")
+
+    body = section(changelog, version)
+    if body is None:
+        print(f"CHANGELOG.md has no section for {version}", file=sys.stderr)
+        return 1
+
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -49,13 +49,13 @@ path = "src/bin/soak/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.23"
-felix-broker = { path = "../../crates/felix-broker", version = "0.1.1" }
-felix-common = { path = "../../crates/felix-common", version = "0.1.1", features = ["lifecycle"] }
-felix-client = { path = "../../crates/felix-client", version = "0.1.1" }
-felix-authz = { path = "../../crates/felix-authz", version = "0.1.1" }
-felix-transport = { path = "../../crates/felix-transport", version = "0.1.1" }
-felix-wire = { path = "../../crates/felix-wire", version = "0.1.1" }
-felix-storage = { path = "../../crates/felix-storage", version = "0.1.1" }
+felix-broker = { path = "../../crates/felix-broker", version = "0.2.0" }
+felix-common = { path = "../../crates/felix-common", version = "0.2.0", features = ["lifecycle"] }
+felix-client = { path = "../../crates/felix-client", version = "0.2.0" }
+felix-authz = { path = "../../crates/felix-authz", version = "0.2.0" }
+felix-transport = { path = "../../crates/felix-transport", version = "0.2.0" }
+felix-wire = { path = "../../crates/felix-wire", version = "0.2.0" }
+felix-storage = { path = "../../crates/felix-storage", version = "0.2.0" }
 bytes = { workspace = true }
 dashmap = "6"
 ed25519-dalek = { version = "2", features = ["pkcs8"] }
@@ -97,7 +97,7 @@ rustls = "0.23"
 # The membership integration test drives the real control-plane router rather
 # than a stub, so a mismatch in the HTTP contract between the two services fails
 # here instead of in a cluster.
-controlplane = { path = "../controlplane", version = "0.1.1" }
+controlplane = { path = "../controlplane", version = "0.2.0" }
 
 [features]
 default = []

--- a/services/controlplane/Cargo.toml
+++ b/services/controlplane/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = { workspace = true }
 axum = "0.8"
-felix-common = { path = "../../crates/felix-common", version = "0.1.1", features = ["lifecycle"] }
+felix-common = { path = "../../crates/felix-common", version = "0.2.0", features = ["lifecycle"] }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.18"
 opentelemetry = "0.32.0"


### PR DESCRIPTION
Release prep for **0.2.0**: changelog, version bump, and a fix to how release notes are produced.

## What 0.2.0 is

**Durable streams.** A stream registered `durable: true` persists every record before acknowledging it, replays it after a restart, and lets a subscriber resume from an exact offset. That's the headline because it's the part a user can actually use.

**No wire-protocol break.** `VERSION` stays `1`. The new capabilities are negotiated flag bits, so a 0.1.1 client and a 0.2.0 broker interoperate — they agree on the original flag set. Verified rather than assumed: `ORIGINAL_V1_FLAGS` is unchanged.

**No on-disk migration.** Storage format is version 2, and there is no version 1 in the wild — durable storage did not exist in 0.1.1. I checked `v0.1.1:crates/felix-storage/src/lib.rs` rather than trusting the version number.

## What 0.2.0 is *not*, and why that's stated loudly

M2's membership work is on `main`, so it ships here whether or not we lead with it. The entry documents it as **plumbing, not clustering**:

> Clustering is not in this release. It contains broker membership plumbing — brokers can register, heartbeat, and appear in a control-plane listing — but nothing routes across brokers.

Plus a *Known limitations* section stating: no sharding, replication, or failover; **registration/heartbeat/drain/deregister are unauthenticated** (#126); at-most-once delivery; single control-plane instance.

"Cluster membership shipped" is precisely the phrase someone would misread as "Felix clusters," which is why it's caveated in the summary, in Added, and in Known limitations.

## Two things the bump exposed

**The workspace comment was wrong.** It claimed bumping a release "means editing this line only." Six crates pin `version = "0.1.1"` on their intra-workspace path dependencies, which Cargo requires to match — the workspace does not resolve without updating them. Fixed, and the comment now says so rather than misleading the next person.

**The release workflow generated its notes from merged PRs.** Across ~53 commits since v0.1.1, that's mostly dependency bumps: accurate about commits, poor about what changed. It now uses the changelog section via `scripts/changelog_section.py`, which **fails closed** — a tag whose changelog entry was forgotten fails the release rather than publishing an empty one. I tested both paths (`v0.2.0` → body, `v9.9.9` → exit 1).

## Verification

`task lint`, `task test` (65 suites), `task deny`, `task publish:check` (15 members), `task demo:check` — all clean on the rebased branch with #223 merged.

## After merge

Tag `v0.2.0` on `main`; the release workflow builds Linux x86_64 binaries and publishes with the changelog as the body. I'll confirm before pushing the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)