### PR TITLE
feat(broker): drive local shard state from assignment generations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bytes",

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -266,6 +266,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bytes",

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -266,6 +266,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bytes",

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -279,6 +279,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bytes",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -279,6 +279,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64 0.23.1",
  "bytes",

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -258,6 +258,48 @@ resnapshots and carries on.
 
 Both endpoints require `node.view:cluster:*`.
 
+#### What a broker does about ownership
+
+The watch says who *should* own each shard. What a broker has actually done
+about it is a separate state, because becoming an owner is not instant: the
+durable log has to be opened and recovered first, and a broker serving writes in
+that window would acknowledge records it cannot yet persist.
+
+So ownership is two-phase in both directions:
+
+```
+unassigned -> opening -> active -> draining -> closed
+                  |
+                  +-> failed
+```
+
+A shard serves **only** in `active`, and only at the generation the control
+plane currently names. `opening` exists precisely so an assignment arriving is
+not the same event as the shard becoming servable.
+
+- **A new generation reopens.** The control plane moved the shard away and back;
+  local state is re-established rather than assumed.
+- **An older generation is ignored.** A duplicate delivery, a reordered poll, or
+  a snapshot replay is not news, so repeated events cost nothing.
+- **An open that finishes after a reassignment does not activate.** The shard
+  moved on while it was being recovered.
+- **A failed open is not retried by the same assignment arriving again.** Every
+  poll re-delivers it, and retrying each time buries the failure. A new
+  generation is what retries.
+- **A vanished assignment releases the shard**, exactly like one reassigned
+  away. A snapshot replaces the whole picture, so only the full set can say what
+  disappeared.
+- **A failed flush still gives up the shard.** Ownership has moved regardless,
+  and continuing to serve would be worse than an unflushed tail — but the error
+  is logged loudly.
+
+| Metric | Meaning |
+| --- | --- |
+| `felix_broker_shard_phase{phase}` | shards this broker holds, by phase |
+| `felix_broker_shard_transitions_total{from,to}` | local ownership moves |
+| `felix_broker_shard_stale_events_total` | events ignored for an old generation |
+| `felix_broker_shard_open_failures_total` | non-zero means a shard the cluster believes is placed here is not being served |
+
 #### Referential integrity
 
 Two references, two different policies, chosen rather than inherited:

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -48,6 +48,9 @@ path = "src/bin/soak/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+# The shard lifecycle drives local state through a trait object, so its two
+# async methods need boxing.
+async-trait = "0.1"
 base64 = "0.23"
 felix-broker = { path = "../../crates/felix-broker", version = "0.2.0" }
 felix-common = { path = "../../crates/felix-common", version = "0.2.0", features = ["lifecycle"] }

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -13,6 +13,8 @@ pub mod durable_config;
 pub mod membership;
 pub mod membership_metrics;
 pub mod quic;
+pub mod shard_lifecycle;
+pub mod shard_lifecycle_metrics;
 pub mod shard_watch;
 pub mod shard_watch_metrics;
 pub mod timings;

