### PR TITLE
feat(controlplane): authenticate and authorize membership writes

### DIFF
--- a/docs-site/src/content/docs/api/control-plane-api.md
+++ b/docs-site/src/content/docs/api/control-plane-api.md
@@ -130,8 +130,12 @@ so a tenant admin cannot grant themselves cluster access. The tenant comes from
 the token's own `tid` claim rather than a path segment, and only selects which
 signing keys to verify against.
 
-The registration, heartbeat, drain, and deregister endpoints brokers use are
-**not yet authenticated**. They are safe on a trusted network only.
+The registration, heartbeat, drain, and deregister endpoints require
+`node.manage` over the node being changed. A broker's credential is scoped to
+`node:{its own id}`, so it cannot act for another broker; an operator holding
+`cluster:*` can manage the whole fleet. Registration authorises the identity in
+the request body, so a broker cannot claim a name its credential does not
+cover.
 
 ### Internal Bootstrap API (Day-0)
 

--- a/docs-site/src/content/docs/features/security.md
+++ b/docs-site/src/content/docs/features/security.md
@@ -256,6 +256,7 @@ After bootstrap, admin actions require explicit Felix permissions:
 - RBAC policy writes: `rbac.policy.manage:<scoped object>`
 - RBAC assignment writes: `rbac.assignment.manage:<scoped object>`
 - Cluster membership reads: `node.view:cluster:*`
+- Cluster membership writes: `node.manage:node:{node_id}` or `node.manage:cluster:*`
 
 ### RBAC Object Grammar and Delegation
 
@@ -265,6 +266,7 @@ Canonical RBAC object formats:
 - `stream:{tenant_id}/{namespace}/{stream_or_*}`
 - `cache:{tenant_id}/{namespace}/{cache_or_*}`
 - `cluster:*` — the cluster itself, outside the tenant hierarchy
+- `node:{node_id}` — one broker, also outside it
 
 Write-time protections:
 - `tenant:*` is rejected
@@ -308,9 +310,11 @@ cluster scope cannot read tenant data.
 - **It contains no tenant object.** Cluster scope is not a backdoor into tenant
   data.
 
-Only `GET /v1/nodes` and `GET /v1/nodes/{node_id}` require it today. The
-endpoints brokers use to register and report health are **not yet
-authenticated** and are safe on a trusted network only.
+Reads require `node.view:cluster:*`. Writes — register, heartbeat, drain,
+deregister — require `node.manage` over the node being changed, held either as
+`node:{node_id}` by that broker or as `cluster:*` by an operator. A node is an
+RBAC object rather than a field the caller asserts, which is what stops one
+broker acting for another.
 
 ### Supported Identity Providers
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -90,6 +90,7 @@ Objects:
 - Stream: `stream:{tenant_id}/{namespace}/{stream}` or `stream:{tenant_id}/{namespace}/*`
 - Cache: `cache:{tenant_id}/{namespace}/{cache}` or `cache:{tenant_id}/{namespace}/*`
 - Cluster: `cluster:*` — see [Cluster scope](#cluster-scope)
+- Node: `node:{node_id}` — one broker
 
 Actions:
 - `rbac.view`, `rbac.policy.manage`, `rbac.assignment.manage`
@@ -97,6 +98,7 @@ Actions:
 - `stream.publish`, `stream.subscribe`
 - `cache.read`, `cache.write`
 - `node.view` — cluster-scoped only
+- `node.manage` — over `node:{node_id}` or `cluster:*`
 
 ### Cluster scope
 

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -77,9 +77,8 @@ Four rules, each of which exists for a reason:
   putting each in the changefeed would evict every real membership change from
   the retention window. Only the lifecycle move that expiry causes is published.
 
-> **Not yet authenticated.** Any caller that can reach this endpoint can report
-> health for any `node_id`. Authenticating broker identity is tracked in #126;
-> until then it is only safe on a trusted network.
+Requires `node.manage` over the node being reported — see
+[Authorizing membership writes](#authorizing-membership-writes).
 
 ### Broker-side lifecycle
 
@@ -163,8 +162,47 @@ themselves cluster access, and nothing in the bootstrap seed grants it either.
 The converse also holds: cluster scope confers nothing inside a tenant, so it is
 not a backdoor into tenant data.
 
-Note that the registration, heartbeat, drain, and deregister endpoints above are
-**not** authenticated yet (#126). Only the operator read endpoints are.
+#### Authorizing membership writes
+
+Registration, heartbeat, drain, and deregistration all require `node.manage`
+over the node being changed:
+
+| Object | Who holds it | Can change |
+| --- | --- | --- |
+| `node:{node_id}` | a broker, for its own identity | that node only |
+| `cluster:*` | an operator managing the fleet | every node |
+
+**A node is an RBAC object, not a field the caller asserts.** A broker
+presenting `node.manage:node:broker-a` for `broker-b` is refused, so one broker
+cannot register, drain, deregister, or report health for another. Registration
+authorises the identity in the *request body*, so a broker cannot claim a name
+its credential does not cover.
+
+`node:*` is deliberately rejected: it would be `cluster:*` under a second name,
+and two spellings for one scope is how a policy review misses one.
+
+A node scope is an island in the same way `cluster:*` is. No tenant scope
+contains it, so a tenant admin cannot grant themselves one; and it confers
+nothing inside a tenant. `node.view` does not imply `node.manage` — reading the
+fleet is not permission to change it.
+
+##### Giving a broker its credential
+
+A broker with `FELIX_NODE_ID` set **must** have a credential, or it refuses to
+start. Starting one that will fail every control-plane call on a loop is worse
+than refusing.
+
+| Env | Meaning |
+| --- | --- |
+| `FELIX_NODE_TOKEN` | the token itself |
+| `FELIX_NODE_TOKEN_FILE` | a path to read it from, for a mounted secret |
+
+The file form exists so a credential need not sit in an environment variable
+visible in a process listing. Whitespace is trimmed, and a blank value is
+treated as no credential rather than as an empty one.
+
+The same credential authenticates the shard-assignment watch, which is cluster
+metadata by the same argument.
 
 ### Shard ownership
 
@@ -355,7 +393,8 @@ state, publish what is servable, then publish the routes. Publishing routes
 first would advertise this node as the owner of a shard it has not opened.
 
 **A broker cannot forward yet.** Building an address book needs `/v1/nodes`,
-which requires a cluster-scoped token, and brokers have no credentials (#126).
+which requires `node.view:cluster:*`; a broker's own credential is scoped to its
+own node.
 So a shard led by this node resolves on the node id alone, and every other shard
 is refused with the owner named rather than forwarded. Forwarding is M4.
 

--- a/docs/security/rbac.md
+++ b/docs/security/rbac.md
@@ -24,6 +24,7 @@ Canonical actions:
 - `cache.read`
 - `cache.write`
 - `node.view` — cluster-scoped only; see [Cluster scope](#cluster-scope)
+- `node.manage` — over `node:{node_id}` or `cluster:*`
 
 ## Object Grammar
 

--- a/services/broker/src/config.rs
+++ b/services/broker/src/config.rs
@@ -14,6 +14,12 @@ use std::net::SocketAddr;
 pub struct MembershipConfig {
     /// Stable across restarts. This is the identity, not the process.
     pub node_id: String,
+    /// Credential proving this broker may act for `node_id`.
+    ///
+    /// Required, not optional. A broker with an identity and no credential
+    /// cannot register, and starting one that will fail every control-plane
+    /// call on a loop is worse than refusing to start.
+    pub token: String,
     /// `host:port` peers reach this broker on. Not the bind address: a broker
     /// bound to 0.0.0.0 has to advertise something routable.
     pub advertise_addr: String,
@@ -241,8 +247,37 @@ fn membership_from_env(
         ));
     }
 
+    // Read from a file when given one, so a token can arrive as a mounted
+    // secret rather than an environment variable visible in a process listing.
+    let token = match std::env::var("FELIX_NODE_TOKEN_FILE")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+    {
+        Some(path) => std::fs::read_to_string(&path)
+            .map_err(|err| {
+                std::io::Error::new(
+                    ErrorKind::InvalidInput,
+                    format!("read FELIX_NODE_TOKEN_FILE {path}: {err}"),
+                )
+            })?
+            .trim()
+            .to_string(),
+        None => std::env::var("FELIX_NODE_TOKEN")
+            .ok()
+            .map(|value| value.trim().to_string())
+            .unwrap_or_default(),
+    };
+    if token.is_empty() {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            "FELIX_NODE_ID is set but no node credential was provided; \
+             set FELIX_NODE_TOKEN or FELIX_NODE_TOKEN_FILE",
+        ));
+    }
+
     Ok(Some(MembershipConfig {
         node_id,
+        token,
         advertise_addr,
         region: std::env::var("FELIX_REGION_ID").unwrap_or_else(|_| "local".to_string()),
     }))
@@ -825,6 +860,7 @@ mod tests {
             env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
             env::set_var("FELIX_REGION_ID", "eu-central-1");
             env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+            env::set_var("FELIX_NODE_TOKEN", "a-node-token");
         }
         let membership = BrokerConfig::from_env()
             .expect("config")
@@ -833,6 +869,61 @@ mod tests {
         assert_eq!(membership.node_id, "broker-a");
         assert_eq!(membership.advertise_addr, "10.0.0.4:7000");
         assert_eq!(membership.region, "eu-central-1");
+        assert_eq!(membership.token, "a-node-token");
+    }
+
+    /// A broker with an identity and no credential cannot register. Starting it
+    /// to fail every control-plane call on a loop is worse than refusing.
+    #[serial]
+    #[test]
+    fn an_identity_without_a_credential_fails_startup() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+        }
+        let err = BrokerConfig::from_env().expect_err("should fail");
+        assert!(err.to_string().contains("FELIX_NODE_TOKEN"), "{err}");
+    }
+
+    /// A token can arrive as a mounted secret rather than an environment
+    /// variable visible in a process listing.
+    #[serial]
+    #[test]
+    fn a_credential_can_come_from_a_file() {
+        let dir = TempDir::new().expect("dir");
+        let path = dir.path().join("node.token");
+        fs::write(&path, "  file-token\n").expect("write");
+
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+            env::set_var("FELIX_NODE_TOKEN_FILE", path.to_str().expect("path"));
+        }
+        let membership = BrokerConfig::from_env()
+            .expect("config")
+            .membership
+            .expect("membership");
+        assert_eq!(
+            membership.token, "file-token",
+            "surrounding whitespace is trimmed"
+        );
+    }
+
+    #[serial]
+    #[test]
+    fn a_blank_credential_is_no_credential() {
+        clear_felix_env();
+        unsafe {
+            env::set_var("FELIX_NODE_ID", "broker-a");
+            env::set_var("FELIX_NODE_ADVERTISE_ADDR", "10.0.0.4:7000");
+            env::set_var("FELIX_CONTROLPLANE_URL", "http://localhost:8443");
+            env::set_var("FELIX_NODE_TOKEN", "   ");
+        }
+        assert!(BrokerConfig::from_env().is_err());
     }
 
     // Helper to clear all Felix env vars

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -365,7 +365,9 @@ where
             let watch = tokio::spawn(shard_watch::run(
                 membership_client.clone(),
                 base_url.clone(),
-                None,
+                // The assignment feed is cluster metadata, so it is read with
+                // the same credential the rest of membership uses.
+                config.membership.as_ref().map(|m| m.token.clone()),
                 Arc::clone(ownership),
                 Duration::from_millis(config.controlplane_sync_interval_ms),
                 sync_shutdown.clone(),
@@ -445,6 +447,7 @@ where
                     &membership_client,
                     base_url,
                     &membership_config.node_id,
+                    &membership_config.token,
                 )
                 .await;
             })

