### PR TITLE
feat(controlplane): add the persisted ShardAssignment resource

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -166,6 +166,43 @@ not a backdoor into tenant data.
 Note that the registration, heartbeat, drain, and deregister endpoints above are
 **not** authenticated yet (#126). Only the operator read endpoints are.
 
+### Shard ownership
+
+`GET /v1/shard-assignments` lists which broker leads each shard, and
+`?leader=<node_id>` narrows it to one broker. Requires the same
+`node.view:cluster:*` as the node listing, because ownership and membership are
+the same view of the cluster.
+
+There is **at most one assignment per (stream, shard)** — that is the primary
+key, and it is the invariant placement depends on.
+
+`generation` increments on every write and is owned by the store, never the
+caller. A broker reports status against the generation it read, so a broker that
+was slow, partitioned, or restarted cannot resurrect an ownership decision that
+placement has already replaced.
+
+States are `assigning` (placement decided, the leader has not confirmed),
+`active` (the leader is serving), and `draining` (ownership is moving). Only a
+shard someone is actually serving can drain, and a drained shard does not return
+to the same leader — placement writes a new assignment at a new generation.
+
+#### Referential integrity
+
+Two references, two different policies, chosen rather than inherited:
+
+- **Stream**: a foreign key with `ON DELETE CASCADE`. Deleting a stream removes
+  its assignments, because the shards no longer exist and keeping ownership
+  records for them leaves placement chasing ghosts.
+- **Node**: deliberately **no** foreign key. Deleting a node that still leads a
+  shard is **rejected**, not cascaded. A cascade would delete the only record of
+  where that shard's data lives, turning an operator's tidy-up into silent data
+  orphaning. Reassign the shard first.
+
+Shard numbers are validated against the stream's `shards` count on every write.
+Streams cannot currently be resized — `StreamPatchRequest` has no `shards` field
+— so no assignment can be orphaned by a shrink. When resize arrives, assignments
+above the new bound have to be removed in the same transaction.
+
 ### Metrics
 
 Every label below is bounded. Lifecycle has four values, region has as many as
@@ -183,6 +220,7 @@ Control plane:
 | `felix_node_expiry_total` | nodes the sweep marked down |
 | `felix_node_expiry_failures_total` | sweeps that failed; non-zero means liveness is stale |
 | `felix_node_changes_total{op}` | membership changes published to the changefeed |
+| `felix_shard_assignment_changes_total{op}` | shard ownership changes: `assigned`, `updated`, `unassigned` |
 
 Broker:
 

--- a/services/controlplane/migrations/0006_shard_assignments.sql
+++ b/services/controlplane/migrations/0006_shard_assignments.sql
@@ -1,0 +1,54 @@
+-- Shard ownership: which broker leads each shard of each stream.
+--
+-- At most one current assignment per (stream, shard) -- that is the primary key,
+-- and it is the invariant placement depends on.
+CREATE TABLE IF NOT EXISTS shard_assignments (
+    tenant_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    stream TEXT NOT NULL,
+    shard INTEGER NOT NULL,
+    leader TEXT NOT NULL,
+    replicas JSONB NOT NULL DEFAULT '[]'::jsonb,
+    generation BIGINT NOT NULL DEFAULT 0,
+    state TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (tenant_id, namespace, stream, shard),
+    -- Deleting a stream removes its assignments: the shards no longer exist, so
+    -- keeping ownership records for them would leave placement chasing ghosts.
+    CONSTRAINT fk_shard_assignments_stream
+        FOREIGN KEY (tenant_id, namespace, stream)
+        REFERENCES streams(tenant_id, namespace, stream) ON DELETE CASCADE
+);
+
+-- Placement asks "what does this node own?" on every rebalance and every node
+-- failure, so the leader is indexed even though the table is keyed by stream.
+CREATE INDEX IF NOT EXISTS idx_shard_assignments_leader ON shard_assignments(leader);
+CREATE INDEX IF NOT EXISTS idx_shard_assignments_state ON shard_assignments(state);
+
+CREATE TABLE IF NOT EXISTS shard_assignment_changes (
+    seq BIGINT PRIMARY KEY,
+    op TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    namespace TEXT NOT NULL,
+    stream TEXT NOT NULL,
+    shard INTEGER NOT NULL,
+    payload JSONB,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_shard_assignment_changes_stream
+    ON shard_assignment_changes(tenant_id, namespace, stream);
+
+-- Allocated from a locked row rather than a BIGSERIAL, for the same reason as
+-- node_change_seq: a sequence hands out numbers in request order, not commit
+-- order, so a snapshot taken between a later commit and an earlier one resumes
+-- past a change it never saw. See 0005_nodes.sql.
+CREATE TABLE IF NOT EXISTS shard_assignment_change_seq (
+    only_row BOOLEAN PRIMARY KEY DEFAULT TRUE
+        CONSTRAINT shard_assignment_change_seq_single CHECK (only_row),
+    next_seq BIGINT NOT NULL DEFAULT 0
+);
+
+INSERT INTO shard_assignment_change_seq (only_row, next_seq) VALUES (TRUE, 0)
+    ON CONFLICT (only_row) DO NOTHING;

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -23,7 +23,7 @@ use crate::api::error::{
 };
 use crate::api::types::{
     NodeHeartbeatRequest, NodeHeartbeatResponse, NodeListResponse, NodePlacement,
-    NodeRegistrationRequest, NodeRegistrationResponse, NodeView,
+    NodeRegistrationRequest, NodeRegistrationResponse, NodeView, ShardAssignmentListResponse,
 };
 use crate::app::AppState;
 use crate::auth::felix_token::verify_token;
@@ -515,4 +515,36 @@ fn unverified_tenant(token: &str) -> Result<String, ApiError> {
         .filter(|value| !value.is_empty())
         .map(str::to_string)
         .ok_or_else(|| api_unauthorized("token has no tenant claim"))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/shard-assignments",
+    tag = "nodes",
+    params(("leader" = Option<String>, Query, description = "Only shards this node leads")),
+    responses((status = 200, description = "List shard assignments", body = ShardAssignmentListResponse))
+)]
+/// List shard ownership.
+///
+/// Answers the two questions an operator has when placement looks wrong: who
+/// owns this shard, and what does this broker own. Requires the same
+/// `node.view:cluster:*` as the node listing, because ownership and membership
+/// are the same view of the cluster.
+///
+/// # Errors
+/// - 500 when the store cannot be read.
+pub(crate) async fn list_shard_assignments(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
+) -> Result<Json<ShardAssignmentListResponse>, ApiError> {
+    require_cluster_node_view(&state, &headers).await?;
+
+    let items = match query.get("leader") {
+        Some(leader) => state.store.list_shard_assignments_for_node(leader).await,
+        None => state.store.list_shard_assignments().await,
+    }
+    .map_err(|ref err| api_internal("failed to list shard assignments", err))?;
+
+    Ok(Json(ShardAssignmentListResponse { items }))
 }

--- a/services/controlplane/src/api/openapi.rs
+++ b/services/controlplane/src/api/openapi.rs
@@ -21,9 +21,10 @@ use crate::api::{
         ErrorResponse, FeatureFlags, HealthStatus, ListRegionsResponse, NamespaceChangesResponse,
         NamespaceCreateRequest, NamespaceListResponse, NamespaceSnapshotResponse,
         NodeHeartbeatRequest, NodeHeartbeatResponse, NodeListResponse, NodePlacement,
-        NodeRegistrationRequest, NodeRegistrationResponse, NodeView, Region, StreamChangesResponse,
-        StreamCreateRequest, StreamListResponse, StreamSnapshotResponse, SystemInfo,
-        TenantChangesResponse, TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
+        NodeRegistrationRequest, NodeRegistrationResponse, NodeView, Region,
+        ShardAssignmentListResponse, StreamChangesResponse, StreamCreateRequest,
+        StreamListResponse, StreamSnapshotResponse, SystemInfo, TenantChangesResponse,
+        TenantCreateRequest, TenantListResponse, TenantSnapshotResponse,
     },
 };
 use crate::auth::admin;
@@ -36,8 +37,8 @@ use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, ConsistencyLevel,
     DeliveryGuarantee, Namespace, NamespaceChange, NamespaceChangeOp, NamespaceKey, Node,
     NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle, NodePatchRequest, NodeSpec, NodeStatus,
-    RetentionPolicy, Stream, StreamChange, StreamChangeOp, StreamKey, StreamKind,
-    StreamPatchRequest, Tenant, TenantChange, TenantChangeOp,
+    RetentionPolicy, ShardAssignment, ShardKey, ShardState, Stream, StreamChange, StreamChangeOp,
+    StreamKey, StreamKind, StreamPatchRequest, Tenant, TenantChange, TenantChangeOp,
 };
 use utoipa::OpenApi;
 
@@ -93,7 +94,8 @@ use utoipa::OpenApi;
         nodes::drain_node,
         nodes::deregister_node,
         nodes::list_nodes,
