### PR TITLE
feat(broker): route publishes through shard ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "felix-broker",
  "felix-client",
  "felix-common",
+ "felix-router",
  "felix-storage",
  "felix-transport",
  "felix-wire",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "felix-broker",
  "felix-client",
  "felix-common",
+ "felix-router",
  "felix-storage",
  "felix-transport",
  "felix-wire",
@@ -955,6 +956,14 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "felix-router"
+version = "0.2.0"
+dependencies = [
+ "arc-swap",
+ "felix-common",
 ]
 
 [[package]]

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -266,6 +266,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "felix-broker",
  "felix-client",
  "felix-common",
+ "felix-router",
  "felix-storage",
  "felix-transport",
  "felix-wire",
@@ -955,6 +956,14 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "felix-router"
+version = "0.2.0"
+dependencies = [
+ "arc-swap",
+ "felix-common",
 ]
 
 [[package]]

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -266,6 +266,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "felix-broker",
  "felix-client",
  "felix-common",
+ "felix-router",
  "felix-storage",
  "felix-transport",
  "felix-wire",
@@ -980,6 +981,14 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "felix-router"
+version = "0.2.0"
+dependencies = [
+ "arc-swap",
+ "felix-common",
 ]
 
 [[package]]

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -279,6 +279,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "felix-broker",
  "felix-client",
  "felix-common",
+ "felix-router",
  "felix-storage",
  "felix-transport",
  "felix-wire",
@@ -980,6 +981,14 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "felix-router"
+version = "0.2.0"
+dependencies = [
+ "arc-swap",
+ "felix-common",
 ]
 
 [[package]]

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -279,6 +279,7 @@ name = "broker"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.23.1",

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -335,6 +335,36 @@ Two rules that look like edge cases and are not:
   unroutable, but one is a missing address and the other is a failover in
   progress, and they send an operator to different places.
 
