### PR TITLE
feat(wire): define the broker-internal forwarding protocol

### DIFF
--- a/crates/felix-wire/src/error.rs
+++ b/crates/felix-wire/src/error.rs
@@ -16,4 +16,12 @@ pub enum Error {
     Serialize(serde_json::Error),
     #[error("failed to deserialize message")]
     Deserialize(serde_json::Error),
+    #[error("string field is not valid utf-8")]
+    InvalidUtf8,
+    #[error("unsupported internal message kind {0}")]
+    UnsupportedInternalKind(u16),
+    #[error("unknown internal error code {0}")]
+    UnknownInternalErrorCode(u16),
+    #[error("unknown internal ack mode {0}")]
+    UnknownInternalAckMode(u8),
 }

--- a/crates/felix-wire/src/internal.rs
+++ b/crates/felix-wire/src/internal.rs
@@ -1,0 +1,470 @@
+//! The protocol brokers speak to each other.
+//!
+//! Deliberately separate from the client protocol, and not a superset of it. A
+//! client able to send `ForwardPublish` could write to a shard on a broker that
+//! never checked ownership; a broker accepting client frames on its internal
+//! listener would treat a peer as an authenticated publisher. The distinct magic
+//! below is what makes a misdirected connection fail loudly rather than parse
+//! into something plausible — it is not the security boundary, which is the
+//! separate listener and peer credential.
+//!
+//! Flows, correlation rules, and the error table live in
+//! `docs/internal-protocol.md`.
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use crate::error::{Error, Result};
+
+/// `FLXI`. Distinct from the client protocol's `FLX1` so neither side can
+/// decode the other's frames.
+pub const INTERNAL_MAGIC: u32 = 0x464C_5849;
+
+/// This protocol's version, independent of the client protocol's.
+///
+/// Additive change happens by adding a [`Kind`], which an older peer already
+/// rejects as unknown. This exists for the change that cannot cover: the header,
+/// or an existing body layout.
+pub const INTERNAL_VERSION: u16 = 1;
+
+/// Largest body this protocol will decode, before any allocation is sized from
+/// a peer-provided number.
+pub const MAX_BODY_BYTES: u32 = 64 * 1024 * 1024;
+
+/// Longest identifier (tenant, namespace, stream, node id) accepted.
+pub const MAX_IDENT_BYTES: usize = 512;
+
+/// Most payloads one forwarded batch may carry.
+pub const MAX_BATCH_PAYLOADS: usize = 65_536;
+
+/// Every payload is a 4-byte length prefix plus its bytes, so a body can never
+/// hold more payloads than it has 4-byte groups left.
+const LEN_PREFIX: usize = 4;
+
+/// Message discriminant.
+///
+/// A discriminant rather than flag bits: the client protocol uses bits because
+/// they modify one payload layout, whereas here each kind *is* a layout, so an
+/// enum makes "unknown kind" one unambiguous check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum Kind {
+    ForwardPublish = 1,
+    ForwardPublishOk = 2,
+    ForwardPublishError = 3,
+    NotLeader = 4,
+}
+
+impl Kind {
+    /// An unknown kind is rejected, never skipped: the kind selects how to read
+    /// the body, so ignoring one means confidently misparsing it.
+    pub fn from_u16(value: u16) -> Result<Self> {
+        match value {
+            1 => Ok(Kind::ForwardPublish),
+            2 => Ok(Kind::ForwardPublishOk),
+            3 => Ok(Kind::ForwardPublishError),
+            4 => Ok(Kind::NotLeader),
+            other => Err(Error::UnsupportedInternalKind(other)),
+        }
+    }
+}
+
+/// Why a forwarded request could not be served.
+///
+/// Typed because each needs a different response from the requester — see the
+/// table in `docs/internal-protocol.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u16)]
+pub enum ErrorCode {
+    /// The responder is behind the generation the requester named. It must not
+    /// accept the write: it may no longer hold the shard.
+    StaleRoute = 1,
+    /// The owner cannot serve yet, e.g. still opening the shard.
+    Unavailable = 2,
+    /// The peer is not permitted. Not retryable.
+    Unauthorized = 3,
+    /// The owner is shedding load.
+    Overload = 4,
+    /// The peer spoke a version this broker does not know. Not retryable.
+    ProtocolVersion = 5,
+    /// The body did not decode. Not retryable.
+    Malformed = 6,
+    /// The owner accepted the request and the local write failed.
+    StorageFailed = 7,
+}
+
+impl ErrorCode {
+    pub fn from_u16(value: u16) -> Result<Self> {
+        match value {
+            1 => Ok(ErrorCode::StaleRoute),
+            2 => Ok(ErrorCode::Unavailable),
+            3 => Ok(ErrorCode::Unauthorized),
+            4 => Ok(ErrorCode::Overload),
+            5 => Ok(ErrorCode::ProtocolVersion),
+            6 => Ok(ErrorCode::Malformed),
+            7 => Ok(ErrorCode::StorageFailed),
+            other => Err(Error::UnknownInternalErrorCode(other)),
+        }
+    }
+
+    /// Whether a requester should try the same peer again.
+    pub fn is_retryable(self) -> bool {
+        matches!(
+            self,
+            ErrorCode::StaleRoute | ErrorCode::Unavailable | ErrorCode::Overload
+        )
+    }
+}
+
+/// How the origin publisher asked for its write to be acknowledged.
+///
+/// Carried across the forward so the owner applies the guarantee the client
+/// asked for, not the one the forwarding broker would have chosen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum AckMode {
+    None = 0,
+    OnAccept = 1,
+    OnCommit = 2,
+}
+
+impl AckMode {
+    pub fn from_u8(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(AckMode::None),
+            1 => Ok(AckMode::OnAccept),
+            2 => Ok(AckMode::OnCommit),
+            other => Err(Error::UnknownInternalAckMode(other)),
+        }
+    }
+}
+
+/// Which shard a forwarded request is for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardRef {
+    pub tenant_id: String,
+    pub namespace: String,
+    pub stream: String,
+    pub shard: u32,
+    /// The assignment generation the requester resolved against.
+    ///
+    /// The owner compares this with its own. Equal proceeds; either mismatch is
+    /// an explicit typed answer, and never a successful ownership claim.
+    pub generation: u64,
+}
+
+/// A publish handed to the broker that owns the shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardPublish {
+    pub correlation_id: u64,
+    pub shard: ShardRef,
+    pub ack: AckMode,
+    pub payloads: Vec<Bytes>,
+}
+
+/// The owner accepted and wrote the batch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ForwardPublishOk {
+    pub correlation_id: u64,
+    pub first_offset: u64,
+    /// Inclusive, so a single-record batch has `first_offset == last_offset`.
+    pub last_offset: u64,
+}
+
+/// The owner refused, with a reason the requester can act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardPublishError {
+    pub correlation_id: u64,
+    pub code: ErrorCode,
+    /// Operator-facing detail. Never parsed for control flow — `code` is what a
+    /// requester branches on.
+    pub detail: String,
+}
+
+/// The shard is owned elsewhere, and here is where.
+///
+/// A distinct kind rather than an error code, because it carries a routing
+/// answer rather than only a reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NotLeader {
+    pub correlation_id: u64,
+    pub node_id: String,
+    /// `host:port` of the owner's internal listener, as the catalog advertises
+    /// it. A string rather than a parsed address: the responder repeats what it
+    /// was told, and the requester decides whether it can be reached.
+    pub advertise_addr: String,
+    /// The generation the responder believes is current.
+    pub generation: u64,
+}
+
+/// A decoded internal message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InternalMessage {
+    ForwardPublish(ForwardPublish),
+    ForwardPublishOk(ForwardPublishOk),
+    ForwardPublishError(ForwardPublishError),
+    NotLeader(NotLeader),
+}
+
+impl InternalMessage {
+    pub fn kind(&self) -> Kind {
+        match self {
+            Self::ForwardPublish(_) => Kind::ForwardPublish,
+            Self::ForwardPublishOk(_) => Kind::ForwardPublishOk,
+            Self::ForwardPublishError(_) => Kind::ForwardPublishError,
+            Self::NotLeader(_) => Kind::NotLeader,
+        }
+    }
+
+    /// The id this message answers, or carries if it is a request.
+    ///
+    /// Every message has one, which is what makes the request lifecycle
+    /// unambiguous: a response can always be matched or discarded, never left
+    /// pending.
+    pub fn correlation_id(&self) -> u64 {
+        match self {
+            Self::ForwardPublish(m) => m.correlation_id,
+            Self::ForwardPublishOk(m) => m.correlation_id,
+            Self::ForwardPublishError(m) => m.correlation_id,
+            Self::NotLeader(m) => m.correlation_id,
+        }
+    }
+
+    /// Encode a complete frame: header then body.
+    pub fn encode(&self) -> Result<Bytes> {
+        let mut body = BytesMut::new();
+        match self {
+            Self::ForwardPublish(m) => {
+                body.put_u64(m.correlation_id);
+                put_str(&mut body, &m.shard.tenant_id)?;
+                put_str(&mut body, &m.shard.namespace)?;
+                put_str(&mut body, &m.shard.stream)?;
+                body.put_u32(m.shard.shard);
+                body.put_u64(m.shard.generation);
+                body.put_u8(m.ack as u8);
+                if m.payloads.len() > MAX_BATCH_PAYLOADS {
+                    return Err(Error::FrameTooLarge);
+                }
+                body.put_u32(m.payloads.len() as u32);
+                for payload in &m.payloads {
+                    body.put_u32(u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?);
+                    body.extend_from_slice(payload);
+                }
+            }
+            Self::ForwardPublishOk(m) => {
+                body.put_u64(m.correlation_id);
+                body.put_u64(m.first_offset);
+                body.put_u64(m.last_offset);
+            }
+            Self::ForwardPublishError(m) => {
+                body.put_u64(m.correlation_id);
+                body.put_u16(m.code as u16);
+                put_str(&mut body, &m.detail)?;
+            }
+            Self::NotLeader(m) => {
+                body.put_u64(m.correlation_id);
+                put_str(&mut body, &m.node_id)?;
+                put_str(&mut body, &m.advertise_addr)?;
+                body.put_u64(m.generation);
+            }
+        }
+
+        let length = u32::try_from(body.len()).map_err(|_| Error::FrameTooLarge)?;
+        if length > MAX_BODY_BYTES {
+            return Err(Error::FrameTooLarge);
+        }
+
+        let mut frame = BytesMut::with_capacity(InternalHeader::LEN + body.len());
+        InternalHeader {
+            kind: self.kind(),
+            length,
+        }
+        .encode(&mut frame);
+        frame.extend_from_slice(&body);
+        Ok(frame.freeze())
+    }
+
+    /// Decode a complete frame.
+    ///
+    /// Every peer-provided length is checked against what remains before it is
+    /// used to size anything. A broker is authenticated, not assumed correct.
+    pub fn decode(buf: Bytes) -> Result<Self> {
+        let header = InternalHeader::decode(&buf)?;
+        let body = buf.slice(InternalHeader::LEN..);
+        if body.len() != header.length as usize {
+            return Err(Error::Incomplete);
+        }
+        let mut body = body;
+
+        match header.kind {
+            Kind::ForwardPublish => {
+                let correlation_id = take_u64(&mut body)?;
+                let tenant_id = take_str(&mut body)?;
+                let namespace = take_str(&mut body)?;
+                let stream = take_str(&mut body)?;
+                let shard = take_u32(&mut body)?;
+                let generation = take_u64(&mut body)?;
+                let ack = AckMode::from_u8(take_u8(&mut body)?)?;
+
+                let declared = take_u32(&mut body)? as usize;
+                // Bounded against what the body could actually hold, before it
+                // reaches `with_capacity`. Same trap the client binary path
+                // documents: a tiny frame declaring u32::MAX payloads otherwise
+                // reserves enough address space to abort the process.
+                if declared > MAX_BATCH_PAYLOADS || declared > body.remaining() / LEN_PREFIX {
+                    return Err(Error::Incomplete);
+                }
+                let mut payloads = Vec::with_capacity(declared);
+                for _ in 0..declared {
+                    let len = take_u32(&mut body)? as usize;
+                    if len > body.remaining() {
+                        return Err(Error::Incomplete);
+                    }
+                    payloads.push(body.split_to(len));
+                }
+                if body.has_remaining() {
+                    // Trailing bytes mean the body did not describe itself, so
+                    // something is wrong with the peer, not merely with this
+                    // message.
+                    return Err(Error::Incomplete);
+                }
+
+                Ok(Self::ForwardPublish(ForwardPublish {
+                    correlation_id,
+                    shard: ShardRef {
+                        tenant_id,
+                        namespace,
+                        stream,
+                        shard,
+                        generation,
+                    },
+                    ack,
+                    payloads,
+                }))
+            }
+            Kind::ForwardPublishOk => {
+                let message = ForwardPublishOk {
+                    correlation_id: take_u64(&mut body)?,
+                    first_offset: take_u64(&mut body)?,
+                    last_offset: take_u64(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::ForwardPublishOk(message))
+            }
+            Kind::ForwardPublishError => {
+                let message = ForwardPublishError {
+                    correlation_id: take_u64(&mut body)?,
+                    code: ErrorCode::from_u16(take_u16(&mut body)?)?,
+                    detail: take_str(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::ForwardPublishError(message))
+            }
+            Kind::NotLeader => {
+                let message = NotLeader {
+                    correlation_id: take_u64(&mut body)?,
+                    node_id: take_str(&mut body)?,
+                    advertise_addr: take_str(&mut body)?,
+                    generation: take_u64(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::NotLeader(message))
+            }
+        }
+    }
+}
+
+/// Fixed-size header preceding every internal body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InternalHeader {
+    pub kind: Kind,
+    pub length: u32,
+}
+
+impl InternalHeader {
+    pub const LEN: usize = 12;
+
+    pub fn encode(&self, buf: &mut BytesMut) {
+        buf.put_u32(INTERNAL_MAGIC);
+        buf.put_u16(INTERNAL_VERSION);
+        buf.put_u16(self.kind as u16);
+        buf.put_u32(self.length);
+    }
+
+    pub fn decode(buf: &Bytes) -> Result<Self> {
+        if buf.len() < Self::LEN {
+            return Err(Error::Incomplete);
+        }
+        let mut head = buf.slice(0..Self::LEN);
+        if head.get_u32() != INTERNAL_MAGIC {
+            return Err(Error::InvalidMagic);
+        }
+        let version = head.get_u16();
+        if version != INTERNAL_VERSION {
+            return Err(Error::UnsupportedVersion(version));
+        }
+        let kind = Kind::from_u16(head.get_u16())?;
+        let length = head.get_u32();
+        if length > MAX_BODY_BYTES {
+            return Err(Error::FrameTooLarge);
+        }
+        Ok(Self { kind, length })
+    }
+}
+
+fn put_str(buf: &mut BytesMut, value: &str) -> Result<()> {
+    if value.len() > MAX_IDENT_BYTES {
+        return Err(Error::FrameTooLarge);
+    }
+    buf.put_u32(value.len() as u32);
+    buf.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn take_str(buf: &mut Bytes) -> Result<String> {
+    let len = take_u32(buf)? as usize;
+    if len > MAX_IDENT_BYTES || len > buf.remaining() {
+        return Err(Error::Incomplete);
+    }
+    let bytes = buf.split_to(len);
+    String::from_utf8(bytes.to_vec()).map_err(|_| Error::InvalidUtf8)
+}
+
+fn take_u8(buf: &mut Bytes) -> Result<u8> {
+    if buf.remaining() < 1 {
+        return Err(Error::Incomplete);
+    }
+    Ok(buf.get_u8())
+}
+
+fn take_u16(buf: &mut Bytes) -> Result<u16> {
+    if buf.remaining() < 2 {
+        return Err(Error::Incomplete);
+    }
+    Ok(buf.get_u16())
+}
+
+fn take_u32(buf: &mut Bytes) -> Result<u32> {
+    if buf.remaining() < 4 {
+        return Err(Error::Incomplete);
+    }
+    Ok(buf.get_u32())
+}
+
+fn take_u64(buf: &mut Bytes) -> Result<u64> {
+    if buf.remaining() < 8 {
+        return Err(Error::Incomplete);
+    }
+    Ok(buf.get_u64())
+}
+
+/// Reject trailing bytes: a body that does not describe itself exactly means
+/// the peer and this decoder disagree about the layout.
+fn expect_empty(buf: &Bytes) -> Result<()> {
+    if buf.has_remaining() {
+        return Err(Error::Incomplete);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "internal_tests.rs"]
+mod tests;

--- a/crates/felix-wire/src/internal_tests.rs
+++ b/crates/felix-wire/src/internal_tests.rs
@@ -1,0 +1,337 @@
+//! Round-trips, byte-exact golden vectors, and malformed input.
+//!
+//! The malformed cases matter most. A peer is authenticated, not assumed
+//! correct: every one of these must be an error, and none may panic.
+use super::*;
+
+fn shard() -> ShardRef {
+    ShardRef {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: "orders".to_string(),
+        shard: 3,
+        generation: 7,
+    }
+}
+
+fn forward() -> InternalMessage {
+    InternalMessage::ForwardPublish(ForwardPublish {
+        correlation_id: 42,
+        shard: shard(),
+        ack: AckMode::OnCommit,
+        payloads: vec![Bytes::from_static(b"a"), Bytes::from_static(b"bb")],
+    })
+}
+
+fn every_message() -> Vec<InternalMessage> {
+    vec![
+        forward(),
+        InternalMessage::ForwardPublishOk(ForwardPublishOk {
+            correlation_id: 42,
+            first_offset: 100,
+            last_offset: 101,
+        }),
+        InternalMessage::ForwardPublishError(ForwardPublishError {
+            correlation_id: 42,
+            code: ErrorCode::StaleRoute,
+            detail: "generation 7 is ahead of mine".to_string(),
+        }),
+        InternalMessage::NotLeader(NotLeader {
+            correlation_id: 42,
+            node_id: "broker-b".to_string(),
+            advertise_addr: "10.0.0.5:7000".to_string(),
+            generation: 9,
+        }),
+    ]
+}
+
+#[test]
+fn every_message_round_trips() {
+    for message in every_message() {
+        let encoded = message.encode().expect("encode");
+        let decoded = InternalMessage::decode(encoded).expect("decode");
+        assert_eq!(decoded, message);
+    }
+}
+
+#[test]
+fn every_message_carries_a_correlation_id() {
+    for message in every_message() {
+        assert_eq!(
+            message.correlation_id(),
+            42,
+            "a response with no correlation could never be matched or discarded",
+        );
+    }
+}
+
+/// The whole point of a distinct magic: a client frame must not decode here,
+/// and an internal frame must not decode as a client frame.
+#[test]
+fn client_and_internal_frames_do_not_decode_as_each_other() {
+    let internal = forward().encode().expect("encode");
+    assert!(
+        matches!(
+            crate::Frame::decode(internal.clone()),
+            Err(Error::InvalidMagic)
+        ),
+        "an internal frame must not parse as a client frame",
+    );
+
+    let client = crate::Frame::new(0x1, Bytes::from_static(b"hello"))
+        .expect("frame")
+        .encode();
+    assert!(
+        matches!(InternalMessage::decode(client), Err(Error::InvalidMagic)),
+        "a client frame must not parse as an internal frame",
+    );
+}
+
+/// Byte-exact, so a layout change has to be deliberate. Every field is at a
+/// known offset; a reordering or a width change fails here rather than in a
+/// cluster.
+#[test]
+fn forward_publish_matches_its_golden_vector() {
+    let encoded = forward().encode().expect("encode");
+    let expected: Vec<u8> = [
+        // header: magic "FLXI", version 1, kind 1, length
+        &[0x46, 0x4C, 0x58, 0x49][..],
+        &[0x00, 0x01][..],
+        &[0x00, 0x01][..],
+        &[0x00, 0x00, 0x00, 0x3A][..],
+        // correlation_id 42
+        &[0, 0, 0, 0, 0, 0, 0, 42][..],
+        // "t1", "ns", "orders"
+        &[0, 0, 0, 2][..],
+        b"t1",
+        &[0, 0, 0, 2][..],
+        b"ns",
+        &[0, 0, 0, 6][..],
+        b"orders",
+        // shard 3, generation 7, ack on-commit
+        &[0, 0, 0, 3][..],
+        &[0, 0, 0, 0, 0, 0, 0, 7][..],
+        &[2][..],
+        // two payloads
+        &[0, 0, 0, 2][..],
+        &[0, 0, 0, 1][..],
+        b"a",
+        &[0, 0, 0, 2][..],
+        b"bb",
+    ]
+    .concat();
+    assert_eq!(encoded.as_ref(), expected.as_slice());
+}
+
+#[test]
+fn not_leader_matches_its_golden_vector() {
+    let message = InternalMessage::NotLeader(NotLeader {
+        correlation_id: 1,
+        node_id: "b".to_string(),
+        advertise_addr: "h:1".to_string(),
+        generation: 2,
+    });
+    let expected: Vec<u8> = [
+        &[0x46, 0x4C, 0x58, 0x49][..],
+        &[0x00, 0x01][..],
+        &[0x00, 0x04][..],
+        &[0x00, 0x00, 0x00, 0x1C][..],
+        &[0, 0, 0, 0, 0, 0, 0, 1][..],
+        &[0, 0, 0, 1][..],
+        b"b",
+        &[0, 0, 0, 3][..],
+        b"h:1",
+        &[0, 0, 0, 0, 0, 0, 0, 2][..],
+    ]
+    .concat();
+    assert_eq!(
+        message.encode().expect("encode").as_ref(),
+        expected.as_slice()
+    );
+}
+
+/// An unknown kind is rejected rather than skipped: the kind selects how to
+/// read the body, so ignoring one means confidently misparsing it.
+#[test]
+fn an_unknown_kind_is_rejected() {
+    let mut frame = BytesMut::new();
+    frame.put_u32(INTERNAL_MAGIC);
+    frame.put_u16(INTERNAL_VERSION);
+    frame.put_u16(999);
+    frame.put_u32(0);
+    assert!(matches!(
+        InternalMessage::decode(frame.freeze()),
+        Err(Error::UnsupportedInternalKind(999)),
+    ));
+}
+
+#[test]
+fn an_unknown_version_is_rejected() {
+    let mut frame = BytesMut::new();
+    frame.put_u32(INTERNAL_MAGIC);
+    frame.put_u16(INTERNAL_VERSION + 1);
+    frame.put_u16(Kind::ForwardPublishOk as u16);
+    frame.put_u32(24);
+    assert!(matches!(
+        InternalMessage::decode(frame.freeze()),
+        Err(Error::UnsupportedVersion(_)),
+    ));
+}
+
+/// The allocation trap the client binary path documents: a tiny body declaring
+/// an enormous payload count must be rejected before `with_capacity` sees it.
+#[test]
+fn a_declared_payload_count_is_bounded_by_the_body() {
+    let mut body = BytesMut::new();
+    body.put_u64(1);
+    for value in ["t1", "ns", "orders"] {
+        body.put_u32(value.len() as u32);
+        body.extend_from_slice(value.as_bytes());
+    }
+    body.put_u32(0);
+    body.put_u64(0);
+    body.put_u8(0);
+    body.put_u32(u32::MAX); // "there are four billion payloads after this"
+
+    let mut frame = BytesMut::new();
+    InternalHeader {
+        kind: Kind::ForwardPublish,
+        length: body.len() as u32,
+    }
+    .encode(&mut frame);
+    frame.extend_from_slice(&body);
+
+    assert!(
+        matches!(
+            InternalMessage::decode(frame.freeze()),
+            Err(Error::Incomplete)
+        ),
+        "a declared count must be checked against the bytes that remain",
+    );
+}
+
+/// Truncation at every byte must be an error, never a panic. This is the test
+/// that says a hostile or buggy peer cannot take a broker down.
+#[test]
+fn truncation_at_every_byte_is_an_error_not_a_panic() {
+    for message in every_message() {
+        let encoded = message.encode().expect("encode");
+        for cut in 0..encoded.len() {
+            let truncated = encoded.slice(0..cut);
+            assert!(
+                InternalMessage::decode(truncated).is_err(),
+                "{:?} truncated to {cut} bytes must not decode",
+                message.kind(),
+            );
+        }
+    }
+}
+
+/// Every single-byte corruption must either decode to something well formed or
+/// error. Neither may panic.
+#[test]
+fn single_byte_corruption_never_panics() {
+    for message in every_message() {
+        let encoded = message.encode().expect("encode");
+        for index in 0..encoded.len() {
+            for bit in 0..8u32 {
+                let mut corrupted = encoded.to_vec();
+                corrupted[index] ^= 1 << bit;
+                let _ = InternalMessage::decode(Bytes::from(corrupted));
+            }
+        }
+    }
+}
+
+#[test]
+fn trailing_bytes_are_rejected() {
+    let mut encoded = forward().encode().expect("encode").to_vec();
+    encoded.push(0);
+    // The header's length no longer matches the body, which is the first thing
+    // checked.
+    assert!(InternalMessage::decode(Bytes::from(encoded)).is_err());
+}
+
+#[test]
+fn a_non_utf8_identifier_is_rejected() {
+    let mut body = BytesMut::new();
+    body.put_u64(1);
+    body.put_u32(2);
+    body.extend_from_slice(&[0xff, 0xfe]);
+
+    let mut frame = BytesMut::new();
+    InternalHeader {
+        kind: Kind::NotLeader,
+        length: body.len() as u32,
+    }
+    .encode(&mut frame);
+    frame.extend_from_slice(&body);
+
+    assert!(matches!(
+        InternalMessage::decode(frame.freeze()),
+        Err(Error::InvalidUtf8),
+    ));
+}
+
+#[test]
+fn an_over_long_identifier_is_refused_on_encode() {
+    let message = InternalMessage::NotLeader(NotLeader {
+        correlation_id: 1,
+        node_id: "n".repeat(MAX_IDENT_BYTES + 1),
+        advertise_addr: "h:1".to_string(),
+        generation: 1,
+    });
+    assert!(matches!(message.encode(), Err(Error::FrameTooLarge)));
+}
+
+#[test]
+fn an_over_large_batch_is_refused_on_encode() {
+    let message = InternalMessage::ForwardPublish(ForwardPublish {
+        correlation_id: 1,
+        shard: shard(),
+        ack: AckMode::None,
+        payloads: vec![Bytes::new(); MAX_BATCH_PAYLOADS + 1],
+    });
+    assert!(matches!(message.encode(), Err(Error::FrameTooLarge)));
+}
+
+#[test]
+fn an_empty_batch_round_trips() {
+    let message = InternalMessage::ForwardPublish(ForwardPublish {
+        correlation_id: 5,
+        shard: shard(),
+        ack: AckMode::None,
+        payloads: Vec::new(),
+    });
+    let decoded = InternalMessage::decode(message.encode().expect("encode")).expect("decode");
+    assert_eq!(decoded, message);
+}
+
+#[test]
+fn unknown_enum_values_are_rejected() {
+    assert!(Kind::from_u16(0).is_err());
+    assert!(ErrorCode::from_u16(0).is_err());
+    assert!(ErrorCode::from_u16(999).is_err());
+    assert!(AckMode::from_u8(9).is_err());
+}
+
+/// Retryability is a property of the code, so a requester does not have to
+/// re-derive it from a message string.
+#[test]
+fn error_codes_say_whether_to_retry() {
+    for code in [
+        ErrorCode::StaleRoute,
+        ErrorCode::Unavailable,
+        ErrorCode::Overload,
+    ] {
+        assert!(code.is_retryable(), "{code:?}");
+    }
+    for code in [
+        ErrorCode::Unauthorized,
+        ErrorCode::ProtocolVersion,
+        ErrorCode::Malformed,
+        ErrorCode::StorageFailed,
+    ] {
+        assert!(!code.is_retryable(), "{code:?}");
+    }
+}

--- a/crates/felix-wire/src/lib.rs
+++ b/crates/felix-wire/src/lib.rs
@@ -21,6 +21,7 @@ mod frame;
 mod message;
 
 pub mod binary;
+pub mod internal;
 pub mod text;
 
 pub use error::{Error, Result};

--- a/docs/internal-protocol.md
+++ b/docs/internal-protocol.md
@@ -1,0 +1,139 @@
+# Broker-internal forwarding protocol
+
+The protocol brokers speak to each other. Separate from the client protocol in
+`docs/protocol.md`, and deliberately not a superset of it.
+
+## Why it is a separate protocol
+
+A client frame and an internal frame must never be mistaken for one another. A
+client that could send `ForwardPublish` could write to a shard on a broker that
+never checked ownership; a broker that accepted client frames on its internal
+listener would treat a peer as an authenticated publisher.
+
+Three things keep them apart, and only the first is a wire concern:
+
+1. **A distinct magic.** `FLXI` rather than `FLX1`, so a frame from one side
+   fails to decode on the other rather than parsing into something plausible.
+2. **A distinct listener.** Internal traffic arrives on the broker-internal QUIC
+   role, never the client one (M4.2).
+3. **A distinct credential.** Peer authentication is mTLS between brokers (M8.1).
+
+The magic alone is not security — it is what makes a misdirected connection fail
+loudly instead of quietly.
+
+## Framing
+
+```
++--------+---------+------+--------+---------+
+| magic  | version | kind | length | body    |
+| u32    | u16     | u16  | u32    | length  |
++--------+---------+------+--------+---------+
+```
+
+Big-endian throughout, matching the client protocol.
+
+`kind` is a message discriminant, not a flag set. The client protocol uses flag
+*bits* because they modify one payload layout; here each kind **is** a layout, and
+an enum makes "unknown kind" a single unambiguous check.
+
+**An unknown kind is rejected, never skipped.** Same reasoning as the client
+protocol's unknown flag bits: the kind selects how to read the body, so ignoring
+one means confidently misparsing it.
+
+### Versioning
+
+`version` is this protocol's own, independent of the client protocol's. A peer
+speaking a version this broker does not know gets `ProtocolVersion` and the
+connection closes; there is no partial understanding.
+
+Additive evolution happens by adding kinds, not by bumping the version. A new
+kind on an old peer is an unknown kind, which is already a typed error rather
+than a misparse. The version exists for the case additive change cannot cover —
+a change to the header or to an existing body layout.
+
+## Correlation
+
+Every request carries a `correlation_id`, unique per connection and chosen by the
+requester. Every response echoes it.
+
+**Every request has exactly one terminal response.** `ForwardPublish` is answered
+by exactly one of `ForwardPublishOk`, `ForwardPublishError`, or `NotLeader`. A
+requester that never receives one, because the connection dropped, treats the
+publish as failed — no forwarded publish is silently abandoned as pending.
+
+Correlation ids are per connection, so two connections may reuse a value.
+Responses are matched within the connection they arrive on and nowhere else.
+
+## Flows
+
+### Forwarded publish
+
+```mermaid
+sequenceDiagram
+    participant A as Broker A (ingress)
+    participant B as Broker B (owner)
+
+    A->>A: resolve shard -> Remote(B, generation)
+    A->>B: ForwardPublish(correlation, shard, generation, payloads)
+    B->>B: check own ownership at that generation
+    alt B owns the shard at that generation
+        B->>B: append and commit locally
+        B-->>A: ForwardPublishOk(correlation, first_offset, last_offset)
+    else B has moved on
+        B-->>A: NotLeader(correlation, owner, its generation)
+    else B cannot serve
+        B-->>A: ForwardPublishError(correlation, code)
+    end
+```
+
+The `generation` field is what makes this safe. A forwarding broker names the
+assignment generation it resolved against; the owner compares it with its own.
+
+- **Equal** — both agree, and the publish proceeds.
+- **Requester behind** — the shard moved. `NotLeader` carries the new owner, so
+  the requester can retry against it rather than guess.
+- **Requester ahead** — the *owner* is behind, and answers `StaleRoute`. It must
+  not accept the write: it would be writing a shard it may no longer hold.
+
+That asymmetry is the point. A generation mismatch in either direction is an
+explicit typed answer, and **never a successful ownership claim**.
+
+### Subscribe
+
+Whether a subscription is redirected to the owner or proxied through the
+receiving broker is decided in M4.4, and the two need different message sets.
+
+What both need is the redirect primitive, which is defined here: `NotLeader`
+carries the owning node's id, its advertised address, and its generation. A
+redirect design uses it as the answer; a proxy design uses it when the shard
+moves mid-subscription. Relay kinds for a proxy design are additive.
+
+## Errors
+
+Typed, because they need different responses:
+
+| Code | Meaning | What the requester does |
+| --- | --- | --- |
+| `NotLeader` | the shard is owned elsewhere | retry against the named owner |
+| `StaleRoute` | the *responder* is behind the requester's generation | retry shortly; the owner is catching up |
+| `Unavailable` | the owner cannot serve right now, e.g. still opening | retry with backoff |
+| `Unauthorized` | the peer is not permitted | do not retry |
+| `Overload` | the owner is shedding load | retry with backoff |
+| `ProtocolVersion` | version not understood | do not retry; close |
+| `Malformed` | the body did not decode | do not retry; close |
+
+`NotLeader` is a distinct kind rather than an error code, because it carries a
+routing answer rather than only a reason.
+
+## Limits and validation
+
+Every peer-provided field is validated before it is used to allocate:
+
+- Declared payload counts are bounded by what the remaining bytes could hold,
+  before any allocation, exactly as the client binary path does.
+- String fields are length-prefixed and bounded, and must be valid UTF-8.
+- The total body is bounded by the frame length, which is itself bounded.
+
+Peer-provided does not mean trusted. A broker is authenticated, not assumed
+correct: a compromised or buggy peer must fail decoding rather than be able to
+allocate on demand.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -3,6 +3,9 @@
 This document defines the language-neutral wire format for Felix. It is the
 source of truth for all client implementations.
 
+> Brokers speak a separate protocol to each other, with its own magic, version
+> and message kinds. See [the broker-internal forwarding protocol](internal-protocol.md).
+
 ## Goals
 - Stable, versioned envelope
 - Minimal message set for v1


### PR DESCRIPTION
Closes #104. **M4.1** — first slice of M4, and M3 is complete.

Flows and correlation rules are in `docs/internal-protocol.md`, written before the code as the issue asks.

## A separate protocol, not a superset

A client able to send `ForwardPublish` could write to a shard on a broker that never checked ownership. A broker accepting client frames on its internal listener would treat a peer as an authenticated publisher.

Three things keep them apart, and **only the first is a wire concern**: a distinct magic (`FLXI` vs `FLX1`), a distinct listener (#105), and a distinct credential (#125). The magic isn't security — it's what makes a misdirected connection fail loudly instead of quietly. A test asserts neither frame decodes as the other.

## Kinds, not flag bits

The client protocol uses flag *bits* because they modify one payload layout. Here each kind **is** a layout, so an enum makes "unknown kind" one unambiguous check — and it's rejected, never skipped, for the same reason CLAUDE.md gives for unknown flag bits.

Additive evolution adds a kind, which an older peer already rejects as unknown rather than misparses. The version exists for what that can't cover: the header, or an existing body layout.

## Generation, and why the asymmetry is the point

| Situation | Answer |
|---|---|
| generations equal | proceed |
| **requester behind** | `NotLeader` with the new owner — retry against it rather than guess |
| **requester ahead** | the *owner* is behind and must refuse: accepting would be writing a shard it may no longer hold |

Neither direction can be mistaken for a successful ownership claim, which is the acceptance criterion.

`NotLeader` is a distinct kind rather than an error code because it carries a *routing answer*, not only a reason. Error codes carry their own `is_retryable()`, so a requester never re-derives that from a message string.

## Hostile input

A peer is authenticated, not assumed correct. Every peer-provided length is checked against what remains before it sizes anything — including the `u32::MAX` payload-count trap the client binary path already documents.

Two tests do the heavy lifting:
- **truncate every message at every byte** — all must error
- **flip every bit of every byte** — none may panic

## Subscribe

Deliberately partial. Redirect-vs-proxy is **#107's decision**, and the two need different message sets, so I defined only what both need: the `NotLeader` redirect primitive. Relay kinds for a proxy design are additive. I'd rather not pre-empt that issue from here.

## The golden vectors earned their place immediately

They caught **my own arithmetic** — two hand-computed body lengths were wrong (55 vs 58, 24 vs 28). The encoder was right. That's exactly what byte-exact vectors are for.

## Verification

`task lint`, `task test` (67 suites), `task deny`, `task demo:check`, mermaid — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)