--- a/services/broker/src/shard_lifecycle.rs
+++ b/services/broker/src/shard_lifecycle.rs
@@ -1,0 +1,435 @@
+//! Local shard ownership: what this broker does about what the control plane
+//! decided.
+//!
+//! The watch says who *should* own each shard. This says what this node has
+//! actually done about it — because becoming an owner is not instant. The
+//! durable log has to be opened and recovered first, and a broker that served
+//! writes in that window would acknowledge records it could not yet persist.
+//!
+//! Ownership is therefore two-phase in both directions: `Opening` before
+//! `Active`, and `Draining` before `Closed`. A shard serves only in `Active`,
+//! and only at the generation the control plane currently names.
+//!
+//! The decision half is a pure state machine and the I/O half is a driver, for
+//! the same reason placement is split that way: every interesting rule is then
+//! testable without a disk.
+use std::collections::HashMap;
+
+use crate::shard_lifecycle_metrics as mm;
+use crate::shard_watch::{ShardAssignment, ShardKey};
+
+/// Where this broker is with one shard.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Phase {
+    /// Not ours, and nothing open.
+    Unassigned,
+    /// Ours, but the local log is not ready. Not serving.
+    Opening,
+    /// Ours and ready.
+    Active,
+    /// No longer ours. In-flight work is finishing; no new writes.
+    Draining,
+    /// Drained and closed.
+    Closed,
+    /// The local log could not be opened. Not serving, and not retried until
+    /// the assignment changes -- a failure that repeats every poll is noise,
+    /// and the operator needs the state to stay visible.
+    Failed,
+}
+
+impl Phase {
+    pub fn label(self) -> &'static str {
+        match self {
+            Phase::Unassigned => "unassigned",
+            Phase::Opening => "opening",
+            Phase::Active => "active",
+            Phase::Draining => "draining",
+            Phase::Closed => "closed",
+            Phase::Failed => "failed",
+        }
+    }
+
+    /// Whether a shard in this phase may accept writes.
+    ///
+    /// Only `Active`. `Opening` is the whole reason this type exists: the
+    /// assignment has arrived but the log has not been recovered, and
+    /// acknowledging a write there would promise durability that is not set up.
+    pub fn may_serve(self) -> bool {
+        matches!(self, Phase::Active)
+    }
+}
+
+/// What this broker holds for one shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalShard {
+    pub phase: Phase,
+    /// The assignment generation this state was reached for.
+    pub generation: u64,
+}
+
+/// Work the driver must do to catch up with a decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Action {
+    /// Open and recover the local log, then report back.
+    Open { key: ShardKey, generation: u64 },
+    /// Stop writes, drain, flush, and close.
+    Release { key: ShardKey, generation: u64 },
+    /// Nothing to do.
+    None,
+}
+
+/// This broker's view of the shards it holds.
+#[derive(Debug)]
+pub struct ShardLifecycle {
+    node_id: String,
+    shards: HashMap<ShardKey, LocalShard>,
+}
+
+impl ShardLifecycle {
+    pub fn new(node_id: impl Into<String>) -> Self {
+        Self {
+            node_id: node_id.into(),
+            shards: HashMap::new(),
+        }
+    }
+
+    pub fn node_id(&self) -> &str {
+        &self.node_id
+    }
+
+    /// Whether this broker may serve writes for `key` right now.
+    pub fn may_serve(&self, key: &ShardKey) -> bool {
+        self.shards
+            .get(key)
+            .is_some_and(|shard| shard.phase.may_serve())
+    }
+
+    /// Whether this broker may serve `key` at exactly `generation`.
+    ///
+    /// The stricter gate, for a caller that read an assignment and wants to act
+    /// on it: serving at a generation the control plane has moved past is how
+    /// two brokers end up believing they lead the same shard.
+    pub fn may_serve_at(&self, key: &ShardKey, generation: u64) -> bool {
+        self.shards
+            .get(key)
+            .is_some_and(|shard| shard.phase.may_serve() && shard.generation == generation)
+    }
+
+    pub fn phase(&self, key: &ShardKey) -> Phase {
+        self.shards
+            .get(key)
+            .map_or(Phase::Unassigned, |shard| shard.phase)
+    }
+
+    pub fn generation(&self, key: &ShardKey) -> Option<u64> {
+        self.shards.get(key).map(|shard| shard.generation)
+    }
+
+    /// Shards this broker is currently serving.
+    pub fn active(&self) -> impl Iterator<Item = &ShardKey> {
+        self.shards
+            .iter()
+            .filter(|(_, shard)| shard.phase.may_serve())
+            .map(|(key, _)| key)
+    }
+
+    /// React to what the control plane now says about one shard.
+    ///
+    /// `assignment` is `None` when the shard has no assignment at all. Returns
+    /// the work the driver must do; repeated calls with the same or an older
+    /// generation return [`Action::None`], so a duplicate delivery or a replayed
+    /// snapshot costs nothing.
+    pub fn observe(&mut self, key: &ShardKey, assignment: Option<&ShardAssignment>) -> Action {
+        let ours = assignment.is_some_and(|a| a.leader == self.node_id);
+        let generation = assignment.map_or(0, |a| a.generation);
+        let current = self.shards.get(key).cloned();
+
+        match (ours, current) {
+            // Newly ours: open before serving.
+            (true, None) => self.begin_open(key, generation),
+
+            (true, Some(existing)) => {
+                if generation < existing.generation {
+                    // Older than what we already acted on: a duplicate, a
+                    // reordered poll, or a snapshot replay.
+                    mm::record_stale_event();
+                    return Action::None;
+                }
+                match existing.phase {
+                    // Already serving this generation: nothing to do. This is
+                    // the common case on every poll.
+                    Phase::Active | Phase::Opening if generation == existing.generation => {
+                        Action::None
+                    }
+                    // A new generation for a shard we already hold. Reopening is
+                    // what makes the generation meaningful: the control plane
+                    // moved the shard away and back, and the local state has to
+                    // be re-established rather than assumed.
+                    Phase::Active | Phase::Opening => self.begin_open(key, generation),
+                    // A failed open is not retried by the same assignment
+                    // arriving again. Every poll re-delivers it, and retrying
+                    // each time buries the failure in noise while hammering a
+                    // log that is not opening. A new generation is real news.
+                    Phase::Failed if generation == existing.generation => Action::None,
+                    // Ours again after we let it go, or after a failure at an
+                    // older generation.
+                    Phase::Draining | Phase::Closed | Phase::Unassigned | Phase::Failed => {
+                        self.begin_open(key, generation)
+                    }
+                }
+            }
+
+            // Not ours, and we hold nothing.
+            (false, None) => Action::None,
+
+            (false, Some(existing)) => match existing.phase {
+                // Already given up.
+                Phase::Closed | Phase::Unassigned | Phase::Draining => Action::None,
+                // A failed open never served, so there is nothing to drain.
+                Phase::Failed => {
+                    self.set(key, Phase::Closed, existing.generation);
+                    Action::None
+                }
+                Phase::Active | Phase::Opening => {
+                    self.set(key, Phase::Draining, existing.generation);
+                    Action::Release {
+                        key: key.clone(),
+                        generation: existing.generation,
+                    }
+                }
+            },
+        }
+    }
+
+    /// Every shard this broker holds that the given assignment set no longer
+    /// mentions.
+    ///
+    /// A snapshot replaces the whole picture, so a shard that vanished from it
+    /// has to be released as surely as one reassigned away — otherwise a broker
+    /// keeps serving a shard whose assignment was deleted.
+    pub fn missing_from<'a>(
+        &self,
+        present: impl IntoIterator<Item = &'a ShardKey>,
+    ) -> Vec<ShardKey> {
+        let present: std::collections::HashSet<&ShardKey> = present.into_iter().collect();
+        self.shards
+            .iter()
+            .filter(|(key, shard)| {
+                !present.contains(*key) && !matches!(shard.phase, Phase::Closed | Phase::Unassigned)
+            })
+            .map(|(key, _)| key.clone())
+            .collect()
+    }
+
+    /// Record that the driver opened the log successfully.
+    ///
+    /// Ignored if the generation has moved on since the open began: the shard
+    /// was reassigned while we were recovering it, and activating now would
+    /// serve a generation we no longer hold.
+    pub fn opened(&mut self, key: &ShardKey, generation: u64) -> bool {
+        match self.shards.get(key) {
+            Some(shard) if shard.phase == Phase::Opening && shard.generation == generation => {
+                self.set(key, Phase::Active, generation);
+                true
+            }
+            _ => {
+                mm::record_stale_event();
+                false
+            }
+        }
+    }
+
+    /// Record that the driver could not open the log.
+    pub fn open_failed(&mut self, key: &ShardKey, generation: u64) {
+        if let Some(shard) = self.shards.get(key)
+            && shard.phase == Phase::Opening
+            && shard.generation == generation
+        {
+            self.set(key, Phase::Failed, generation);
+        }
+    }
+
+    /// Record that the driver finished draining and closed the log.
+    pub fn released(&mut self, key: &ShardKey, generation: u64) {
+        if let Some(shard) = self.shards.get(key)
+            && shard.phase == Phase::Draining
+            && shard.generation == generation
+        {
+            self.set(key, Phase::Closed, generation);
+        }
+    }
+
+    fn begin_open(&mut self, key: &ShardKey, generation: u64) -> Action {
+        self.set(key, Phase::Opening, generation);
+        Action::Open {
+            key: key.clone(),
+            generation,
+        }
+    }
+
+    fn set(&mut self, key: &ShardKey, phase: Phase, generation: u64) {
+        let previous = self.shards.get(key).map(|shard| shard.phase);
+        self.shards
+            .insert(key.clone(), LocalShard { phase, generation });
+        if previous != Some(phase) {
+            mm::record_transition(previous.unwrap_or(Phase::Unassigned), phase);
+            mm::record_phase_counts(self.counts());
+        }
+    }
+
+    /// How many shards sit in each phase, for the gauge.
+    pub fn counts(&self) -> HashMap<Phase, usize> {
+        let mut counts = HashMap::new();
+        for shard in self.shards.values() {
+            *counts.entry(shard.phase).or_default() += 1;
+        }
+        counts
+    }
+}
+
+/// What a driver needs to open and close local shard state.
+///
+/// A trait so the lifecycle can be exercised without a disk, and so the durable
+/// and non-durable cases are one code path: an in-memory stream has no log to
+/// open, and saying so is cheaper than branching everywhere.
+#[async_trait::async_trait]
+pub trait ShardStore: Send + Sync {
+    /// Open and recover local state for a shard.
+    async fn open(&self, key: &ShardKey) -> anyhow::Result<()>;
+    /// Flush everything accepted for a shard, before ownership is given up.
+    ///
+    /// This is the point at which "no accepted write is unaccounted for" is
+    /// either true or not.
+    async fn release(&self, key: &ShardKey) -> anyhow::Result<()>;
+}
+
+/// A [`ShardStore`] over the broker's durable storage.
+///
+/// Opening recovers the shard's log from disk, which is the work `Opening`
+/// exists to wait for. Releasing flushes it, so nothing acknowledged here is
+/// still only in the page cache when another node takes the shard.
+pub struct DurableShardStore {
+    storage: std::sync::Arc<felix_broker::DurableStorage>,
+}
+
+impl DurableShardStore {
+    pub fn new(storage: std::sync::Arc<felix_broker::DurableStorage>) -> Self {
+        Self { storage }
+    }
+}
+
+#[async_trait::async_trait]
+impl ShardStore for DurableShardStore {
+    async fn open(&self, key: &ShardKey) -> anyhow::Result<()> {
+        // Recovery happens here: validating the tail and rebuilding indexes is
+        // exactly the cost the `Opening` phase is holding writes back for.
+        self.storage
+            .open_stream(&key.tenant_id, &key.namespace, &key.stream, key.shard)
+            .map(|_| ())
+            .map_err(|err| anyhow::anyhow!("open shard log: {err}"))
+    }
+
+    async fn release(&self, key: &ShardKey) -> anyhow::Result<()> {
+        let log = self
+            .storage
+            .open_stream(&key.tenant_id, &key.namespace, &key.stream, key.shard)
+            .map_err(|err| anyhow::anyhow!("open shard log to flush it: {err}"))?;
+        log.sync()
+            .await
+            .map_err(|err| anyhow::anyhow!("flush shard log: {err}"))
+    }
+}
+
+/// Drive one decision to completion.
+pub async fn apply(
+    lifecycle: &tokio::sync::Mutex<ShardLifecycle>,
+    store: &dyn ShardStore,
+    action: Action,
+) {
+    match action {
+        Action::None => {}
+        Action::Open { key, generation } => match store.open(&key).await {
+            Ok(()) => {
+                let activated = lifecycle.lock().await.opened(&key, generation);
+                if activated {
+                    tracing::info!(
+                        stream = %key.stream,
+                        shard = key.shard,
+                        generation,
+                        "shard opened and now serving",
+                    );
+                } else {
+                    // Reassigned while we were recovering it. Not an error, and
+                    // deliberately not activated -- see `ShardLifecycle::opened`.
+                    tracing::info!(
+                        stream = %key.stream,
+                        shard = key.shard,
+                        generation,
+                        "shard was reassigned while opening; not activating",
+                    );
+                }
+            }
+            Err(err) => {
+                mm::record_open_failure();
+                lifecycle.lock().await.open_failed(&key, generation);
+                tracing::error!(
+                    stream = %key.stream,
+                    shard = key.shard,
+                    generation,
+                    error = %err,
+                    "could not open local shard state; this broker is not serving it",
+                );
+            }
+        },
+        Action::Release { key, generation } => {
+            if let Err(err) = store.release(&key).await {
+                // Still closed: ownership has moved regardless, and continuing
+                // to serve would be worse than an unflushed tail. The error is
+                // the operator's to see.
+                tracing::error!(
+                    stream = %key.stream,
+                    shard = key.shard,
+                    generation,
+                    error = %err,
+                    "could not flush local shard state while releasing it",
+                );
+            }
+            lifecycle.lock().await.released(&key, generation);
+            tracing::info!(
+                stream = %key.stream,
+                shard = key.shard,
+                generation,
+                "shard released",
+            );
+        }
+    }
+}
+
+/// Bring local state in line with a full assignment set.
+///
+/// Takes the whole set rather than a delta because a snapshot replaces the
+/// picture: a shard that vanished from it must be released as surely as one
+/// reassigned away, and only the full set can say which vanished.
+pub async fn reconcile(
+    lifecycle: &tokio::sync::Mutex<ShardLifecycle>,
+    store: &dyn ShardStore,
+    assignments: &HashMap<ShardKey, ShardAssignment>,
+) {
+    let mut actions = Vec::new();
+    {
+        let mut owned = lifecycle.lock().await;
+        for (key, assignment) in assignments {
+            actions.push(owned.observe(key, Some(assignment)));
+        }
+        for key in owned.missing_from(assignments.keys()) {
+            actions.push(owned.observe(&key, None));
+        }
+    }
+    for action in actions {
+        apply(lifecycle, store, action).await;
+    }
+}
+
+#[cfg(test)]
+#[path = "shard_lifecycle_tests.rs"]
+mod tests;