+#### The ingress gate
+
+Every publish passes through `resolve_stream_cached`, which is why the ownership
+check lives there: nothing reaches storage without it.
+
+Ownership is checked **outside** the stream-handle cache. That cache exists to
+avoid a registry lookup and holds for a TTL; ownership changes the instant the
+control plane says so, and caching it would keep a broker serving a reassigned
+shard for up to a TTL. The check is two atomic loads, so paying it per publish
+costs less than reasoning about staleness.
+
+Both reads are `ArcSwap` loads, so the resolver is synchronous and allocation
+free — no lock a writer can hold, and no await added to the publish path. A
+single-node broker short-circuits on a null check before either.
+
+One task keeps the two views in step, in a fixed order: reconcile local shard
+state, publish what is servable, then publish the routes. Publishing routes
+first would advertise this node as the owner of a shard it has not opened.
+
+**A broker cannot forward yet.** Building an address book needs `/v1/nodes`,
+which requires a cluster-scoped token, and brokers have no credentials (#126).
+So a shard led by this node resolves on the node id alone, and every other shard
+is refused with the owner named rather than forwarded. Forwarding is M4.
+
+**Sharding is not reachable from the wire.** `Publish` carries no routing key,
+so every record of a stream lands on shard 0 and a stream's configured `shards`
+count is metadata the data path does not use. `shard_for` is where a negotiated
+key plugs in; the hashing is written and tested, so adding the field is a wire
+change rather than a routing change.
+
 #### Referential integrity
 
 Two references, two different policies, chosen rather than inherited:

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -52,6 +52,7 @@ anyhow = { workspace = true }
 # async methods need boxing.
 async-trait = "0.1"
 felix-router = { path = "../../crates/felix-router", version = "0.2.0" }
+arc-swap = "1"
 base64 = "0.23"
 felix-broker = { path = "../../crates/felix-broker", version = "0.2.0" }
 felix-common = { path = "../../crates/felix-common", version = "0.2.0", features = ["lifecycle"] }

--- a/services/broker/Cargo.toml
+++ b/services/broker/Cargo.toml
@@ -51,6 +51,7 @@ anyhow = { workspace = true }
 # The shard lifecycle drives local state through a trait object, so its two
 # async methods need boxing.
 async-trait = "0.1"
+felix-router = { path = "../../crates/felix-router", version = "0.2.0" }
 base64 = "0.23"
 felix-broker = { path = "../../crates/felix-broker", version = "0.2.0" }
 felix-common = { path = "../../crates/felix-common", version = "0.2.0", features = ["lifecycle"] }

--- a/services/broker/src/bin/soak/main.rs
+++ b/services/broker/src/bin/soak/main.rs
@@ -277,6 +277,8 @@ async fn start_broker(auth: &AuthFixture) -> Result<BrokerHarness> {
                 auth,
                 accept_shutdown,
                 connections,
+                // The soak harness is a single-node broker.
+                None,
             )
             .await
             {

--- a/services/broker/src/durable_config.rs
+++ b/services/broker/src/durable_config.rs
@@ -162,6 +162,7 @@ fn parse_bool_env(name: &str) -> Result<Option<bool>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     /// The environment is process-global, so these tests take a lock and clean
     /// up after themselves rather than running in parallel against each other.
@@ -179,6 +180,10 @@ mod tests {
         "FELIX_DURABLE_REPAIR_CHECKSUM_TAIL",
     ];
 
+    /// Every caller is `#[serial]`, which is what actually keeps these apart
+    /// from the `config` tests: those clear every `FELIX_*` variable, including
+    /// the ones set here, and a local lock cannot exclude a test that does not
+    /// take it. The lock below is kept as a second belt for direct callers.
     fn with_env<T>(pairs: &[(&str, &str)], body: impl FnOnce() -> T) -> T {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|err| err.into_inner());
         for name in VARS {
@@ -198,6 +203,7 @@ mod tests {
         result
     }
 
+    #[serial]
     #[test]
     fn durability_is_off_unless_a_directory_is_set() {
         with_env(&[], || {
@@ -208,6 +214,7 @@ mod tests {
         });
     }
 
+    #[serial]
     #[test]
     fn a_directory_alone_enables_the_defaults() {
         with_env(&[("FELIX_DURABLE_STORAGE_DIR", "/var/lib/felix")], || {
@@ -223,6 +230,7 @@ mod tests {
         });
     }
 
+    #[serial]
     #[test]
     fn every_fsync_mode_is_selectable() {
         for (raw, expected) in [
@@ -253,6 +261,7 @@ mod tests {
         }
     }
 
+    #[serial]
     #[test]
     fn a_periodic_interval_is_honoured() {
         with_env(
@@ -275,6 +284,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn an_interval_without_a_mode_still_applies() {
         with_env(
@@ -296,6 +306,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn an_unknown_fsync_mode_is_rejected() {
         with_env(
@@ -310,6 +321,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn a_zero_periodic_interval_is_rejected_at_startup() {
         with_env(
@@ -339,6 +351,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn segment_and_index_sizes_are_configurable() {
         with_env(
@@ -363,6 +376,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn an_unparseable_size_is_reported_with_its_variable_name() {
         with_env(
@@ -380,6 +394,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn a_segment_too_small_to_hold_a_record_is_rejected() {
         with_env(
@@ -394,6 +409,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn an_invalid_boolean_is_rejected() {
         with_env(
@@ -411,6 +427,7 @@ mod tests {
         );
     }
 
+    #[serial]
     #[test]
     fn the_summary_names_the_durability_policy() {
         with_env(

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -15,6 +15,7 @@ pub mod membership_metrics;
 pub mod quic;
 pub mod shard_lifecycle;
 pub mod shard_lifecycle_metrics;
+pub mod shard_routing;
 pub mod shard_watch;
 pub mod shard_watch_metrics;
 pub mod timings;

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -36,6 +36,7 @@ mod test_support;
 use anyhow::{Context, Result};
 use broker::membership;
 use broker::{auth::BrokerAuth, config, durable_config::DurableStorageConfig, quic};
+use broker::{shard_lifecycle, shard_routing, shard_watch};
 use felix_broker::{Broker, DurableStorage};
 use felix_common::lifecycle::{self, DrainBudget, Readiness};
 use felix_storage::EphemeralCache;
@@ -102,6 +103,28 @@ where
     // neither advertises itself nor answers a direct client before its streams
     // exist.
     let seeded = CancellationToken::new();
+
+    // Cluster ownership, when this broker has an identity. Built before the
+    // accept loop because the publish path consults it, and `None` on a
+    // single-node broker so that path is a null check.
+    let cluster = config.membership.as_ref().map(|membership| {
+        let router = Arc::new(felix_router::ShardRouter::new(
+            membership.node_id.clone(),
+            membership.region.clone(),
+            felix_router::RegionRouter::new(membership.region.clone()),
+        ));
+        let ingress = Arc::new(shard_routing::IngressRouter::new(Arc::clone(&router)));
+        let lifecycle = Arc::new(tokio::sync::Mutex::new(
+            shard_lifecycle::ShardLifecycle::new(membership.node_id.clone()),
+        ));
+        let ownership = Arc::new(tokio::sync::RwLock::new(
+            shard_watch::ShardOwnership::default(),
+        ));
+        (router, ingress, lifecycle, ownership)
+    });
+    let ingress_router = cluster
+        .as_ref()
+        .map(|(_, ingress, _, _)| Arc::clone(ingress));
     let sync_shutdown = CancellationToken::new();
     let metrics_shutdown = CancellationToken::new();
     let connections = TaskTracker::new();
@@ -187,6 +210,7 @@ where
         let accept_shutdown = accept_shutdown.clone();
         let connections = connections.clone();
         let seeded = seeded.clone();
+        let ingress_router = ingress_router.clone();
         tokio::spawn(async move {
             // A durable broker does not accept until its streams exist.
             // Readiness alone only steers orchestrated traffic; a client with
@@ -213,6 +237,7 @@ where
                 auth,
                 accept_shutdown,
                 connections,
+                ingress_router,
             )
             .await
             {
@@ -325,6 +350,40 @@ where
         }
     };
 
+    // Shard ownership: follow the control plane's assignments, and keep local
+    // state and the routing table in step with them.
+    let shard_tasks = match (&cluster, &config.controlplane_url, &durable_storage) {
+        (Some((router, ingress, lifecycle, ownership)), Some(base_url), storage) => {
+            let store: Arc<dyn shard_lifecycle::ShardStore> = match storage {
+                Some(storage) => Arc::new(shard_lifecycle::DurableShardStore::new(Arc::new(
+                    storage.clone(),
+                ))),
+                // Without durable storage there is no log to open, so taking a
+                // shard is bookkeeping only.
+                None => Arc::new(shard_lifecycle::EphemeralShardStore),
+            };
+            let watch = tokio::spawn(shard_watch::run(
+                membership_client.clone(),
+                base_url.clone(),
+                None,
+                Arc::clone(ownership),
+                Duration::from_millis(config.controlplane_sync_interval_ms),
+                sync_shutdown.clone(),
+            ));
+            let feed = shard_routing::spawn_feed(
+                Arc::clone(ownership),
+                Arc::clone(lifecycle),
+                store,
+                Arc::clone(ingress),
+                Arc::clone(router),
+                Duration::from_millis(config.controlplane_sync_interval_ms),
+                sync_shutdown.clone(),
+            );
+            Some((watch, feed))
+        }
+        _ => None,
+    };
+
     // Block until the shutdown signal resolves so the process stays alive.
     // A refused registration ends the process too: a broker that is not a
     // cluster member should say so and stop, not serve traffic nobody routes.
@@ -390,6 +449,28 @@ where
                 .await;
             })
             .await;
+    }
+
+    if let Some((watch, feed)) = shard_tasks {
+        sync_shutdown.cancel();
+        let mut watch = watch;
+        let mut feed = feed;
+        if !budget
+            .drain("shard_watch", async {
+                let _ = (&mut watch).await;
+            })
+            .await
+        {
+            watch.abort();
+        }
+        if !budget
+            .drain("shard_feed", async {
+                let _ = (&mut feed).await;
+            })
+            .await
+        {
+            feed.abort();
+        }
     }
 
     let mut membership = membership;

--- a/services/broker/src/shard_lifecycle.rs
+++ b/services/broker/src/shard_lifecycle.rs
@@ -277,6 +277,18 @@ impl ShardLifecycle {
         }
     }
 
+    /// Shards this broker can serve, and the generation each was opened at.
+    ///
+    /// The form ingress reads on every publish. Handing out a snapshot rather
+    /// than exposing the lock keeps the hot path off any mutex this holds.
+    pub fn servable(&self) -> HashMap<ShardKey, u64> {
+        self.shards
+            .iter()
+            .filter(|(_, shard)| shard.phase.may_serve())
+            .map(|(key, shard)| (key.clone(), shard.generation))
+            .collect()
+    }
+
     /// How many shards sit in each phase, for the gauge.
     pub fn counts(&self) -> HashMap<Phase, usize> {
         let mut counts = HashMap::new();
@@ -337,6 +349,24 @@ impl ShardStore for DurableShardStore {
         log.sync()
             .await
             .map_err(|err| anyhow::anyhow!("flush shard log: {err}"))
+    }
+}
+
+/// A [`ShardStore`] for a broker with no durable storage.
+///
+/// Taking a shard is bookkeeping only: there is no log to open and nothing to
+/// flush, so both operations succeed immediately. Kept explicit rather than
+/// making the store optional, so the lifecycle has one code path.
+pub struct EphemeralShardStore;
+
+#[async_trait::async_trait]
+impl ShardStore for EphemeralShardStore {
+    async fn open(&self, _key: &ShardKey) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn release(&self, _key: &ShardKey) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/services/broker/src/shard_routing.rs
+++ b/services/broker/src/shard_routing.rs
@@ -1,0 +1,209 @@
+//! Ownership resolution on the ingress path.
+//!
+//! Every publish asks one question before anything else happens: is this shard
+//! mine? The answer is `Local`, `Forward`, or a typed refusal — never a
+//! shrug. A broker that treats an unresolved shard as its own is a broker
+//! writing data another node owns.
+//!
+//! **Single-node brokers are unaffected.** A broker with no cluster identity has
+//! no router to consult and no assignments to honour, so dispatch is `Local` by
+//! construction. Clustering is opt-in, and a broker that never joined one must
+//! behave exactly as it did before this existed.
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use felix_router::{Resolution, ShardRouter, Unavailable};
+use tokio::sync::Mutex;
+
+use crate::shard_lifecycle::ShardLifecycle;
+use crate::shard_watch::ShardKey;
+
+/// What ingress should do with a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Dispatch {
+    /// Serve it here.
+    Local,
+    /// Another node owns it. M4 forwards; until then the caller refuses with
+    /// this attached, so "someone else's shard" stays distinguishable from
+    /// "something went wrong".
+    Forward {
+        node_id: String,
+        advertise_addr: SocketAddr,
+    },
+    /// Nobody can serve it right now, and this says why.
+    Unavailable(Reason),
+}
+
+/// Why a request cannot be served.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reason {
+    /// Placement has not assigned the shard.
+    NotAssigned,
+    /// The owner is known but unreachable or not live.
+    OwnerUnavailable(String),
+    /// This node owns the shard but has not finished opening it.
+    ///
+    /// Deliberately not `Local`: serving now would acknowledge a write against
+    /// a log that is not yet recovered.
+    NotReady,
+    /// This node's routing view is behind the caller's.
+    Stale { have: u64, wanted: u64 },
+}
+
+impl std::fmt::Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAssigned => write!(f, "shard is not assigned to any broker"),
+            Self::OwnerUnavailable(detail) => write!(f, "shard owner is unavailable: {detail}"),
+            Self::NotReady => write!(f, "this broker is still opening the shard"),
+            Self::Stale { have, wanted } => {
+                write!(
+                    f,
+                    "routing view is behind: have generation {have}, caller has {wanted}"
+                )
+            }
+        }
+    }
+}
+
+/// Map a request to a shard number.
+///
+/// Deterministic, and a pure function of its inputs, so the same key lands on
+/// the same shard on every broker and across restarts.
+///
+/// **The wire protocol carries no routing key today**, so `routing_key` is
+/// always `None` and every record of a stream lands on shard 0. That makes a
+/// stream's configured `shards` count metadata the data path does not yet use.
+/// Adding a negotiated key field is what makes `shards > 1` mean anything; this
+/// function is the place it plugs in, and the rest of the path is already
+/// shard-aware.
+pub fn shard_for(shards: u32, routing_key: Option<&[u8]>) -> u32 {
+    if shards <= 1 {
+        return 0;
+    }
+    match routing_key {
+        // Same construction as placement's: FNV-1a with a finalizer, written
+        // out so the mapping cannot shift with a toolchain change.
+        Some(key) => (finalize(fnv1a(key)) % u64::from(shards)) as u32,
+        None => 0,
+    }
+}
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn finalize(mut hash: u64) -> u64 {
+    hash ^= hash >> 30;
+    hash = hash.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    hash ^= hash >> 27;
+    hash = hash.wrapping_mul(0x94d0_49bb_1331_11eb);
+    hash ^ (hash >> 31)
+}
+
+/// Resolves ingress requests against cluster ownership.
+///
+/// Absent on a single-node broker — see [`dispatch`].
+pub struct IngressRouter {
+    router: Arc<ShardRouter>,
+    lifecycle: Arc<Mutex<ShardLifecycle>>,
+}
+
+impl IngressRouter {
+    pub fn new(router: Arc<ShardRouter>, lifecycle: Arc<Mutex<ShardLifecycle>>) -> Self {
+        Self { router, lifecycle }
+    }
+
+    /// Decide what to do with a request for `key`.
+    ///
+    /// Two sources have to agree. The router says who the cluster believes owns
+    /// the shard; the lifecycle says whether this broker has actually opened it.
+    /// Trusting only the router would serve writes during recovery; trusting
+    /// only the lifecycle would keep serving a shard that has been reassigned.
+    pub async fn dispatch(&self, key: &ShardKey) -> Dispatch {
+        let route = self.router.resolve(&to_router_key(key));
+        match route {
+            Resolution::Local { generation } => {
+                // The cluster says ours. Local state has the deciding vote on
+                // whether it is servable yet.
+                if self.lifecycle.lock().await.may_serve_at(key, generation) {
+                    Dispatch::Local
+                } else {
+                    Dispatch::Unavailable(Reason::NotReady)
+                }
+            }
+            Resolution::Remote {
+                node_id,
+                advertise_addr,
+                ..
+            } => Dispatch::Forward {
+                node_id,
+                advertise_addr,
+            },
+            Resolution::Stale { have, wanted } => {
+                Dispatch::Unavailable(Reason::Stale { have, wanted })
+            }
+            Resolution::Unavailable(Unavailable::NoAssignment) => {
+                Dispatch::Unavailable(Reason::NotAssigned)
+            }
+            Resolution::Unavailable(other) => {
+                Dispatch::Unavailable(Reason::OwnerUnavailable(other.to_string()))
+            }
+        }
+    }
+}
+
+/// Decide what to do with a request, for a broker that may or may not be in a
+/// cluster.
+///
+/// `None` is a single-node broker: no identity, no assignments, nothing to
+/// resolve against. Everything is local, exactly as it was before clustering
+/// existed.
+pub async fn dispatch(ingress: Option<&IngressRouter>, key: &ShardKey) -> Dispatch {
+    match ingress {
+        None => Dispatch::Local,
+        Some(ingress) => ingress.dispatch(key).await,
+    }
+}
+
+fn to_router_key(key: &ShardKey) -> felix_router::ShardKey {
+    felix_router::ShardKey {
+        tenant_id: key.tenant_id.clone(),
+        namespace: key.namespace.clone(),
+        stream: key.stream.clone(),
+        shard: key.shard,
+    }
+}
+
+/// Build a routing table from what the watch currently holds.
+///
+/// Lives here rather than in the watch because it is the point where two
+/// separate views -- ownership and node addresses -- are joined into the one
+/// the hot path reads.
+pub fn routing_table_from(
+    assignments: &std::collections::HashMap<ShardKey, crate::shard_watch::ShardAssignment>,
+    nodes: &std::collections::HashMap<String, felix_router::NodeRef>,
+) -> felix_router::RoutingTable {
+    felix_router::RoutingTable::build(
+        assignments.values().map(|assignment| {
+            (
+                to_router_key(&assignment.key),
+                assignment.leader.clone(),
+                assignment.replicas.clone(),
+                assignment.generation,
+            )
+        }),
+        nodes,
+    )
+}
+
+#[cfg(test)]
+#[path = "shard_routing_tests.rs"]
+mod tests;

--- a/services/broker/src/shard_routing.rs
+++ b/services/broker/src/shard_routing.rs
@@ -9,13 +9,13 @@
 //! no router to consult and no assignments to honour, so dispatch is `Local` by
 //! construction. Clustering is opt-in, and a broker that never joined one must
 //! behave exactly as it did before this existed.
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use felix_router::{Resolution, ShardRouter, Unavailable};
-use tokio::sync::Mutex;
 
-use crate::shard_lifecycle::ShardLifecycle;
 use crate::shard_watch::ShardKey;
 
 /// What ingress should do with a request.
@@ -108,32 +108,57 @@ fn finalize(mut hash: u64) -> u64 {
     hash ^ (hash >> 31)
 }
 
+/// Shards this broker has opened, and the generation each was opened at.
+///
+/// Published as an immutable snapshot for the same reason routes are: the
+/// publish path reads this on every request, and it must not take a lock a
+/// writer can hold -- least of all an async one, which would put an await into
+/// the hot path for a lookup that is two loads.
+pub type ServableShards = HashMap<ShardKey, u64>;
+
 /// Resolves ingress requests against cluster ownership.
 ///
 /// Absent on a single-node broker — see [`dispatch`].
+///
+/// Both reads are `ArcSwap` loads, so `dispatch` is synchronous and allocation
+/// free. That is deliberate: it sits in front of every publish, and a resolver
+/// that cost a lock or an await would show up in p999 long before it showed up
+/// in a correctness test.
 pub struct IngressRouter {
     router: Arc<ShardRouter>,
-    lifecycle: Arc<Mutex<ShardLifecycle>>,
+    servable: ArcSwap<ServableShards>,
 }
 
 impl IngressRouter {
-    pub fn new(router: Arc<ShardRouter>, lifecycle: Arc<Mutex<ShardLifecycle>>) -> Self {
-        Self { router, lifecycle }
+    pub fn new(router: Arc<ShardRouter>) -> Self {
+        Self {
+            router,
+            servable: ArcSwap::from_pointee(ServableShards::new()),
+        }
+    }
+
+    /// Replace the set of shards this broker can serve.
+    ///
+    /// Called after each lifecycle reconcile, which is the only thing that
+    /// changes it.
+    pub fn publish_servable(&self, servable: ServableShards) {
+        self.servable.store(Arc::new(servable));
     }
 
     /// Decide what to do with a request for `key`.
     ///
     /// Two sources have to agree. The router says who the cluster believes owns
-    /// the shard; the lifecycle says whether this broker has actually opened it.
-    /// Trusting only the router would serve writes during recovery; trusting
-    /// only the lifecycle would keep serving a shard that has been reassigned.
-    pub async fn dispatch(&self, key: &ShardKey) -> Dispatch {
-        let route = self.router.resolve(&to_router_key(key));
-        match route {
+    /// the shard; the servable set says whether this broker has actually opened
+    /// it. Trusting only the router would serve writes during recovery;
+    /// trusting only local state would keep serving a shard that has been
+    /// reassigned.
+    pub fn dispatch(&self, key: &ShardKey) -> Dispatch {
+        match self.router.resolve(&to_router_key(key)) {
             Resolution::Local { generation } => {
-                // The cluster says ours. Local state has the deciding vote on
-                // whether it is servable yet.
-                if self.lifecycle.lock().await.may_serve_at(key, generation) {
+                // The cluster says ours. Local readiness has the deciding vote,
+                // and only at this exact generation: an older one means we have
+                // not caught up with a reassignment that already happened.
+                if self.servable.load().get(key) == Some(&generation) {
                     Dispatch::Local
                 } else {
                     Dispatch::Unavailable(Reason::NotReady)
@@ -165,11 +190,12 @@ impl IngressRouter {
 ///
 /// `None` is a single-node broker: no identity, no assignments, nothing to
 /// resolve against. Everything is local, exactly as it was before clustering
-/// existed.
-pub async fn dispatch(ingress: Option<&IngressRouter>, key: &ShardKey) -> Dispatch {
+/// existed, and it costs one branch.
+#[inline]
+pub fn dispatch(ingress: Option<&IngressRouter>, key: &ShardKey) -> Dispatch {
     match ingress {
         None => Dispatch::Local,
-        Some(ingress) => ingress.dispatch(key).await,
+        Some(ingress) => ingress.dispatch(key),
     }
 }
 
@@ -202,6 +228,48 @@ pub fn routing_table_from(
         }),
         nodes,
     )
+}
+
+/// Keep local shard state and the routing table in step with the watch.
+///
+/// One task owns the sequence, so the two never disagree: reconcile local state
+/// first, then publish what is servable, then publish the routes. Publishing
+/// routes first would advertise this node as the owner of a shard it has not
+/// opened.
+///
+/// The routing table is built with an empty node catalog, because a broker has
+/// no way to read one: `/v1/nodes` requires a cluster-scoped token and brokers
+/// do not have credentials yet (#126). The consequence is deliberate and
+/// correct for M3 -- a shard led by this node resolves `Local` on the node id
+/// alone, and every other shard resolves to a refusal naming its owner rather
+/// than a forward. Forwarding needs an address book, and that arrives with M4.
+pub fn spawn_feed(
+    ownership: Arc<tokio::sync::RwLock<crate::shard_watch::ShardOwnership>>,
+    lifecycle: Arc<tokio::sync::Mutex<crate::shard_lifecycle::ShardLifecycle>>,
+    store: Arc<dyn crate::shard_lifecycle::ShardStore>,
+    ingress: Arc<IngressRouter>,
+    router: Arc<ShardRouter>,
+    interval: std::time::Duration,
+    shutdown: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let catalog = HashMap::new();
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => return,
+                _ = ticker.tick() => {}
+            }
+
+            let assignments = ownership.read().await.assignments().clone();
+            crate::shard_lifecycle::reconcile(&lifecycle, store.as_ref(), &assignments).await;
+
+            let servable = lifecycle.lock().await.servable();
+            ingress.publish_servable(servable);
+            router.publish(routing_table_from(&assignments, &catalog), &catalog);
+        }
+    })
 }
 
 #[cfg(test)]

--- a/services/broker/src/shard_routing_tests.rs
+++ b/services/broker/src/shard_routing_tests.rs
@@ -1,0 +1,264 @@
+//! Ingress dispatch: what a broker does with a request for each ownership state.
+use super::*;
+use crate::shard_lifecycle::ShardLifecycle;
+use crate::shard_watch::ShardAssignment;
+use felix_router::{NodeRef, RegionRouter};
+use std::collections::HashMap;
+
+fn key(shard: u32) -> ShardKey {
+    ShardKey {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: "orders".to_string(),
+        shard,
+    }
+}
+
+fn assignment(shard: u32, leader: &str, generation: u64) -> ShardAssignment {
+    ShardAssignment {
+        key: key(shard),
+        leader: leader.to_string(),
+        replicas: Vec::new(),
+        generation,
+        state: "active".to_string(),
+    }
+}
+
+fn node(id: &str, port: u16, live: bool) -> NodeRef {
+    NodeRef {
+        node_id: id.to_string(),
+        advertise_addr: SocketAddr::from(([10, 0, 0, 4], port)),
+        region: "us-west-2".to_string(),
+        live,
+    }
+}
+
+fn catalog() -> HashMap<String, NodeRef> {
+    [node("broker-a", 7001, true), node("broker-b", 7002, true)]
+        .into_iter()
+        .map(|n| (n.node_id.clone(), n))
+        .collect()
+}
+
+/// Build an ingress router whose view is `assignments`, with `opened` shards
+/// already through their opening phase locally.
+async fn ingress(assignments: &[ShardAssignment], opened: &[u32]) -> IngressRouter {
+    let nodes = catalog();
+    let router = Arc::new(ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let owned: HashMap<ShardKey, ShardAssignment> = assignments
+        .iter()
+        .map(|a| (a.key.clone(), a.clone()))
+        .collect();
+    router.publish(routing_table_from(&owned, &nodes), &nodes);
+
+    let mut lifecycle = ShardLifecycle::new("broker-a");
+    for assignment in assignments {
+        lifecycle.observe(&assignment.key, Some(assignment));
+        if opened.contains(&assignment.key.shard) {
+            lifecycle.opened(&assignment.key, assignment.generation);
+        }
+    }
+    IngressRouter::new(router, Arc::new(Mutex::new(lifecycle)))
+}
+
+/// The property that must not regress: a broker with no cluster identity
+/// behaves exactly as it did before clustering existed.
+#[tokio::test]
+async fn a_single_node_broker_always_serves_locally() {
+    assert_eq!(dispatch(None, &key(0)).await, Dispatch::Local);
+    assert_eq!(dispatch(None, &key(41)).await, Dispatch::Local);
+}
+
+#[tokio::test]
+async fn an_owned_and_open_shard_is_served_locally() {
+    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[0]).await;
+    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+}
+
+/// The reason ownership and readiness are two separate sources: the cluster
+/// says this shard is ours, but the log is not recovered, and acknowledging a
+/// write now would promise durability that is not set up.
+#[tokio::test]
+async fn an_owned_shard_still_opening_is_not_served() {
+    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[]).await;
+    assert_eq!(
+        dispatch(Some(&ingress), &key(0)).await,
+        Dispatch::Unavailable(Reason::NotReady),
+    );
+}
+
+/// Remote must be its own outcome, not an error, or M4 has nothing to act on.
+#[tokio::test]
+async fn a_shard_owned_elsewhere_is_forwardable() {
+    let ingress = ingress(&[assignment(0, "broker-b", 2)], &[]).await;
+    assert_eq!(
+        dispatch(Some(&ingress), &key(0)).await,
+        Dispatch::Forward {
+            node_id: "broker-b".to_string(),
+            advertise_addr: SocketAddr::from(([10, 0, 0, 4], 7002)),
+        },
+    );
+}
+
+/// The acceptance criterion: an unassigned shard must never be accepted
+/// locally, or a broker writes data nobody asked it to hold.
+#[tokio::test]
+async fn an_unassigned_shard_is_refused() {
+    let ingress = ingress(&[], &[]).await;
+    assert_eq!(
+        dispatch(Some(&ingress), &key(0)).await,
+        Dispatch::Unavailable(Reason::NotAssigned),
+    );
+}
+
+#[tokio::test]
+async fn an_unavailable_owner_is_reported_with_its_reason() {
+    let nodes: HashMap<String, NodeRef> = [
+        node("broker-a", 7001, true),
+        node("broker-dead", 7009, false),
+    ]
+    .into_iter()
+    .map(|n| (n.node_id.clone(), n))
+    .collect();
+    let router = Arc::new(ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let owned: HashMap<ShardKey, ShardAssignment> = [(key(0), assignment(0, "broker-dead", 1))]
+        .into_iter()
+        .collect();
+    router.publish(routing_table_from(&owned, &nodes), &nodes);
+
+    let ingress = IngressRouter::new(
+        router,
+        Arc::new(Mutex::new(ShardLifecycle::new("broker-a"))),
+    );
+    match dispatch(Some(&ingress), &key(0)).await {
+        Dispatch::Unavailable(Reason::OwnerUnavailable(detail)) => {
+            assert!(detail.contains("broker-dead"), "{detail}");
+        }
+        other => panic!("expected an unavailable owner, got {other:?}"),
+    }
+}
+
+/// A shard moving away must stop being served here immediately, not on the next
+/// restart.
+#[tokio::test]
+async fn losing_a_shard_stops_local_service() {
+    let nodes = catalog();
+    let router = Arc::new(ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let mut lifecycle = ShardLifecycle::new("broker-a");
+    let mine = assignment(0, "broker-a", 1);
+    lifecycle.observe(&mine.key, Some(&mine));
+    lifecycle.opened(&mine.key, 1);
+
+    let owned: HashMap<ShardKey, ShardAssignment> = [(key(0), mine)].into_iter().collect();
+    router.publish(routing_table_from(&owned, &nodes), &nodes);
+    let lifecycle = Arc::new(Mutex::new(lifecycle));
+    let ingress = IngressRouter::new(Arc::clone(&router), Arc::clone(&lifecycle));
+    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+
+    // Reassigned to broker-b.
+    let moved: HashMap<ShardKey, ShardAssignment> = [(key(0), assignment(0, "broker-b", 2))]
+        .into_iter()
+        .collect();
+    router.publish(routing_table_from(&moved, &nodes), &nodes);
+
+    assert!(
+        matches!(
+            dispatch(Some(&ingress), &key(0)).await,
+            Dispatch::Forward { .. }
+        ),
+        "a reassigned shard must stop being served here",
+    );
+}
+
+/// The router moved on before local state did. Serving at the old generation
+/// would be two brokers believing they lead the same shard.
+#[tokio::test]
+async fn a_local_route_at_a_newer_generation_is_not_served_until_reopened() {
+    let nodes = catalog();
+    let router = Arc::new(ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let mut lifecycle = ShardLifecycle::new("broker-a");
+    let first = assignment(0, "broker-a", 1);
+    lifecycle.observe(&first.key, Some(&first));
+    lifecycle.opened(&first.key, 1);
+
+    // The table now says generation 4; local state is still at 1.
+    let newer: HashMap<ShardKey, ShardAssignment> = [(key(0), assignment(0, "broker-a", 4))]
+        .into_iter()
+        .collect();
+    router.publish(routing_table_from(&newer, &nodes), &nodes);
+
+    let ingress = IngressRouter::new(router, Arc::new(Mutex::new(lifecycle)));
+    assert_eq!(
+        dispatch(Some(&ingress), &key(0)).await,
+        Dispatch::Unavailable(Reason::NotReady),
+        "local state must catch up before serving the new generation",
+    );
+}
+
+#[tokio::test]
+async fn a_multi_shard_stream_dispatches_per_shard() {
+    let ingress = ingress(
+        &[
+            assignment(0, "broker-a", 1),
+            assignment(1, "broker-b", 1),
+            assignment(2, "broker-a", 1),
+        ],
+        &[0, 2],
+    )
+    .await;
+
+    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+    assert!(matches!(
+        dispatch(Some(&ingress), &key(1)).await,
+        Dispatch::Forward { .. }
+    ));
+    assert_eq!(dispatch(Some(&ingress), &key(2)).await, Dispatch::Local);
+}
+
+/// Without a routing key on the wire there is only one shard to choose, and
+/// choosing it must be stable.
+#[test]
+fn shard_selection_is_deterministic() {
+    assert_eq!(shard_for(1, None), 0);
+    assert_eq!(shard_for(4, None), 0, "no key on the wire yet");
+
+    // The mapping a negotiated key would use, pinned so it cannot drift.
+    for shards in [2u32, 4, 8, 16] {
+        let first = shard_for(shards, Some(b"customer-42"));
+        assert!(first < shards);
+        for _ in 0..10 {
+            assert_eq!(shard_for(shards, Some(b"customer-42")), first);
+        }
+    }
+}
+
+#[test]
+fn keys_spread_across_shards() {
+    let mut seen = std::collections::HashSet::new();
+    for i in 0..200u32 {
+        seen.insert(shard_for(8, Some(format!("key-{i}").as_bytes())));
+    }
+    assert_eq!(seen.len(), 8, "every shard should be reachable: {seen:?}");
+}
+
+#[test]
+fn a_single_shard_stream_always_maps_to_zero() {
+    assert_eq!(shard_for(0, Some(b"anything")), 0);
+    assert_eq!(shard_for(1, Some(b"anything")), 0);
+}

--- a/services/broker/src/shard_routing_tests.rs
+++ b/services/broker/src/shard_routing_tests.rs
@@ -42,7 +42,7 @@ fn catalog() -> HashMap<String, NodeRef> {
 
 /// Build an ingress router whose view is `assignments`, with `opened` shards
 /// already through their opening phase locally.
-async fn ingress(assignments: &[ShardAssignment], opened: &[u32]) -> IngressRouter {
+fn ingress(assignments: &[ShardAssignment], opened: &[u32]) -> IngressRouter {
     let nodes = catalog();
     let router = Arc::new(ShardRouter::new(
         "broker-a",
@@ -62,21 +62,23 @@ async fn ingress(assignments: &[ShardAssignment], opened: &[u32]) -> IngressRout
             lifecycle.opened(&assignment.key, assignment.generation);
         }
     }
-    IngressRouter::new(router, Arc::new(Mutex::new(lifecycle)))
+    let ingress = IngressRouter::new(router);
+    ingress.publish_servable(lifecycle.servable());
+    ingress
 }
 
 /// The property that must not regress: a broker with no cluster identity
 /// behaves exactly as it did before clustering existed.
 #[tokio::test]
 async fn a_single_node_broker_always_serves_locally() {
-    assert_eq!(dispatch(None, &key(0)).await, Dispatch::Local);
-    assert_eq!(dispatch(None, &key(41)).await, Dispatch::Local);
+    assert_eq!(dispatch(None, &key(0)), Dispatch::Local);
+    assert_eq!(dispatch(None, &key(41)), Dispatch::Local);
 }
 
 #[tokio::test]
 async fn an_owned_and_open_shard_is_served_locally() {
-    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[0]).await;
-    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[0]);
+    assert_eq!(dispatch(Some(&ingress), &key(0)), Dispatch::Local);
 }
 
 /// The reason ownership and readiness are two separate sources: the cluster
@@ -84,9 +86,9 @@ async fn an_owned_and_open_shard_is_served_locally() {
 /// write now would promise durability that is not set up.
 #[tokio::test]
 async fn an_owned_shard_still_opening_is_not_served() {
-    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[]).await;
+    let ingress = ingress(&[assignment(0, "broker-a", 3)], &[]);
     assert_eq!(
-        dispatch(Some(&ingress), &key(0)).await,
+        dispatch(Some(&ingress), &key(0)),
         Dispatch::Unavailable(Reason::NotReady),
     );
 }
@@ -94,9 +96,9 @@ async fn an_owned_shard_still_opening_is_not_served() {
 /// Remote must be its own outcome, not an error, or M4 has nothing to act on.
 #[tokio::test]
 async fn a_shard_owned_elsewhere_is_forwardable() {
-    let ingress = ingress(&[assignment(0, "broker-b", 2)], &[]).await;
+    let ingress = ingress(&[assignment(0, "broker-b", 2)], &[]);
     assert_eq!(
-        dispatch(Some(&ingress), &key(0)).await,
+        dispatch(Some(&ingress), &key(0)),
         Dispatch::Forward {
             node_id: "broker-b".to_string(),
             advertise_addr: SocketAddr::from(([10, 0, 0, 4], 7002)),
@@ -108,9 +110,9 @@ async fn a_shard_owned_elsewhere_is_forwardable() {
 /// locally, or a broker writes data nobody asked it to hold.
 #[tokio::test]
 async fn an_unassigned_shard_is_refused() {
-    let ingress = ingress(&[], &[]).await;
+    let ingress = ingress(&[], &[]);
     assert_eq!(
-        dispatch(Some(&ingress), &key(0)).await,
+        dispatch(Some(&ingress), &key(0)),
         Dispatch::Unavailable(Reason::NotAssigned),
     );
 }
@@ -134,11 +136,8 @@ async fn an_unavailable_owner_is_reported_with_its_reason() {
         .collect();
     router.publish(routing_table_from(&owned, &nodes), &nodes);
 
-    let ingress = IngressRouter::new(
-        router,
-        Arc::new(Mutex::new(ShardLifecycle::new("broker-a"))),
-    );
-    match dispatch(Some(&ingress), &key(0)).await {
+    let ingress = IngressRouter::new(router);
+    match dispatch(Some(&ingress), &key(0)) {
         Dispatch::Unavailable(Reason::OwnerUnavailable(detail)) => {
             assert!(detail.contains("broker-dead"), "{detail}");
         }
@@ -163,9 +162,9 @@ async fn losing_a_shard_stops_local_service() {
 
     let owned: HashMap<ShardKey, ShardAssignment> = [(key(0), mine)].into_iter().collect();
     router.publish(routing_table_from(&owned, &nodes), &nodes);
-    let lifecycle = Arc::new(Mutex::new(lifecycle));
-    let ingress = IngressRouter::new(Arc::clone(&router), Arc::clone(&lifecycle));
-    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+    let ingress = IngressRouter::new(Arc::clone(&router));
+    ingress.publish_servable(lifecycle.servable());
+    assert_eq!(dispatch(Some(&ingress), &key(0)), Dispatch::Local);
 
     // Reassigned to broker-b.
     let moved: HashMap<ShardKey, ShardAssignment> = [(key(0), assignment(0, "broker-b", 2))]
@@ -174,10 +173,7 @@ async fn losing_a_shard_stops_local_service() {
     router.publish(routing_table_from(&moved, &nodes), &nodes);
 
     assert!(
-        matches!(
-            dispatch(Some(&ingress), &key(0)).await,
-            Dispatch::Forward { .. }
-        ),
+        matches!(dispatch(Some(&ingress), &key(0)), Dispatch::Forward { .. }),
         "a reassigned shard must stop being served here",
     );
 }
@@ -203,9 +199,10 @@ async fn a_local_route_at_a_newer_generation_is_not_served_until_reopened() {
         .collect();
     router.publish(routing_table_from(&newer, &nodes), &nodes);
 
-    let ingress = IngressRouter::new(router, Arc::new(Mutex::new(lifecycle)));
+    let ingress = IngressRouter::new(router);
+    ingress.publish_servable(lifecycle.servable());
     assert_eq!(
-        dispatch(Some(&ingress), &key(0)).await,
+        dispatch(Some(&ingress), &key(0)),
         Dispatch::Unavailable(Reason::NotReady),
         "local state must catch up before serving the new generation",
     );
@@ -220,15 +217,14 @@ async fn a_multi_shard_stream_dispatches_per_shard() {
             assignment(2, "broker-a", 1),
         ],
         &[0, 2],
-    )
-    .await;
+    );
 
-    assert_eq!(dispatch(Some(&ingress), &key(0)).await, Dispatch::Local);
+    assert_eq!(dispatch(Some(&ingress), &key(0)), Dispatch::Local);
     assert!(matches!(
-        dispatch(Some(&ingress), &key(1)).await,
+        dispatch(Some(&ingress), &key(1)),
         Dispatch::Forward { .. }
     ));
-    assert_eq!(dispatch(Some(&ingress), &key(2)).await, Dispatch::Local);
+    assert_eq!(dispatch(Some(&ingress), &key(2)), Dispatch::Local);
 }
 
 /// Without a routing key on the wire there is only one shard to choose, and

--- a/services/broker/src/shard_watch.rs
+++ b/services/broker/src/shard_watch.rs
@@ -101,6 +101,11 @@ impl ShardOwnership {
             .collect();
     }
 
+    /// Everything this broker currently believes about ownership.
+    pub fn assignments(&self) -> &HashMap<ShardKey, ShardAssignment> {
+        &self.assignments
+    }
+
     pub fn get(&self, key: &ShardKey) -> Option<&ShardAssignment> {
         self.assignments.get(key)
     }

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -27,6 +27,7 @@ use tokio_util::task::TaskTracker;
 
 use crate::auth::BrokerAuth;
 use crate::config::BrokerConfig;
+use crate::shard_routing::IngressRouter;
 use crate::timings;
 
 use super::GLOBAL_INGRESS_DEPTH;
@@ -74,6 +75,9 @@ pub async fn serve(
         auth,
         CancellationToken::new(),
         TaskTracker::new(),
+        // The simple entry point is single-node; a cluster member goes through
+        // `serve_with_shutdown` so it can pass its ownership view.
+        None,
     )
     .await
 }
@@ -98,8 +102,9 @@ pub async fn serve_with_shutdown(
     auth: Arc<BrokerAuth>,
     shutdown: CancellationToken,
     connections: TaskTracker,
+    ingress: Option<Arc<IngressRouter>>,
 ) -> Result<()> {
-    let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
+    let publish_ctx = build_publish_context(Arc::clone(&broker), &config, ingress);
     // Main accept loop: spawn a task per incoming QUIC connection.
     if config.disable_timings {
         timings::set_enabled(false);
@@ -142,7 +147,11 @@ pub async fn serve_with_shutdown(
     }
 }
 
-fn build_publish_context(broker: Arc<Broker>, config: &BrokerConfig) -> PublishContext {
+fn build_publish_context(
+    broker: Arc<Broker>,
+    config: &BrokerConfig,
+    ingress: Option<Arc<IngressRouter>>,
+) -> PublishContext {
     // NOTE: This is intentionally global for the process (not per-connection).
     // With per-connection worker pools, adding more publisher connections multiplied
     // concurrent broker.publish_batch callers and caused lock contention on shared broker state.
@@ -227,6 +236,7 @@ fn build_publish_context(broker: Arc<Broker>, config: &BrokerConfig) -> PublishC
         worker_txs.push(publish_tx);
     }
     PublishContext {
+        ingress,
         workers: Arc::new(worker_txs),
         worker_count,
         depth: queue_depth,
@@ -288,6 +298,7 @@ pub(crate) async fn handle_connection_with_shutdown(
     // instances from `build_publish_context` — only `conn_admission`, `subscriptions`, and
     // `lane_manager` are fresh per connection.
     let publish_ctx = PublishContext {
+        ingress: None,
         conn_admission: Arc::new(PublishAdmission::new(config.pub_conn_inflight_bytes)),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
         lane_manager: WriterLaneManager::new(&config),
@@ -474,7 +485,7 @@ mod tests {
             publish_queue_wait_timeout_ms: 17,
             ..BrokerConfig::default()
         };
-        let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
+        let publish_ctx = build_publish_context(Arc::clone(&broker), &config, None);
         assert_eq!(publish_ctx.worker_count, 1);
         assert_eq!(publish_ctx.workers.len(), 1);
         assert_eq!(publish_ctx.wait_timeout, Duration::from_millis(17));
@@ -503,7 +514,7 @@ mod tests {
         broker.register_tenant("t1").await?;
         broker.register_namespace("t1", "default").await?;
         let config = BrokerConfig::default();
-        let publish_ctx = build_publish_context(broker, &config);
+        let publish_ctx = build_publish_context(broker, &config, None);
 
         let (response_tx, response_rx) = oneshot::channel();
         publish_ctx.workers[0]
@@ -534,7 +545,7 @@ mod tests {
         broker.register_namespace("t1", "default").await?;
 
         let config = BrokerConfig::default();
-        let publish_ctx = build_publish_context(Arc::clone(&broker), &config);
+        let publish_ctx = build_publish_context(Arc::clone(&broker), &config, None);
         let auth = Arc::new(BrokerAuth::new("http://127.0.0.1".to_string()));
 
         let cert = generate_simple_self_signed(vec!["localhost".into()])?;

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -66,6 +66,8 @@ pub(crate) use uni::{
 // exercises directly, without widening them for the rest of the crate.
 #[cfg(test)]
 use crate::auth::AuthContext;
+use crate::shard_routing::{Dispatch, IngressRouter, dispatch, shard_for};
+use crate::shard_watch::ShardKey;
 #[cfg(test)]
 use crate::transport::quic::errors::AckEnqueueError;
 #[cfg(test)]
@@ -127,6 +129,11 @@ pub(crate) struct PublishJob {
 ///   (`handle_connection`) and closes that gap without touching the shared worker pool.
 #[derive(Clone)]
 pub(crate) struct PublishContext {
+    /// Cluster ownership, when this broker is a member.
+    ///
+    /// `None` on a single-node broker, which is the default: there is nothing
+    /// to resolve against, and the gate costs one null check.
+    pub(crate) ingress: Option<Arc<IngressRouter>>,
     pub(crate) workers: Arc<Vec<mpsc::Sender<PublishJob>>>,
     pub(crate) worker_count: usize,
     pub(crate) depth: Arc<AtomicUsize>,
@@ -168,14 +175,61 @@ impl PublishContext {
     }
 }
 
+/// Resolve a stream, refusing one whose shard this broker does not own.
+///
+/// The single chokepoint every publish path funnels through, which is why the
+/// ownership gate is here: nothing reaches storage without passing it.
+///
+/// Ownership is checked *outside* the handle cache, deliberately. The cache
+/// exists to avoid a registry lookup and holds for `STREAM_CACHE_TTL`; ownership
+/// changes the instant the control plane says so, and caching it would keep a
+/// broker serving a reassigned shard for up to a TTL. The check is two atomic
+/// loads, so paying it per publish costs less than reasoning about staleness.
 pub(crate) async fn resolve_stream_cached(
     broker: &Broker,
+    ingress: Option<&IngressRouter>,
     cache: &mut StreamHandleCache,
     key_scratch: &mut String,
     tenant_id: &str,
     namespace: &str,
     stream: &str,
 ) -> Option<StreamHandle> {
+    // Single-node brokers short-circuit on a null check; a cluster member pays
+    // two loads. Either way there is no lock and no await.
+    if ingress.is_some() {
+        let key = ShardKey {
+            tenant_id: tenant_id.to_string(),
+            namespace: namespace.to_string(),
+            stream: stream.to_string(),
+            // No routing key on the wire yet, so every record of a stream lands
+            // on shard 0. See `shard_routing::shard_for`.
+            shard: shard_for(1, None),
+        };
+        match dispatch(ingress, &key) {
+            Dispatch::Local => {}
+            Dispatch::Forward { ref node_id, .. } => {
+                // M4 forwards here. Until then the frame is refused rather than
+                // written locally, which is the whole point of the gate.
+                t_counter!("felix_publish_requests_total", "result" => "not_owner").increment(1);
+                tracing::debug!(
+                    tenant_id, namespace, stream,
+                    owner = %node_id,
+                    "publish refused: shard is owned by another broker",
+                );
+                return None;
+            }
+            Dispatch::Unavailable(reason) => {
+                t_counter!("felix_publish_requests_total", "result" => "unroutable").increment(1);
+                tracing::debug!(
+                    tenant_id, namespace, stream,
+                    reason = %reason,
+                    "publish refused: shard is not servable here",
+                );
+                return None;
+            }
+        }
+    }
+
     // Short-lived cache to avoid repeated stream lookups on hot paths.
     key_scratch.clear();
     let needed = tenant_id.len() + namespace.len() + stream.len() + 2;

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -83,6 +83,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
     }
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &batch.tenant_id,
@@ -397,6 +398,7 @@ pub(crate) async fn handle_publish_message(
     };
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &tenant_id,
@@ -751,6 +753,7 @@ pub(crate) async fn handle_publish_batch_message(
     }
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &tenant_id,

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -29,6 +29,7 @@ fn make_publish_context(
 ) {
     let (tx, rx) = mpsc::channel(buffer);
     let context = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -79,6 +80,7 @@ async fn publish_admission_try_acquire_fails_when_exhausted() {
 async fn enqueue_publish_drop_sheds_load_when_byte_budget_exhausted() {
     let (tx, _rx) = mpsc::channel(8);
     let ctx = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -103,6 +105,7 @@ async fn enqueue_publish_drop_sheds_load_when_byte_budget_exhausted() {
 async fn enqueue_publish_drop_sheds_load_when_conn_byte_budget_exhausted() {
     let (tx, _rx) = mpsc::channel(8);
     let ctx = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -128,6 +131,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     // Two connections sharing one global budget, each with its own conn_admission.
     let admission = Arc::new(PublishAdmission::new(8));
     let ctx_a = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -139,6 +143,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
         ingress_wait: false,
     };
     let ctx_b = PublishContext {
+        ingress: None,
         conn_admission: Arc::new(PublishAdmission::new(4)),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
         lane_manager: test_lane_manager(),
@@ -277,6 +282,7 @@ async fn enqueue_publish_wait_times_out_when_queue_full() {
     let (tx, _rx) = mpsc::channel(1);
     tx.try_send(make_job()).unwrap();
     let ctx = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -298,6 +304,7 @@ async fn enqueue_publish_returns_error_when_queue_closed() {
     let (tx, rx) = mpsc::channel(1);
     drop(rx);
     let ctx = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -1713,7 +1720,8 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
     let mut cache = HashMap::new();
     let mut key = String::new();
 
-    let handle = resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let handle =
+        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
     assert!(handle.is_none(), "no tenant/namespace yet");
 
     broker.register_tenant("t1").await.expect("tenant");
@@ -1731,7 +1739,8 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         .await
         .expect("stream");
 
-    let cached = resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let cached =
+        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
     assert!(
         cached.is_none(),
         "cached miss should be returned until cache expires or clears"
@@ -1739,7 +1748,7 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
 
     cache.clear();
     let refreshed =
-        resolve_stream_cached(&broker, &mut cache, &mut key, "t1", "ns", "stream").await;
+        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
     assert!(refreshed.is_some(), "cache refresh should see stream");
 }
 
@@ -2602,4 +2611,190 @@ async fn backpressure_gives_up_when_the_connection_is_cancelled() {
         err.to_string().contains("cancelled"),
         "unexpected error: {err}"
     );
+}
+
+/// The gate on the publish path itself, not just the decision behind it.
+mod ownership_gate {
+    use super::*;
+    use crate::shard_routing::{IngressRouter, routing_table_from};
+    use crate::shard_watch::{ShardAssignment, ShardKey as WatchKey};
+    use felix_router::{RegionRouter, ShardRouter};
+    use std::collections::HashMap;
+
+    /// A broker with the stream registered, so only the ownership gate can
+    /// refuse anything below.
+    async fn broker_with_stream() -> Broker {
+        let broker = Broker::new(EphemeralCache::new().into());
+        broker.register_tenant("t1").await.expect("tenant");
+        broker
+            .register_namespace("t1", "ns")
+            .await
+            .expect("namespace");
+        broker
+            .register_stream(
+                "t1",
+                "ns",
+                "stream",
+                felix_broker::StreamMetadata::default(),
+            )
+            .await
+            .expect("stream");
+        broker
+    }
+
+    fn watch_key() -> WatchKey {
+        WatchKey {
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            stream: "stream".to_string(),
+            shard: 0,
+        }
+    }
+
+    fn ingress_for(leader: &str, servable: bool) -> IngressRouter {
+        let router = Arc::new(ShardRouter::new(
+            "broker-a",
+            "us-west-2",
+            RegionRouter::new("us-west-2".to_string()),
+        ));
+        let assignment = ShardAssignment {
+            key: watch_key(),
+            leader: leader.to_string(),
+            replicas: Vec::new(),
+            generation: 1,
+            state: "active".to_string(),
+        };
+        let assignments: HashMap<WatchKey, ShardAssignment> =
+            [(watch_key(), assignment)].into_iter().collect();
+        let nodes = HashMap::new();
+        router.publish(routing_table_from(&assignments, &nodes), &nodes);
+
+        let ingress = IngressRouter::new(router);
+        if servable {
+            ingress.publish_servable([(watch_key(), 1)].into_iter().collect());
+        }
+        ingress
+    }
+
+    /// A shard this broker owns and has opened resolves normally.
+    #[tokio::test]
+    async fn an_owned_shard_resolves() {
+        let broker = broker_with_stream().await;
+        let ingress = ingress_for("broker-a", true);
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        let handle = resolve_stream_cached(
+            &broker,
+            Some(&ingress),
+            &mut cache,
+            &mut key,
+            "t1",
+            "ns",
+            "stream",
+        )
+        .await;
+        assert!(handle.is_some(), "an owned, open shard must be servable");
+    }
+
+    /// The acceptance criterion, on the real path: a broker must not write a
+    /// shard it does not own, however healthy the stream is locally.
+    #[tokio::test]
+    async fn a_shard_owned_elsewhere_is_refused() {
+        let broker = broker_with_stream().await;
+        let ingress = ingress_for("broker-b", false);
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        let handle = resolve_stream_cached(
+            &broker,
+            Some(&ingress),
+            &mut cache,
+            &mut key,
+            "t1",
+            "ns",
+            "stream",
+        )
+        .await;
+        assert!(
+            handle.is_none(),
+            "a shard owned by another broker must not resolve locally",
+        );
+    }
+
+    /// Owned but not yet opened. The stream exists locally, so only the gate
+    /// can refuse this.
+    #[tokio::test]
+    async fn an_owned_but_unopened_shard_is_refused() {
+        let broker = broker_with_stream().await;
+        let ingress = ingress_for("broker-a", false);
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        let handle = resolve_stream_cached(
+            &broker,
+            Some(&ingress),
+            &mut cache,
+            &mut key,
+            "t1",
+            "ns",
+            "stream",
+        )
+        .await;
+        assert!(handle.is_none(), "an unopened shard must not accept writes");
+    }
+
+    /// Ownership is checked outside the handle cache, so a reassignment takes
+    /// effect immediately rather than after the cache TTL.
+    #[tokio::test]
+    async fn losing_a_shard_takes_effect_without_waiting_for_the_cache() {
+        let broker = broker_with_stream().await;
+        let ingress = ingress_for("broker-a", true);
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        assert!(
+            resolve_stream_cached(
+                &broker,
+                Some(&ingress),
+                &mut cache,
+                &mut key,
+                "t1",
+                "ns",
+                "stream"
+            )
+            .await
+            .is_some(),
+            "warm the handle cache while the shard is ours",
+        );
+
+        // The shard moves away. The stream handle is still cached and valid.
+        let moved = ingress_for("broker-b", false);
+        assert!(
+            resolve_stream_cached(
+                &broker,
+                Some(&moved),
+                &mut cache,
+                &mut key,
+                "t1",
+                "ns",
+                "stream"
+            )
+            .await
+            .is_none(),
+            "a cached handle must not outlive ownership",
+        );
+    }
+
+    /// The single-node path: no router, no gate, unchanged behaviour.
+    #[tokio::test]
+    async fn a_single_node_broker_is_unaffected() {
+        let broker = broker_with_stream().await;
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        let handle =
+            resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+        assert!(handle.is_some());
+    }
 }

--- a/services/broker/src/transport/quic/handlers/publish/uni.rs
+++ b/services/broker/src/transport/quic/handlers/publish/uni.rs
@@ -65,6 +65,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
     }
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &batch.tenant_id,
@@ -128,6 +129,7 @@ pub(crate) async fn handle_publish_message_uni(
     }
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &tenant_id,
@@ -190,6 +192,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
     }
     let Some(stream_handle) = resolve_stream_cached(
         broker,
+        publish_ctx.ingress.as_deref(),
         stream_cache,
         stream_cache_key,
         &tenant_id,

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -574,6 +574,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
         }
     });
     PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3483,6 +3484,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
     let (tx, rx) = mpsc::channel::<PublishJob>(1);
     drop(rx);
     let publish_ctx = PublishContext {
+        ingress: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3658,6 +3660,7 @@ async fn handle_stream_drain_timeout_sleep_branch() -> Result<()> {
             }
         });
         let publish_ctx = PublishContext {
+            ingress: None,
             workers: Arc::new(vec![tx]),
             worker_count: 1,
             depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/services/broker/tests/graceful_shutdown.rs
+++ b/services/broker/tests/graceful_shutdown.rs
@@ -74,6 +74,7 @@ async fn start_broker() -> Result<Harness> {
         auth,
         accept_shutdown.clone(),
         connections.clone(),
+        None,
     ));
 
     Ok(Harness {


### PR DESCRIPTION
**Closes #103.** M3.6, and the last issue in M3.

Every publish now passes an ownership check before anything reaches storage. `resolve_stream_cached` is the one function all eleven publish call sites funnel through, which is why the gate lives there — nothing bypasses it.

## Performance: a mistake I made and fixed

My first version took a `tokio::Mutex` on the lifecycle to check local readiness. **That puts an `await` and a lock into the publish hot path** for what is fundamentally two lookups — exactly the kind of thing that shows up in p999 long before it shows up in a correctness test.

The servable set is now published as an `ArcSwap` snapshot alongside the routes, so `dispatch` is **synchronous, lock-free, and allocation-free**: two atomic loads, no await. A single-node broker short-circuits on a null check before either.

**Ownership is checked outside the stream-handle cache**, deliberately. That cache avoids a registry lookup and holds for a TTL; ownership changes the instant the control plane says so, and caching it would keep a broker serving a reassigned shard for up to a TTL. `losing_a_shard_takes_effect_without_waiting_for_the_cache` pins that.

## Ordering

One task keeps local state and routes in step, in a fixed order: reconcile local shard state → publish what is servable → publish the routes. The other order would advertise this node as the owner of a shard it has not opened.

## What a broker still cannot do

**Forward.** An address book needs `/v1/nodes`, which requires a cluster-scoped token — and brokers have no credentials (#126). So a shard led by this node resolves on the node id alone, and every other shard is **refused with its owner named** rather than forwarded. That satisfies "a broker never writes a shard it does not own"; forwarding is M4, and `Dispatch::Forward` is already the shape it plugs into.

**Shard by key.** `Publish` carries no routing key, so every record of a stream lands on shard 0 and a stream's `shards` count is metadata the data path does not use. `shard_for` is where a negotiated key plugs in — the hashing is written and tested, so adding the field is a wire change, not a routing change.

## A pre-existing race this surfaced

`durable_config` tests guarded the environment with a local lock while the `config` tests clear every `FELIX_*` variable under a *different* one — two locks, no mutual exclusion. The extra tests here made it fire: **once in ten runs before, zero in ten after** serialising them. I checked it against `main` first to confirm I hadn't caused it.

## Tests

17 total: 12 on the dispatch decision (single-node always local, owned-and-open, owned-but-opening, owned-elsewhere, unassigned, unavailable owner, losing a shard mid-flight, newer generation than local state, multi-shard, and the shard mapping) plus **5 on the real publish path**, including that a single-node broker is unaffected and that a cached handle does not outlive ownership.

## Verification

`task lint`, `task test` (66 suites), `task deny`, `task demo:check`, mermaid — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)