-        nodes::get_node
+        nodes::get_node,
+        nodes::list_shard_assignments
     ),
     components(schemas(
         FeatureFlags,
@@ -154,6 +156,10 @@ use utoipa::OpenApi;
         NodeView,
         NodePlacement,
         NodeListResponse,
+        ShardAssignment,
+        ShardKey,
+        ShardState,
+        ShardAssignmentListResponse,
         TokenExchangeRequest,
         TokenExchangeResponse,
         IdpIssuerConfig,
@@ -198,6 +204,10 @@ mod tests {
             "NodePatchRequest",
             "NodeChange",
             "NodeChangeOp",
+            "ShardAssignment",
+            "ShardKey",
+            "ShardState",
+            "ShardAssignmentListResponse",
             "NodeView",
             "NodePlacement",
             "NodeListResponse",
@@ -227,6 +237,7 @@ mod tests {
             ("/v1/nodes/{node_id}/heartbeat", "post"),
             ("/v1/nodes/{node_id}/drain", "post"),
             ("/v1/nodes/{node_id}/deregister", "post"),
+            ("/v1/shard-assignments", "get"),
         ] {
             let described = paths
                 .get(path)

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -220,3 +220,8 @@ pub struct NodeView {
 pub struct NodeListResponse {
     pub items: Vec<NodeView>,
 }
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ShardAssignmentListResponse {
+    pub items: Vec<crate::model::ShardAssignment>,
+}

--- a/services/controlplane/src/app.rs
+++ b/services/controlplane/src/app.rs
@@ -110,6 +110,10 @@ pub fn build_router(state: AppState) -> Router {
             axum::routing::get(api::nodes::get_node),
         )
         .route(
+            "/v1/shard-assignments",
+            axum::routing::get(api::nodes::list_shard_assignments),
+        )
+        .route(
             "/v1/nodes/{node_id}/heartbeat",
             axum::routing::post(api::nodes::report_health),
         )

--- a/services/controlplane/src/model/mod.rs
+++ b/services/controlplane/src/model/mod.rs
@@ -5,6 +5,7 @@
 mod cache;
 mod namespace;
 mod node;
+mod shard;
 mod stream;
 mod tenant;
 
@@ -13,6 +14,10 @@ pub use namespace::{Namespace, NamespaceChange, NamespaceChangeOp, NamespaceKey}
 pub use node::{
     Node, NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle, NodePatchRequest, NodeSpec,
     NodeStatus, NodeValidationError,
+};
+pub use shard::{
+    ShardAssignment, ShardAssignmentChange, ShardAssignmentChangeOp, ShardKey, ShardState,
+    ShardValidationError,
 };
 pub use stream::{
     ConsistencyLevel, DeliveryGuarantee, RetentionPolicy, Stream, StreamChange, StreamChangeOp,

--- a/services/controlplane/src/model/node.rs
+++ b/services/controlplane/src/model/node.rs
@@ -244,7 +244,7 @@ pub enum NodeChangeOp {
     Deregistered,
 }
 
-fn validate_node_id(node_id: &str) -> Result<(), NodeValidationError> {
+pub(crate) fn validate_node_id(node_id: &str) -> Result<(), NodeValidationError> {
     if node_id.is_empty() {
         return Err(NodeValidationError::EmptyNodeId);
     }

--- a/services/controlplane/src/model/shard.rs
+++ b/services/controlplane/src/model/shard.rs
@@ -1,0 +1,158 @@
+//! Shard assignment: which broker leads a stream shard, and who replicates it.
+//!
+//! One assignment per `(stream, shard)`, and it is the authority on ownership.
+//! Placement writes it; brokers read it and take or release shards to match.
+//!
+//! `generation` is what makes that safe. A broker reporting on an assignment it
+//! read some time ago carries the generation it saw, and the control plane
+//! rejects it if placement has moved on. Without that, a slow broker's status
+//! could resurrect an ownership decision that was already replaced.
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use utoipa::ToSchema;
+
+use crate::model::node::validate_node_id;
+use crate::model::{NodeValidationError, StreamKey};
+
+/// Why a shard assignment was rejected.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ShardValidationError {
+    #[error("shard {shard} is out of bounds for a stream with {shards} shards")]
+    ShardOutOfBounds { shard: u32, shards: u32 },
+    #[error("leader node is invalid: {0}")]
+    InvalidLeader(NodeValidationError),
+    #[error("replica node is invalid: {0}")]
+    InvalidReplica(NodeValidationError),
+    #[error("node {0:?} is both the leader and a replica")]
+    LeaderIsAlsoReplica(String),
+    #[error("node {0:?} appears twice in the replica set")]
+    DuplicateReplica(String),
+    #[error("cannot move a shard from {from:?} to {to:?}")]
+    UnsupportedTransition { from: ShardState, to: ShardState },
+}
+
+/// Where an assignment is between being decided and being served.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub enum ShardState {
+    /// Placement has decided, and the leader has not confirmed it is serving.
+    Assigning,
+    /// The leader is serving this shard.
+    Active,
+    /// Ownership is moving elsewhere. The leader still serves until it stops.
+    Draining,
+}
+
+impl ShardState {
+    /// Whether `self` may move to `next`.
+    ///
+    /// Draining is only meaningful for a shard someone is actually serving, and
+    /// a drained shard does not return to the same leader — placement writes a
+    /// new assignment, at a new generation, instead.
+    pub fn can_transition_to(self, next: ShardState) -> bool {
+        use ShardState::*;
+        matches!(
+            (self, next),
+            (Assigning, Assigning | Active) | (Active, Active | Draining) | (Draining, Draining)
+        )
+    }
+}
+
+/// Identifies one shard of one stream.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq, Hash)]
+pub struct ShardKey {
+    pub tenant_id: String,
+    pub namespace: String,
+    pub stream: String,
+    pub shard: u32,
+}
+
+impl ShardKey {
+    pub fn stream_key(&self) -> StreamKey {
+        StreamKey {
+            tenant_id: self.tenant_id.clone(),
+            namespace: self.namespace.clone(),
+            stream: self.stream.clone(),
+        }
+    }
+}
+
+/// Who owns a shard right now.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct ShardAssignment {
+    #[serde(flatten)]
+    pub key: ShardKey,
+    /// The node that serves reads and writes for this shard.
+    pub leader: String,
+    /// Nodes holding a copy. Never contains the leader, never repeats.
+    ///
+    /// Empty until M5 — replication does not exist yet, and an assignment that
+    /// claimed replicas nothing maintains would be a lie placement acts on.
+    #[serde(default)]
+    pub replicas: Vec<String>,
+    /// Increments on every change to this assignment.
+    ///
+    /// A broker reports status against the generation it read; the control plane
+    /// rejects anything older, so a slow broker cannot resurrect an ownership
+    /// decision that placement has already replaced.
+    pub generation: u64,
+    pub state: ShardState,
+}
+
+impl ShardAssignment {
+    /// Check node identities and replica-set shape.
+    ///
+    /// Does not check the shard bound, which needs the stream's shard count, or
+    /// that the nodes exist, which needs the catalog. Both are the store's.
+    pub fn validate(&self) -> Result<(), ShardValidationError> {
+        validate_node_id(&self.leader).map_err(ShardValidationError::InvalidLeader)?;
+
+        let mut seen = std::collections::BTreeSet::new();
+        for replica in &self.replicas {
+            validate_node_id(replica).map_err(ShardValidationError::InvalidReplica)?;
+            if replica == &self.leader {
+                return Err(ShardValidationError::LeaderIsAlsoReplica(replica.clone()));
+            }
+            if !seen.insert(replica) {
+                return Err(ShardValidationError::DuplicateReplica(replica.clone()));
+            }
+        }
+        Ok(())
+    }
+
+    /// Check this assignment's shard number against the stream that owns it.
+    pub fn validate_within(&self, shards: u32) -> Result<(), ShardValidationError> {
+        if self.key.shard >= shards {
+            return Err(ShardValidationError::ShardOutOfBounds {
+                shard: self.key.shard,
+                shards,
+            });
+        }
+        self.validate()
+    }
+
+    /// Every node this assignment refers to, leader first.
+    pub fn nodes(&self) -> impl Iterator<Item = &String> {
+        std::iter::once(&self.leader).chain(self.replicas.iter())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, PartialEq, Eq)]
+pub struct ShardAssignmentChange {
+    pub seq: u64,
+    pub op: ShardAssignmentChangeOp,
+    pub key: ShardKey,
+    pub assignment: Option<ShardAssignment>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ShardAssignmentChangeOp {
+    Assigned,
+    Updated,
+    Unassigned,
+}
+
+#[cfg(test)]
+#[path = "shard_tests.rs"]
+mod tests;

--- a/services/controlplane/src/model/shard_tests.rs
+++ b/services/controlplane/src/model/shard_tests.rs
@@ -1,0 +1,191 @@
+//! Shard assignment validation, transitions, and serialization.
+use super::*;
+
+fn assignment() -> ShardAssignment {
+    ShardAssignment {
+        key: ShardKey {
+            tenant_id: "t1".to_string(),
+            namespace: "payments".to_string(),
+            stream: "orders".to_string(),
+            shard: 2,
+        },
+        leader: "broker-a".to_string(),
+        replicas: vec!["broker-b".to_string(), "broker-c".to_string()],
+        generation: 7,
+        state: ShardState::Active,
+    }
+}
+
+#[test]
+fn a_well_formed_assignment_validates() {
+    assert_eq!(assignment().validate(), Ok(()));
+    assert_eq!(assignment().validate_within(4), Ok(()));
+}
+
+/// The bound is the stream's shard count, so shard N is valid only for a stream
+/// with more than N shards.
+#[test]
+fn a_shard_outside_the_stream_is_rejected() {
+    let a = assignment();
+    assert_eq!(
+        a.validate_within(2),
+        Err(ShardValidationError::ShardOutOfBounds {
+            shard: 2,
+            shards: 2
+        }),
+    );
+    assert_eq!(a.validate_within(3), Ok(()), "shard 2 fits in 3 shards");
+}
+
+#[test]
+fn a_leader_that_is_also_a_replica_is_rejected() {
+    let mut a = assignment();
+    a.replicas.push("broker-a".to_string());
+    assert_eq!(
+        a.validate(),
+        Err(ShardValidationError::LeaderIsAlsoReplica(
+            "broker-a".to_string()
+        )),
+    );
+}
+
+/// A repeated replica would make a quorum look larger than it is.
+#[test]
+fn a_repeated_replica_is_rejected() {
+    let mut a = assignment();
+    a.replicas = vec!["broker-b".to_string(), "broker-b".to_string()];
+    assert_eq!(
+        a.validate(),
+        Err(ShardValidationError::DuplicateReplica(
+            "broker-b".to_string()
+        )),
+    );
+}
+
+#[test]
+fn malformed_node_identities_are_rejected() {
+    let mut a = assignment();
+    a.leader = "Broker A".to_string();
+    assert!(matches!(
+        a.validate(),
+        Err(ShardValidationError::InvalidLeader(_))
+    ));
+
+    let mut a = assignment();
+    a.replicas = vec![String::new()];
+    assert!(matches!(
+        a.validate(),
+        Err(ShardValidationError::InvalidReplica(_))
+    ));
+}
+
+#[test]
+fn an_assignment_with_no_replicas_is_valid() {
+    let mut a = assignment();
+    a.replicas.clear();
+    assert_eq!(a.validate(), Ok(()), "replication does not exist until M5");
+}
+
+/// Draining is only meaningful for a shard someone is serving, and a drained
+/// shard does not return to the same leader: placement writes a new assignment
+/// at a new generation instead.
+#[test]
+fn only_a_serving_shard_can_drain() {
+    assert!(ShardState::Active.can_transition_to(ShardState::Draining));
+    assert!(!ShardState::Assigning.can_transition_to(ShardState::Draining));
+    assert!(!ShardState::Draining.can_transition_to(ShardState::Active));
+    assert!(!ShardState::Draining.can_transition_to(ShardState::Assigning));
+    assert!(!ShardState::Active.can_transition_to(ShardState::Assigning));
+}
+
+#[test]
+fn every_state_can_stay_where_it_is() {
+    for state in [
+        ShardState::Assigning,
+        ShardState::Active,
+        ShardState::Draining,
+    ] {
+        assert!(state.can_transition_to(state), "{state:?} should be stable");
+    }
+}
+
+#[test]
+fn nodes_lists_the_leader_first_then_replicas() {
+    let a = assignment();
+    let nodes: Vec<&str> = a.nodes().map(String::as_str).collect();
+    assert_eq!(nodes, vec!["broker-a", "broker-b", "broker-c"]);
+}
+
+#[test]
+fn an_assignment_round_trips_through_json() {
+    let before = assignment();
+    let encoded = serde_json::to_string(&before).expect("serialize");
+    let after: ShardAssignment = serde_json::from_str(&encoded).expect("deserialize");
+    assert_eq!(after, before);
+}
+
+/// The key is flattened, so an assignment reads as one object rather than
+/// nesting the identity a caller already has from the path.
+#[test]
+fn the_key_is_flattened_on_the_wire() {
+    let encoded = serde_json::to_value(assignment()).expect("serialize");
+    assert_eq!(encoded["tenant_id"], "t1");
+    assert_eq!(encoded["shard"], 2);
+    assert!(encoded.get("key").is_none());
+}
+
+#[test]
+fn replicas_default_to_empty_when_absent() {
+    let json = serde_json::json!({
+        "tenant_id": "t1",
+        "namespace": "payments",
+        "stream": "orders",
+        "shard": 0,
+        "leader": "broker-a",
+        "generation": 1,
+        "state": "active",
+    });
+    let decoded: ShardAssignment = serde_json::from_value(json).expect("deserialize");
+    assert!(decoded.replicas.is_empty());
+    assert_eq!(decoded.state, ShardState::Active);
+}
+
+#[test]
+fn states_and_ops_serialize_as_camel_case() {
+    for (state, expected) in [
+        (ShardState::Assigning, "\"assigning\""),
+        (ShardState::Active, "\"active\""),
+        (ShardState::Draining, "\"draining\""),
+    ] {
+        assert_eq!(serde_json::to_string(&state).expect("serialize"), expected);
+    }
+    for (op, expected) in [
+        (ShardAssignmentChangeOp::Assigned, "\"assigned\""),
+        (ShardAssignmentChangeOp::Updated, "\"updated\""),
+        (ShardAssignmentChangeOp::Unassigned, "\"unassigned\""),
+    ] {
+        assert_eq!(serde_json::to_string(&op).expect("serialize"), expected);
+    }
+}
+
+#[test]
+fn a_change_round_trips_with_and_without_a_body() {
+    for change in [
+        ShardAssignmentChange {
+            seq: 3,
+            op: ShardAssignmentChangeOp::Assigned,
+            key: assignment().key,
+            assignment: Some(assignment()),
+        },
+        ShardAssignmentChange {
+            seq: 4,
+            op: ShardAssignmentChangeOp::Unassigned,
+            key: assignment().key,
+            assignment: None,
+        },
+    ] {
+        let encoded = serde_json::to_string(&change).expect("serialize");
+        let decoded: ShardAssignmentChange = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded, change);
+    }
+}

--- a/services/controlplane/src/store/memory.rs
+++ b/services/controlplane/src/store/memory.rs
@@ -39,8 +39,9 @@ use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, Namespace, NamespaceChange,
     NamespaceChangeOp, NamespaceKey, Node, NodeChange, NodeChangeOp, NodeLifecycle,
-    NodePatchRequest, Stream, StreamChange, StreamChangeOp, StreamKey, StreamPatchRequest, Tenant,
-    TenantChange, TenantChangeOp,
+    NodePatchRequest, ShardAssignment, ShardAssignmentChange, ShardAssignmentChangeOp, ShardKey,
+    Stream, StreamChange, StreamChangeOp, StreamKey, StreamPatchRequest, Tenant, TenantChange,
+    TenantChangeOp,
 };
 use async_trait::async_trait;
 use std::collections::{HashMap, VecDeque};
@@ -95,6 +96,15 @@ fn invalid_node(err: crate::model::NodeValidationError) -> StoreError {
     StoreError::Conflict(err.to_string())
 }
 
+fn invalid_shard(err: crate::model::ShardValidationError) -> StoreError {
+    StoreError::Conflict(err.to_string())
+}
+
+/// Sort key giving a stable stream-then-shard order.
+fn shard_order(key: &ShardKey) -> (&str, &str, &str, u32) {
+    (&key.tenant_id, &key.namespace, &key.stream, key.shard)
+}
+
 fn invalid_transition(from: NodeLifecycle, to: NodeLifecycle) -> StoreError {
     invalid_node(crate::model::NodeValidationError::UnsupportedTransition { from, to })
 }
@@ -116,6 +126,29 @@ impl NodeState {
             op,
             node_id: node_id.to_string(),
             node,
+        });
+    }
+}
+
+/// Shard assignments and their change log under one lock.
+#[derive(Debug)]
+struct ShardState {
+    records: HashMap<ShardKey, ShardAssignment>,
+    changes: ChangeLog<ShardAssignmentChange>,
+}
+
+impl ShardState {
+    fn record(
+        &mut self,
+        op: ShardAssignmentChangeOp,
+        key: &ShardKey,
+        assignment: Option<ShardAssignment>,
+    ) {
+        self.changes.record(|seq| ShardAssignmentChange {
+            seq,
+            op,
+            key: key.clone(),
+            assignment,
         });
     }
 }
@@ -152,6 +185,9 @@ pub struct InMemoryStore {
     /// the records and the log position as one value, or a change committed
     /// between the two reads is missed by every consumer that resumes from it.
     nodes: Arc<RwLock<NodeState>>,
+    /// Shard ownership and its change log, under one lock for the same reason
+    /// as `nodes`: a snapshot must read records and log position as one value.
+    shards: Arc<RwLock<ShardState>>,
     /// Bounded change log for tenant changes.
     ///
     /// `next_seq` is per-entity-type (not a global sequence across all entities).
@@ -192,6 +228,10 @@ impl InMemoryStore {
             streams: Arc::new(RwLock::new(HashMap::new())),
             caches: Arc::new(RwLock::new(HashMap::new())),
             nodes: Arc::new(RwLock::new(NodeState {
+                records: HashMap::new(),
+                changes: ChangeLog::new(capacity),
+            })),
+            shards: Arc::new(RwLock::new(ShardState {
                 records: HashMap::new(),
                 changes: ChangeLog::new(capacity),
             })),
@@ -822,6 +862,22 @@ impl ControlPlaneStore for InMemoryStore {
     }
 
     async fn delete_node(&self, node_id: &str) -> StoreResult<()> {
+        // Refused rather than cascaded: deleting the assignment would erase the
+        // only record of where that shard's data lives.
+        let led = self
+            .shards
+            .read()
+            .await
+            .records
+            .values()
+            .filter(|assignment| assignment.leader == node_id)
+            .count();
+        if led > 0 {
+            return Err(StoreError::Conflict(format!(
+                "node {node_id} still leads {led} shard(s); reassign them first"
+            )));
+        }
+
         let mut state = self.nodes.write().await;
         if state.records.remove(node_id).is_none() {
             return Err(StoreError::NotFound("node".into()));
@@ -923,6 +979,145 @@ impl ControlPlaneStore for InMemoryStore {
 
     async fn node_changes(&self, since: u64) -> StoreResult<ChangeSet<NodeChange>> {
         let state = self.nodes.read().await;
+        let items = state
+            .changes
+            .items
+            .iter()
+            .filter(|item| item.seq >= since)
+            .take(self.limit())
+            .cloned()
+            .collect();
+        Ok(ChangeSet {
+            items,
+            next_seq: state.changes.next_seq,
+        })
+    }
+
+    async fn put_shard_assignment(
+        &self,
+        assignment: ShardAssignment,
+    ) -> StoreResult<ShardAssignment> {
+        assignment.validate().map_err(invalid_shard)?;
+
+        // The stream bounds the shard number, and it has to exist at all.
+        let stream = self
+            .streams
+            .read()
+            .await
+            .get(&assignment.key.stream_key())
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound("stream".into()))?;
+        assignment
+            .validate_within(stream.shards)
+            .map_err(invalid_shard)?;
+
+        // Checked here rather than by a foreign key: the node reference has none
+        // deliberately, so that deleting a node cannot cascade an assignment away.
+        {
+            let nodes = self.nodes.read().await;
+            for node_id in assignment.nodes() {
+                if !nodes.records.contains_key(node_id) {
+                    return Err(StoreError::NotFound(format!("node {node_id}")));
+                }
+            }
+        }
+
+        let mut state = self.shards.write().await;
+        let (op, generation) = match state.records.get(&assignment.key) {
+            Some(existing) => {
+                if !existing.state.can_transition_to(assignment.state) {
+                    return Err(invalid_shard(
+                        crate::model::ShardValidationError::UnsupportedTransition {
+                            from: existing.state,
+                            to: assignment.state,
+                        },
+                    ));
+                }
+                (
+                    ShardAssignmentChangeOp::Updated,
+                    existing.generation.saturating_add(1),
+                )
+            }
+            None => (ShardAssignmentChangeOp::Assigned, 0),
+        };
+
+        // Store-owned, so a caller cannot pin a generation and make its own
+        // stale report look current.
+        let stored = ShardAssignment {
+            generation,
+            ..assignment
+        };
+        state.records.insert(stored.key.clone(), stored.clone());
+        state.record(op, &stored.key, Some(stored.clone()));
+        metrics::counter!("felix_shard_assignment_changes_total", "op" => match op {
+            ShardAssignmentChangeOp::Assigned => "assigned",
+            ShardAssignmentChangeOp::Updated => "updated",
+            ShardAssignmentChangeOp::Unassigned => "unassigned",
+        })
+        .increment(1);
+        Ok(stored)
+    }
+
+    async fn get_shard_assignment(&self, key: &ShardKey) -> StoreResult<ShardAssignment> {
+        self.shards
+            .read()
+            .await
+            .records
+            .get(key)
+            .cloned()
+            .ok_or_else(|| StoreError::NotFound("shard assignment".into()))
+    }
+
+    async fn list_shard_assignments(&self) -> StoreResult<Vec<ShardAssignment>> {
+        let mut items: Vec<ShardAssignment> =
+            self.shards.read().await.records.values().cloned().collect();
+        items.sort_by(|a, b| shard_order(&a.key).cmp(&shard_order(&b.key)));
+        Ok(items)
+    }
+
+    async fn list_shard_assignments_for_node(
+        &self,
+        node_id: &str,
+    ) -> StoreResult<Vec<ShardAssignment>> {
+        let mut items: Vec<ShardAssignment> = self
+            .shards
+            .read()
+            .await
+            .records
+            .values()
+            .filter(|assignment| assignment.leader == node_id)
+            .cloned()
+            .collect();
+        items.sort_by(|a, b| shard_order(&a.key).cmp(&shard_order(&b.key)));
+        Ok(items)
+    }
+
+    async fn delete_shard_assignment(&self, key: &ShardKey) -> StoreResult<()> {
+        let mut state = self.shards.write().await;
+        if state.records.remove(key).is_none() {
+            return Err(StoreError::NotFound("shard assignment".into()));
+        }
+        state.record(ShardAssignmentChangeOp::Unassigned, key, None);
+        metrics::counter!("felix_shard_assignment_changes_total", "op" => "unassigned")
+            .increment(1);
+        Ok(())
+    }
+
+    async fn shard_assignment_snapshot(&self) -> StoreResult<Snapshot<ShardAssignment>> {
+        let state = self.shards.read().await;
+        let mut items: Vec<ShardAssignment> = state.records.values().cloned().collect();
+        items.sort_by(|a, b| shard_order(&a.key).cmp(&shard_order(&b.key)));
+        Ok(Snapshot {
+            items,
+            next_seq: state.changes.next_seq,
+        })
+    }
+
+    async fn shard_assignment_changes(
+        &self,
+        since: u64,
+    ) -> StoreResult<ChangeSet<ShardAssignmentChange>> {
+        let state = self.shards.read().await;
         let items = state
             .changes
             .items
@@ -1137,6 +1332,14 @@ mod tests {
         let store = std::sync::Arc::new(store_with_limits(100, 1000));
         crate::store::node_contract::run_node_contract(store.clone()).await;
         crate::store::node_contract::run_node_concurrency_contract(store).await;
+    }
+
+    /// The same suite Postgres runs.
+    #[tokio::test]
+    async fn satisfies_the_shard_store_contract() {
+        let store = std::sync::Arc::new(store_with_limits(100, 1000));
+        crate::store::shard_contract::run_shard_contract(store.clone()).await;
+        crate::store::shard_contract::run_shard_concurrency_contract(store).await;
     }
 
     fn store_with_limits(changes_limit: u64, retention: i64) -> InMemoryStore {

--- a/services/controlplane/src/store/mod.rs
+++ b/services/controlplane/src/store/mod.rs
@@ -10,8 +10,8 @@ use crate::auth::idp_registry::IdpIssuerConfig;
 use crate::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use crate::model::{
     Cache, CacheChange, CacheKey, CachePatchRequest, Namespace, NamespaceChange, NamespaceKey,
-    Node, NodeChange, NodePatchRequest, Stream, StreamChange, StreamKey, StreamPatchRequest,
-    Tenant, TenantChange,
+    Node, NodeChange, NodePatchRequest, ShardAssignment, ShardAssignmentChange, ShardKey, Stream,
+    StreamChange, StreamKey, StreamPatchRequest, Tenant, TenantChange,
 };
 use async_trait::async_trait;
 use thiserror::Error;
@@ -23,6 +23,8 @@ pub mod postgres;
 pub(crate) mod node_contract;
 #[cfg(test)]
 mod postgres_tests;
+#[cfg(test)]
+pub(crate) mod shard_contract;
 
 #[derive(Debug, Clone)]
 pub struct StoreConfig {
@@ -126,6 +128,13 @@ pub trait ControlPlaneStore: Send + Sync {
     /// Apply an operator patch. Rejects a lifecycle transition the model
     /// disallows, and never touches heartbeat-derived fields.
     async fn patch_node(&self, node_id: &str, patch: NodePatchRequest) -> StoreResult<Node>;
+    /// Remove a node.
+    ///
+    /// Rejected while the node still leads a shard. Cascading instead would
+    /// delete the only record of where that shard's data lives, turning an
+    /// operator's tidy-up into silent data orphaning; refusing forces the shard
+    /// to be reassigned first. There is deliberately no foreign key doing this,
+    /// because a database-level cascade is exactly the behaviour being avoided.
     async fn delete_node(&self, node_id: &str) -> StoreResult<()>;
     /// Record liveness without emitting a change.
     ///
@@ -169,6 +178,38 @@ pub trait ControlPlaneStore: Send + Sync {
     ) -> StoreResult<Option<Node>>;
     async fn node_snapshot(&self) -> StoreResult<Snapshot<Node>>;
     async fn node_changes(&self, since: u64) -> StoreResult<ChangeSet<NodeChange>>;
+
+    /// Write the assignment for one shard, replacing whatever it had.
+    ///
+    /// The caller supplies the assignment; the store owns `generation` and
+    /// increments it on every write, so a broker reporting against a generation
+    /// it read earlier can be told it is stale.
+    ///
+    /// Rejects a shard outside the stream's shard count, a leader or replica
+    /// that is not a registered node, and a state transition the model
+    /// disallows. Referential integrity is checked here rather than left to the
+    /// database because the node reference deliberately has no foreign key --
+    /// see [`ControlPlaneStore::delete_node`].
+    async fn put_shard_assignment(
+        &self,
+        assignment: ShardAssignment,
+    ) -> StoreResult<ShardAssignment>;
+    async fn get_shard_assignment(&self, key: &ShardKey) -> StoreResult<ShardAssignment>;
+    /// Every assignment, ordered by stream then shard.
+    async fn list_shard_assignments(&self) -> StoreResult<Vec<ShardAssignment>>;
+    /// Assignments a node currently leads. The question placement asks when a
+    /// node fails or is drained.
+    async fn list_shard_assignments_for_node(
+        &self,
+        node_id: &str,
+    ) -> StoreResult<Vec<ShardAssignment>>;
+    /// Remove one assignment, leaving the shard unowned.
+    async fn delete_shard_assignment(&self, key: &ShardKey) -> StoreResult<()>;
+    async fn shard_assignment_snapshot(&self) -> StoreResult<Snapshot<ShardAssignment>>;
+    async fn shard_assignment_changes(
+        &self,
+        since: u64,
+    ) -> StoreResult<ChangeSet<ShardAssignmentChange>>;
 
     async fn tenant_exists(&self, tenant_id: &str) -> StoreResult<bool>;
     async fn namespace_exists(&self, key: &NamespaceKey) -> StoreResult<bool>;

--- a/services/controlplane/src/store/postgres.rs
+++ b/services/controlplane/src/store/postgres.rs
@@ -33,9 +33,10 @@ use crate::config::PostgresConfig;
 use crate::model::{
     Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest, Namespace, NamespaceChange,
     NamespaceChangeOp, NamespaceKey, Node, NodeCapacity, NodeChange, NodeChangeOp, NodeLifecycle,
-    NodePatchRequest, NodeSpec, NodeStatus, NodeValidationError, RetentionPolicy, Stream,
-    StreamChange, StreamChangeOp, StreamKey, StreamKind, StreamPatchRequest, Tenant, TenantChange,
-    TenantChangeOp,
+    NodePatchRequest, NodeSpec, NodeStatus, NodeValidationError, RetentionPolicy, ShardAssignment,
+    ShardAssignmentChange, ShardAssignmentChangeOp, ShardKey, ShardState, ShardValidationError,
+    Stream, StreamChange, StreamChangeOp, StreamKey, StreamKind, StreamPatchRequest, Tenant,
+    TenantChange, TenantChangeOp,
 };
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -1447,6 +1448,21 @@ impl ControlPlaneStore for PostgresStore {
 
     async fn delete_node(&self, node_id: &str) -> StoreResult<()> {
         let mut tx = self.pool.begin().await?;
+
+        // Refused rather than cascaded: deleting the assignment would erase the
+        // only record of where that shard's data lives. Deliberately not a
+        // foreign key, because a cascade is the behaviour being avoided.
+        let led: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM shard_assignments WHERE leader = $1")
+                .bind(node_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if led > 0 {
+            return Err(StoreError::Conflict(format!(
+                "node {node_id} still leads {led} shard(s); reassign them first"
+            )));
+        }
+
         let deleted = sqlx::query("DELETE FROM nodes WHERE node_id = $1")
             .bind(node_id)
             .execute(&mut *tx)
@@ -1627,6 +1643,231 @@ impl ControlPlaneStore for PostgresStore {
         Ok(ChangeSet { items, next_seq })
     }
 
+    async fn put_shard_assignment(
+        &self,
+        assignment: ShardAssignment,
+    ) -> StoreResult<ShardAssignment> {
+        assignment.validate().map_err(invalid_shard)?;
+        let mut tx = self.pool.begin().await?;
+
+        let shards: Option<i32> = sqlx::query_scalar(
+            "SELECT shards FROM streams WHERE tenant_id = $1 AND namespace = $2 AND stream = $3",
+        )
+        .bind(&assignment.key.tenant_id)
+        .bind(&assignment.key.namespace)
+        .bind(&assignment.key.stream)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let shards = shards.ok_or_else(|| StoreError::NotFound("stream".into()))? as u32;
+        assignment.validate_within(shards).map_err(invalid_shard)?;
+
+        // Checked here rather than by a foreign key: the node reference has none
+        // deliberately, so deleting a node cannot cascade an assignment away.
+        for node_id in assignment.nodes() {
+            let exists: bool =
+                sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM nodes WHERE node_id = $1)")
+                    .bind(node_id)
+                    .fetch_one(&mut *tx)
+                    .await?;
+            if !exists {
+                return Err(StoreError::NotFound(format!("node {node_id}")));
+            }
+        }
+
+        // `FOR UPDATE` so a concurrent write to the same shard waits rather than
+        // reading the row this transaction is about to replace.
+        let existing = sqlx::query_as::<_, DbShardAssignment>(
+            r#"SELECT tenant_id, namespace, stream, shard, leader, replicas, generation, state
+               FROM shard_assignments
+               WHERE tenant_id = $1 AND namespace = $2 AND stream = $3 AND shard = $4
+               FOR UPDATE"#,
+        )
+        .bind(&assignment.key.tenant_id)
+        .bind(&assignment.key.namespace)
+        .bind(&assignment.key.stream)
+        .bind(assignment.key.shard as i32)
+        .fetch_optional(&mut *tx)
+        .await?
+        .map(shard_from_db)
+        .transpose()?;
+
+        let (op, generation) = match &existing {
+            Some(existing) => {
+                if !existing.state.can_transition_to(assignment.state) {
+                    return Err(invalid_shard(ShardValidationError::UnsupportedTransition {
+                        from: existing.state,
+                        to: assignment.state,
+                    }));
+                }
+                (
+                    ShardAssignmentChangeOp::Updated,
+                    existing.generation.saturating_add(1),
+                )
+            }
+            None => (ShardAssignmentChangeOp::Assigned, 0),
+        };
+
+        // Store-owned, so a caller cannot pin a generation and make its own
+        // stale report look current.
+        let stored = ShardAssignment {
+            generation,
+            ..assignment
+        };
+
+        sqlx::query(
+            r#"INSERT INTO shard_assignments (tenant_id, namespace, stream, shard, leader, replicas, generation, state)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+               ON CONFLICT (tenant_id, namespace, stream, shard) DO UPDATE SET
+                 leader = EXCLUDED.leader,
+                 replicas = EXCLUDED.replicas,
+                 generation = EXCLUDED.generation,
+                 state = EXCLUDED.state,
+                 updated_at = now()"#,
+        )
+        .bind(&stored.key.tenant_id)
+        .bind(&stored.key.namespace)
+        .bind(&stored.key.stream)
+        .bind(stored.key.shard as i32)
+        .bind(&stored.leader)
+        .bind(serde_json::to_value(&stored.replicas)?)
+        .bind(stored.generation as i64)
+        .bind(shard_state_to_str(stored.state))
+        .execute(&mut *tx)
+        .await?;
+
+        record_shard_change(&mut tx, op, &stored.key, Some(&stored)).await?;
+        tx.commit().await?;
+        metrics::counter!("felix_shard_assignment_changes_total", "op" => shard_op_to_str(op))
+            .increment(1);
+        Ok(stored)
+    }
+
+    async fn get_shard_assignment(&self, key: &ShardKey) -> StoreResult<ShardAssignment> {
+        sqlx::query_as::<_, DbShardAssignment>(
+            r#"SELECT tenant_id, namespace, stream, shard, leader, replicas, generation, state
+               FROM shard_assignments
+               WHERE tenant_id = $1 AND namespace = $2 AND stream = $3 AND shard = $4"#,
+        )
+        .bind(&key.tenant_id)
+        .bind(&key.namespace)
+        .bind(&key.stream)
+        .bind(key.shard as i32)
+        .fetch_optional(&self.pool)
+        .await?
+        .map(shard_from_db)
+        .transpose()?
+        .ok_or_else(|| StoreError::NotFound("shard assignment".into()))
+    }
+
+    async fn list_shard_assignments(&self) -> StoreResult<Vec<ShardAssignment>> {
+        let rows = sqlx::query_as::<_, DbShardAssignment>(
+            r#"SELECT tenant_id, namespace, stream, shard, leader, replicas, generation, state
+               FROM shard_assignments ORDER BY tenant_id, namespace, stream, shard"#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(shard_from_db).collect()
+    }
+
+    async fn list_shard_assignments_for_node(
+        &self,
+        node_id: &str,
+    ) -> StoreResult<Vec<ShardAssignment>> {
+        let rows = sqlx::query_as::<_, DbShardAssignment>(
+            r#"SELECT tenant_id, namespace, stream, shard, leader, replicas, generation, state
+               FROM shard_assignments WHERE leader = $1
+               ORDER BY tenant_id, namespace, stream, shard"#,
+        )
+        .bind(node_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(shard_from_db).collect()
+    }
+
+    async fn delete_shard_assignment(&self, key: &ShardKey) -> StoreResult<()> {
+        let mut tx = self.pool.begin().await?;
+        let deleted = sqlx::query(
+            r#"DELETE FROM shard_assignments
+               WHERE tenant_id = $1 AND namespace = $2 AND stream = $3 AND shard = $4"#,
+        )
+        .bind(&key.tenant_id)
+        .bind(&key.namespace)
+        .bind(&key.stream)
+        .bind(key.shard as i32)
+        .execute(&mut *tx)
+        .await?;
+        if deleted.rows_affected() == 0 {
+            return Err(StoreError::NotFound("shard assignment".into()));
+        }
+        record_shard_change(&mut tx, ShardAssignmentChangeOp::Unassigned, key, None).await?;
+        tx.commit().await?;
+        metrics::counter!("felix_shard_assignment_changes_total", "op" => "unassigned")
+            .increment(1);
+        Ok(())
+    }
+
+    async fn shard_assignment_snapshot(&self) -> StoreResult<Snapshot<ShardAssignment>> {
+        // REPEATABLE READ for the same reason as `node_snapshot`: under READ
+        // COMMITTED the two reads below see different snapshots, so an
+        // assignment committed between them is missing from `items` while
+        // already counted in `next_seq`.
+        let mut tx = self.pool.begin().await?;
+        begin_consistent_read(&mut tx).await?;
+        let rows = sqlx::query_as::<_, DbShardAssignment>(
+            r#"SELECT tenant_id, namespace, stream, shard, leader, replicas, generation, state
+               FROM shard_assignments ORDER BY tenant_id, namespace, stream, shard"#,
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+        let items = rows
+            .into_iter()
+            .map(shard_from_db)
+            .collect::<StoreResult<Vec<_>>>()?;
+        let next_seq =
+            sqlx::query_scalar::<_, i64>("SELECT next_seq FROM shard_assignment_change_seq")
+                .fetch_one(&mut *tx)
+                .await? as u64;
+        tx.commit().await?;
+        Ok(Snapshot { items, next_seq })
+    }
+
+    async fn shard_assignment_changes(
+        &self,
+        since: u64,
+    ) -> StoreResult<ChangeSet<ShardAssignmentChange>> {
+        let mut tx = self.pool.begin().await?;
+        begin_consistent_read(&mut tx).await?;
+        let rows = sqlx::query_as::<_, ShardAssignmentChangeRow>(
+            r#"SELECT seq, op, tenant_id, namespace, stream, shard, payload
+               FROM shard_assignment_changes WHERE seq >= $1 ORDER BY seq ASC LIMIT $2"#,
+        )
+        .bind(since as i64)
+        .bind(self.limit())
+        .fetch_all(&mut *tx)
+        .await?;
+        let next_seq =
+            sqlx::query_scalar::<_, i64>("SELECT next_seq FROM shard_assignment_change_seq")
+                .fetch_one(&mut *tx)
+                .await? as u64;
+        tx.commit().await?;
+
+        let mut items = Vec::with_capacity(rows.len());
+        for row in rows {
+            items.push(ShardAssignmentChange {
+                seq: row.seq as u64,
+                op: parse_shard_op(&row.op)?,
+                key: ShardKey {
+                    tenant_id: row.tenant_id,
+                    namespace: row.namespace,
+                    stream: row.stream,
+                    shard: row.shard as u32,
+                },
+                assignment: row.payload.map(serde_json::from_value).transpose()?,
+            });
+        }
+        Ok(ChangeSet { items, next_seq })
+    }
+
     async fn tenant_exists(&self, tenant_id: &str) -> StoreResult<bool> {
         let exists: bool =
             sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM tenants WHERE tenant_id = $1)")
@@ -1719,6 +1960,119 @@ async fn record_node_change(
         .bind(node.map(serde_json::to_value).transpose()?)
         .execute(&mut **tx)
         .await?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct DbShardAssignment {
+    tenant_id: String,
+    namespace: String,
+    stream: String,
+    shard: i32,
+    leader: String,
+    replicas: serde_json::Value,
+    generation: i64,
+    state: String,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct ShardAssignmentChangeRow {
+    seq: i64,
+    op: String,
+    tenant_id: String,
+    namespace: String,
+    stream: String,
+    shard: i32,
+    payload: Option<serde_json::Value>,
+}
+
+fn shard_from_db(row: DbShardAssignment) -> StoreResult<ShardAssignment> {
+    Ok(ShardAssignment {
+        key: ShardKey {
+            tenant_id: row.tenant_id,
+            namespace: row.namespace,
+            stream: row.stream,
+            shard: row.shard as u32,
+        },
+        leader: row.leader,
+        replicas: serde_json::from_value(row.replicas)?,
+        generation: row.generation as u64,
+        state: parse_shard_state(&row.state)?,
+    })
+}
+
+fn shard_state_to_str(state: ShardState) -> &'static str {
+    match state {
+        ShardState::Assigning => "assigning",
+        ShardState::Active => "active",
+        ShardState::Draining => "draining",
+    }
+}
+
+fn parse_shard_state(value: &str) -> StoreResult<ShardState> {
+    match value {
+        "assigning" => Ok(ShardState::Assigning),
+        "active" => Ok(ShardState::Active),
+        "draining" => Ok(ShardState::Draining),
+        other => Err(StoreError::Unexpected(anyhow!(
+            "unknown shard state: {other}"
+        ))),
+    }
+}
+
+fn shard_op_to_str(op: ShardAssignmentChangeOp) -> &'static str {
+    match op {
+        ShardAssignmentChangeOp::Assigned => "assigned",
+        ShardAssignmentChangeOp::Updated => "updated",
+        ShardAssignmentChangeOp::Unassigned => "unassigned",
+    }
+}
+
+fn parse_shard_op(value: &str) -> StoreResult<ShardAssignmentChangeOp> {
+    match value {
+        "assigned" => Ok(ShardAssignmentChangeOp::Assigned),
+        "updated" => Ok(ShardAssignmentChangeOp::Updated),
+        "unassigned" => Ok(ShardAssignmentChangeOp::Unassigned),
+        other => Err(StoreError::Unexpected(anyhow!(
+            "unknown shard change op: {other}"
+        ))),
+    }
+}
+
+fn invalid_shard(err: ShardValidationError) -> StoreError {
+    StoreError::Conflict(err.to_string())
+}
+
+/// Append a shard change, taking its `seq` from the locked counter.
+///
+/// Same construction as `record_node_change`: the row lock makes seq order equal
+/// commit order, which is what lets a consumer resume at `next_seq` without
+/// skipping a change. See 0006_shard_assignments.sql.
+async fn record_shard_change(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    op: ShardAssignmentChangeOp,
+    key: &ShardKey,
+    assignment: Option<&ShardAssignment>,
+) -> StoreResult<()> {
+    let seq = sqlx::query_scalar::<_, i64>(
+        "UPDATE shard_assignment_change_seq SET next_seq = next_seq + 1 RETURNING next_seq - 1",
+    )
+    .fetch_one(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        r#"INSERT INTO shard_assignment_changes (seq, op, tenant_id, namespace, stream, shard, payload)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)"#,
+    )
+    .bind(seq)
+    .bind(shard_op_to_str(op))
+    .bind(&key.tenant_id)
+    .bind(&key.namespace)
+    .bind(&key.stream)
+    .bind(key.shard as i32)
+    .bind(assignment.map(serde_json::to_value).transpose()?)
+    .execute(&mut **tx)
+    .await?;
     Ok(())
 }
 

--- a/services/controlplane/src/store/postgres_tests.rs
+++ b/services/controlplane/src/store/postgres_tests.rs
@@ -205,7 +205,8 @@ async fn reset_db(url: &str, schema: &str) -> Result<(), sqlx::Error> {
          {schema_ident}.caches, {schema_ident}.namespaces, {schema_ident}.idp_issuers, \
          {schema_ident}.rbac_policies, {schema_ident}.rbac_groupings, \
          {schema_ident}.tenant_signing_keys, {schema_ident}.nodes, \
-         {schema_ident}.node_changes, {schema_ident}.tenants RESTART IDENTITY CASCADE",
+         {schema_ident}.node_changes, {schema_ident}.shard_assignments, \
+         {schema_ident}.shard_assignment_changes, {schema_ident}.tenants RESTART IDENTITY CASCADE",
     );
     // Same as `ensure_schema`: the interpolated identifier is our own generated schema name,
     // which cannot be passed as a bind parameter.
@@ -275,6 +276,84 @@ async fn a_reconnected_store_still_sees_registered_nodes() -> anyhow::Result<()>
     // not forced to re-bootstrap.
     let changes = store.node_changes(0).await?;
     assert!(changes.items.iter().any(|c| c.node_id == "broker-a"));
+    Ok(())
+}
+
+/// Assignments are authoritative state, so a new store over the same database
+/// must find them exactly as they were, generation included.
+#[tokio::test]
+#[serial]
+async fn a_reconnected_store_still_sees_shard_assignments() -> anyhow::Result<()> {
+    let Some(url) = pg_url().await else {
+        return Ok(());
+    };
+    let schema = ensure_schema(&url).await?;
+    let url = url_with_schema(&url, &schema);
+    run_migrations_once(&url).await?;
+    reset_db(&url, &schema).await?;
+
+    let pg_cfg = config::PostgresConfig {
+        url: url.clone(),
+        max_connections: 5,
+        connect_timeout_ms: 10_000,
+        acquire_timeout_ms: 10_000,
+    };
+    let store_config = StoreConfig {
+        changes_limit: config::DEFAULT_CHANGES_LIMIT,
+        change_retention_max_rows: None,
+    };
+
+    let before = {
+        let store =
+            PostgresStore::connect_without_migrations(&pg_cfg, store_config.clone()).await?;
+        let store = std::sync::Arc::new(store);
+        crate::store::shard_contract::seed_for_restart(store.as_ref()).await;
+        let assigned = crate::store::shard_contract::assign_for_restart(store.as_ref()).await;
+        drop(store);
+        assigned
+    };
+
+    // A different store handle over the same database: a control-plane restart.
+    let store = PostgresStore::connect_without_migrations(&pg_cfg, store_config).await?;
+    let after = store.get_shard_assignment(&before.key).await?;
+    assert_eq!(after, before, "the assignment survives unchanged");
+
+    // The changefeed survives too, so a broker resuming after the restart is not
+    // forced to re-bootstrap its ownership view.
+    let changes = store.shard_assignment_changes(0).await?;
+    assert!(changes.items.iter().any(|c| c.key == before.key));
+    Ok(())
+}
+
+/// The same shard suite the memory store runs, so parity is enforced.
+#[tokio::test]
+#[serial]
+async fn satisfies_the_shard_store_contract() -> anyhow::Result<()> {
+    let Some(url) = pg_url().await else {
+        return Ok(());
+    };
+    let schema = ensure_schema(&url).await?;
+    let url = url_with_schema(&url, &schema);
+    run_migrations_once(&url).await?;
+    reset_db(&url, &schema).await?;
+
+    let store = PostgresStore::connect_without_migrations(
+        &config::PostgresConfig {
+            url,
+            max_connections: 5,
+            connect_timeout_ms: 10_000,
+            acquire_timeout_ms: 10_000,
+        },
+        StoreConfig {
+            changes_limit: config::DEFAULT_CHANGES_LIMIT,
+            change_retention_max_rows: None,
+        },
+    )
+    .await?;
+
+    let store = std::sync::Arc::new(store);
+    crate::store::shard_contract::run_shard_contract(store.clone()).await;
+    crate::store::shard_contract::run_shard_concurrency_contract(store).await;
     Ok(())
 }
 

--- a/services/controlplane/src/store/shard_contract.rs
+++ b/services/controlplane/src/store/shard_contract.rs
@@ -1,0 +1,458 @@
+//! Shard assignment behaviour both backends must satisfy.
+//!
+//! One body, two callers, for the same reason as `node_contract`: a rule that
+//! holds only in memory is a rule the deployed system does not have.
+use std::sync::Arc;
+
+use super::{ControlPlaneStore, StoreError};
+use crate::model::{
+    ConsistencyLevel, DeliveryGuarantee, Namespace, RetentionPolicy, ShardAssignment, ShardKey,
+    ShardState, Stream, StreamKind, Tenant,
+};
+use crate::store::node_contract::node;
+
+const TENANT: &str = "shard-t";
+const NAMESPACE: &str = "shard-ns";
+const STREAM: &str = "orders";
+const SHARDS: u32 = 4;
+
+fn key(shard: u32) -> ShardKey {
+    ShardKey {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard,
+    }
+}
+
+fn assignment(shard: u32, leader: &str) -> ShardAssignment {
+    ShardAssignment {
+        key: key(shard),
+        leader: leader.to_string(),
+        replicas: Vec::new(),
+        // Deliberately non-zero: the store owns this, and every test that checks
+        // a generation is checking the store ignored what the caller sent.
+        generation: 999,
+        state: ShardState::Assigning,
+    }
+}
+
+/// Build the tenant, namespace, stream, and two nodes every case needs.
+async fn seed(store: &dyn ControlPlaneStore) {
+    let _ = store
+        .create_tenant(Tenant {
+            tenant_id: TENANT.to_string(),
+            display_name: "Shards".to_string(),
+        })
+        .await;
+    let _ = store
+        .create_namespace(Namespace {
+            tenant_id: TENANT.to_string(),
+            namespace: NAMESPACE.to_string(),
+            display_name: "Shards".to_string(),
+        })
+        .await;
+    let _ = store
+        .create_stream(Stream {
+            tenant_id: TENANT.to_string(),
+            namespace: NAMESPACE.to_string(),
+            stream: STREAM.to_string(),
+            kind: StreamKind::Stream,
+            shards: SHARDS,
+            retention: RetentionPolicy {
+                max_age_seconds: None,
+                max_size_bytes: None,
+            },
+            consistency: ConsistencyLevel::Leader,
+            delivery: DeliveryGuarantee::AtMostOnce,
+            durable: true,
+        })
+        .await;
+
+    for (i, id) in ["broker-x", "broker-y"].iter().enumerate() {
+        let _ = store.register_node(node(id, 7500 + i as u16)).await;
+    }
+}
+
+async fn clear(store: &dyn ControlPlaneStore) {
+    for assignment in store.list_shard_assignments().await.expect("list") {
+        store
+            .delete_shard_assignment(&assignment.key)
+            .await
+            .expect("delete");
+    }
+}
+
+pub(crate) async fn run_shard_contract(store: Arc<dyn ControlPlaneStore>) {
+    let store: &dyn ControlPlaneStore = store.as_ref();
+    seed(store).await;
+
+    an_assignment_is_readable(store).await;
+    the_store_owns_the_generation(store).await;
+    one_assignment_per_shard(store).await;
+    a_shard_outside_the_stream_is_rejected(store).await;
+    an_unknown_stream_is_rejected(store).await;
+    an_unknown_node_is_rejected(store).await;
+    an_unsupported_state_transition_is_rejected(store).await;
+    assignments_can_be_listed_by_leader(store).await;
+    missing_assignments_report_not_found(store).await;
+    deleting_leaves_the_shard_unowned(store).await;
+    a_node_leading_a_shard_cannot_be_deleted(store).await;
+    a_snapshot_and_the_changes_after_it_lose_nothing(store).await;
+}
+
+/// Cases needing an owned handle to share across tasks.
+pub(crate) async fn run_shard_concurrency_contract(store: Arc<dyn ControlPlaneStore>) {
+    seed(store.as_ref()).await;
+    concurrent_writes_to_one_shard_serialise(store).await;
+}
+
+/// Two placement passes can write the same shard at once. Whatever order they
+/// land in, the shard must end with one assignment, and the generation must
+/// count every write rather than two writers both reading generation 0 and both
+/// storing 1 -- which is how a broker gets told its current view is stale.
+async fn concurrent_writes_to_one_shard_serialise(store: Arc<dyn ControlPlaneStore>) {
+    const WRITERS: u64 = 8;
+
+    clear(store.as_ref()).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("initial");
+
+    let writers: Vec<_> = (0..WRITERS)
+        .map(|i| {
+            let store = Arc::clone(&store);
+            tokio::spawn(async move {
+                let leader = if i % 2 == 0 { "broker-x" } else { "broker-y" };
+                store
+                    .put_shard_assignment(assignment(0, leader))
+                    .await
+                    .expect("concurrent put")
+                    .generation
+            })
+        })
+        .collect();
+
+    let mut generations = Vec::new();
+    for writer in writers {
+        generations.push(writer.await.expect("writer"));
+    }
+    generations.sort_unstable();
+
+    assert_eq!(
+        store.list_shard_assignments().await.expect("list").len(),
+        1,
+        "concurrent writes must not create a second assignment",
+    );
+    assert_eq!(
+        generations,
+        (1..=WRITERS).collect::<Vec<_>>(),
+        "every write must take a distinct, consecutive generation",
+    );
+    assert_eq!(
+        store
+            .get_shard_assignment(&key(0))
+            .await
+            .expect("get")
+            .generation,
+        WRITERS,
+        "the stored generation must be the last one handed out",
+    );
+}
+
+async fn an_assignment_is_readable(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let stored = store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+    assert_eq!(stored.key, key(0));
+    assert_eq!(stored.leader, "broker-x");
+    assert_eq!(
+        store.get_shard_assignment(&key(0)).await.expect("get"),
+        stored
+    );
+    assert_eq!(
+        store.list_shard_assignments().await.expect("list"),
+        vec![stored]
+    );
+}
+
+/// A broker reports against the generation it read. If a caller could choose
+/// one, a stale report could be made to look current.
+async fn the_store_owns_the_generation(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let first = store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+    assert_eq!(first.generation, 0, "the caller's 999 must be ignored");
+
+    let second = store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put again");
+    assert_eq!(second.generation, 1, "every write moves the generation on");
+}
+
+/// The invariant placement depends on: writing a shard replaces its assignment
+/// rather than adding a second one.
+async fn one_assignment_per_shard(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(1, "broker-x"))
+        .await
+        .expect("put");
+    let mut moved = assignment(1, "broker-y");
+    moved.state = ShardState::Assigning;
+    store.put_shard_assignment(moved).await.expect("reassign");
+
+    let all = store.list_shard_assignments().await.expect("list");
+    assert_eq!(all.len(), 1, "one assignment per shard");
+    assert_eq!(all[0].leader, "broker-y");
+}
+
+async fn a_shard_outside_the_stream_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let err = store
+        .put_shard_assignment(assignment(SHARDS, "broker-x"))
+        .await
+        .expect_err("out of bounds");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+    assert!(
+        store
+            .list_shard_assignments()
+            .await
+            .expect("list")
+            .is_empty()
+    );
+}
+
+async fn an_unknown_stream_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let mut orphan = assignment(0, "broker-x");
+    orphan.key.stream = "no-such-stream".to_string();
+    let err = store
+        .put_shard_assignment(orphan)
+        .await
+        .expect_err("unknown stream");
+    assert!(matches!(err, StoreError::NotFound(_)), "got {err:?}");
+}
+
+/// Checked in the store rather than by a foreign key, because the node
+/// reference deliberately has none.
+async fn an_unknown_node_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    let err = store
+        .put_shard_assignment(assignment(0, "broker-ghost"))
+        .await
+        .expect_err("unknown leader");
+    assert!(matches!(err, StoreError::NotFound(_)), "got {err:?}");
+
+    let mut with_ghost_replica = assignment(0, "broker-x");
+    with_ghost_replica.replicas = vec!["broker-ghost".to_string()];
+    let err = store
+        .put_shard_assignment(with_ghost_replica)
+        .await
+        .expect_err("unknown replica");
+    assert!(matches!(err, StoreError::NotFound(_)), "got {err:?}");
+}
+
+async fn an_unsupported_state_transition_is_rejected(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("assigning");
+
+    // Assigning -> Draining is not a move: nothing is serving yet.
+    let mut draining = assignment(0, "broker-x");
+    draining.state = ShardState::Draining;
+    let err = store
+        .put_shard_assignment(draining)
+        .await
+        .expect_err("bad transition");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+
+    let unchanged = store.get_shard_assignment(&key(0)).await.expect("get");
+    assert_eq!(unchanged.state, ShardState::Assigning);
+    assert_eq!(unchanged.generation, 0, "a rejected write moves nothing");
+}
+
+/// The question placement asks when a node fails or is drained.
+async fn assignments_can_be_listed_by_leader(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+    store
+        .put_shard_assignment(assignment(1, "broker-y"))
+        .await
+        .expect("put");
+    store
+        .put_shard_assignment(assignment(2, "broker-x"))
+        .await
+        .expect("put");
+
+    let owned = store
+        .list_shard_assignments_for_node("broker-x")
+        .await
+        .expect("by node");
+    assert_eq!(
+        owned.iter().map(|a| a.key.shard).collect::<Vec<_>>(),
+        vec![0, 2],
+    );
+    assert!(
+        store
+            .list_shard_assignments_for_node("broker-ghost")
+            .await
+            .expect("by node")
+            .is_empty()
+    );
+}
+
+async fn missing_assignments_report_not_found(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    assert!(matches!(
+        store.get_shard_assignment(&key(3)).await.expect_err("get"),
+        StoreError::NotFound(_)
+    ));
+    assert!(matches!(
+        store
+            .delete_shard_assignment(&key(3))
+            .await
+            .expect_err("delete"),
+        StoreError::NotFound(_)
+    ));
+}
+
+async fn deleting_leaves_the_shard_unowned(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+    let since = store
+        .shard_assignment_snapshot()
+        .await
+        .expect("snapshot")
+        .next_seq;
+
+    store
+        .delete_shard_assignment(&key(0))
+        .await
+        .expect("delete");
+
+    assert!(store.get_shard_assignment(&key(0)).await.is_err());
+    let changes = store
+        .shard_assignment_changes(since)
+        .await
+        .expect("changes");
+    assert_eq!(changes.items.len(), 1);
+    assert!(
+        changes.items[0].assignment.is_none(),
+        "an unassignment carries no body",
+    );
+}
+
+/// Cascading would delete the only record of where that shard's data lives.
+async fn a_node_leading_a_shard_cannot_be_deleted(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+
+    let err = store
+        .delete_node("broker-x")
+        .await
+        .expect_err("should refuse");
+    assert!(matches!(err, StoreError::Conflict(_)), "got {err:?}");
+    assert!(
+        store.get_node("broker-x").await.is_ok(),
+        "node must survive"
+    );
+
+    // Reassigning frees it.
+    store
+        .delete_shard_assignment(&key(0))
+        .await
+        .expect("delete");
+    assert!(store.delete_node("broker-x").await.is_ok());
+    store
+        .register_node(node("broker-x", 7500))
+        .await
+        .expect("re-register for later cases");
+}
+
+async fn a_snapshot_and_the_changes_after_it_lose_nothing(store: &dyn ControlPlaneStore) {
+    clear(store).await;
+    store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+
+    let snapshot = store.shard_assignment_snapshot().await.expect("snapshot");
+    assert_eq!(snapshot.items.len(), 1);
+
+    store
+        .put_shard_assignment(assignment(1, "broker-y"))
+        .await
+        .expect("put");
+    store
+        .delete_shard_assignment(&key(0))
+        .await
+        .expect("delete");
+
+    let mut reconstructed: std::collections::BTreeMap<(String, u32), ShardAssignment> = snapshot
+        .items
+        .into_iter()
+        .map(|a| ((a.key.stream.clone(), a.key.shard), a))
+        .collect();
+    for change in store
+        .shard_assignment_changes(snapshot.next_seq)
+        .await
+        .expect("changes")
+        .items
+    {
+        let id = (change.key.stream.clone(), change.key.shard);
+        match change.assignment {
+            Some(assignment) => {
+                reconstructed.insert(id, assignment);
+            }
+            None => {
+                reconstructed.remove(&id);
+            }
+        }
+    }
+
+    let actual: std::collections::BTreeMap<(String, u32), ShardAssignment> = store
+        .list_shard_assignments()
+        .await
+        .expect("list")
+        .into_iter()
+        .map(|a| ((a.key.stream.clone(), a.key.shard), a))
+        .collect();
+    assert_eq!(reconstructed, actual);
+}
+
+/// Seeding exposed for the restart test, which needs the catalog in place
+/// across two store handles.
+pub(crate) async fn seed_for_restart(store: &dyn ControlPlaneStore) {
+    seed(store).await;
+}
+
+/// Write one assignment and hand it back, for the restart test to compare.
+pub(crate) async fn assign_for_restart(store: &dyn ControlPlaneStore) -> ShardAssignment {
+    clear(store).await;
+    let first = store
+        .put_shard_assignment(assignment(0, "broker-x"))
+        .await
+        .expect("put");
+    let mut active = assignment(0, "broker-x");
+    active.state = ShardState::Active;
+    let _ = first;
+    store.put_shard_assignment(active).await.expect("activate")
+}

--- a/services/controlplane/tests/http_smoke.rs
+++ b/services/controlplane/tests/http_smoke.rs
@@ -12,8 +12,8 @@ use controlplane::auth::idp_registry::IdpIssuerConfig;
 use controlplane::auth::rbac::policy_store::{GroupingRule, PolicyRule};
 use controlplane::model::{
     Cache, CacheChange, CacheKey, CachePatchRequest, Namespace, NamespaceChange, NamespaceKey,
-    Node, NodeChange, NodeLifecycle, NodePatchRequest, Stream, StreamChange, StreamKey,
-    StreamPatchRequest, Tenant, TenantChange,
+    Node, NodeChange, NodeLifecycle, NodePatchRequest, ShardAssignment, ShardAssignmentChange,
+    ShardKey, Stream, StreamChange, StreamKey, StreamPatchRequest, Tenant, TenantChange,
 };
 use controlplane::store::{
     AuthStore, ChangeSet, ControlPlaneStore, Snapshot, StoreError, StoreResult,
@@ -985,6 +985,43 @@ impl ControlPlaneStore for FailingStore {
     }
 
     async fn node_changes(&self, _since: u64) -> StoreResult<ChangeSet<NodeChange>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn put_shard_assignment(
+        &self,
+        _assignment: ShardAssignment,
+    ) -> StoreResult<ShardAssignment> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn get_shard_assignment(&self, _key: &ShardKey) -> StoreResult<ShardAssignment> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn list_shard_assignments(&self) -> StoreResult<Vec<ShardAssignment>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn list_shard_assignments_for_node(
+        &self,
+        _node_id: &str,
+    ) -> StoreResult<Vec<ShardAssignment>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn delete_shard_assignment(&self, _key: &ShardKey) -> StoreResult<()> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn shard_assignment_snapshot(&self) -> StoreResult<Snapshot<ShardAssignment>> {
+        Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
+    }
+
+    async fn shard_assignment_changes(
+        &self,
+        _since: u64,
+    ) -> StoreResult<ChangeSet<ShardAssignmentChange>> {
         Err(StoreError::Unexpected(anyhow::anyhow!("fail")))
     }
 

--- a/services/controlplane/tests/node_admin_api.rs
+++ b/services/controlplane/tests/node_admin_api.rs
@@ -9,7 +9,10 @@ use controlplane::app::{AppState, build_router};
 use controlplane::auth::felix_token::{TenantSigningKeys, mint_token};
 use controlplane::auth::keys::generate_signing_keys;
 use controlplane::config::NodeLivenessConfig;
-use controlplane::model::{Node, NodeCapacity, NodeLifecycle, NodeSpec, NodeStatus};
+use controlplane::model::{
+    ConsistencyLevel, DeliveryGuarantee, Namespace, Node, NodeCapacity, NodeLifecycle, NodeSpec,
+    NodeStatus, RetentionPolicy, ShardAssignment, ShardKey, ShardState, Stream, StreamKind, Tenant,
+};
 use controlplane::store::memory::InMemoryStore;
 use controlplane::store::{AuthStore, ControlPlaneAuthStore, ControlPlaneStore, StoreConfig};
 use std::collections::BTreeMap;
@@ -333,4 +336,123 @@ async fn the_node_view_exposes_no_secrets() {
             "{forbidden} leaked: {rendered}"
         );
     }
+}
+
+async fn seed_shards(store: &InMemoryStore) {
+    store
+        .create_tenant(Tenant {
+            tenant_id: "t1".to_string(),
+            display_name: "T".to_string(),
+        })
+        .await
+        .expect("tenant");
+    store
+        .create_namespace(Namespace {
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            display_name: "NS".to_string(),
+        })
+        .await
+        .expect("namespace");
+    store
+        .create_stream(Stream {
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            stream: "orders".to_string(),
+            kind: StreamKind::Stream,
+            shards: 3,
+            retention: RetentionPolicy {
+                max_age_seconds: None,
+                max_size_bytes: None,
+            },
+            consistency: ConsistencyLevel::Leader,
+            delivery: DeliveryGuarantee::AtMostOnce,
+            durable: true,
+        })
+        .await
+        .expect("stream");
+
+    for (i, id) in ["broker-a", "broker-b"].iter().enumerate() {
+        store
+            .register_node(node(id, 7100 + i as u16, "us-west-2", "a1"))
+            .await
+            .expect("node");
+    }
+    for (shard, leader) in [(0u32, "broker-a"), (1, "broker-b"), (2, "broker-a")] {
+        store
+            .put_shard_assignment(ShardAssignment {
+                key: ShardKey {
+                    tenant_id: "t1".to_string(),
+                    namespace: "ns".to_string(),
+                    stream: "orders".to_string(),
+                    shard,
+                },
+                leader: leader.to_string(),
+                replicas: Vec::new(),
+                generation: 0,
+                state: ShardState::Active,
+            })
+            .await
+            .expect("assign");
+    }
+}
+
+#[tokio::test]
+async fn listing_shard_assignments_requires_cluster_scope() {
+    let (app, _store, _keys) = setup().await;
+    let response = app
+        .oneshot(get("/v1/shard-assignments", None))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Ownership and membership are the same view of the cluster, so a tenant
+/// scope must not open either.
+#[tokio::test]
+async fn a_tenant_scope_does_not_open_shard_assignments() {
+    let (app, _store, keys) = setup().await;
+    let response = app
+        .oneshot(get(
+            "/v1/shard-assignments",
+            Some(&token(&keys, vec!["tenant.manage:tenant:t1"])),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn shard_assignments_list_and_filter_by_leader() {
+    let (app, store, keys) = setup().await;
+    seed_shards(&store).await;
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+
+    let response = app
+        .clone()
+        .oneshot(get("/v1/shard-assignments", Some(&bearer)))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: serde_json::Value = read_json(response).await;
+    let items = body["items"].as_array().expect("items");
+    assert_eq!(items.len(), 3);
+    // Ordered by stream then shard, so a listing reads the same way twice.
+    assert_eq!(items[0]["shard"], 0);
+    assert_eq!(items[0]["leader"], "broker-a");
+    assert_eq!(items[0]["state"], "active");
+
+    // The question an operator asks when a broker misbehaves.
+    let response = app
+        .oneshot(get("/v1/shard-assignments?leader=broker-a", Some(&bearer)))
+        .await
+        .expect("request");
+    let body: serde_json::Value = read_json(response).await;
+    let shards: Vec<u64> = body["items"]
+        .as_array()
+        .expect("items")
+        .iter()
+        .map(|i| i["shard"].as_u64().unwrap_or_default())
+        .collect();
+    assert_eq!(shards, vec![0, 2]);
 }


### PR DESCRIPTION
Closes #98. **First slice of M3.**

## What's here

One assignment per `(stream, shard)` — the primary key, and the invariant placement depends on. Stored in both backends with an ordered changefeed, plus `GET /v1/shard-assignments` (and `?leader=<node_id>`) behind the same `node.view:cluster:*` as the node listing, because ownership and membership are the same view of the cluster.

## The generation is the store's, not the caller's

A broker reports status against the generation it read. If a caller could choose one, a broker that was slow, partitioned, or restarted could make a stale report look current and resurrect an ownership decision placement had already replaced.

So `generation` increments on every write and ignores whatever the caller sent. The contract makes that explicit rather than incidental: **every write in the suite sends `generation: 999`**, and the tests assert the store stored 0, then 1, then 2.

## Two references, two policies — chosen, not inherited

| Reference | Policy | Why |
|---|---|---|
| **Stream** | FK, `ON DELETE CASCADE` | Once a stream is gone its shards don't exist. Keeping ownership records leaves placement chasing ghosts. |
| **Node** | **No FK**; delete is *refused* | A cascade would delete the only record of where that shard's data lives — an operator's tidy-up becomes silent data orphaning. |

That second one is a behaviour change to `delete_node`: it now fails while the node still leads a shard, and you reassign first. Node existence is checked in the store precisely *because* there's no foreign key doing it.

## Concurrency

Eight writers racing on one shard must take eight distinct consecutive generations — not several reading generation 0 and all storing 1, which is exactly how a broker gets wrongly told its view is current.

`FOR UPDATE` on the read-before-write serialises them. **Verified in both directions: removing it fails that case 5 times in 5.** Without that check the lock would have been unproven decoration.

## Also

- Snapshot uses `REPEATABLE READ` and the changefeed seq comes from a locked counter row, matching the node tables — the same two properties that made snapshot-then-poll exactly-once in #93.
- `a_reconnected_store_still_sees_shard_assignments` covers restart persistence, generation included.
- Streams cannot be resized today (`StreamPatchRequest` has no `shards`), so no assignment can be orphaned by a shrink. Documented for when it arrives.

## Tests

14 model tests, a 13-case shared contract both stores run, a concurrency case, restart persistence, and 3 HTTP tests including that a tenant scope does not open the shard listing. The OpenAPI test asserts the new route and schemas.

## Verification

`task lint`, `task test` (65 suites), `task deny`, `task demo:check`, mermaid, and the pg suite against real Postgres 16 — all clean. I confirmed the Postgres contract genuinely hit the database (23 change rows) rather than skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)