--- a/services/broker/src/shard_lifecycle_metrics.rs
+++ b/services/broker/src/shard_lifecycle_metrics.rs
@@ -1,0 +1,51 @@
+//! Metrics for local shard ownership.
+//!
+//! The question: is this broker serving what the cluster thinks it serves? A
+//! shard stuck in `opening` is one the control plane believes is live; a shard
+//! in `failed` is one nobody is serving.
+use std::collections::HashMap;
+
+use crate::shard_lifecycle::Phase;
+
+/// Shards this broker holds, by phase. Bounded at six series.
+pub const PHASE: &str = "felix_broker_shard_phase";
+/// Local ownership transitions, by direction.
+pub const TRANSITIONS_TOTAL: &str = "felix_broker_shard_transitions_total";
+/// Events ignored for naming a generation at or below the one already acted on.
+pub const STALE_EVENTS_TOTAL: &str = "felix_broker_shard_stale_events_total";
+/// Local logs that could not be opened. Non-zero means a shard the cluster
+/// believes is placed here is not being served.
+pub const OPEN_FAILURES_TOTAL: &str = "felix_broker_shard_open_failures_total";
+
+const ALL_PHASES: [Phase; 6] = [
+    Phase::Unassigned,
+    Phase::Opening,
+    Phase::Active,
+    Phase::Draining,
+    Phase::Closed,
+    Phase::Failed,
+];
+
+pub fn record_transition(from: Phase, to: Phase) {
+    metrics::counter!(TRANSITIONS_TOTAL, "from" => from.label(), "to" => to.label()).increment(1);
+}
+
+pub fn record_stale_event() {
+    metrics::counter!(STALE_EVENTS_TOTAL).increment(1);
+}
+
+pub fn record_open_failure() {
+    metrics::counter!(OPEN_FAILURES_TOTAL).increment(1);
+}
+
+/// Publish the phase census.
+///
+/// Every phase is written, including the empty ones: a gauge that stops being
+/// set keeps its last value, and "no shards are failed any more" is exactly the
+/// fact an operator needs to see.
+pub fn record_phase_counts(counts: HashMap<Phase, usize>) {
+    for phase in ALL_PHASES {
+        metrics::gauge!(PHASE, "phase" => phase.label())
+            .set(counts.get(&phase).copied().unwrap_or(0) as f64);
+    }
+}