--- a/services/broker/src/membership.rs
+++ b/services/broker/src/membership.rs
@@ -76,6 +76,8 @@ struct HeartbeatResponse {
 #[derive(Debug, Clone)]
 pub struct Registration {
     pub node_id: String,
+    /// Carried so the heartbeat loop does not need the whole config.
+    pub token: String,
     /// This process's incarnation. Sent with every heartbeat so one delayed
     /// past a restart is rejected instead of counted for its successor.
     pub incarnation: u64,
@@ -136,6 +138,10 @@ pub async fn register(
 ) -> std::result::Result<Registration, MembershipError> {
     let response = client
         .post(format!("{}/v1/nodes", base_url.trim_end_matches('/')))
+        // Proves this broker may claim `node_id`. The control plane authorises
+        // the identity in the body against it, so a broker cannot register
+        // under a name its credential does not cover.
+        .bearer_auth(&config.token)
         .json(&RegistrationRequest {
             node_id: &config.node_id,
             advertise_addr: &config.advertise_addr,
@@ -176,6 +182,7 @@ pub async fn register(
 
     Ok(Registration {
         node_id: config.node_id.clone(),
+        token: config.token.clone(),
         incarnation: registered.node.status.incarnation,
         heartbeat_interval_ms: registered.heartbeat_interval_ms,
     })
@@ -213,7 +220,7 @@ pub async fn run_heartbeat(
             _ = tokio::time::sleep(jittered(delay)) => {}
         }
 
-        match send_heartbeat(&client, &url, registration.incarnation).await {
+        match send_heartbeat(&client, &url, &registration.token, registration.incarnation).await {
             Ok(response) => {
                 consecutive_failures.store(0, Ordering::Release);
                 last_success = std::time::Instant::now();
@@ -256,10 +263,12 @@ pub async fn run_heartbeat(
 async fn send_heartbeat(
     client: &reqwest::Client,
     url: &str,
+    token: &str,
     incarnation: u64,
 ) -> std::result::Result<HeartbeatResponse, MembershipError> {
     let response = client
         .post(url)
+        .bearer_auth(token)
         .json(&HeartbeatRequest { incarnation })
         .send()
         .await
@@ -282,19 +291,30 @@ async fn send_heartbeat(
 }
 
 /// Stop receiving new placement, without stopping service.
-pub async fn drain(client: &reqwest::Client, base_url: &str, node_id: &str) -> Result<()> {
-    post_lifecycle(client, base_url, node_id, "drain").await
+pub async fn drain(
+    client: &reqwest::Client,
+    base_url: &str,
+    node_id: &str,
+    token: &str,
+) -> Result<()> {
+    post_lifecycle(client, base_url, node_id, token, "drain").await
 }
 
 /// Leave the cluster on purpose, so this is not mistaken for a crash.
-pub async fn deregister(client: &reqwest::Client, base_url: &str, node_id: &str) -> Result<()> {
-    post_lifecycle(client, base_url, node_id, "deregister").await
+pub async fn deregister(
+    client: &reqwest::Client,
+    base_url: &str,
+    node_id: &str,
+    token: &str,
+) -> Result<()> {
+    post_lifecycle(client, base_url, node_id, token, "deregister").await
 }
 
 async fn post_lifecycle(
     client: &reqwest::Client,
     base_url: &str,
     node_id: &str,
+    token: &str,
     action: &str,
 ) -> Result<()> {
     let response = client
@@ -302,6 +322,7 @@ async fn post_lifecycle(
             "{}/v1/nodes/{node_id}/{action}",
             base_url.trim_end_matches('/')
         ))
+        .bearer_auth(token)
         .send()
         .await
         .with_context(|| format!("{action} node {node_id}"))?;
@@ -434,11 +455,16 @@ pub fn spawn(
 /// then deregister so this reads as intentional rather than as a crash.
 /// Neither failure is worth aborting a shutdown over: if the control plane
 /// cannot be told, heartbeat expiry reaches the same conclusion a timeout later.
-pub async fn shutdown_membership(client: &reqwest::Client, base_url: &str, node_id: &str) {
-    if let Err(err) = drain(client, base_url, node_id).await {
+pub async fn shutdown_membership(
+    client: &reqwest::Client,
+    base_url: &str,
+    node_id: &str,
+    token: &str,
+) {
+    if let Err(err) = drain(client, base_url, node_id, token).await {
         tracing::warn!(node_id, error = %err, "could not mark this broker draining");
     }
-    if let Err(err) = deregister(client, base_url, node_id).await {
+    if let Err(err) = deregister(client, base_url, node_id, token).await {
         tracing::warn!(
             node_id,
             error = %err,

--- a/services/broker/src/membership_tests.rs
+++ b/services/broker/src/membership_tests.rs
@@ -102,6 +102,7 @@ async fn serve(
 fn config() -> MembershipConfig {
     MembershipConfig {
         node_id: "broker-a".to_string(),
+        token: "test-token".to_string(),
         advertise_addr: "10.0.0.4:7000".to_string(),
         region: "us-west-2".to_string(),
     }
@@ -251,8 +252,10 @@ async fn draining_and_deregistering_hit_the_right_endpoints() {
     let (base_url, stop, handle) = serve(Arc::clone(&calls)).await;
     let client = build_test_client().expect("client");
 
-    drain(&client, &base_url, "broker-a").await.expect("drain");
-    deregister(&client, &base_url, "broker-a")
+    drain(&client, &base_url, "broker-a", "test-token")
+        .await
+        .expect("drain");
+    deregister(&client, &base_url, "broker-a", "test-token")
         .await
         .expect("deregister");
 

--- a/services/broker/tests/membership_lifecycle.rs
+++ b/services/broker/tests/membership_lifecycle.rs
@@ -12,7 +12,7 @@ use controlplane::app::{AppState, build_router};
 use controlplane::config::NodeLivenessConfig;
 use controlplane::model::NodeLifecycle;
 use controlplane::store::memory::InMemoryStore;
-use controlplane::store::{ControlPlaneStore, StoreConfig};
+use controlplane::store::{AuthStore, ControlPlaneStore, StoreConfig};
 use reqwest::{Client, redirect::Policy};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -30,6 +30,9 @@ struct Cluster {
     base_url: String,
     store: Arc<InMemoryStore>,
     client: Client,
+    /// A credential scoped to `broker-a`, which is the broker these tests are.
+    token: String,
+    keys: controlplane::auth::felix_token::TenantSigningKeys,
     stop: tokio::sync::oneshot::Sender<()>,
     server: tokio::task::JoinHandle<()>,
 }
@@ -40,6 +43,21 @@ impl Cluster {
             changes_limit: 1000,
             change_retention_max_rows: Some(1000),
         }));
+        let keys = controlplane::auth::keys::generate_signing_keys().expect("keys");
+        store
+            .set_tenant_signing_keys("t1", keys.clone())
+            .await
+            .expect("keys");
+        // Scoped to this broker's own identity, which is what a real deployment
+        // would hand it. `broker-b` cases below rely on that being a real limit.
+        let token = controlplane::auth::felix_token::mint_token(
+            &keys,
+            "t1",
+            "p:broker-a",
+            vec!["node.manage:node:broker-a".to_string()],
+            Duration::from_secs(900),
+        )
+        .expect("token");
         let state = AppState {
             region: Region {
                 region_id: "us-west-2".to_string(),
@@ -75,6 +93,8 @@ impl Cluster {
         Self {
             base_url: format!("http://{addr}"),
             store,
+            token,
+            keys,
             client: Client::builder()
                 .timeout(Duration::from_secs(2))
                 .no_proxy()
@@ -84,6 +104,18 @@ impl Cluster {
             stop,
             server,
         }
+    }
+
+    /// A credential covering every node, for cases that are not about scope.
+    fn fleet_token(&self) -> String {
+        controlplane::auth::felix_token::mint_token(
+            &self.keys,
+            "t1",
+            "p:operator",
+            vec!["node.manage:cluster:*".to_string()],
+            Duration::from_secs(900),
+        )
+        .expect("token")
     }
 
     async fn lifecycle(&self, node_id: &str) -> NodeLifecycle {
@@ -101,9 +133,10 @@ impl Cluster {
     }
 }
 
-fn config(node_id: &str, port: u16) -> MembershipConfig {
+fn config(node_id: &str, port: u16, token: &str) -> MembershipConfig {
     MembershipConfig {
         node_id: node_id.to_string(),
+        token: token.to_string(),
         advertise_addr: format!("10.0.0.4:{port}"),
         region: "us-west-2".to_string(),
     }
@@ -118,7 +151,7 @@ async fn boot_produces_one_live_record_and_a_restart_reuses_it() {
     let first = membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-a", 7001),
+        &config("broker-a", 7001, &cluster.token),
     )
     .await
     .expect("register");
@@ -129,7 +162,7 @@ async fn boot_produces_one_live_record_and_a_restart_reuses_it() {
     let second = membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-a", 7001),
+        &config("broker-a", 7001, &cluster.token),
     )
     .await
     .expect("re-register");
@@ -156,12 +189,18 @@ async fn graceful_shutdown_leaves_rather_than_expiring() {
     membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-a", 7001),
+        &config("broker-a", 7001, &cluster.token),
     )
     .await
     .expect("register");
 
-    membership::shutdown_membership(&cluster.client, &cluster.base_url, "broker-a").await;
+    membership::shutdown_membership(
+        &cluster.client,
+        &cluster.base_url,
+        "broker-a",
+        &cluster.token,
+    )
+    .await;
 
     assert_eq!(cluster.lifecycle("broker-a").await, NodeLifecycle::Left);
     cluster.shutdown().await;
@@ -174,7 +213,7 @@ async fn an_abrupt_stop_is_detected_by_expiry() {
     let registered = membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-a", 7001),
+        &config("broker-a", 7001, &cluster.token),
     )
     .await
     .expect("register");
@@ -211,15 +250,18 @@ async fn a_duplicate_advertised_address_is_refused_terminally() {
     membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-a", 7001),
+        &config("broker-a", 7001, &cluster.token),
     )
     .await
     .expect("register");
 
+    // Cluster-scoped on purpose: this test is about the duplicate address, and a
+    // node-scoped token would fail authorisation first and prove nothing.
+    let fleet_token = cluster.fleet_token();
     let err = membership::register(
         &cluster.client,
         &cluster.base_url,
-        &config("broker-b", 7001),
+        &config("broker-b", 7001, &fleet_token),
     )
     .await
     .expect_err("should be refused");
@@ -243,7 +285,7 @@ async fn heartbeats_keep_a_broker_live_past_its_expiry_window() {
     let task = membership::spawn(
         cluster.client.clone(),
         cluster.base_url.clone(),
-        config("broker-a", 7001),
+        config("broker-a", 7001, &cluster.token),
         serving,
         shutdown.clone(),
     );
@@ -273,5 +315,66 @@ async fn heartbeats_keep_a_broker_live_past_its_expiry_window() {
 
     shutdown.cancel();
     let _ = task.handle.await;
+    cluster.shutdown().await;
+}
+
+/// End to end, through the real broker client and the real control plane: a
+/// broker's own credential cannot be turned on another broker.
+///
+/// This is the hole that was open — anyone who could reach the control plane
+/// could deregister any broker in the fleet.
+#[tokio::test]
+async fn a_brokers_credential_cannot_deregister_another_broker() {
+    let cluster = Cluster::start().await;
+
+    // broker-b exists, registered by an operator.
+    let fleet_token = cluster.fleet_token();
+    membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-b", 7002, &fleet_token),
+    )
+    .await
+    .expect("register broker-b");
+    assert_eq!(cluster.lifecycle("broker-b").await, NodeLifecycle::Live);
+
+    // broker-a holds only its own credential.
+    let err = membership::deregister(
+        &cluster.client,
+        &cluster.base_url,
+        "broker-b",
+        &cluster.token,
+    )
+    .await
+    .expect_err("broker-a must not deregister broker-b");
+    assert!(err.to_string().contains("403"), "{err}");
+
+    assert_eq!(
+        cluster.lifecycle("broker-b").await,
+        NodeLifecycle::Live,
+        "the attempt must leave broker-b untouched",
+    );
+
+    cluster.shutdown().await;
+}
+
+/// A broker with no credential at all gets nowhere, and finds out at
+/// registration rather than silently running as a non-member.
+#[tokio::test]
+async fn an_unauthenticated_broker_cannot_register() {
+    let cluster = Cluster::start().await;
+
+    let err = membership::register(
+        &cluster.client,
+        &cluster.base_url,
+        &config("broker-a", 7001, ""),
+    )
+    .await
+    .expect_err("should be refused");
+    assert!(
+        matches!(err, MembershipError::Rejected(_)),
+        "a missing credential is terminal, not something to retry: {err:?}",
+    );
+
     cluster.shutdown().await;
 }

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -15,9 +15,12 @@
 //!   claim a future heartbeat and outlive its timeout.
 //!
 //! # Security considerations
-//! - **This endpoint is not yet authenticated.** Any caller that can reach it
-//!   can report health for any node_id. Authenticating broker identity is
-//!   tracked in #126; until then this is only safe on a trusted network.
+//! - Every write requires `node.manage` over the node being changed. A broker's
+//!   credential is scoped to `node:{its own id}`, so it cannot register, drain,
+//!   deregister, or report health for another broker; an operator holding
+//!   `cluster:*` can manage the whole fleet.
+//! - Reads require `node.view:cluster:*`. The listing exposes advertised
+//!   internal addresses, which is the cluster's network layout.
 use crate::api::error::{
     ApiError, api_conflict, api_forbidden, api_internal, api_not_found, api_unauthorized,
 };
@@ -28,7 +31,9 @@ use crate::api::types::{
 };
 use crate::app::AppState;
 use crate::auth::felix_token::verify_token;
-use crate::auth::rbac::authorize::{ACTION_NODE_VIEW, ParsedObject, parse_permission};
+use crate::auth::rbac::authorize::{
+    ACTION_NODE_MANAGE, ACTION_NODE_VIEW, ParsedObject, object_within_scope, parse_permission,
+};
 use crate::model::{Node, NodeLifecycle, NodeSpec, NodeStatus};
 use crate::store::StoreError;
 use axum::Json;
@@ -59,9 +64,11 @@ use std::collections::HashMap;
 /// - 409 when the reported incarnation is older than the recorded one.
 pub(crate) async fn report_health(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(node_id): Path<String>,
     Json(request): Json<NodeHeartbeatRequest>,
 ) -> Result<Json<NodeHeartbeatResponse>, ApiError> {
+    require_node_manage(&state, &headers, &node_id).await?;
     // The control plane's clock, deliberately: expiry is judged against it, so
     // letting a caller supply the time would let it postpone its own timeout.
     let now = now_millis();
@@ -115,8 +122,13 @@ pub fn now_millis() -> u64 {
 ///   already belongs to another node.
 pub(crate) async fn register_node(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(request): Json<NodeRegistrationRequest>,
 ) -> Result<Json<NodeRegistrationResponse>, ApiError> {
+    // The identity being claimed comes from the body, so that is what the
+    // token has to be authorised for. A broker cannot register as someone else
+    // by asking to.
+    require_node_manage(&state, &headers, &request.node_id).await?;
     let now = now_millis();
     let node = Node {
         node_id: request.node_id,
@@ -173,8 +185,10 @@ pub(crate) async fn register_node(
 /// - 409 when the node is not currently serving, since there is nothing to drain.
 pub(crate) async fn drain_node(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(node_id): Path<String>,
 ) -> Result<Json<Node>, ApiError> {
+    require_node_manage(&state, &headers, &node_id).await?;
     set_lifecycle(&state, &node_id, NodeLifecycle::Draining).await
 }
 
@@ -199,8 +213,10 @@ pub(crate) async fn drain_node(
 /// - 404 when the node is not registered.
 pub(crate) async fn deregister_node(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Path(node_id): Path<String>,
 ) -> Result<Json<Node>, ApiError> {
+    require_node_manage(&state, &headers, &node_id).await?;
     set_lifecycle(&state, &node_id, NodeLifecycle::Left).await
 }
 
@@ -462,22 +478,7 @@ pub(crate) async fn get_node(
 /// `node.view:cluster:*`, and no tenant scope contains a cluster object, so a
 /// tenant admin cannot write that rule for themselves.
 async fn require_cluster_node_view(state: &AppState, headers: &HeaderMap) -> Result<(), ApiError> {
-    let bearer = headers
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| value.strip_prefix("Bearer "))
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| api_unauthorized("missing bearer token"))?;
-
-    let tenant_id = unverified_tenant(bearer)?;
-    let keys = state
-        .store
-        .get_tenant_signing_keys(&tenant_id)
-        .await
-        .map_err(|ref err| api_internal("failed to load signing keys", err))?;
-    let claims = verify_token(&keys, &tenant_id, bearer, 5)
-        .map_err(|_| api_unauthorized("invalid token"))?;
+    let (tenant_id, claims) = verified_claims(state, headers).await?;
 
     let allowed = claims.perms.iter().any(|perm| {
         // Parsed against the token's own tenant; a cluster object ignores it.
@@ -494,6 +495,73 @@ async fn require_cluster_node_view(state: &AppState, headers: &HeaderMap) -> Res
     } else {
         Err(api_forbidden("missing node.view:cluster:* permission"))
     }
+}
+
+/// Require permission to change one node's membership.
+///
+/// The node id comes from the request -- a path segment, or the body on
+/// registration -- and the token has to carry `node.manage` over a scope that
+/// contains it. A broker's credential is scoped to `node:{its own id}`, so
+/// presenting it for another node fails here rather than being trusted because
+/// the request said so. An operator holding `cluster:*` covers every node.
+///
+/// This is what closes the hole where any caller that could reach the control
+/// plane could register, drain, or deregister any broker, or keep a dead one
+/// looking alive.
+async fn require_node_manage(
+    state: &AppState,
+    headers: &HeaderMap,
+    node_id: &str,
+) -> Result<(), ApiError> {
+    let (tenant_id, claims) = verified_claims(state, headers).await?;
+    let target = ParsedObject::Node {
+        node_id: node_id.to_string(),
+    };
+
+    let allowed = claims.perms.iter().any(|perm| {
+        // Unparsable entries are skipped rather than trusted, so a malformed
+        // permission can never widen access.
+        matches!(
+            parse_permission(perm, &tenant_id),
+            Ok(parsed) if parsed.action == ACTION_NODE_MANAGE
+                && object_within_scope(&parsed.object, &target)
+        )
+    });
+
+    if allowed {
+        Ok(())
+    } else {
+        Err(api_forbidden(&format!(
+            "missing node.manage on node:{node_id} or cluster:*"
+        )))
+    }
+}
+
+/// Verify a bearer token and return the tenant whose keys signed it.
+///
+/// Shared by the read and write guards so there is one verification path, not
+/// two that can drift.
+async fn verified_claims(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<(String, crate::auth::felix_token::FelixClaims), ApiError> {
+    let bearer = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| api_unauthorized("missing bearer token"))?;
+
+    let tenant_id = unverified_tenant(bearer)?;
+    let keys = state
+        .store
+        .get_tenant_signing_keys(&tenant_id)
+        .await
+        .map_err(|ref err| api_internal("failed to load signing keys", err))?;
+    let claims = verify_token(&keys, &tenant_id, bearer, 5)
+        .map_err(|_| api_unauthorized("invalid token"))?;
+    Ok((tenant_id, claims))
 }
 
 /// Read `tid` from an unverified token, only to choose a verification key.

--- a/services/controlplane/src/auth/rbac/authorize.rs
+++ b/services/controlplane/src/auth/rbac/authorize.rs
@@ -19,6 +19,12 @@ pub const ACTION_CACHE_WRITE: &str = "cache.write";
 /// Read cluster membership. Cluster-scoped, so it is never reachable from a
 /// tenant scope -- see [`ParsedObject::Cluster`].
 pub const ACTION_NODE_VIEW: &str = "node.view";
+/// Claim or change a node's membership: register, report health, drain, leave.
+///
+/// Granted over `node:{node_id}` for a broker, which is what stops one broker
+/// speaking for another, or over `cluster:*` for an operator that manages the
+/// whole fleet.
+pub const ACTION_NODE_MANAGE: &str = "node.manage";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Segment {
@@ -28,6 +34,15 @@ pub enum Segment {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParsedObject {
+    /// One named node.
+    ///
+    /// The scope a broker's own credential carries. It contains only itself, so
+    /// a broker holding `node.manage:node:broker-a` cannot register, drain, or
+    /// report health for `broker-b` -- which is the whole reason node identity
+    /// is an object rather than a field the caller asserts.
+    Node {
+        node_id: String,
+    },
     /// The cluster itself: brokers, their liveness, their placement standing.
     ///
     /// Deliberately outside the tenant hierarchy. No tenant scope contains it,
@@ -76,6 +91,7 @@ pub fn canonical_action(action: &str) -> Option<&'static str> {
         ACTION_CACHE_READ => Some(ACTION_CACHE_READ),
         ACTION_CACHE_WRITE => Some(ACTION_CACHE_WRITE),
         ACTION_NODE_VIEW => Some(ACTION_NODE_VIEW),
+        ACTION_NODE_MANAGE => Some(ACTION_NODE_MANAGE),
         _ => None,
     }
 }
@@ -95,6 +111,7 @@ pub fn parse_permission(raw: &str, tenant_id: &str) -> Result<ParsedPermission, 
 ///
 /// Canonical grammar:
 /// - `cluster:*`
+/// - `node:{node_id}`
 /// - `tenant:{tenant_id}`
 /// - `namespace:{tenant_id}/{namespace}`
 /// - `stream:{tenant_id}/{namespace}/{stream}`
@@ -111,6 +128,18 @@ pub fn parse_object(raw: &str, tenant_id: &str) -> Result<ParsedObject, String> 
     }
     if raw.starts_with("cluster:") {
         return Err("the only cluster object is cluster:*".to_string());
+    }
+
+    // Also tenant-independent: a node belongs to the cluster, not to a tenant.
+    if let Some(node_id) = raw.strip_prefix("node:") {
+        if node_id.is_empty() || node_id == "*" {
+            // `node:*` would be `cluster:*` by another name, and having two
+            // spellings for one scope is how a policy review misses one.
+            return Err("node objects must name one node; use cluster:* for all".to_string());
+        }
+        return Ok(ParsedObject::Node {
+            node_id: node_id.to_string(),
+        });
     }
 
     if let Some(rest) = raw.strip_prefix("tenant:") {
@@ -168,7 +197,16 @@ pub fn object_within_scope(scope: &ParsedObject, target: &ParsedObject) -> bool 
         // themselves cluster access; and cluster scope confers nothing inside a
         // tenant, so it cannot be used to read tenant data either.
         (ParsedObject::Cluster, ParsedObject::Cluster) => true,
+        // Cluster scope covers every node, which is what an operator managing
+        // the fleet holds.
+        (ParsedObject::Cluster, ParsedObject::Node { .. }) => true,
         (ParsedObject::Cluster, _) | (_, ParsedObject::Cluster) => false,
+        // A node scope is exactly one node. No wildcard, no hierarchy: this is
+        // the boundary that stops one broker acting as another.
+        (ParsedObject::Node { node_id: scope }, ParsedObject::Node { node_id: target }) => {
+            scope == target
+        }
+        (ParsedObject::Node { .. }, _) | (_, ParsedObject::Node { .. }) => false,
         (ParsedObject::Tenant { tenant_id: s }, ParsedObject::Tenant { tenant_id: t }) => s == t,
         (ParsedObject::Tenant { tenant_id: s }, ParsedObject::Namespace { tenant_id: t, .. }) => {
             s == t
@@ -334,6 +372,99 @@ fn split3(input: &str) -> Result<(&str, &str, &str), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The boundary the whole node credential rests on: a scope for one node
+    /// contains that node and nothing else.
+    #[test]
+    fn a_node_scope_covers_exactly_one_node() {
+        let a = parse_object("node:broker-a", "t1").expect("parse");
+        let b = parse_object("node:broker-b", "t1").expect("parse");
+
+        assert!(object_within_scope(&a, &a));
+        assert!(
+            !object_within_scope(&a, &b),
+            "a broker must not be able to act for another broker",
+        );
+        assert!(!object_within_scope(&b, &a));
+    }
+
+    /// An operator managing the fleet holds cluster scope, which covers every
+    /// node -- but a node scope never widens back out to the cluster.
+    #[test]
+    fn cluster_scope_covers_every_node_but_not_the_reverse() {
+        let cluster = ParsedObject::Cluster;
+        let node = parse_object("node:broker-a", "t1").expect("parse");
+
+        assert!(object_within_scope(&cluster, &node));
+        assert!(
+            !object_within_scope(&node, &cluster),
+            "one node's credential must not confer fleet-wide access",
+        );
+    }
+
+    /// Two spellings for one scope is how a policy review misses one.
+    #[test]
+    fn a_node_wildcard_is_rejected() {
+        assert!(parse_object("node:*", "t1").is_err());
+        assert!(parse_object("node:", "t1").is_err());
+    }
+
+    #[test]
+    fn a_node_object_ignores_the_request_tenant() {
+        assert_eq!(
+            parse_object("node:broker-a", "t1"),
+            parse_object("node:broker-a", "t2"),
+        );
+    }
+
+    #[test]
+    fn node_manage_is_a_recognised_action() {
+        let parsed = parse_permission("node.manage:node:broker-a", "t1").expect("parse");
+        assert_eq!(parsed.action, ACTION_NODE_MANAGE);
+        assert_eq!(
+            parsed.object,
+            ParsedObject::Node {
+                node_id: "broker-a".to_string()
+            }
+        );
+    }
+
+    /// A tenant admin must not be able to write themselves a node permission,
+    /// for the same reason they cannot write a cluster one.
+    #[test]
+    fn a_tenant_scope_never_reaches_a_node() {
+        let tenant_scopes = [
+            ParsedObject::Tenant {
+                tenant_id: "t1".to_string(),
+            },
+            parse_object("namespace:t1/*", "t1").expect("namespace"),
+        ];
+        let node = parse_object("node:broker-a", "t1").expect("parse");
+
+        for scope in &tenant_scopes {
+            assert!(!object_within_scope(scope, &node), "{scope:?}");
+        }
+
+        let rule = PolicyRule {
+            subject: "role:tenant-admin".to_string(),
+            object: "node:broker-a".to_string(),
+            action: ACTION_NODE_MANAGE.to_string(),
+        };
+        assert!(
+            validate_new_rule_allowed(&tenant_scopes, "t1", &rule).is_err(),
+            "a tenant admin must not be able to grant node access",
+        );
+    }
+
+    /// And a node credential confers nothing inside a tenant.
+    #[test]
+    fn a_node_scope_confers_nothing_in_a_tenant() {
+        let node = [parse_object("node:broker-a", "t1").expect("parse")];
+        for target in ["tenant:t1", "namespace:t1/payments", "stream:t1/ns/orders"] {
+            let parsed = parse_object(target, "t1").expect("parse");
+            assert!(!object_within_scope(&node[0], &parsed), "{target}");
+        }
+    }
 
     #[test]
     fn the_cluster_object_parses_independently_of_any_tenant() {

--- a/services/controlplane/tests/node_heartbeat.rs
+++ b/services/controlplane/tests/node_heartbeat.rs
@@ -3,17 +3,18 @@ mod common;
 mod http_helpers;
 
 use axum::body::Body;
-use axum::http::StatusCode;
+use axum::http::{Request, StatusCode};
 use common::read_json;
 use controlplane::api::types::FeatureFlags;
 use controlplane::app::{AppState, build_router};
 use controlplane::config::NodeLivenessConfig;
 use controlplane::model::{Node, NodeCapacity, NodeLifecycle, NodeSpec, NodeStatus};
 use controlplane::store::memory::InMemoryStore;
-use controlplane::store::{ControlPlaneStore, StoreConfig};
+use controlplane::store::{AuthStore, ControlPlaneStore, StoreConfig};
 use http_helpers::json_request;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tower::ServiceExt;
 
 const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
@@ -39,6 +40,33 @@ fn node(node_id: &str) -> Node {
             incarnation: 0,
         },
     }
+}
+
+/// A credential covering every node. These tests are about heartbeat
+/// behaviour, not authorisation -- `node_write_auth.rs` covers that.
+async fn fleet_token(store: &InMemoryStore) -> String {
+    let keys = controlplane::auth::keys::generate_signing_keys().expect("keys");
+    store
+        .set_tenant_signing_keys("t1", keys.clone())
+        .await
+        .expect("keys");
+    controlplane::auth::felix_token::mint_token(
+        &keys,
+        "t1",
+        "p:operator",
+        vec!["node.manage:cluster:*".to_string()],
+        Duration::from_secs(900),
+    )
+    .expect("token")
+}
+
+fn authed(bearer: &str, method: &str, uri: &str, body: serde_json::Value) -> Request<Body> {
+    let mut request = json_request(method, uri, body);
+    request.headers_mut().insert(
+        axum::http::header::AUTHORIZATION,
+        format!("Bearer {bearer}").parse().expect("header"),
+    );
+    request
 }
 
 async fn app_with(store: Arc<InMemoryStore>) -> axum::routing::RouterIntoService<Body, ()> {
@@ -76,10 +104,12 @@ async fn a_heartbeat_returns_the_lifecycle_and_the_expected_cadence() {
         .register_node(node("broker-a"))
         .await
         .expect("register");
+    let token = fleet_token(&store).await;
     let app = app_with(Arc::clone(&store)).await;
 
     let response = app
-        .oneshot(json_request(
+        .oneshot(authed(
+            &token,
             "POST",
             "/v1/nodes/broker-a/heartbeat",
             serde_json::json!({ "incarnation": 0 }),
@@ -110,9 +140,11 @@ async fn a_heartbeat_records_the_control_planes_clock() {
         .expect("register");
     let before = controlplane::api::nodes::now_millis();
 
+    let token = fleet_token(&store).await;
     let app = app_with(Arc::clone(&store)).await;
     let response = app
-        .oneshot(json_request(
+        .oneshot(authed(
+            &token,
             "POST",
             "/v1/nodes/broker-a/heartbeat",
             serde_json::json!({ "incarnation": 0, "last_heartbeat_at_millis": 99_999_999_999_999u64 }),
@@ -135,9 +167,12 @@ async fn a_heartbeat_records_the_control_planes_clock() {
 
 #[tokio::test]
 async fn a_heartbeat_for_an_unregistered_node_is_not_found() {
-    let app = app_with(store()).await;
+    let store = store();
+    let token = fleet_token(&store).await;
+    let app = app_with(store).await;
     let response = app
-        .oneshot(json_request(
+        .oneshot(authed(
+            &token,
             "POST",
             "/v1/nodes/absent/heartbeat",
             serde_json::json!({ "incarnation": 0 }),
@@ -159,9 +194,11 @@ async fn a_heartbeat_for_a_superseded_incarnation_conflicts() {
         .await
         .expect("restart");
 
+    let token = fleet_token(&store).await;
     let app = app_with(Arc::clone(&store)).await;
     let response = app
-        .oneshot(json_request(
+        .oneshot(authed(
+            &token,
             "POST",
             "/v1/nodes/broker-a/heartbeat",
             serde_json::json!({ "incarnation": 0 }),
@@ -185,9 +222,11 @@ async fn an_expired_broker_is_told_it_is_down() {
         .await
         .expect("down");
 
+    let token = fleet_token(&store).await;
     let app = app_with(Arc::clone(&store)).await;
     let response = app
-        .oneshot(json_request(
+        .oneshot(authed(
+            &token,
             "POST",
             "/v1/nodes/broker-a/heartbeat",
             serde_json::json!({ "incarnation": 0 }),

--- a/services/controlplane/tests/node_write_auth.rs
+++ b/services/controlplane/tests/node_write_auth.rs
@@ -1,0 +1,345 @@
+//! Authorization on the membership write path.
+//!
+//! Registration, heartbeat, drain, and deregistration were reachable by any
+//! caller. These are the tests that say they are not, one per endpoint and one
+//! per way of getting it wrong.
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use controlplane::api::types::{FeatureFlags, Region};
+use controlplane::app::{AppState, build_router};
+use controlplane::auth::felix_token::{TenantSigningKeys, mint_token};
+use controlplane::auth::keys::generate_signing_keys;
+use controlplane::config::NodeLivenessConfig;
+use controlplane::model::{Node, NodeCapacity, NodeLifecycle, NodeSpec, NodeStatus};
+use controlplane::store::memory::InMemoryStore;
+use controlplane::store::{AuthStore, ControlPlaneAuthStore, ControlPlaneStore, StoreConfig};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tower::ServiceExt;
+
+const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
+    heartbeat_interval_ms: 5_000,
+    expiry_timeout_ms: 15_000,
+    sweep_interval_ms: 2_000,
+    shard_reconcile_interval_ms: 5_000,
+};
+
+type App = axum::routing::RouterIntoService<Body, ()>;
+
+async fn setup() -> (App, Arc<InMemoryStore>, TenantSigningKeys) {
+    let store = Arc::new(InMemoryStore::new(StoreConfig {
+        changes_limit: 1000,
+        change_retention_max_rows: Some(1000),
+    }));
+    let keys = generate_signing_keys().expect("keys");
+    store
+        .set_tenant_signing_keys("t1", keys.clone())
+        .await
+        .expect("keys");
+
+    let state = AppState {
+        region: Region {
+            region_id: "local".to_string(),
+            display_name: "Local".to_string(),
+        },
+        api_version: "v1".to_string(),
+        features: FeatureFlags {
+            durable_storage: store.is_durable(),
+            tiered_storage: false,
+            bridges: false,
+        },
+        store: Arc::clone(&store) as Arc<dyn ControlPlaneAuthStore + Send + Sync>,
+        oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
+        bootstrap_enabled: false,
+        bootstrap_token: None,
+        node_liveness: LIVENESS,
+    };
+    (build_router(state).into_service(), store, keys)
+}
+
+fn token(keys: &TenantSigningKeys, perms: Vec<&str>) -> String {
+    mint_token(
+        keys,
+        "t1",
+        "p:broker",
+        perms.into_iter().map(str::to_string).collect(),
+        Duration::from_secs(900),
+    )
+    .expect("token")
+}
+
+fn post(path: &str, bearer: Option<&str>, body: serde_json::Value) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json");
+    if let Some(bearer) = bearer {
+        builder = builder.header("authorization", format!("Bearer {bearer}"));
+    }
+    builder.body(Body::from(body.to_string())).expect("request")
+}
+
+fn registration(node_id: &str, port: u16) -> serde_json::Value {
+    serde_json::json!({
+        "node_id": node_id,
+        "advertise_addr": format!("10.0.0.4:{port}"),
+        "region": "us-west-2",
+    })
+}
+
+async fn seed_node(store: &InMemoryStore, node_id: &str, port: u16) {
+    store
+        .register_node(Node {
+            node_id: node_id.to_string(),
+            spec: NodeSpec {
+                advertise_addr: format!("10.0.0.4:{port}"),
+                region: "us-west-2".to_string(),
+                labels: BTreeMap::new(),
+                capacity: NodeCapacity::default(),
+            },
+            status: NodeStatus {
+                lifecycle: NodeLifecycle::Live,
+                last_heartbeat_at_millis: 1,
+                registered_at_millis: 1,
+                incarnation: 0,
+            },
+        })
+        .await
+        .expect("seed");
+}
+
+/// Every write endpoint, with no credential at all. This is the hole being
+/// closed, and there is one case per endpoint so a regression names itself.
+#[tokio::test]
+async fn every_membership_write_requires_a_token() {
+    let (app, store, _keys) = setup().await;
+    seed_node(&store, "broker-a", 7001).await;
+
+    for (path, body) in [
+        ("/v1/nodes", registration("broker-a", 7001)),
+        (
+            "/v1/nodes/broker-a/heartbeat",
+            serde_json::json!({"incarnation": 0}),
+        ),
+        ("/v1/nodes/broker-a/drain", serde_json::json!({})),
+        ("/v1/nodes/broker-a/deregister", serde_json::json!({})),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(post(path, None, body))
+            .await
+            .expect("request");
+        assert_eq!(
+            response.status(),
+            StatusCode::UNAUTHORIZED,
+            "{path} must not be reachable without a token",
+        );
+    }
+}
+
+/// The property the node-scoped object exists for: broker-a's own credential
+/// cannot be used to speak for broker-b.
+#[tokio::test]
+async fn a_broker_cannot_act_for_another_broker() {
+    let (app, store, keys) = setup().await;
+    seed_node(&store, "broker-a", 7001).await;
+    seed_node(&store, "broker-b", 7002).await;
+    let bearer = token(&keys, vec!["node.manage:node:broker-a"]);
+
+    for (path, body) in [
+        ("/v1/nodes", registration("broker-b", 7002)),
+        (
+            "/v1/nodes/broker-b/heartbeat",
+            serde_json::json!({"incarnation": 0}),
+        ),
+        ("/v1/nodes/broker-b/drain", serde_json::json!({})),
+        ("/v1/nodes/broker-b/deregister", serde_json::json!({})),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(post(path, Some(&bearer), body))
+            .await
+            .expect("request");
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "{path} must reject a credential scoped to a different node",
+        );
+    }
+
+    // And broker-b is untouched by the attempt.
+    assert_eq!(
+        store
+            .get_node("broker-b")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Live,
+    );
+}
+
+#[tokio::test]
+async fn a_broker_can_manage_itself() {
+    let (app, store, keys) = setup().await;
+    let bearer = token(&keys, vec!["node.manage:node:broker-a"]);
+
+    let registered = app
+        .clone()
+        .oneshot(post(
+            "/v1/nodes",
+            Some(&bearer),
+            registration("broker-a", 7001),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(registered.status(), StatusCode::OK);
+
+    for path in [
+        "/v1/nodes/broker-a/heartbeat",
+        "/v1/nodes/broker-a/drain",
+        "/v1/nodes/broker-a/deregister",
+    ] {
+        let body = if path.ends_with("heartbeat") {
+            serde_json::json!({"incarnation": 0})
+        } else {
+            serde_json::json!({})
+        };
+        let response = app
+            .clone()
+            .oneshot(post(path, Some(&bearer), body))
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+    }
+
+    assert_eq!(
+        store
+            .get_node("broker-a")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Left,
+    );
+}
+
+/// An operator managing the fleet holds cluster scope, which covers every node.
+#[tokio::test]
+async fn cluster_scope_can_manage_any_node() {
+    let (app, store, keys) = setup().await;
+    seed_node(&store, "broker-b", 7002).await;
+    let bearer = token(&keys, vec!["node.manage:cluster:*"]);
+
+    let response = app
+        .clone()
+        .oneshot(post(
+            "/v1/nodes/broker-b/drain",
+            Some(&bearer),
+            serde_json::json!({}),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        store
+            .get_node("broker-b")
+            .await
+            .expect("get")
+            .status
+            .lifecycle,
+        NodeLifecycle::Draining,
+    );
+}
+
+/// Reading the fleet is not permission to change it.
+#[tokio::test]
+async fn node_view_does_not_grant_node_manage() {
+    let (app, store, keys) = setup().await;
+    seed_node(&store, "broker-a", 7001).await;
+    let bearer = token(&keys, vec!["node.view:cluster:*"]);
+
+    let response = app
+        .oneshot(post(
+            "/v1/nodes/broker-a/deregister",
+            Some(&bearer),
+            serde_json::json!({}),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+/// A tenant admin's own scope must not open the membership write path.
+#[tokio::test]
+async fn tenant_scoped_permissions_do_not_grant_node_manage() {
+    let (app, store, keys) = setup().await;
+    seed_node(&store, "broker-a", 7001).await;
+
+    for perm in [
+        "tenant.manage:tenant:t1",
+        "ns.manage:namespace:t1/*",
+        "rbac.policy.manage:tenant:t1",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(post(
+                "/v1/nodes/broker-a/drain",
+                Some(&token(&keys, vec![perm])),
+                serde_json::json!({}),
+            ))
+            .await
+            .expect("request");
+        assert_eq!(response.status(), StatusCode::FORBIDDEN, "{perm}");
+    }
+}
+
+/// A correctly shaped token signed by the wrong key is still no token.
+#[tokio::test]
+async fn a_token_signed_by_another_key_is_rejected() {
+    let (app, store, _keys) = setup().await;
+    seed_node(&store, "broker-a", 7001).await;
+    let foreign = generate_signing_keys().expect("keys");
+    let bearer = mint_token(
+        &foreign,
+        "t1",
+        "p:attacker",
+        vec!["node.manage:cluster:*".to_string()],
+        Duration::from_secs(900),
+    )
+    .expect("token");
+
+    let response = app
+        .oneshot(post(
+            "/v1/nodes/broker-a/drain",
+            Some(&bearer),
+            serde_json::json!({}),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// Registration takes its identity from the body, so that is what must be
+/// authorised -- otherwise a broker could claim any name it liked.
+#[tokio::test]
+async fn registration_authorises_the_identity_in_the_body() {
+    let (app, _store, keys) = setup().await;
+    let bearer = token(&keys, vec!["node.manage:node:broker-a"]);
+
+    let response = app
+        .clone()
+        .oneshot(post(
+            "/v1/nodes",
+            Some(&bearer),
+            registration("broker-impostor", 7009),
+        ))
+        .await
+        .expect("request");
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "a broker must not register under another identity",
+    );
+}


### PR DESCRIPTION
Closes the unauthenticated membership write path. **Refs #126** — this is that issue's core, ahead of M8, because M4 turns an open registration endpoint into a traffic-redirection primitive rather than merely a bad catalog entry.

## The hole

Anyone who could reach the control plane could:

- register a broker under **any** identity, including one already in use;
- **keep a dead node looking alive** by heartbeating for it;
- bump an incarnation so the *real* broker's heartbeats were rejected as stale;
- drain or deregister any broker in the fleet.

You named register, drain, and deregister. **`report_health` was open too** — it's the same class of hole, so it's included here. I'd rather over-cover than leave a fourth door open.

## The design

`node.manage` over the node being changed:

| Object | Held by | Can change |
|---|---|---|
| `node:{node_id}` | a broker, for its own identity | that node only |
| `cluster:*` | an operator managing the fleet | every node |

**Node identity is an RBAC object, not a field the caller asserts.** A broker presenting `node.manage:node:broker-a` for `broker-b` fails authorisation rather than being believed because the request said so. That directly satisfies #126's "prevent one broker from reporting health or claiming identity for another."

**Registration authorises the identity in the request body**, not a path segment — otherwise a broker could claim any name it liked.

`node:*` is rejected: it would be `cluster:*` under a second name, and two spellings for one scope is how a policy review misses one.

A node scope is an island exactly as `cluster:*` is — no tenant scope reaches it (so a tenant admin can't grant themselves one), and it confers nothing inside a tenant. **`node.view` does not imply `node.manage`**: reading the fleet is not permission to change it.

## Fail closed on the broker

A credential is **required**, not optional. A broker with `FELIX_NODE_ID` and no token **refuses to start** — starting one that will fail every control-plane call on a loop is worse than refusing.

`FELIX_NODE_TOKEN_FILE` reads from a mounted secret so the credential need not sit in an environment variable visible in a process listing. Whitespace is trimmed; a blank value is no credential, not an empty one.

The same credential authenticates the shard-assignment watch — cluster metadata by the same argument.

## Tests

**8 HTTP tests** (`node_write_auth.rs`), one case per endpoint per failure mode: no token on all four, a broker-a token rejected on all four broker-b endpoints, self-management working, `cluster:*` managing anyone, `node.view` not granting write, tenant scopes not granting write, a token signed by the wrong key, and registration authorising the body.

**7 RBAC tests** on the grammar, including that a tenant admin cannot write themselves a node rule.

**2 end-to-end** through the real broker client *and* the real control-plane router: a broker's own credential cannot deregister another broker (and leaves it untouched), and an unauthenticated broker cannot register.

The existing `membership_lifecycle` and `node_heartbeat` suites now mint real tokens — they failed when the guard landed, which is the check that the guard is actually on the path.

## Docs

Removed every "not yet authenticated" claim — `control-plane.md`, `auth.md`, `security/rbac.md`, and both published site pages now describe the real model.

## Not in scope

This is a **bearer credential**, not mTLS workload identity. #126 also asks for credential rotation and an mTLS-or-equivalent binding; those remain open, and the token is verified with the same Ed25519 machinery as every other Felix token. What's closed is the part that was actually wide open.

## Verification

`task lint`, `task test` (67 suites), `task deny`, `task demo:check`, mermaid, docs-site build, and the pg suite against real Postgres 16 — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)