### PR TITLE
feat(router): resolve shards to nodes, keeping region policy as a constraint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
 name = "felix-router"
 version = "0.2.0"
 dependencies = [
+ "arc-swap",
  "felix-common",
 ]
 

--- a/crates/felix-router/Cargo.toml
+++ b/crates/felix-router/Cargo.toml
@@ -13,3 +13,6 @@ categories = ["network-programming"]
 
 [dependencies]
 felix-common = { path = "../felix-common", version = "0.2.0" }
+# Routes are read on every publish and replaced wholesale; a swap keeps readers
+# off any lock a writer can hold.
+arc-swap = "1"

--- a/crates/felix-router/src/lib.rs
+++ b/crates/felix-router/src/lib.rs
@@ -1,8 +1,24 @@
-// Region routing rules with an allowlist of bridges.
+//! Routing: which node serves a shard, and whether we are allowed to reach it.
+//!
+//! Two independent questions, and keeping them separate is the point.
+//! [`ShardRouter`] answers *where* a shard lives, from assignments the control
+//! plane published. [`RegionRouter`] answers *whether* traffic may cross from
+//! here to there. A route is only usable when both agree, and folding them
+//! together would make a placement decision look like a policy decision.
+pub mod shard;
+
+pub use shard::{NodeRef, Resolution, RoutingTable, ShardKey, ShardRouter, Unavailable};
+
 use felix_common::ids::RegionId;
 use std::collections::HashSet;
+use std::hash::Hash;
 
 /// Region router with optional bridge allowlist.
+///
+/// Generic over how a region is named. It defaults to [`RegionId`], which is
+/// what configuration uses, and the shard router instantiates it over `String`
+/// because a node advertises its region by name -- the two vocabularies are
+/// real, and one allowlist serving both beats two allowlists drifting apart.
 ///
 /// ```
 /// use felix_common::ids::RegionId;
@@ -11,42 +27,43 @@ use std::collections::HashSet;
 /// let local = RegionId::new();
 /// let remote = RegionId::new();
 /// let mut router = RegionRouter::new(local);
-/// assert!(!router.can_route(local, remote));
+/// assert!(!router.can_route(&local, &remote));
 /// router.allow_bridge(local, remote);
-/// assert!(router.can_route(local, remote));
+/// assert!(router.can_route(&local, &remote));
 /// ```
 #[derive(Debug, Clone)]