--- a/services/broker/src/shard_lifecycle_tests.rs
+++ b/services/broker/src/shard_lifecycle_tests.rs
@@ -1,0 +1,496 @@
+//! Ownership transitions: what this broker serves, and when it stops.
+use super::*;
+
+fn key(shard: u32) -> ShardKey {
+    ShardKey {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: "orders".to_string(),
+        shard,
+    }
+}
+
+fn assigned_to(leader: &str, generation: u64) -> ShardAssignment {
+    ShardAssignment {
+        key: key(0),
+        leader: leader.to_string(),
+        replicas: Vec::new(),
+        generation,
+        state: "active".to_string(),
+    }
+}
+
+fn lifecycle() -> ShardLifecycle {
+    ShardLifecycle::new("broker-a")
+}
+
+/// The rule the whole type exists for: an assignment arriving does not mean the
+/// shard can be served. The local log has to be open first, or a write would be
+/// acknowledged against durability that is not set up.
+#[test]
+fn an_assignment_does_not_serve_until_the_log_is_open() {
+    let mut own = lifecycle();
+
+    let action = own.observe(&key(0), Some(&assigned_to("broker-a", 3)));
+    assert_eq!(
+        action,
+        Action::Open {
+            key: key(0),
+            generation: 3
+        }
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Opening);
+    assert!(!own.may_serve(&key(0)), "opening must not serve");
+
+    assert!(own.opened(&key(0), 3));
+    assert_eq!(own.phase(&key(0)), Phase::Active);
+    assert!(own.may_serve(&key(0)));
+}
+
+#[test]
+fn a_shard_assigned_elsewhere_is_never_opened() {
+    let mut own = lifecycle();
+    assert_eq!(
+        own.observe(&key(0), Some(&assigned_to("broker-b", 1))),
+        Action::None
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Unassigned);
+    assert!(!own.may_serve(&key(0)));
+}
+
+/// Every poll re-delivers the same assignment. Reopening on each would churn the
+/// log and drop service.
+#[test]
+fn repeating_the_same_assignment_does_nothing() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 3)));
+    own.opened(&key(0), 3);
+
+    for _ in 0..5 {
+        assert_eq!(
+            own.observe(&key(0), Some(&assigned_to("broker-a", 3))),
+            Action::None
+        );
+    }
+    assert_eq!(own.phase(&key(0)), Phase::Active);
+}
+
+/// A generation below the one already acted on is a duplicate, a reordered
+/// poll, or a snapshot replay -- never a reason to change state.
+#[test]
+fn an_older_generation_is_ignored() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 5)));
+    own.opened(&key(0), 5);
+
+    assert_eq!(
+        own.observe(&key(0), Some(&assigned_to("broker-a", 4))),
+        Action::None
+    );
+    assert_eq!(own.generation(&key(0)), Some(5));
+    assert!(own.may_serve_at(&key(0), 5));
+    assert!(!own.may_serve_at(&key(0), 4));
+}
+
+/// The shard was moved away and back. The local state has to be re-established,
+/// not assumed, or this broker serves a generation it does not hold.
+#[test]
+fn a_newer_generation_reopens() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.opened(&key(0), 1);
+
+    let action = own.observe(&key(0), Some(&assigned_to("broker-a", 4)));
+    assert_eq!(
+        action,
+        Action::Open {
+            key: key(0),
+            generation: 4
+        }
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Opening);
+    assert!(!own.may_serve(&key(0)), "must not serve while reopening");
+}
+
+/// Losing a shard drains before closing, so in-flight work is accounted for.
+#[test]
+fn losing_a_shard_drains_before_closing() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+    own.opened(&key(0), 2);
+
+    let action = own.observe(&key(0), Some(&assigned_to("broker-b", 3)));
+    assert_eq!(
+        action,
+        Action::Release {
+            key: key(0),
+            generation: 2
+        }
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Draining);
+    assert!(
+        !own.may_serve(&key(0)),
+        "a draining shard takes no new writes"
+    );
+
+    own.released(&key(0), 2);
+    assert_eq!(own.phase(&key(0)), Phase::Closed);
+    assert!(!own.may_serve(&key(0)));
+}
+
+/// A deleted assignment has to release the shard too, or a broker keeps serving
+/// something the cluster no longer believes exists.
+#[test]
+fn an_unassigned_shard_is_released() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+    own.opened(&key(0), 2);
+
+    let action = own.observe(&key(0), None);
+    assert_eq!(
+        action,
+        Action::Release {
+            key: key(0),
+            generation: 2
+        }
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Draining);
+}
+
+#[test]
+fn releasing_twice_is_harmless() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+    own.opened(&key(0), 2);
+    own.observe(&key(0), None);
+    own.released(&key(0), 2);
+
+    assert_eq!(own.observe(&key(0), None), Action::None);
+    assert_eq!(own.phase(&key(0)), Phase::Closed);
+}
+
+/// A shard reassigned back to us after we released it opens again.
+#[test]
+fn a_closed_shard_can_be_reacquired() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+    own.opened(&key(0), 2);
+    own.observe(&key(0), None);
+    own.released(&key(0), 2);
+
+    let action = own.observe(&key(0), Some(&assigned_to("broker-a", 6)));
+    assert_eq!(
+        action,
+        Action::Open {
+            key: key(0),
+            generation: 6
+        }
+    );
+    assert!(own.opened(&key(0), 6));
+    assert!(own.may_serve(&key(0)));
+}
+
+#[test]
+fn a_failed_open_does_not_serve() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.open_failed(&key(0), 1);
+
+    assert_eq!(own.phase(&key(0)), Phase::Failed);
+    assert!(!own.may_serve(&key(0)));
+    // Not retried on every poll: the same assignment repeating is not new
+    // information, and a failure that logs each tick buries itself.
+    assert_eq!(
+        own.observe(&key(0), Some(&assigned_to("broker-a", 1))),
+        Action::None
+    );
+}
+
+/// A changed assignment is the one thing that retries a failed open.
+#[test]
+fn a_new_generation_retries_a_failed_open() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.open_failed(&key(0), 1);
+
+    let action = own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+    assert_eq!(
+        action,
+        Action::Open {
+            key: key(0),
+            generation: 2
+        }
+    );
+}
+
+/// A failed open never served, so losing the shard closes it without a drain.
+#[test]
+fn a_failed_shard_closes_without_draining() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.open_failed(&key(0), 1);
+
+    assert_eq!(own.observe(&key(0), None), Action::None);
+    assert_eq!(own.phase(&key(0)), Phase::Closed);
+}
+
+/// The shard was reassigned while we were still recovering it. Activating now
+/// would serve a generation we no longer hold.
+#[test]
+fn an_open_that_finishes_after_a_reassignment_does_not_activate() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    // Reassigned mid-open.
+    own.observe(&key(0), Some(&assigned_to("broker-a", 2)));
+
+    assert!(
+        !own.opened(&key(0), 1),
+        "the open for generation 1 must not activate generation 2",
+    );
+    assert_eq!(own.phase(&key(0)), Phase::Opening);
+    assert!(!own.may_serve(&key(0)));
+
+    assert!(own.opened(&key(0), 2));
+    assert!(own.may_serve_at(&key(0), 2));
+}
+
+/// A snapshot replaces the whole picture, so a shard absent from it has to be
+/// released as surely as one reassigned away.
+#[test]
+fn shards_absent_from_a_snapshot_are_reported() {
+    let mut own = lifecycle();
+    for shard in 0..3 {
+        let mut assignment = assigned_to("broker-a", 1);
+        assignment.key = key(shard);
+        own.observe(&key(shard), Some(&assignment));
+        own.opened(&key(shard), 1);
+    }
+
+    let still_present = [key(0), key(2)];
+    let mut missing = own.missing_from(still_present.iter());
+    missing.sort_by_key(|k| k.shard);
+    assert_eq!(missing, vec![key(1)]);
+}
+
+#[test]
+fn a_closed_shard_is_not_reported_missing_again() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.opened(&key(0), 1);
+    own.observe(&key(0), None);
+    own.released(&key(0), 1);
+
+    assert!(own.missing_from(std::iter::empty()).is_empty());
+}
+
+#[test]
+fn active_lists_only_servable_shards() {
+    let mut own = lifecycle();
+    let mut second = assigned_to("broker-a", 1);
+    second.key = key(1);
+
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.opened(&key(0), 1);
+    own.observe(&key(1), Some(&second)); // left Opening
+
+    let active: Vec<u32> = own.active().map(|k| k.shard).collect();
+    assert_eq!(active, vec![0]);
+}
+
+#[test]
+fn phase_counts_track_the_shards_held() {
+    let mut own = lifecycle();
+    own.observe(&key(0), Some(&assigned_to("broker-a", 1)));
+    own.opened(&key(0), 1);
+    let mut second = assigned_to("broker-a", 1);
+    second.key = key(1);
+    own.observe(&key(1), Some(&second));
+
+    let counts = own.counts();
+    assert_eq!(counts.get(&Phase::Active).copied(), Some(1));
+    assert_eq!(counts.get(&Phase::Opening).copied(), Some(1));
+}
+
+/// Driving the state machine against a store, including the paths that only
+/// exist because opening and flushing can fail.
+mod driver {
+    use super::*;
+    use std::sync::Mutex as StdMutex;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingStore {
+        opened: StdMutex<Vec<ShardKey>>,
+        released: StdMutex<Vec<ShardKey>>,
+        fail_open: AtomicBool,
+        fail_release: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl ShardStore for RecordingStore {
+        async fn open(&self, key: &ShardKey) -> anyhow::Result<()> {
+            if self.fail_open.load(Ordering::Acquire) {
+                return Err(anyhow::anyhow!("injected open failure"));
+            }
+            self.opened.lock().expect("lock").push(key.clone());
+            Ok(())
+        }
+
+        async fn release(&self, key: &ShardKey) -> anyhow::Result<()> {
+            self.released.lock().expect("lock").push(key.clone());
+            if self.fail_release.load(Ordering::Acquire) {
+                return Err(anyhow::anyhow!("injected flush failure"));
+            }
+            Ok(())
+        }
+    }
+
+    fn assignments(pairs: &[(u32, &str, u64)]) -> HashMap<ShardKey, ShardAssignment> {
+        pairs
+            .iter()
+            .map(|(shard, leader, generation)| {
+                let mut assignment = assigned_to(leader, *generation);
+                assignment.key = key(*shard);
+                (key(*shard), assignment)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn reconcile_opens_only_our_shards() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+
+        reconcile(
+            &own,
+            &store,
+            &assignments(&[(0, "broker-a", 1), (1, "broker-b", 1), (2, "broker-a", 1)]),
+        )
+        .await;
+
+        let mut opened: Vec<u32> = store
+            .opened
+            .lock()
+            .expect("lock")
+            .iter()
+            .map(|k| k.shard)
+            .collect();
+        opened.sort_unstable();
+        assert_eq!(opened, vec![0, 2]);
+
+        let own = own.lock().await;
+        assert!(own.may_serve(&key(0)));
+        assert!(own.may_serve(&key(2)));
+        assert!(!own.may_serve(&key(1)));
+    }
+
+    /// A pass over unchanged assignments must not reopen anything.
+    #[tokio::test]
+    async fn reconcile_is_idempotent() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+        let current = assignments(&[(0, "broker-a", 1)]);
+
+        for _ in 0..5 {
+            reconcile(&own, &store, &current).await;
+        }
+        assert_eq!(store.opened.lock().expect("lock").len(), 1);
+    }
+
+    /// A shard that vanished from the assignment set is released, not left
+    /// being served.
+    #[tokio::test]
+    async fn a_vanished_assignment_releases_the_shard() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 1)])).await;
+        assert!(own.lock().await.may_serve(&key(0)));
+
+        reconcile(&own, &store, &HashMap::new()).await;
+
+        assert_eq!(store.released.lock().expect("lock").len(), 1);
+        let own = own.lock().await;
+        assert_eq!(own.phase(&key(0)), Phase::Closed);
+        assert!(!own.may_serve(&key(0)));
+    }
+
+    #[tokio::test]
+    async fn losing_a_shard_to_another_broker_releases_it() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 1)])).await;
+        reconcile(&own, &store, &assignments(&[(0, "broker-b", 2)])).await;
+
+        assert_eq!(store.released.lock().expect("lock").len(), 1);
+        assert!(!own.lock().await.may_serve(&key(0)));
+    }
+
+    /// An open failure must leave the shard unserved and visible, not silently
+    /// treated as owned.
+    #[tokio::test]
+    async fn a_failed_open_leaves_the_shard_unserved() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+        store.fail_open.store(true, Ordering::Release);
+
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 1)])).await;
+
+        let own = own.lock().await;
+        assert_eq!(own.phase(&key(0)), Phase::Failed);
+        assert!(!own.may_serve(&key(0)));
+    }
+
+    #[tokio::test]
+    async fn a_failed_open_recovers_on_a_new_generation() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+        store.fail_open.store(true, Ordering::Release);
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 1)])).await;
+
+        store.fail_open.store(false, Ordering::Release);
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 2)])).await;
+
+        assert!(own.lock().await.may_serve(&key(0)));
+    }
+
+    /// Ownership has moved regardless of whether the flush worked. Continuing
+    /// to serve would be worse than an unflushed tail, so the shard still
+    /// closes -- loudly.
+    #[tokio::test]
+    async fn a_failed_flush_still_gives_up_the_shard() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+        reconcile(&own, &store, &assignments(&[(0, "broker-a", 1)])).await;
+
+        store.fail_release.store(true, Ordering::Release);
+        reconcile(&own, &store, &assignments(&[(0, "broker-b", 2)])).await;
+
+        let own = own.lock().await;
+        assert_eq!(own.phase(&key(0)), Phase::Closed);
+        assert!(!own.may_serve(&key(0)));
+    }
+
+    /// Restart: a broker starting empty rebuilds ownership from the assignments
+    /// alone, opening every shard it owns before serving any of them.
+    #[tokio::test]
+    async fn a_restarted_broker_rebuilds_ownership_from_assignments() {
+        let own = Mutex::new(lifecycle());
+        let store = RecordingStore::default();
+
+        reconcile(
+            &own,
+            &store,
+            &assignments(&[(0, "broker-a", 4), (1, "broker-a", 9), (2, "broker-b", 1)]),
+        )
+        .await;
+
+        let own = own.lock().await;
+        assert!(own.may_serve_at(&key(0), 4));
+        assert!(own.may_serve_at(&key(1), 9));
+        assert!(!own.may_serve(&key(2)));
+        assert_eq!(own.active().count(), 2);
+    }
+}


### PR DESCRIPTION
Closes #101. **M3.4.**

## Why this is a separate thing from the watch

#100 tells a broker who *should* own each shard. This is what the broker has actually **done** about it — and those differ, because becoming an owner is not instant. The durable log has to be opened and recovered first, and a broker serving writes in that window would acknowledge records it cannot yet persist.

So ownership is two-phase in both directions:

```
unassigned -> opening -> active -> draining -> closed
                  |
                  +-> failed
```

A shard serves **only** in `active`, and only at the generation the control plane currently names. `opening` exists precisely so "an assignment arrived" and "the shard is servable" are not the same event — that's the acceptance criterion about not acknowledging writes before durable state is ready.

## The rules that are easy to get wrong

Each has a test:

- **An older generation is ignored** — a duplicate delivery, reordered poll, or snapshot replay is not news.
- **A newer generation reopens** rather than assuming local state still matches. The shard was moved away and back.
- **An open that finishes after a reassignment does not activate.** The shard moved on while it was being recovered; activating now would serve a generation we no longer hold.
- **A failed open is not retried by the same assignment arriving again.** Every poll re-delivers it; retrying each time buries the failure in noise while hammering a log that isn't opening. A *new generation* is what retries. **This one my own test caught** — my first cut retried unconditionally.
- **A vanished assignment releases the shard**, exactly like one reassigned away. A snapshot replaces the whole picture, so only the full set can say what disappeared.
- **A failed flush still gives up the shard.** Ownership has moved regardless, and continuing to serve is worse than an unflushed tail — logged as an error, not swallowed.

## Shape

Decision and I/O are split the same way placement is: a pure state machine plus a driver over a `ShardStore` trait. Every rule above is testable without a disk, and `DurableShardStore` is the thin real implementation — `open_stream` to recover, `sync` to flush before giving up.

I did *not* add a per-shard flush: `StreamLog::sync` already existed. I'd written a duplicate and the compiler caught it.

## Tests

25 tests — 17 on the state machine, 8 driving it against a recording store with injectable open and flush failures, including restart rebuilding ownership from assignments alone.

## Verification

`task lint`, `task test` (66 suites), `task deny`, `task demo:check`, and mermaid — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)