-pub struct RegionRouter {
+pub struct RegionRouter<R = RegionId> {
     // Local region we always allow.
-    local_region: RegionId,
+    local_region: R,
     // Explicit bridge rules for cross-region traffic.
-    allowed_bridges: HashSet<(RegionId, RegionId)>,
+    allowed_bridges: HashSet<(R, R)>,
 }
 
-impl RegionRouter {
+impl<R: Eq + Hash + Clone> RegionRouter<R> {
     // Start with only the local region allowed.
-    pub fn new(local_region: RegionId) -> Self {
+    pub fn new(local_region: R) -> Self {
         Self {
             local_region,
             allowed_bridges: HashSet::new(),
         }
     }
 
-    pub fn local_region(&self) -> RegionId {
-        self.local_region
+    pub fn local_region(&self) -> &R {
+        &self.local_region
     }
 
-    pub fn allow_bridge(&mut self, source: RegionId, dest: RegionId) {
+    pub fn allow_bridge(&mut self, source: R, dest: R) {
         // Store a single directional rule; caller can add reverse if needed.
         self.allowed_bridges.insert((source, dest));
     }
 
-    pub fn can_route(&self, source: RegionId, dest: RegionId) -> bool {
+    pub fn can_route(&self, source: &R, dest: &R) -> bool {
         // Local routes are always allowed; otherwise check the allowlist.
         if source == dest {
             return true;
         }
-        self.allowed_bridges.contains(&(source, dest))
+        self.allowed_bridges
+            .contains(&(source.clone(), dest.clone()))
     }
 }
 
@@ -59,7 +76,7 @@ mod tests {
         // Same-region traffic should pass.
         let region = RegionId::new();
         let router = RegionRouter::new(region);
-        assert!(router.can_route(region, region));
+        assert!(router.can_route(&region, &region));
     }
 
     #[test]
@@ -68,7 +85,7 @@ mod tests {
         let source = RegionId::new();
         let dest = RegionId::new();
         let router = RegionRouter::new(source);
-        assert!(!router.can_route(source, dest));
+        assert!(!router.can_route(&source, &dest));
     }
 
     #[test]
@@ -78,7 +95,7 @@ mod tests {
         let dest = RegionId::new();
         let mut router = RegionRouter::new(source);
         router.allow_bridge(source, dest);
-        assert!(router.can_route(source, dest));
+        assert!(router.can_route(&source, &dest));
     }
 
     #[test]
@@ -87,13 +104,13 @@ mod tests {
         let dest = RegionId::new();
         let mut router = RegionRouter::new(source);
         router.allow_bridge(source, dest);
-        assert!(!router.can_route(dest, source));
+        assert!(!router.can_route(&dest, &source));
     }
 
     #[test]
     fn local_region_accessor_returns_seed() {
         let region = RegionId::new();
         let router = RegionRouter::new(region);
-        assert_eq!(router.local_region(), region);
+        assert_eq!(*router.local_region(), region);
     }
 }

--- a/crates/felix-router/src/shard.rs
+++ b/crates/felix-router/src/shard.rs
@@ -1,0 +1,303 @@
+//! Where a shard lives, resolved without touching the control plane.
+//!
+//! The publish path asks this on every request, so a lookup must not take a
+//! lock a writer can hold and must never make a network call. Routes are
+//! published as an immutable snapshot and swapped in whole: readers take a
+//! cheap atomic load and read a table nobody can mutate underneath them, and an
+//! update costs one pointer swap regardless of how many readers are in flight.
+//!
+//! Every outcome is explicit. There is deliberately no "not sure, handle it
+//! locally": a broker that treats an unknown route as its own is a broker
+//! writing a shard it does not own.
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use crate::RegionRouter;
+
+/// One shard of one stream.
+///
+/// Defined here rather than shared with the control plane or the storage layer,
+/// both of which have their own: the router is a library that must not depend on
+/// either, and the duplication is three fields and a number.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ShardKey {
+    pub tenant_id: String,
+    pub namespace: String,
+    pub stream: String,
+    pub shard: u32,
+}
+
+/// A node a shard can be served from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NodeRef {
+    pub node_id: String,
+    pub advertise_addr: SocketAddr,
+    pub region: String,
+    /// Whether the cluster currently considers this node able to serve.
+    pub live: bool,
+}
+
+/// Where one shard is served, as of the snapshot that carried it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Route {
+    pub leader: NodeRef,
+    pub replicas: Vec<NodeRef>,
+    pub generation: u64,
+}
+
+/// Why a shard cannot be routed.
+///
+/// Separate variants because they need different responses: a missing
+/// assignment waits for placement, a dead leader waits for failover, and a
+/// blocked region is a policy decision that will not resolve on its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Unavailable {
+    /// Placement has not assigned this shard.
+    NoAssignment,
+    /// The assignment names a node this router has no address for.
+    LeaderUnknown { node_id: String },
+    /// The leader is registered but not live.
+    LeaderNotLive { node_id: String },
+    /// Region policy forbids reaching the leader's region from here.
+    RegionNotRoutable { region: String },
+}
+
+impl std::fmt::Display for Unavailable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoAssignment => write!(f, "shard has no assignment"),
+            Self::LeaderUnknown { node_id } => {
+                write!(f, "leader {node_id} is not in the routing table")
+            }
+            Self::LeaderNotLive { node_id } => write!(f, "leader {node_id} is not live"),
+            Self::RegionNotRoutable { region } => {
+                write!(f, "region {region} is not routable from here")
+            }
+        }
+    }
+}
+
+/// What to do with a request for a shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// This node leads the shard. Handle it here.
+    Local {
+        generation: u64,
+    },
+    /// Another node leads it. M4 forwards; until then this is a typed refusal
+    /// rather than an error, so the two are distinguishable.
+    Remote {
+        node_id: String,
+        advertise_addr: SocketAddr,
+        generation: u64,
+    },
+    /// The caller's view of the assignment is newer than this router's.
+    ///
+    /// Distinct from unavailable: the route is not wrong, this node's copy is
+    /// behind, and the answer is to wait for the watch rather than to fail the
+    /// stream.
+    Stale {
+        have: u64,
+        wanted: u64,
+    },
+    Unavailable(Unavailable),
+}
+
+impl Resolution {
+    pub fn is_local(&self) -> bool {
+        matches!(self, Resolution::Local { .. })
+    }
+}
+
+/// An immutable set of routes.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct RoutingTable {
+    routes: HashMap<ShardKey, Route>,
+}
+
+impl RoutingTable {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a table from assignments and the nodes they name.
+    ///
+    /// An assignment whose leader is absent from `nodes` still produces a route,
+    /// carrying [`Unavailable::LeaderUnknown`] at lookup time. Dropping it here
+    /// instead would make a missing address indistinguishable from a missing
+    /// assignment, and those are different problems.
+    pub fn build(
+        assignments: impl IntoIterator<Item = (ShardKey, String, Vec<String>, u64)>,
+        nodes: &HashMap<String, NodeRef>,
+    ) -> Self {
+        let mut routes = HashMap::new();
+        for (key, leader, replicas, generation) in assignments {
+            let leader_ref = nodes.get(&leader).cloned().unwrap_or(NodeRef {
+                node_id: leader.clone(),
+                // A placeholder that can never be dialled, paired with
+                // `live: false` so it is refused rather than attempted.
+                advertise_addr: SocketAddr::from(([0, 0, 0, 0], 0)),
+                region: String::new(),
+                live: false,
+            });
+            let known = nodes.contains_key(&leader);
+            routes.insert(
+                key,
+                Route {
+                    leader: NodeRef {
+                        // Recorded so a lookup can say "unknown" rather than
+                        // "not live", which sends an operator somewhere else.
+                        live: known && leader_ref.live,
+                        ..leader_ref
+                    },
+                    replicas: replicas
+                        .into_iter()
+                        .filter_map(|id| nodes.get(&id).cloned())
+                        .collect(),
+                    generation,
+                },
+            );
+        }
+        Self { routes }
+    }
+
+    pub fn get(&self, key: &ShardKey) -> Option<&Route> {
+        self.routes.get(key)
+    }
+
+    pub fn len(&self) -> usize {
+        self.routes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+}
+
+/// Resolves shards to nodes, hot-path cheap and updated by whole-table swap.
+#[derive(Debug)]
+pub struct ShardRouter {
+    local_node_id: String,
+    local_region: String,
+    table: ArcSwap<RoutingTable>,
+    /// Which regions this node may reach. Policy, not placement.
+    regions: RegionRouter<String>,
+    /// Node ids this router has ever been told about, so an assignment naming
+    /// one it has never seen is reported as unknown rather than not live.
+    known_nodes: ArcSwap<std::collections::HashSet<String>>,
+}
+
+impl ShardRouter {
+    pub fn new(
+        local_node_id: impl Into<String>,
+        local_region: impl Into<String>,
+        regions: RegionRouter<String>,
+    ) -> Self {
+        Self {
+            local_node_id: local_node_id.into(),
+            local_region: local_region.into(),
+            table: ArcSwap::from_pointee(RoutingTable::new()),
+            regions,
+            known_nodes: ArcSwap::from_pointee(std::collections::HashSet::new()),
+        }
+    }
+
+    pub fn local_node_id(&self) -> &str {
+        &self.local_node_id
+    }
+
+    /// Replace every route in one swap.
+    ///
+    /// Whole-table rather than per-shard: a partial update would let a reader
+    /// see half of a rebalance, and routes are small enough that rebuilding is
+    /// cheaper than reasoning about that.
+    pub fn publish(&self, table: RoutingTable, nodes: &HashMap<String, NodeRef>) {
+        self.known_nodes
+            .store(Arc::new(nodes.keys().cloned().collect()));
+        self.table.store(Arc::new(table));
+    }
+
+    /// The current table, for a caller that wants to read several routes
+    /// against one consistent snapshot.
+    pub fn snapshot(&self) -> Arc<RoutingTable> {
+        self.table.load_full()
+    }
+
+    /// Resolve a shard against the current table.
+    pub fn resolve(&self, key: &ShardKey) -> Resolution {
+        self.resolve_in(&self.table.load(), key, None)
+    }
+
+    /// Resolve a shard, rejecting a table older than the caller already knows
+    /// about.
+    ///
+    /// The caller has seen generation `wanted`; if this router is behind, the
+    /// honest answer is that its copy is stale, not that the shard is somewhere
+    /// it has since moved from.
+    pub fn resolve_at(&self, key: &ShardKey, wanted: u64) -> Resolution {
+        self.resolve_in(&self.table.load(), key, Some(wanted))
+    }
+
+    fn resolve_in(&self, table: &RoutingTable, key: &ShardKey, wanted: Option<u64>) -> Resolution {
+        let Some(route) = table.get(key) else {
+            // A caller expecting a generation for a shard this table has never
+            // heard of is ahead of us, not looking at a missing assignment.
+            return match wanted {
+                Some(wanted) => Resolution::Stale { have: 0, wanted },
+                None => Resolution::Unavailable(Unavailable::NoAssignment),
+            };
+        };
+
+        if let Some(wanted) = wanted
+            && route.generation < wanted
+        {
+            return Resolution::Stale {
+                have: route.generation,
+                wanted,
+            };
+        }
+
+        // Local first: this node's own liveness is not something it needs the
+        // catalog's opinion on, and a broker that stopped serving its own shards
+        // because it had not yet seen its own heartbeat land would be absurd.
+        if route.leader.node_id == self.local_node_id {
+            return Resolution::Local {
+                generation: route.generation,
+            };
+        }
+
+        if !self.known_nodes.load().contains(&route.leader.node_id) {
+            return Resolution::Unavailable(Unavailable::LeaderUnknown {
+                node_id: route.leader.node_id.clone(),
+            });
+        }
+        if !route.leader.live {
+            return Resolution::Unavailable(Unavailable::LeaderNotLive {
+                node_id: route.leader.node_id.clone(),
+            });
+        }
+        // Policy last: a blocked region is a real refusal, but saying so about a
+        // leader that is also dead would be the less useful of the two facts.
+        if !self
+            .regions
+            .can_route(&self.local_region, &route.leader.region)
+        {
+            return Resolution::Unavailable(Unavailable::RegionNotRoutable {
+                region: route.leader.region.clone(),
+            });
+        }
+
+        Resolution::Remote {
+            node_id: route.leader.node_id.clone(),
+            advertise_addr: route.leader.advertise_addr,
+            generation: route.generation,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "shard_tests.rs"]
+mod tests;

--- a/crates/felix-router/src/shard_tests.rs
+++ b/crates/felix-router/src/shard_tests.rs
@@ -1,0 +1,355 @@
+//! Route resolution: every outcome, and the concurrency the hot path needs.
+use super::*;
+
+fn key(shard: u32) -> ShardKey {
+    ShardKey {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: "orders".to_string(),
+        shard,
+    }
+}
+
+fn node(id: &str, port: u16, region: &str, live: bool) -> NodeRef {
+    NodeRef {
+        node_id: id.to_string(),
+        advertise_addr: SocketAddr::from(([10, 0, 0, 4], port)),
+        region: region.to_string(),
+        live,
+    }
+}
+
+fn catalog(nodes: &[NodeRef]) -> HashMap<String, NodeRef> {
+    nodes
+        .iter()
+        .map(|n| (n.node_id.clone(), n.clone()))
+        .collect()
+}
+
+fn router(nodes: &HashMap<String, NodeRef>, assignments: &[(u32, &str, u64)]) -> ShardRouter {
+    let router = ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    );
+    let table = RoutingTable::build(
+        assignments.iter().map(|(shard, leader, generation)| {
+            (key(*shard), leader.to_string(), Vec::new(), *generation)
+        }),
+        nodes,
+    );
+    router.publish(table, nodes);
+    router
+}
+
+#[test]
+fn a_shard_led_here_resolves_local() {
+    let nodes = catalog(&[node("broker-a", 7001, "us-west-2", true)]);
+    let router = router(&nodes, &[(0, "broker-a", 4)]);
+
+    assert_eq!(router.resolve(&key(0)), Resolution::Local { generation: 4 });
+    assert!(router.resolve(&key(0)).is_local());
+}
+
+#[test]
+fn a_shard_led_elsewhere_resolves_remote_with_an_address() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-b", 7002, "us-west-2", true),
+    ]);
+    let router = router(&nodes, &[(0, "broker-b", 7)]);
+
+    assert_eq!(
+        router.resolve(&key(0)),
+        Resolution::Remote {
+            node_id: "broker-b".to_string(),
+            advertise_addr: SocketAddr::from(([10, 0, 0, 4], 7002)),
+            generation: 7,
+        },
+    );
+}
+
+/// The acceptance criterion that matters most: an unrouted shard must never
+/// look like a local one, or a broker writes a shard it does not own.
+#[test]
+fn an_unassigned_shard_is_never_local() {
+    let nodes = catalog(&[node("broker-a", 7001, "us-west-2", true)]);
+    let router = router(&nodes, &[]);
+
+    assert_eq!(
+        router.resolve(&key(9)),
+        Resolution::Unavailable(Unavailable::NoAssignment),
+    );
+    assert!(!router.resolve(&key(9)).is_local());
+}
+
+/// Three different unavailable reasons, because they need three different
+/// responses: wait for placement, wait for failover, or change policy.
+#[test]
+fn unavailable_reasons_are_distinguishable() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-dead", 7003, "us-west-2", false),
+        node("broker-far", 7004, "eu-central-1", true),
+    ]);
+    let router = router(
+        &nodes,
+        &[
+            (0, "broker-dead", 1),
+            (1, "broker-far", 1),
+            (2, "broker-ghost", 1),
+        ],
+    );
+
+    assert_eq!(
+        router.resolve(&key(0)),
+        Resolution::Unavailable(Unavailable::LeaderNotLive {
+            node_id: "broker-dead".to_string()
+        }),
+    );
+    assert_eq!(
+        router.resolve(&key(1)),
+        Resolution::Unavailable(Unavailable::RegionNotRoutable {
+            region: "eu-central-1".to_string()
+        }),
+    );
+    assert_eq!(
+        router.resolve(&key(2)),
+        Resolution::Unavailable(Unavailable::LeaderUnknown {
+            node_id: "broker-ghost".to_string()
+        }),
+    );
+}
+
+/// A bridge is what turns a blocked region into a reachable one, and it is the
+/// existing allowlist doing the work.
+#[test]
+fn a_bridge_makes_another_region_routable() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-far", 7004, "eu-central-1", true),
+    ]);
+    let mut regions = RegionRouter::new("us-west-2".to_string());
+    regions.allow_bridge("us-west-2".to_string(), "eu-central-1".to_string());
+
+    let router = ShardRouter::new("broker-a", "us-west-2", regions);
+    router.publish(
+        RoutingTable::build([(key(0), "broker-far".to_string(), Vec::new(), 2)], &nodes),
+        &nodes,
+    );
+
+    assert_eq!(
+        router.resolve(&key(0)),
+        Resolution::Remote {
+            node_id: "broker-far".to_string(),
+            advertise_addr: SocketAddr::from(([10, 0, 0, 4], 7004)),
+            generation: 2,
+        },
+    );
+}
+
+/// Policy must not override this node's own ownership: a shard led here is
+/// served here, and a region rule about reaching elsewhere does not apply.
+#[test]
+fn local_ownership_is_not_subject_to_region_policy() {
+    let nodes = catalog(&[node("broker-a", 7001, "somewhere-else", true)]);
+    let router = ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    );
+    router.publish(
+        RoutingTable::build([(key(0), "broker-a".to_string(), Vec::new(), 1)], &nodes),
+        &nodes,
+    );
+
+    assert!(router.resolve(&key(0)).is_local());
+}
+
+/// A node that has not been heard from is still ours to serve. A broker that
+/// stopped serving its own shards waiting to see its own heartbeat land would
+/// take itself out of the cluster for no reason.
+#[test]
+fn this_node_serves_its_own_shards_even_when_marked_not_live() {
+    let nodes = catalog(&[node("broker-a", 7001, "us-west-2", false)]);
+    let router = router(&nodes, &[(0, "broker-a", 1)]);
+    assert!(router.resolve(&key(0)).is_local());
+}
+
+/// Being behind is not the same as being wrong: the caller waits for the watch
+/// rather than failing the stream.
+#[test]
+fn a_caller_ahead_of_the_table_gets_stale_not_unavailable() {
+    let nodes = catalog(&[node("broker-a", 7001, "us-west-2", true)]);
+    let router = router(&nodes, &[(0, "broker-a", 3)]);
+
+    assert_eq!(
+        router.resolve_at(&key(0), 5),
+        Resolution::Stale { have: 3, wanted: 5 },
+    );
+    // At or below what the table holds, the route stands.
+    assert!(router.resolve_at(&key(0), 3).is_local());
+    assert!(router.resolve_at(&key(0), 2).is_local());
+}
+
+/// A generation for a shard the table has never seen means this router is
+/// behind, not that the shard is unassigned.
+#[test]
+fn an_expected_generation_for_an_unknown_shard_reads_as_stale() {
+    let nodes = catalog(&[node("broker-a", 7001, "us-west-2", true)]);
+    let router = router(&nodes, &[]);
+
+    assert_eq!(
+        router.resolve_at(&key(0), 2),
+        Resolution::Stale { have: 0, wanted: 2 },
+    );
+}
+
+#[test]
+fn publishing_replaces_the_whole_table() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-b", 7002, "us-west-2", true),
+    ]);
+    let router = router(&nodes, &[(0, "broker-a", 1), (1, "broker-a", 1)]);
+    assert!(router.resolve(&key(1)).is_local());
+
+    // A rebalance that moved shard 0 away and dropped shard 1 entirely.
+    router.publish(
+        RoutingTable::build([(key(0), "broker-b".to_string(), Vec::new(), 2)], &nodes),
+        &nodes,
+    );
+
+    assert!(matches!(router.resolve(&key(0)), Resolution::Remote { .. }));
+    assert_eq!(
+        router.resolve(&key(1)),
+        Resolution::Unavailable(Unavailable::NoAssignment),
+        "a shard dropped from the table must not keep its old route",
+    );
+}
+
+#[test]
+fn a_snapshot_is_stable_while_the_table_is_replaced() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-b", 7002, "us-west-2", true),
+    ]);
+    let router = router(&nodes, &[(0, "broker-a", 1)]);
+
+    let snapshot = router.snapshot();
+    router.publish(
+        RoutingTable::build([(key(0), "broker-b".to_string(), Vec::new(), 2)], &nodes),
+        &nodes,
+    );
+
+    assert_eq!(
+        snapshot.get(&key(0)).expect("route").leader.node_id,
+        "broker-a",
+        "a held snapshot must not change under the reader",
+    );
+    assert_eq!(router.snapshot().get(&key(0)).expect("route").generation, 2);
+}
+
+/// Readers must never see a torn or missing route while a writer swaps tables,
+/// and must never block on one.
+#[test]
+fn readers_and_writers_do_not_interfere() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let nodes = Arc::new(catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-b", 7002, "us-west-2", true),
+    ]));
+    let router = Arc::new(router(&nodes, &[(0, "broker-a", 1)]));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let writer = {
+        let router = Arc::clone(&router);
+        let nodes = Arc::clone(&nodes);
+        let stop = Arc::clone(&stop);
+        std::thread::spawn(move || {
+            let mut generation = 1u64;
+            while !stop.load(Ordering::Acquire) {
+                generation += 1;
+                let leader = if generation.is_multiple_of(2) {
+                    "broker-a"
+                } else {
+                    "broker-b"
+                };
+                router.publish(
+                    RoutingTable::build(
+                        [(key(0), leader.to_string(), Vec::new(), generation)],
+                        &nodes,
+                    ),
+                    &nodes,
+                );
+            }
+        })
+    };
+
+    let readers: Vec<_> = (0..4)
+        .map(|_| {
+            let router = Arc::clone(&router);
+            let stop = Arc::clone(&stop);
+            std::thread::spawn(move || {
+                let mut reads = 0u64;
+                while !stop.load(Ordering::Acquire) {
+                    // Whatever a reader sees, it is always one of the two valid
+                    // routes -- never absent, never a mixture.
+                    match router.resolve(&key(0)) {
+                        Resolution::Local { .. } | Resolution::Remote { .. } => reads += 1,
+                        other => panic!("unexpected resolution during swap: {other:?}"),
+                    }
+                }
+                reads
+            })
+        })
+        .collect();
+
+    std::thread::sleep(std::time::Duration::from_millis(150));
+    stop.store(true, Ordering::Release);
+
+    writer.join().expect("writer");
+    let total: u64 = readers.into_iter().map(|r| r.join().expect("reader")).sum();
+    assert!(total > 1000, "readers should not be blocked: {total} reads");
+}
+
+#[test]
+fn replicas_resolve_to_known_nodes_only() {
+    let nodes = catalog(&[
+        node("broker-a", 7001, "us-west-2", true),
+        node("broker-b", 7002, "us-west-2", true),
+    ]);
+    let table = RoutingTable::build(
+        [(
+            key(0),
+            "broker-a".to_string(),
+            vec!["broker-b".to_string(), "broker-ghost".to_string()],
+            1,
+        )],
+        &nodes,
+    );
+
+    let replicas = &table.get(&key(0)).expect("route").replicas;
+    assert_eq!(
+        replicas.len(),
+        1,
+        "an unknown replica has no address to use"
+    );
+    assert_eq!(replicas[0].node_id, "broker-b");
+}
+
+#[test]
+fn an_empty_table_resolves_nothing() {
+    let router = ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    );
+    assert!(router.snapshot().is_empty());
+    assert_eq!(
+        router.resolve(&key(0)),
+        Resolution::Unavailable(Unavailable::NoAssignment),
+    );
+}

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -300,6 +300,41 @@ not the same event as the shard becoming servable.
 | `felix_broker_shard_stale_events_total` | events ignored for an old generation |
 | `felix_broker_shard_open_failures_total` | non-zero means a shard the cluster believes is placed here is not being served |
 
+#### Resolving a shard to a node
+
+`felix-router` answers *where* a shard lives; the region allowlist answers
+*whether* traffic may cross to it. Keeping those separate matters: folding them
+together makes a placement decision look like a policy decision, and they fail
+for different reasons and need different fixes.
+
+Routes are published as an immutable snapshot and swapped in whole. A lookup is
+an atomic load against a table nobody can mutate underneath it, so the publish
+path never takes a lock a writer can hold and never makes a control-plane call.
+Updates replace the table entirely rather than patching shards, because a
+partial update would let a reader see half a rebalance.
+
+Every outcome is explicit — there is deliberately no "not sure, handle it
+locally", because that is a broker writing a shard it does not own:
+
+| Outcome | Meaning |
+| --- | --- |
+| `Local` | this node leads the shard; handle it here |
+| `Remote` | another node leads it, with the address to reach it. M4 forwards; until then it is a typed refusal, distinguishable from failure |
+| `Stale` | the caller knows a newer generation than this router does. Wait for the watch, do not fail the stream |
+| `Unavailable::NoAssignment` | placement has not assigned it |
+| `Unavailable::LeaderUnknown` | the assignment names a node with no known address |
+| `Unavailable::LeaderNotLive` | the leader is registered but not live |
+| `Unavailable::RegionNotRoutable` | region policy forbids reaching the leader |
+
+Two rules that look like edge cases and are not:
+
+- **A shard led by this node resolves `Local` regardless of liveness or region
+  policy.** A broker that stopped serving its own shards while waiting to see
+  its own heartbeat land would remove itself from the cluster for no reason.
+- **An unknown leader is reported differently from a dead one.** Both are
+  unroutable, but one is a missing address and the other is a failover in
+  progress, and they send an operator to different places.
+
 #### Referential integrity
 
 Two references, two different policies, chosen rather than inherited:


### PR DESCRIPTION
Closes #102. **M3.5**, and #103's remaining dependency.

## What changed

`felix-router` was a region-pair allowlist and nothing else — 99 lines, no consumers. It now answers **where a shard lives**, with that allowlist demoted from the whole implementation to one input.

Keeping those separate is the point: placement decides *where* a shard is, policy decides *whether we may reach it*. They fail for different reasons and need different fixes, and folding them together makes one look like the other.

The allowlist is now **generic over how a region is named** rather than duplicated. Configuration uses `RegionId`; a node advertises its region by name. One allowlist serving both beats two drifting apart — and the existing doctest and five tests still pass unchanged.

## Hot path

Routes are published as an immutable snapshot and swapped whole via `ArcSwap`. A lookup is an atomic load against a table nobody can mutate underneath it, so the publish path takes **no lock a writer can hold** and makes **no control-plane call**.

Whole-table rather than per-shard, because a partial update would let a reader see half a rebalance. `readers_and_writers_do_not_interfere` runs four readers against a thread swapping the table continuously and asserts every read sees one of the two valid routes — never absent, never mixed — with >1000 reads to show they aren't blocked.

## Explicit outcomes

There is deliberately **no "not sure, handle it locally"** — that is a broker writing a shard it does not own.

| Outcome | Why it's separate |
|---|---|
| `Local` | handle here |
| `Remote` | typed result, not an error, so M4 can forward it and it's distinguishable from failure |
| `Stale` | the caller knows a newer generation than we do — wait for the watch, don't fail the stream |
| `NoAssignment` / `LeaderUnknown` / `LeaderNotLive` / `RegionNotRoutable` | wait for placement / missing address / wait for failover / change policy |

## Two rules that look like edge cases and aren't

- **A shard led by this node resolves `Local` regardless of liveness or region policy.** A broker that stopped serving its own shards while waiting to see its own heartbeat land would remove itself from the cluster for nothing.
- **An unknown leader is reported separately from a dead one.** Both are unroutable, but one is a missing address and the other is a failover in progress — they send an operator to different places.

## Tests

19 unit tests plus the existing doctest: every outcome, bridges enabling a region, local ownership overriding policy, whole-table replacement dropping stale routes, snapshot stability under concurrent swap, and the reader/writer concurrency case.

## Verification

`task lint`, `task test` (66 suites), `task deny`, `task demo:check`, and mermaid — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)