### PR TITLE
feat(broker): forward remote publishes to the owner and relay its ack (#106)

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -104,6 +104,16 @@ pub struct StreamMetadata {
     pub shards: u32,
 }
 
+/// What a publish did.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PublishOutcome {
+    /// Subscribers the batch was enqueued to.
+    pub subscribers: usize,
+    /// First and last log offset, inclusive. `None` for an ephemeral stream,
+    /// which has no log and therefore no offsets to report.
+    pub offsets: Option<(u64, u64)>,
+}
+
 #[derive(Clone, Debug)]
 pub struct StreamHandle {
     pub(crate) state: Arc<StreamState>,
@@ -256,6 +266,21 @@ impl Broker {
         handle: &StreamHandle,
         payloads: &[Bytes],
     ) -> Result<usize> {
+        Ok(self
+            .publish_batch_with_outcome(handle, payloads)
+            .await?
+            .subscribers)
+    }
+
+    /// Publish, and report the log offsets the batch was assigned.
+    ///
+    /// Same path as [`Self::publish_batch_to_handle`]; the offsets are what a
+    /// forwarding broker relays to the requester, which cannot see this log.
+    pub async fn publish_batch_with_outcome(
+        &self,
+        handle: &StreamHandle,
+        payloads: &[Bytes],
+    ) -> Result<PublishOutcome> {
         if !handle.state.active.load(Ordering::Acquire) {
             return Err(BrokerError::StreamHandleInactive(handle.id()));
         }
@@ -265,7 +290,10 @@ impl Broker {
         // each subscriber has a bounded queue and publish uses try_send so a slow consumer
         // drops locally instead of stalling all publishers.
         if payloads.is_empty() {
-            return Ok(0);
+            return Ok(PublishOutcome {
+                subscribers: 0,
+                offsets: None,
+            });
         }
 
         let sample = t_should_sample();
@@ -444,7 +472,12 @@ impl Broker {
                 .record(send_ns as f64);
             }
         }
-        Ok(sent)
+        Ok(PublishOutcome {
+            subscribers: sent,
+            // Inclusive, and contiguous by construction: a batch consumes one
+            // run of offsets.
+            offsets: durable_first_offset.map(|first| (first, first + item_count as u64 - 1)),
+        })
     }
 
     pub async fn subscribe(

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -34,8 +34,8 @@ mod subscription;
 pub mod timings;
 
 pub use broker::{
-    Broker, CacheMetadata, HistoryRange, ResumedSubscription, StartPosition, StreamHandle,
-    StreamMetadata,
+    Broker, CacheMetadata, HistoryRange, PublishOutcome, ResumedSubscription, StartPosition,
+    StreamHandle, StreamMetadata,
 };
 pub use config::SubQueuePolicy;
 pub use delivery::DeliveryEnvelope;

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -143,7 +143,7 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Durable streams | ✅ Today | Opt-in per stream via `durable: true`, and only when the broker runs with `FELIX_DURABLE_STORAGE_DIR`. Segmented crash-safe log: CRC-verified records, torn-tail recovery, group commit, three fsync policies. Single node, and nothing trims it |
 | Resumable subscriptions | ✅ Today | `Subscribe` takes `latest` / `earliest` / an offset; every delivered event carries its offset (`Event.offset`) so an application can checkpoint and resume at `offset + 1`. Stored history joins live delivery with no gap, backfilling from disk if the live queue overflowed. Durable streams only; bounded by retention when it is configured, unbounded otherwise |
 | Graceful shutdown | 🚧 Partial | Readiness flip, bounded drain, and accept-loop cancellation done; per-subsystem cancellation still open |
-| Sharding | 🚧 Partial | Streams carry a shard count, the control plane assigns each shard an owner, and a publish resolves against that ownership before anything else happens. A publish for a shard this broker does not own is refused with the owner named — it is not yet forwarded there. The wire protocol still carries no routing key, so every record of a stream lands on shard 0 |
+| Sharding | 🚧 Partial | Streams carry a shard count, the control plane assigns each shard an owner, and a publish resolves against that ownership before anything else happens. A publish for a shard this broker does not own is forwarded to the owner and acknowledged only once the owner has written it. The wire protocol still carries no routing key, so every record of a stream lands on shard 0, which is what keeps this partial |
 
 ### Measured performance
 
@@ -208,7 +208,7 @@ ship rather than being marked off here.
 | Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` takes an offset, so *changes since a known point* is gap-free. The missing half is the snapshot: there is no way to ask for current state and subsequent changes in one call |
 | Queue semantics (consumer groups, acks, redelivery) | 🎯 Target | Explicitly post-MVP; not started |
 | Tiered / cold storage | 🎯 Target | `TieredStore` trait declared, no implementation |
-| Multi-node clustering and replication | 🎯 Target | Brokers register with the control plane, their liveness is tracked, and shards are assigned to owners. Brokers reach each other over a broker-internal QUIC transport with its own protocol, listener, and pooling. What is missing is the thing that uses it: no publish is forwarded to its owner yet, and there is no replication or failover |
+| Multi-node clustering and replication | 🎯 Target | Brokers register, their liveness is tracked, shards are assigned to owners, and a publish that reaches the wrong broker is forwarded to the right one over a broker-internal QUIC transport. Subscribe is not: it is still served only by the broker holding the shard, and there is no replication and no failover |
 | Raft consensus for cluster metadata | 🎯 Target | `felix-consensus` is a configuration struct with no protocol implementation |
 | Cross-region routing and data sovereignty enforcement | 🎯 Target | `felix-router` is a directional region-pair allowlist, not wired into enforcement |
 | At-least-once / quorum acks | 🎯 Target | Not started |

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -99,6 +99,14 @@ peers are the only thing that reads it. A broker that advertises a port it does
 not bind logs a warning at startup rather than refusing, because a deployment
 may legitimately map ports.
 
+A broker also polls `/v1/nodes` on the same interval to build its address book.
+Shard assignments name an owner by node id, and only the catalog turns that into
+an address to forward to — without it a broker knows a shard is owned elsewhere
+and cannot reach it. A refresh that fails keeps the previous catalog rather than
+emptying it, because a control-plane blip must not turn a healthy cluster into
+one that refuses every remote publish. `felix_broker_node_catalog_nodes` reading
+zero while assignments are known is exactly that failure.
+
 The internal transport is described in
 [the broker-internal forwarding protocol](internal-protocol.md); its remaining
 settings (`FELIX_INTERNAL_CONNS_PER_PEER`, `FELIX_INTERNAL_STREAMS_PER_CONN`,

--- a/docs/internal-protocol.md
+++ b/docs/internal-protocol.md
@@ -167,6 +167,57 @@ Typed, because they need different responses:
 `NotLeader` is a distinct kind rather than an error code, because it carries a
 routing answer rather than only a reason.
 
+## Acknowledging a forwarded publish
+
+**The ingress broker never acknowledges before the owner has.** A forwarded
+publish is acknowledged from the owner's answer and from nothing else.
+
+This overrides `ack_on_commit`, the broker setting that otherwise decides
+whether a publish is acknowledged on enqueue or after commit. That setting is a
+statement about a *local* write — "accepted into this broker's ingress queue is
+good enough" — and for a forward the ingress broker has accepted nothing: the
+data is not on its disk, and the owner may still refuse it. So a forward always
+takes the commit-ack path, whatever the setting says.
+
+The owner's write is durable-then-answer, so `ForwardPublishOk` means the batch
+is as safe on the owner as a local publish would have been on the ingress
+broker.
+
+## Retrying a forwarded publish
+
+One question decides it: *could the owner already have applied this batch?* If it
+could, a retry is a duplicate rather than a repair, and the ingress broker has no
+way to tell the two apart.
+
+| Outcome | Applied? | Retried |
+| --- | --- | --- |
+| Shed, backoff, unreachable | No — nothing was sent | Yes |
+| `NotLeader` | No — the refusal is the evidence | Yes, against the owner it names |
+| `StaleRoute`, `Unavailable`, `Overload` | No — refused before writing | Yes |
+| `Unauthorized`, `Malformed`, `StorageFailed` | Refused, or tried and failed | No |
+| Connection dropped, request timed out | **Unknown** | **No** |
+
+The last row is the important one. The batch may be on the owner's disk, and no
+answer is coming. The publish is reported as *indeterminate* rather than failed,
+because "failed" is a claim the ingress broker cannot make.
+
+**This is stricter than `AtLeastOnce` allows**, deliberately. A duplicate
+produced inside the broker is invisible to the client, which holds the
+`request_id` and is the only layer that could deduplicate. A client that wants
+the retry can reissue and know that it did.
+
+Retries are bounded by an attempt budget, so a shard being reassigned converges
+or fails explicitly instead of chasing `NotLeader` around the cluster. A redirect
+that does not advance the generation is refused rather than followed: it would
+send the batch back where it came from.
+
+## Chains are refused, not relayed
+
+A broker asked for a shard it does not own answers `NotLeader`. It never forwards
+onward on the requester's behalf. One publish crossing an unbounded chain of
+brokers would have unbounded latency and a failure mode nobody can reason about;
+the requester holds the decision instead.
+
 ## The transport
 
 Peers reach each other over a QUIC endpoint of their own. What it guarantees,

--- a/services/broker/src/bin/soak/main.rs
+++ b/services/broker/src/bin/soak/main.rs
@@ -277,8 +277,9 @@ async fn start_broker(auth: &AuthFixture) -> Result<BrokerHarness> {
                 auth,
                 accept_shutdown,
                 connections,
-                // The soak harness is a single-node broker.
-                None,
+                // The soak harness is a single-node broker: nothing to route
+                // against, and no peers to forward to.
+                Default::default(),
             )
             .await
             {

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -12,6 +12,7 @@ pub mod core_shards;
 pub mod durable_config;
 pub mod membership;
 pub mod membership_metrics;
+pub mod node_catalog;
 pub mod peer;
 pub mod quic;
 pub mod shard_lifecycle;

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -126,6 +126,23 @@ where
     let ingress_router = cluster
         .as_ref()
         .map(|(_, ingress, _, _)| Arc::clone(ingress));
+
+    // Outbound peer connections. Built here because the publish path forwards
+    // through it, and before the accept loop for the same reason the router is:
+    // a publish must never arrive at a broker that can resolve a remote owner
+    // and not reach it.
+    let peer_shutdown = CancellationToken::new();
+    let peers = match (&config.peer_transport, &config.membership) {
+        (Some(peer_config), Some(membership_config)) => Some(
+            peer::PeerPool::new(
+                membership_config.node_id.clone(),
+                peer_config.clone(),
+                peer_shutdown.clone(),
+            )
+            .context("bind peer transport")?,
+        ),
+        _ => None,
+    };
     let sync_shutdown = CancellationToken::new();
     let metrics_shutdown = CancellationToken::new();
     let connections = TaskTracker::new();
@@ -212,6 +229,7 @@ where
         let connections = connections.clone();
         let seeded = seeded.clone();
         let ingress_router = ingress_router.clone();
+        let peers_for_accept = peers.clone();
         tokio::spawn(async move {
             // A durable broker does not accept until its streams exist.
             // Readiness alone only steers orchestrated traffic; a client with
@@ -238,7 +256,10 @@ where
                 auth,
                 accept_shutdown,
                 connections,
-                ingress_router,
+                quic::ClusterContext {
+                    ingress: ingress_router,
+                    peers: peers_for_accept,
+                },
             )
             .await
             {
@@ -353,16 +374,18 @@ where
 
     // The broker-internal listener, when this broker is in a cluster. This is
     // the address `NodeSpec.advertise_addr` names, so it must be up for peers to
-    // reach this node at all. Nothing forwards to it yet (#106): a peer that
-    // connects is told plainly that this broker cannot apply a forwarded write,
-    // rather than being left to time out.
-    let peer_shutdown = CancellationToken::new();
-    let peer_task = match (&config.peer_transport, &config.membership) {
-        (Some(peer_config), Some(membership_config)) => {
+    // reach this node at all.
+    let peer_task = match (&config.peer_transport, &config.membership, &cluster) {
+        (Some(peer_config), Some(membership_config), Some((router, ingress, _, _))) => {
             let server = peer::PeerServer::bind(
                 membership_config.node_id.clone(),
                 peer_config,
-                Arc::new(peer::UnavailableHandler),
+                Arc::new(peer::ForwardingHandler::new(
+                    Arc::clone(&broker),
+                    Arc::clone(ingress),
+                    Arc::clone(router),
+                    membership_config.advertise_addr.clone(),
+                )),
             )
             .context("bind broker-internal listener")?;
             tracing::info!(
@@ -398,11 +421,18 @@ where
                 sync_shutdown.clone(),
             ));
             let feed = shard_routing::spawn_feed(
-                Arc::clone(ownership),
-                Arc::clone(lifecycle),
-                store,
-                Arc::clone(ingress),
-                Arc::clone(router),
+                shard_routing::FeedState {
+                    ownership: Arc::clone(ownership),
+                    lifecycle: Arc::clone(lifecycle),
+                    store,
+                    ingress: Arc::clone(ingress),
+                    router: Arc::clone(router),
+                },
+                Some(shard_routing::CatalogSource {
+                    client: membership_client.clone(),
+                    base_url: base_url.clone(),
+                    token: config.membership.as_ref().map(|m| m.token.clone()),
+                }),
                 Duration::from_millis(config.controlplane_sync_interval_ms),
                 sync_shutdown.clone(),
             );
@@ -454,6 +484,9 @@ where
     // publish this broker is still applying is not cut off by its own shutdown.
     // Cancelling closes the connections, which tells every peer immediately
     // rather than leaving each to wait out its request timeout.
+    if let Some(pool) = &peers {
+        pool.shutdown().await;
+    }
     if let Some(peer_task) = peer_task {
         peer_shutdown.cancel();
         let mut peer_task = peer_task;

--- a/services/broker/src/node_catalog.rs
+++ b/services/broker/src/node_catalog.rs
@@ -1,0 +1,92 @@
+//! The address book: which broker is where.
+//!
+//! Shard assignments name an owner by node id. Forwarding needs an address, and
+//! only the control plane's node catalog has one. Without this the router
+//! resolves every remote shard to "owner unavailable" — the assignment is known
+//! and the node behind it is not.
+//!
+//! Read with the same credential as the assignment feed: `/v1/nodes` requires
+//! `node.view:cluster:*`, which a broker already holds to read assignments at
+//! all.
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, anyhow};
+use felix_router::NodeRef;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct NodeListResponse {
+    items: Vec<NodeView>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeView {
+    node: Node,
+    placement: Placement,
+}
+
+#[derive(Debug, Deserialize)]
+struct Node {
+    node_id: String,
+    spec: NodeSpec,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeSpec {
+    advertise_addr: String,
+    region: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct Placement {
+    eligible: bool,
+}
+
+/// Fetch the catalog.
+///
+/// A node whose advertised address does not parse is skipped rather than
+/// failing the fetch: one malformed registration must not cost this broker every
+/// other route it knows.
+pub async fn fetch(
+    client: &reqwest::Client,
+    base_url: &str,
+    bearer: Option<&str>,
+) -> Result<HashMap<String, NodeRef>> {
+    let mut request = client.get(format!("{base_url}/v1/nodes"));
+    if let Some(bearer) = bearer {
+        request = request.bearer_auth(bearer);
+    }
+    let response = request.send().await.context("send node list request")?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!("{status}: {body}"));
+    }
+    let response: NodeListResponse = response.json().await.context("decode node list")?;
+
+    let mut catalog = HashMap::with_capacity(response.items.len());
+    for item in response.items {
+        let Ok(advertise_addr) = item.node.spec.advertise_addr.parse() else {
+            tracing::warn!(
+                node_id = %item.node.node_id,
+                advertise_addr = %item.node.spec.advertise_addr,
+                "skipping node: advertised address does not parse",
+            );
+            continue;
+        };
+        catalog.insert(
+            item.node.node_id.clone(),
+            NodeRef {
+                node_id: item.node.node_id,
+                advertise_addr,
+                region: item.node.spec.region,
+                // The control plane's own verdict, which folds in lifecycle and
+                // heartbeat age together. A broker re-deriving that from the
+                // lifecycle alone would keep forwarding to a node whose
+                // heartbeat has lapsed but whose sweep has not yet run.
+                live: item.placement.eligible,
+            },
+        );
+    }
+    Ok(catalog)
+}

--- a/services/broker/src/peer/forward.rs
+++ b/services/broker/src/peer/forward.rs
@@ -1,0 +1,203 @@
+//! Forwarding a publish to the broker that owns its shard.
+//!
+//! # What may be retried, and what may not
+//!
+//! The rule is one question: *could the owner already have applied this batch?*
+//! If it could, a retry is a duplicate rather than a repair, and this broker has
+//! no way to tell the two apart.
+//!
+//! - **Nothing was sent** — the peer was shed, in backoff, or unreachable.
+//!   Retryable.
+//! - **The owner refused** — `NotLeader`, `StaleRoute`, `Unavailable`,
+//!   `Overload`. The refusal *is* the evidence nothing was applied. Retryable,
+//!   and `NotLeader` carries where to go instead.
+//! - **The answer was lost** — the connection dropped, or the request timed out.
+//!   The batch may be on the owner's disk. **Never retried here**, for a stream
+//!   of any delivery guarantee.
+//!
+//! That last rule is stricter than `AtLeastOnce` requires. It is deliberate: a
+//! duplicate produced inside the broker is invisible to the client, which holds
+//! the `request_id` and is the only layer that could deduplicate. A client that
+//! wants a retry can reissue and know it did.
+//!
+//! Retries are bounded by [`MAX_ATTEMPTS`] so a shard being reassigned converges
+//! or fails explicitly, rather than chasing `NotLeader` around a cluster.
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use bytes::Bytes;
+use felix_wire::internal::{AckMode, ForwardPublish, InternalMessage, ShardRef};
+
+use super::metrics;
+use super::pool::{PeerError, PeerPool};
+
+/// Total attempts for one publish, across every owner it is redirected to.
+///
+/// Three covers the case this exists for — a reassignment observed mid-publish,
+/// which costs one redirect — with one spare. Beyond that the routing view is
+/// churning faster than a publish can complete, and failing explicitly beats
+/// chasing it.
+const MAX_ATTEMPTS: u32 = 3;
+
+/// Where a publish is being sent, as this broker currently resolves it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardTarget {
+    pub node_id: String,
+    pub advertise_addr: SocketAddr,
+    pub generation: u64,
+}
+
+/// Which shard the batch belongs to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForwardKey {
+    pub tenant_id: String,
+    pub namespace: String,
+    pub stream: String,
+    pub shard: u32,
+}
+
+/// Why a forward did not succeed.
+#[derive(Debug, thiserror::Error)]
+pub enum ForwardError {
+    /// The owner refused, or could not be reached, and retrying is allowed but
+    /// exhausted. Nothing was applied.
+    #[error("could not forward to the owner of {stream}: {detail}")]
+    Refused { stream: String, detail: String },
+    /// The batch was sent and its answer never arrived. It may or may not have
+    /// been applied, and this broker cannot tell.
+    #[error("forwarded publish to {node_id} was not acknowledged: {detail}")]
+    Indeterminate { node_id: String, detail: String },
+}
+
+/// Forward one batch and wait for the owner's answer.
+///
+/// Returns the log offsets the owner assigned, when the stream has a log.
+pub async fn forward_publish(
+    pool: &PeerPool,
+    target: &ForwardTarget,
+    key: &ForwardKey,
+    ack: AckMode,
+    payloads: Vec<Bytes>,
+) -> Result<Option<(u64, u64)>, ForwardError> {
+    let mut target = target.clone();
+    let mut last = String::new();
+
+    for attempt in 0..MAX_ATTEMPTS {
+        if attempt > 0 {
+            metrics::record_forward_retry();
+        }
+        let request = InternalMessage::ForwardPublish(ForwardPublish {
+            // The pool assigns the real id; it owns the connection this lands on.
+            correlation_id: 0,
+            shard: ShardRef {
+                tenant_id: key.tenant_id.clone(),
+                namespace: key.namespace.clone(),
+                stream: key.stream.clone(),
+                shard: key.shard,
+                generation: target.generation,
+            },
+            ack,
+            payloads: payloads.clone(),
+        });
+
+        match pool
+            .request(&target.node_id, target.advertise_addr, request)
+            .await
+        {
+            Ok(InternalMessage::ForwardPublishOk(ok)) => {
+                metrics::record_forward(metrics::OUTCOME_OK);
+                return Ok(Some((ok.first_offset, ok.last_offset)));
+            }
+            Ok(InternalMessage::NotLeader(moved)) => {
+                // The owner refused, so nothing was applied, and it named where
+                // to go. Following that beats waiting for this broker's watch to
+                // catch up — but only within the attempt budget, so a shard
+                // being reassigned repeatedly fails rather than loops.
+                last = format!(
+                    "shard moved to {} at generation {}",
+                    moved.node_id, moved.generation
+                );
+                let Ok(advertise_addr) = moved.advertise_addr.parse() else {
+                    metrics::record_forward(metrics::OUTCOME_REFUSED);
+                    return Err(ForwardError::Refused {
+                        stream: key.stream.clone(),
+                        detail: format!(
+                            "owner {} advertised an unusable address {}",
+                            moved.node_id, moved.advertise_addr
+                        ),
+                    });
+                };
+                // A redirect that does not advance the generation would send the
+                // batch straight back where it came from.
+                if moved.generation <= target.generation {
+                    metrics::record_forward(metrics::OUTCOME_REFUSED);
+                    return Err(ForwardError::Refused {
+                        stream: key.stream.clone(),
+                        detail: format!(
+                            "owner {} redirected to generation {}, not ahead of {}",
+                            moved.node_id, moved.generation, target.generation
+                        ),
+                    });
+                }
+                target = ForwardTarget {
+                    node_id: moved.node_id,
+                    advertise_addr,
+                    generation: moved.generation,
+                };
+            }
+            Ok(InternalMessage::ForwardPublishError(err)) => {
+                last = format!("{:?}: {}", err.code, err.detail);
+                if !err.code.is_retryable() {
+                    metrics::record_forward(metrics::OUTCOME_REFUSED);
+                    return Err(ForwardError::Refused {
+                        stream: key.stream.clone(),
+                        detail: last,
+                    });
+                }
+                // `StorageFailed` is not retryable and lands above; every code
+                // that reaches here refused before writing.
+                tokio::time::sleep(retry_delay(attempt)).await;
+            }
+            Ok(other) => {
+                metrics::record_forward(metrics::OUTCOME_REFUSED);
+                return Err(ForwardError::Refused {
+                    stream: key.stream.clone(),
+                    detail: format!("owner answered with an unexpected {:?}", other.kind()),
+                });
+            }
+            Err(err) if err.is_retryable() => {
+                last = err.to_string();
+                tokio::time::sleep(retry_delay(attempt)).await;
+            }
+            Err(err @ (PeerError::Disconnected { .. } | PeerError::Timeout { .. })) => {
+                // The batch is out there. Retrying would duplicate it, and this
+                // broker cannot tell whether it landed.
+                metrics::record_forward(metrics::OUTCOME_INDETERMINATE);
+                return Err(ForwardError::Indeterminate {
+                    node_id: target.node_id,
+                    detail: err.to_string(),
+                });
+            }
+            Err(err) => {
+                metrics::record_forward(metrics::OUTCOME_REFUSED);
+                return Err(ForwardError::Refused {
+                    stream: key.stream.clone(),
+                    detail: err.to_string(),
+                });
+            }
+        }
+    }
+
+    metrics::record_forward(metrics::OUTCOME_EXHAUSTED);
+    Err(ForwardError::Refused {
+        stream: key.stream.clone(),
+        detail: format!("gave up after {MAX_ATTEMPTS} attempts: {last}"),
+    })
+}
+
+/// A short pause between attempts, so a shard mid-reassignment is not retried
+/// before anything can have changed. Deliberately small: the client is waiting,
+/// and the attempt budget is the real bound.
+fn retry_delay(attempt: u32) -> Duration {
+    Duration::from_millis(5 << attempt.min(4))
+}

--- a/services/broker/src/peer/handler.rs
+++ b/services/broker/src/peer/handler.rs
@@ -1,0 +1,197 @@
+//! The owner's side: applying a publish another broker forwarded.
+//!
+//! Ownership is re-checked here, against this broker's own view, and the
+//! requester's generation has to match it exactly. That check is the whole
+//! safety property: the requester resolved against a snapshot that may already
+//! be wrong, and a broker that trusted it would write a shard it no longer
+//! holds.
+//!
+//! A mismatch in either direction is answered, never guessed at:
+//!
+//! - **The requester is behind** — this broker no longer owns the shard, or owns
+//!   it at a newer generation. `NotLeader`, naming the current owner.
+//! - **The requester is ahead** — this broker's watch has not caught up.
+//!   `StaleRoute`. It must not accept: it may already have lost the shard.
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use felix_broker::Broker;
+use felix_router::{Resolution, ShardRouter};
+use felix_wire::internal::{
+    ErrorCode, ForwardPublish, ForwardPublishError, ForwardPublishOk, InternalMessage, NotLeader,
+};
+
+use super::metrics;
+use super::server::PeerRequestHandler;
+use crate::shard_routing::{Dispatch, IngressRouter};
+use crate::shard_watch::ShardKey;
+
+/// Applies forwarded publishes against the local broker.
+pub struct ForwardingHandler {
+    broker: Arc<Broker>,
+    ingress: Arc<IngressRouter>,
+    router: Arc<ShardRouter>,
+    /// This broker's own internal address, so a `NotLeader` that names *this*
+    /// node at a newer generation is one the requester can act on.
+    advertise_addr: String,
+}
+
+impl ForwardingHandler {
+    pub fn new(
+        broker: Arc<Broker>,
+        ingress: Arc<IngressRouter>,
+        router: Arc<ShardRouter>,
+        advertise_addr: String,
+    ) -> Self {
+        Self {
+            broker,
+            ingress,
+            router,
+            advertise_addr,
+        }
+    }
+
+    async fn apply(&self, publish: ForwardPublish) -> InternalMessage {
+        let correlation_id = publish.correlation_id;
+        let key = ShardKey {
+            tenant_id: publish.shard.tenant_id.clone(),
+            namespace: publish.shard.namespace.clone(),
+            stream: publish.shard.stream.clone(),
+            shard: publish.shard.shard,
+        };
+
+        match self.ingress.dispatch(&key) {
+            Dispatch::Local => {}
+            Dispatch::Forward {
+                node_id,
+                advertise_addr,
+                generation,
+            } => {
+                // The shard moved on. Answering `NotLeader` rather than
+                // forwarding again is deliberate: a chain of brokers each
+                // relaying to the next would make one publish's latency and
+                // failure modes unbounded. The requester decides.
+                metrics::record_served(metrics::OUTCOME_NOT_LEADER);
+                return InternalMessage::NotLeader(NotLeader {
+                    correlation_id,
+                    node_id,
+                    advertise_addr: advertise_addr.to_string(),
+                    generation,
+                });
+            }
+            Dispatch::Unavailable(reason) => {
+                metrics::record_served(metrics::OUTCOME_REFUSED);
+                return error(correlation_id, ErrorCode::Unavailable, reason.to_string());
+            }
+        }
+
+        // Local, but at which generation? `dispatch` already required local
+        // readiness to match the router, so this reads the same number it
+        // agreed on.
+        let ours = match self.router.resolve(&felix_router::ShardKey {
+            tenant_id: key.tenant_id.clone(),
+            namespace: key.namespace.clone(),
+            stream: key.stream.clone(),
+            shard: key.shard,
+        }) {
+            Resolution::Local { generation } => generation,
+            // Between the dispatch above and here the view changed. Refusing is
+            // the only safe answer; the requester retries and gets a definite
+            // one.
+            _ => {
+                metrics::record_served(metrics::OUTCOME_REFUSED);
+                return error(
+                    correlation_id,
+                    ErrorCode::Unavailable,
+                    "ownership changed while the request was being served".to_string(),
+                );
+            }
+        };
+
+        if publish.shard.generation != ours {
+            metrics::record_served(metrics::OUTCOME_REFUSED);
+            return if publish.shard.generation > ours {
+                // The requester has seen a newer assignment than this broker.
+                // Accepting would be writing a shard we may already have lost.
+                error(
+                    correlation_id,
+                    ErrorCode::StaleRoute,
+                    format!(
+                        "this broker is at generation {ours}, the requester at {}",
+                        publish.shard.generation
+                    ),
+                )
+            } else {
+                InternalMessage::NotLeader(NotLeader {
+                    correlation_id,
+                    node_id: self.router.local_node_id().to_string(),
+                    advertise_addr: self.advertise_addr.clone(),
+                    generation: ours,
+                })
+            };
+        }
+
+        let handle = match self
+            .broker
+            .resolve_stream_handle(&key.tenant_id, &key.namespace, &key.stream)
+            .await
+        {
+            Ok(handle) => handle,
+            Err(err) => {
+                metrics::record_served(metrics::OUTCOME_REFUSED);
+                return error(correlation_id, ErrorCode::Unavailable, err.to_string());
+            }
+        };
+
+        match self
+            .broker
+            .publish_batch_with_outcome(&handle, &publish.payloads)
+            .await
+        {
+            Ok(outcome) => {
+                metrics::record_served(metrics::OUTCOME_OK);
+                // An ephemeral stream has no log, so there are no offsets to
+                // report. Zero is not a lie here: the requester only relays an
+                // acknowledgement, and the client protocol carries no offset on
+                // a publish ack at all.
+                let (first, last) = outcome.offsets.unwrap_or((0, 0));
+                InternalMessage::ForwardPublishOk(ForwardPublishOk {
+                    correlation_id,
+                    first_offset: first,
+                    last_offset: last,
+                })
+            }
+            Err(err) => {
+                // The owner accepted the request and the write failed. Distinct
+                // from a refusal: the requester must not retry, because this
+                // broker did try.
+                metrics::record_served(metrics::OUTCOME_ERROR);
+                error(correlation_id, ErrorCode::StorageFailed, err.to_string())
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl PeerRequestHandler for ForwardingHandler {
+    async fn handle(&self, request: InternalMessage) -> InternalMessage {
+        match request {
+            InternalMessage::ForwardPublish(publish) => self.apply(publish).await,
+            // Responses have no business arriving as requests, and a broker that
+            // answered one would be inventing a request that was never made.
+            other => error(
+                other.correlation_id(),
+                ErrorCode::Malformed,
+                format!("{:?} is not a request", other.kind()),
+            ),
+        }
+    }
+}
+
+fn error(correlation_id: u64, code: ErrorCode, detail: String) -> InternalMessage {
+    InternalMessage::ForwardPublishError(ForwardPublishError {
+        correlation_id,
+        code,
+        detail,
+    })
+}

--- a/services/broker/src/peer/metrics.rs
+++ b/services/broker/src/peer/metrics.rs
@@ -40,6 +40,10 @@ pub const OUTCOME_OK: &str = "ok";
 pub const OUTCOME_ERROR: &str = "error";
 pub const OUTCOME_TIMEOUT: &str = "timeout";
 pub const OUTCOME_DISCONNECTED: &str = "disconnected";
+/// This broker was asked for a shard it does not own, and said so.
+pub const OUTCOME_NOT_LEADER: &str = "not_leader";
+/// This broker refused before applying anything.
+pub const OUTCOME_REFUSED: &str = "refused";
 
 pub fn record_connect_attempt(outcome: &'static str) {
     metrics::counter!(CONNECT_ATTEMPTS_TOTAL, "outcome" => outcome).increment(1);
@@ -76,4 +80,25 @@ pub fn record_served(outcome: &'static str) {
 
 pub fn record_inbound_rejected(reason: &'static str) {
     metrics::counter!(INBOUND_REJECTED_TOTAL, "reason" => reason).increment(1);
+}
+
+/// Publishes this broker forwarded to an owner, by `outcome`.
+pub const FORWARDS_TOTAL: &str = "felix_broker_forwards_total";
+/// Forward attempts that were not the first: a redirect followed, or a
+/// retryable refusal retried. Rising steadily means the routing view is
+/// churning, not that anything is broken.
+pub const FORWARD_RETRIES_TOTAL: &str = "felix_broker_forward_retries_total";
+
+/// The attempt budget ran out while the owner kept refusing or moving.
+pub const OUTCOME_EXHAUSTED: &str = "exhausted";
+/// The batch was sent and its answer never arrived. Alert on this: it is the
+/// only outcome where the broker cannot say whether the write landed.
+pub const OUTCOME_INDETERMINATE: &str = "indeterminate";
+
+pub fn record_forward(outcome: &'static str) {
+    metrics::counter!(FORWARDS_TOTAL, "outcome" => outcome).increment(1);
+}
+
+pub fn record_forward_retry() {
+    metrics::counter!(FORWARD_RETRIES_TOTAL).increment(1);
 }

--- a/services/broker/src/peer/mod.rs
+++ b/services/broker/src/peer/mod.rs
@@ -11,12 +11,16 @@
 //! consume this broker.
 pub mod codec;
 pub mod config;
+pub mod forward;
+pub mod handler;
 pub mod metrics;
 pub mod pool;
 pub mod server;
 mod tls;
 
 pub use config::PeerTransportConfig;
+pub use forward::{ForwardError, ForwardKey, ForwardTarget, forward_publish};
+pub use handler::ForwardingHandler;
 pub use pool::{PeerError, PeerPool};
 pub use server::{PeerRequestHandler, PeerServer, UnavailableHandler};
 

--- a/services/broker/src/shard_routing.rs
+++ b/services/broker/src/shard_routing.rs
@@ -23,12 +23,17 @@ use crate::shard_watch::ShardKey;
 pub enum Dispatch {
     /// Serve it here.
     Local,
-    /// Another node owns it. M4 forwards; until then the caller refuses with
-    /// this attached, so "someone else's shard" stays distinguishable from
-    /// "something went wrong".
+    /// Another node owns it. The publish is forwarded there over the internal
+    /// protocol and its answer is relayed back to the client.
     Forward {
         node_id: String,
         advertise_addr: SocketAddr,
+        /// The generation this broker resolved against.
+        ///
+        /// Carried to the owner, which compares it with its own. A mismatch in
+        /// either direction is a typed answer and never a successful ownership
+        /// claim — see `docs/internal-protocol.md`.
+        generation: u64,
     },
     /// Nobody can serve it right now, and this says why.
     Unavailable(Reason),
@@ -167,10 +172,11 @@ impl IngressRouter {
             Resolution::Remote {
                 node_id,
                 advertise_addr,
-                ..
+                generation,
             } => Dispatch::Forward {
                 node_id,
                 advertise_addr,
+                generation,
             },
             Resolution::Stale { have, wanted } => {
                 Dispatch::Unavailable(Reason::Stale { have, wanted })
@@ -230,6 +236,25 @@ pub fn routing_table_from(
     )
 }
 
+/// The cluster state one task keeps in step. Grouped because they are only ever
+/// used together, and only in the order this feed applies them.
+pub struct FeedState {
+    pub ownership: Arc<tokio::sync::RwLock<crate::shard_watch::ShardOwnership>>,
+    pub lifecycle: Arc<tokio::sync::Mutex<crate::shard_lifecycle::ShardLifecycle>>,
+    pub store: Arc<dyn crate::shard_lifecycle::ShardStore>,
+    pub ingress: Arc<IngressRouter>,
+    pub router: Arc<ShardRouter>,
+}
+
+/// What the feed needs to read the node catalog.
+pub struct CatalogSource {
+    pub client: reqwest::Client,
+    pub base_url: String,
+    /// The same credential the assignment feed uses: `/v1/nodes` and
+    /// `/v1/shard-assignments` both require `node.view:cluster:*`.
+    pub token: Option<String>,
+}
+
 /// Keep local shard state and the routing table in step with the watch.
 ///
 /// One task owns the sequence, so the two never disagree: reconcile local state
@@ -237,29 +262,50 @@ pub fn routing_table_from(
 /// routes first would advertise this node as the owner of a shard it has not
 /// opened.
 ///
-/// The routing table is built with an empty node catalog, because a broker has
-/// no way to read one: `/v1/nodes` requires a cluster-scoped token and brokers
-/// do not have credentials yet (#126). The consequence is deliberate and
-/// correct for M3 -- a shard led by this node resolves `Local` on the node id
-/// alone, and every other shard resolves to a refusal naming its owner rather
-/// than a forward. Forwarding needs an address book, and that arrives with M4.
+/// The node catalog is refreshed on the same tick, because a route is only
+/// usable when both halves are known: an assignment names an owner by id, and
+/// only the catalog turns that into an address to forward to.
 pub fn spawn_feed(
-    ownership: Arc<tokio::sync::RwLock<crate::shard_watch::ShardOwnership>>,
-    lifecycle: Arc<tokio::sync::Mutex<crate::shard_lifecycle::ShardLifecycle>>,
-    store: Arc<dyn crate::shard_lifecycle::ShardStore>,
-    ingress: Arc<IngressRouter>,
-    router: Arc<ShardRouter>,
+    state: FeedState,
+    catalog_source: Option<CatalogSource>,
     interval: std::time::Duration,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
+    let FeedState {
+        ownership,
+        lifecycle,
+        store,
+        ingress,
+        router,
+    } = state;
     tokio::spawn(async move {
         let mut ticker = tokio::time::interval(interval);
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        let catalog = HashMap::new();
+        let mut catalog = HashMap::new();
         loop {
             tokio::select! {
                 _ = shutdown.cancelled() => return,
                 _ = ticker.tick() => {}
+            }
+
+            if let Some(source) = &catalog_source {
+                match crate::node_catalog::fetch(
+                    &source.client,
+                    &source.base_url,
+                    source.token.as_deref(),
+                )
+                .await
+                {
+                    Ok(fetched) => catalog = fetched,
+                    // The previous catalog is kept: a control-plane blip must
+                    // not erase every address this broker can forward to and
+                    // turn a healthy cluster into one that refuses every remote
+                    // publish.
+                    Err(err) => {
+                        tracing::warn!(error = %err, "node catalog refresh failed; keeping the last one");
+                        crate::shard_watch_metrics::record_catalog_refresh_failure();
+                    }
+                }
             }
 
             let assignments = ownership.read().await.assignments().clone();
@@ -268,6 +314,7 @@ pub fn spawn_feed(
             let servable = lifecycle.lock().await.servable();
             ingress.publish_servable(servable);
             router.publish(routing_table_from(&assignments, &catalog), &catalog);
+            crate::shard_watch_metrics::set_catalog_nodes(catalog.len());
         }
     })
 }

--- a/services/broker/src/shard_routing_tests.rs
+++ b/services/broker/src/shard_routing_tests.rs
@@ -102,6 +102,8 @@ async fn a_shard_owned_elsewhere_is_forwardable() {
         Dispatch::Forward {
             node_id: "broker-b".to_string(),
             advertise_addr: SocketAddr::from(([10, 0, 0, 4], 7002)),
+            // Carried through so the owner can compare it with its own.
+            generation: 2,
         },
     );
 }

--- a/services/broker/src/shard_watch_metrics.rs
+++ b/services/broker/src/shard_watch_metrics.rs
@@ -49,3 +49,22 @@ pub fn record_resync(reason: super::shard_watch::Resync) {
     };
     metrics::counter!(RESYNCS_TOTAL, "reason" => label).increment(1);
 }
+
+/// Nodes in the address book this broker can forward to.
+///
+/// Zero while assignments are known is the shape of a cluster that cannot
+/// forward: every remote shard resolves to "owner unavailable" because the id
+/// has no address behind it.
+pub const CATALOG_NODES: &str = "felix_broker_node_catalog_nodes";
+/// Node-catalog refreshes that failed. The previous catalog is kept, so this
+/// rising while `CATALOG_NODES` holds steady means routes are going stale
+/// rather than disappearing.
+pub const CATALOG_REFRESH_FAILURES_TOTAL: &str = "felix_broker_node_catalog_refresh_failures_total";
+
+pub fn set_catalog_nodes(count: usize) {
+    metrics::gauge!(CATALOG_NODES).set(count as f64);
+}
+
+pub fn record_catalog_refresh_failure() {
+    metrics::counter!(CATALOG_REFRESH_FAILURES_TOTAL).increment(1);
+}

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -76,8 +76,8 @@ pub async fn serve(
         CancellationToken::new(),
         TaskTracker::new(),
         // The simple entry point is single-node; a cluster member goes through
-        // `serve_with_shutdown` so it can pass its ownership view.
-        None,
+        // `serve_with_shutdown` so it can pass its ownership view and its peers.
+        ClusterContext::default(),
     )
     .await
 }
@@ -102,9 +102,9 @@ pub async fn serve_with_shutdown(
     auth: Arc<BrokerAuth>,
     shutdown: CancellationToken,
     connections: TaskTracker,
-    ingress: Option<Arc<IngressRouter>>,
+    cluster: ClusterContext,
 ) -> Result<()> {
-    let publish_ctx = build_publish_context(Arc::clone(&broker), &config, ingress);
+    let publish_ctx = build_publish_context(Arc::clone(&broker), &config, cluster);
     // Main accept loop: spawn a task per incoming QUIC connection.
     if config.disable_timings {
         timings::set_enabled(false);
@@ -147,11 +147,23 @@ pub async fn serve_with_shutdown(
     }
 }
 
+/// What a broker needs to serve traffic as part of a cluster.
+///
+/// Both halves or neither: a broker that can resolve a remote owner and has no
+/// way to reach it would refuse publishes it should forward. `Default` is a
+/// single-node broker, which has neither.
+#[derive(Clone, Default)]
+pub struct ClusterContext {
+    pub ingress: Option<Arc<IngressRouter>>,
+    pub peers: Option<Arc<crate::peer::PeerPool>>,
+}
+
 fn build_publish_context(
     broker: Arc<Broker>,
     config: &BrokerConfig,
-    ingress: Option<Arc<IngressRouter>>,
+    cluster: ClusterContext,
 ) -> PublishContext {
+    let ClusterContext { ingress, peers } = cluster;
     // NOTE: This is intentionally global for the process (not per-connection).
     // With per-connection worker pools, adding more publisher connections multiplied
     // concurrent broker.publish_batch callers and caused lock contention on shared broker state.
@@ -175,6 +187,7 @@ fn build_publish_context(
         let (publish_tx, mut publish_rx) = mpsc::channel::<PublishJob>(publish_queue_depth);
         let queue_depth_worker = Arc::clone(&queue_depth);
         let broker_for_worker = Arc::clone(&broker);
+        let peers_for_worker = peers.clone();
         let worker_task = async move {
             while let Some(job) = publish_rx.recv().await {
                 #[cfg(feature = "perf_debug")]
@@ -190,25 +203,48 @@ fn build_publish_context(
                 );
                 #[cfg(feature = "perf_debug")]
                 let worker_start = std::time::Instant::now();
-                let result = match &job.target {
-                    PublishTarget::Resolved(handle) => {
-                        broker_for_worker
-                            .publish_batch_to_handle(handle, &job.payloads)
-                            .await
-                    }
+                let result: Result<(), anyhow::Error> = match &job.target {
+                    PublishTarget::Resolved(handle) => broker_for_worker
+                        .publish_batch_to_handle(handle, &job.payloads)
+                        .await
+                        .map(|_| ())
+                        .map_err(Into::into),
                     #[cfg(test)]
                     PublishTarget::Named {
                         tenant_id,
                         namespace,
                         stream,
-                    } => {
-                        broker_for_worker
-                            .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                    } => broker_for_worker
+                        .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                        .await
+                        .map(|_| ())
+                        .map_err(Into::into),
+                    PublishTarget::Forward { target, key, ack } => {
+                        // Forwarding runs on the publish worker, not inline on
+                        // the read loop, so a slow peer backs up the same queue
+                        // a slow disk would and the existing backpressure and
+                        // ack plumbing apply unchanged.
+                        match &peers_for_worker {
+                            Some(pool) => crate::peer::forward_publish(
+                                pool,
+                                target,
+                                key,
+                                *ack,
+                                job.payloads.clone(),
+                            )
                             .await
+                            .map(|_| ())
+                            .map_err(|err| anyhow::anyhow!("{err}")),
+                            // The route said forward and there is nothing to
+                            // forward with. Refusing beats writing another
+                            // broker's shard locally.
+                            None => Err(anyhow::anyhow!(
+                                "no peer transport: this broker cannot forward to {}",
+                                target.node_id
+                            )),
+                        }
                     }
-                }
-                .map(|_| ())
-                .map_err(Into::into);
+                };
                 #[cfg(feature = "perf_debug")]
                 {
                     let ns = worker_start.elapsed().as_nanos() as u64;
@@ -237,6 +273,7 @@ fn build_publish_context(
     }
     PublishContext {
         ingress,
+        peers,
         workers: Arc::new(worker_txs),
         worker_count,
         depth: queue_depth,
@@ -485,7 +522,8 @@ mod tests {
             publish_queue_wait_timeout_ms: 17,
             ..BrokerConfig::default()
         };
-        let publish_ctx = build_publish_context(Arc::clone(&broker), &config, None);
+        let publish_ctx =
+            build_publish_context(Arc::clone(&broker), &config, ClusterContext::default());
         assert_eq!(publish_ctx.worker_count, 1);
         assert_eq!(publish_ctx.workers.len(), 1);
         assert_eq!(publish_ctx.wait_timeout, Duration::from_millis(17));
@@ -514,7 +552,7 @@ mod tests {
         broker.register_tenant("t1").await?;
         broker.register_namespace("t1", "default").await?;
         let config = BrokerConfig::default();
-        let publish_ctx = build_publish_context(broker, &config, None);
+        let publish_ctx = build_publish_context(broker, &config, ClusterContext::default());
 
         let (response_tx, response_rx) = oneshot::channel();
         publish_ctx.workers[0]
@@ -545,7 +583,8 @@ mod tests {
         broker.register_namespace("t1", "default").await?;
 
         let config = BrokerConfig::default();
-        let publish_ctx = build_publish_context(Arc::clone(&broker), &config, None);
+        let publish_ctx =
+            build_publish_context(Arc::clone(&broker), &config, ClusterContext::default());
         let auth = Arc::new(BrokerAuth::new("http://127.0.0.1".to_string()));
 
         let cert = generate_simple_self_signed(vec!["localhost".into()])?;

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -66,6 +66,7 @@ pub(crate) use uni::{
 // exercises directly, without widening them for the rest of the crate.
 #[cfg(test)]
 use crate::auth::AuthContext;
+use crate::peer::ForwardTarget;
 use crate::shard_routing::{Dispatch, IngressRouter, dispatch, shard_for};
 use crate::shard_watch::ShardKey;
 #[cfg(test)]
@@ -134,6 +135,10 @@ pub(crate) struct PublishContext {
     /// `None` on a single-node broker, which is the default: there is nothing
     /// to resolve against, and the gate costs one null check.
     pub(crate) ingress: Option<Arc<IngressRouter>>,
+    /// Connections to peer brokers, when this broker is in a cluster. Present so
+    /// the handlers can tell "forwardable" from "cannot forward" before
+    /// enqueueing rather than after.
+    pub(crate) peers: Option<Arc<crate::peer::PeerPool>>,
     pub(crate) workers: Arc<Vec<mpsc::Sender<PublishJob>>>,
     pub(crate) worker_count: usize,
     pub(crate) depth: Arc<AtomicUsize>,
@@ -175,7 +180,74 @@ impl PublishContext {
     }
 }
 
-/// Resolve a stream, refusing one whose shard this broker does not own.
+/// Turn a resolved route into a publish target.
+///
+/// `None` means this broker cannot serve the publish: the stream did not
+/// resolve, or the shard belongs to a peer this broker has no transport to.
+/// Callers answer that the same way they always answered an unresolvable
+/// stream.
+pub(crate) fn publish_target(
+    route: PublishRoute,
+    publish_ctx: &PublishContext,
+    tenant_id: &str,
+    namespace: &str,
+    stream: &str,
+    ack: felix_wire::internal::AckMode,
+) -> Option<PublishTarget> {
+    match route {
+        PublishRoute::Local(handle) => Some(PublishTarget::Resolved(handle)),
+        PublishRoute::Forward(target) => {
+            if publish_ctx.peers.is_none() {
+                t_counter!("felix_publish_requests_total", "result" => "not_owner").increment(1);
+                tracing::debug!(
+                    tenant_id, namespace, stream,
+                    owner = %target.node_id,
+                    "publish refused: shard is owned by another broker and this one cannot forward",
+                );
+                return None;
+            }
+            t_counter!("felix_publish_requests_total", "result" => "forwarded").increment(1);
+            Some(PublishTarget::Forward {
+                target,
+                key: crate::peer::ForwardKey {
+                    tenant_id: tenant_id.to_string(),
+                    namespace: namespace.to_string(),
+                    stream: stream.to_string(),
+                    // Matches `resolve_route`: no routing key on the wire yet.
+                    shard: shard_for(1, None),
+                },
+                ack,
+            })
+        }
+        PublishRoute::Refused => None,
+    }
+}
+
+/// How the owner should treat a forwarded batch, from what the client asked of
+/// this broker.
+///
+/// Anything other than "no ack" becomes `OnCommit`, because the owner's write
+/// path is durable-then-answer either way: a weaker mode would describe the
+/// answer inaccurately rather than make it cheaper.
+pub(crate) fn internal_ack(ack: Option<felix_wire::AckMode>) -> felix_wire::internal::AckMode {
+    match ack {
+        Some(felix_wire::AckMode::None) => felix_wire::internal::AckMode::None,
+        _ => felix_wire::internal::AckMode::OnCommit,
+    }
+}
+
+/// Where a publish should be applied.
+#[derive(Debug)]
+pub(crate) enum PublishRoute {
+    /// This broker owns the shard and the stream resolved here.
+    Local(StreamHandle),
+    /// Another broker owns it.
+    Forward(ForwardTarget),
+    /// Nobody can take it right now, or the stream does not resolve.
+    Refused,
+}
+
+/// Resolve a stream, or say where else the publish belongs.
 ///
 /// The single chokepoint every publish path funnels through, which is why the
 /// ownership gate is here: nothing reaches storage without passing it.
@@ -185,7 +257,7 @@ impl PublishContext {
 /// changes the instant the control plane says so, and caching it would keep a
 /// broker serving a reassigned shard for up to a TTL. The check is two atomic
 /// loads, so paying it per publish costs less than reasoning about staleness.
-pub(crate) async fn resolve_stream_cached(
+pub(crate) async fn resolve_route(
     broker: &Broker,
     ingress: Option<&IngressRouter>,
     cache: &mut StreamHandleCache,
@@ -193,7 +265,7 @@ pub(crate) async fn resolve_stream_cached(
     tenant_id: &str,
     namespace: &str,
     stream: &str,
-) -> Option<StreamHandle> {
+) -> PublishRoute {
     // Single-node brokers short-circuit on a null check; a cluster member pays
     // two loads. Either way there is no lock and no await.
     if ingress.is_some() {
@@ -207,16 +279,16 @@ pub(crate) async fn resolve_stream_cached(
         };
         match dispatch(ingress, &key) {
             Dispatch::Local => {}
-            Dispatch::Forward { ref node_id, .. } => {
-                // M4 forwards here. Until then the frame is refused rather than
-                // written locally, which is the whole point of the gate.
-                t_counter!("felix_publish_requests_total", "result" => "not_owner").increment(1);
-                tracing::debug!(
-                    tenant_id, namespace, stream,
-                    owner = %node_id,
-                    "publish refused: shard is owned by another broker",
-                );
-                return None;
+            Dispatch::Forward {
+                node_id,
+                advertise_addr,
+                generation,
+            } => {
+                return PublishRoute::Forward(ForwardTarget {
+                    node_id,
+                    advertise_addr,
+                    generation,
+                });
             }
             Dispatch::Unavailable(reason) => {
                 t_counter!("felix_publish_requests_total", "result" => "unroutable").increment(1);
@@ -225,7 +297,7 @@ pub(crate) async fn resolve_stream_cached(
                     reason = %reason,
                     "publish refused: shard is not servable here",
                 );
-                return None;
+                return PublishRoute::Refused;
             }
         }
     }
@@ -245,7 +317,7 @@ pub(crate) async fn resolve_stream_cached(
         && *expires > Instant::now()
         && handle.as_ref().is_none_or(StreamHandle::is_active)
     {
-        return handle.clone();
+        return PublishRoute::from(handle.clone());
     }
     let handle = broker
         .resolve_stream_handle(tenant_id, namespace, stream)
@@ -255,5 +327,14 @@ pub(crate) async fn resolve_stream_cached(
         key_scratch.clone(),
         (handle.clone(), Instant::now() + STREAM_CACHE_TTL),
     );
-    handle
+    PublishRoute::from(handle)
+}
+
+impl From<Option<StreamHandle>> for PublishRoute {
+    fn from(handle: Option<StreamHandle>) -> Self {
+        match handle {
+            Some(handle) => Self::Local(handle),
+            None => Self::Refused,
+        }
+    }
 }

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -21,7 +21,7 @@ use crate::transport::quic::handlers::publish::ack::{
 };
 use crate::transport::quic::handlers::publish::ingress::{PublishTarget, enqueue_publish};
 use crate::transport::quic::handlers::publish::{
-    PublishContext, PublishJob, StreamHandleCache, resolve_stream_cached,
+    PublishContext, PublishJob, StreamHandleCache, internal_ack, publish_target, resolve_route,
 };
 use crate::transport::quic::telemetry::{log_decode_error, t_consume_instant, t_now_if};
 
@@ -81,17 +81,25 @@ pub(crate) async fn handle_binary_publish_batch_control(
         timings::record_decode_ns(decode_ns);
         t_histogram!("felix_broker_decode_ns").record(decode_ns as f64);
     }
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let Some(target) = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &batch.tenant_id,
+            &batch.namespace,
+            &batch.stream,
+        )
+        .await,
+        publish_ctx,
         &batch.tenant_id,
         &batch.namespace,
         &batch.stream,
-    )
-    .await
-    else {
+        // Fire-and-forget: the owner is told no acknowledgement is expected, the
+        // same contract the client gave this broker.
+        felix_wire::internal::AckMode::None,
+    ) else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(());
     };
@@ -112,7 +120,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads,
             response: None,
             admission_permit: None,
@@ -390,23 +398,38 @@ pub(crate) async fn handle_publish_message(
         .await?;
         return Ok(());
     }
-    let (response_tx, response_rx) = if ack_mode != felix_wire::AckMode::None && ack_on_commit {
-        let (response_tx, response_rx) = oneshot::channel();
-        (Some(response_tx), Some(response_rx))
-    } else {
-        (None, None)
-    };
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let target = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &tenant_id,
+            &namespace,
+            &stream,
+        )
+        .await,
+        publish_ctx,
         &tenant_id,
         &namespace,
         &stream,
-    )
-    .await
-    else {
+        internal_ack(ack),
+    );
+
+    // A forwarded publish is acknowledged only once the owner has answered,
+    // whatever `ack_on_commit` says. That setting is a local policy — "accepted
+    // by this broker is good enough" — and for a forward this broker has
+    // accepted nothing: the data is not on its disk, and the owner may still
+    // refuse it.
+    let forwarding = matches!(target, Some(PublishTarget::Forward { .. }));
+    let (response_tx, response_rx) =
+        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding) {
+            let (response_tx, response_rx) = oneshot::channel();
+            (Some(response_tx), Some(response_rx))
+        } else {
+            (None, None)
+        };
+    let Some(target) = target else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         if ack_mode != felix_wire::AckMode::None {
             let request_id = request_id.expect("request id checked");
@@ -435,14 +458,14 @@ pub(crate) async fn handle_publish_message(
     let enqueue_result = enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads: vec![Bytes::from(payload)],
             response: response_tx,
             admission_permit: None,
         },
         if ack_mode == felix_wire::AckMode::None {
             publish_ctx.overflow_policy()
-        } else if ack_on_commit {
+        } else if ack_on_commit || forwarding {
             EnqueuePolicy::Wait
         } else {
             EnqueuePolicy::Fail
@@ -520,7 +543,10 @@ pub(crate) async fn handle_publish_message(
     if ack_mode == felix_wire::AckMode::None {
         return Ok(());
     }
-    if !ack_on_commit {
+    // A forward has no enqueue-ack mode: this broker enqueued the batch to send
+    // it somewhere else, which is not a fact worth acknowledging. The commit-ack
+    // path below waits for the owner's answer instead.
+    if !ack_on_commit && !forwarding {
         // Enqueue-ack mode:
         // Ack means "accepted into the ingress queue", not "committed". This keeps
         // latency low but can report success even if a later broker error occurs.
@@ -751,17 +777,27 @@ pub(crate) async fn handle_publish_batch_message(
         .await?;
         return Ok(());
     }
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let target = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &tenant_id,
+            &namespace,
+            &stream,
+        )
+        .await,
+        publish_ctx,
         &tenant_id,
         &namespace,
         &stream,
-    )
-    .await
-    else {
+        internal_ack(ack),
+    );
+    // See the single-publish path: a forward is acknowledged only once the owner
+    // has answered, whatever `ack_on_commit` says.
+    let forwarding = matches!(target, Some(PublishTarget::Forward { .. }));
+    let Some(target) = target else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         if ack_mode != felix_wire::AckMode::None {
             let request_id = request_id.expect("request id checked");
@@ -789,24 +825,25 @@ pub(crate) async fn handle_publish_batch_message(
         .map(|payload| payload.len())
         .collect::<Vec<_>>();
     let payloads = payloads.into_iter().map(Bytes::from).collect::<Vec<_>>();
-    let (response_tx, response_rx) = if ack_mode != felix_wire::AckMode::None && ack_on_commit {
-        let (response_tx, response_rx) = oneshot::channel();
-        (Some(response_tx), Some(response_rx))
-    } else {
-        (None, None)
-    };
+    let (response_tx, response_rx) =
+        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding) {
+            let (response_tx, response_rx) = oneshot::channel();
+            (Some(response_tx), Some(response_rx))
+        } else {
+            (None, None)
+        };
     let fanout_start = t_now_if(sample);
     let enqueue_result = enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads,
             response: response_tx,
             admission_permit: None,
         },
         if ack_mode == felix_wire::AckMode::None {
             publish_ctx.overflow_policy()
-        } else if ack_on_commit {
+        } else if ack_on_commit || forwarding {
             EnqueuePolicy::Wait
         } else {
             EnqueuePolicy::Fail
@@ -871,7 +908,10 @@ pub(crate) async fn handle_publish_batch_message(
     if ack_mode == felix_wire::AckMode::None {
         return Ok(());
     }
-    if !ack_on_commit {
+    // A forward has no enqueue-ack mode: this broker enqueued the batch to send
+    // it somewhere else, which is not a fact worth acknowledging. The commit-ack
+    // path below waits for the owner's answer instead.
+    if !ack_on_commit && !forwarding {
         // Enqueue-ack mode:
         // Ack means "accepted into the ingress queue", not "committed". This keeps
         // latency low but can report success even if a later broker error occurs.

--- a/services/broker/src/transport/quic/handlers/publish/ingress.rs
+++ b/services/broker/src/transport/quic/handlers/publish/ingress.rs
@@ -3,10 +3,8 @@
 use anyhow::{Result, anyhow};
 use bytes::Bytes;
 use felix_broker::StreamHandle;
-#[cfg(test)]
 use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
-#[cfg(test)]
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -21,6 +19,14 @@ use crate::transport::quic::handlers::publish::{PublishContext, PublishJob};
 
 pub(crate) enum PublishTarget {
     Resolved(StreamHandle),
+    /// Another broker owns the shard. The batch is sent there and its answer
+    /// relayed, from the same worker a local write would have used, so the ack
+    /// path is identical either way.
+    Forward {
+        target: crate::peer::ForwardTarget,
+        key: crate::peer::ForwardKey,
+        ack: felix_wire::internal::AckMode,
+    },
     #[cfg(test)]
     Named {
         tenant_id: String,
@@ -36,7 +42,6 @@ pub(crate) enum PublishTarget {
 ///
 /// This *must* be stable across processes for predictable performance; it does not need to be
 /// cryptographically secure.
-#[cfg(test)]
 pub(crate) fn publish_worker_index(
     tenant_id: &str,
     namespace: &str,
@@ -108,6 +113,15 @@ pub(crate) async fn enqueue_publish(
 ) -> Result<bool> {
     let worker_index = match &job.target {
         PublishTarget::Resolved(handle) => handle.id() as usize % publish_ctx.worker_count.max(1),
+        // Hashed by name, because there is no local handle to hash. Same
+        // function the named path uses, so one stream's forwards stay on one
+        // worker and keep their order.
+        PublishTarget::Forward { key, .. } => publish_worker_index(
+            &key.tenant_id,
+            &key.namespace,
+            &key.stream,
+            publish_ctx.worker_count,
+        ),
         #[cfg(test)]
         PublishTarget::Named {
             tenant_id,

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -30,6 +30,7 @@ fn make_publish_context(
     let (tx, rx) = mpsc::channel(buffer);
     let context = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -81,6 +82,7 @@ async fn enqueue_publish_drop_sheds_load_when_byte_budget_exhausted() {
     let (tx, _rx) = mpsc::channel(8);
     let ctx = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -106,6 +108,7 @@ async fn enqueue_publish_drop_sheds_load_when_conn_byte_budget_exhausted() {
     let (tx, _rx) = mpsc::channel(8);
     let ctx = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -132,6 +135,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     let admission = Arc::new(PublishAdmission::new(8));
     let ctx_a = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -144,6 +148,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     };
     let ctx_b = PublishContext {
         ingress: None,
+        peers: None,
         conn_admission: Arc::new(PublishAdmission::new(4)),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
         lane_manager: test_lane_manager(),
@@ -283,6 +288,7 @@ async fn enqueue_publish_wait_times_out_when_queue_full() {
     tx.try_send(make_job()).unwrap();
     let ctx = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -305,6 +311,7 @@ async fn enqueue_publish_returns_error_when_queue_closed() {
     drop(rx);
     let ctx = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -1720,9 +1727,11 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
     let mut cache = HashMap::new();
     let mut key = String::new();
 
-    let handle =
-        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
-    assert!(handle.is_none(), "no tenant/namespace yet");
+    let handle = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    assert!(
+        matches!(handle, PublishRoute::Refused),
+        "no tenant/namespace yet"
+    );
 
     broker.register_tenant("t1").await.expect("tenant");
     broker
@@ -1739,17 +1748,18 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         .await
         .expect("stream");
 
-    let cached =
-        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let cached = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
     assert!(
-        cached.is_none(),
+        matches!(cached, PublishRoute::Refused),
         "cached miss should be returned until cache expires or clears"
     );
 
     cache.clear();
-    let refreshed =
-        resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
-    assert!(refreshed.is_some(), "cache refresh should see stream");
+    let refreshed = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    assert!(
+        matches!(refreshed, PublishRoute::Local(_)),
+        "cache refresh should see stream"
+    );
 }
 
 #[tokio::test]
@@ -2666,7 +2676,28 @@ mod ownership_gate {
         };
         let assignments: HashMap<WatchKey, ShardAssignment> =
             [(watch_key(), assignment)].into_iter().collect();
-        let nodes = HashMap::new();
+        // A catalog with both brokers in it, because a route is only usable when
+        // the owner's id has an address behind it. An empty catalog would make
+        // every remote shard look unavailable rather than forwardable, which is
+        // the wrong thing for these tests to be asserting against.
+        let nodes: HashMap<String, felix_router::NodeRef> = ["broker-a", "broker-b"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, node_id)| {
+                (
+                    node_id.to_string(),
+                    felix_router::NodeRef {
+                        node_id: node_id.to_string(),
+                        advertise_addr: std::net::SocketAddr::from((
+                            [127, 0, 0, 1],
+                            7000 + index as u16,
+                        )),
+                        region: "us-west-2".to_string(),
+                        live: true,
+                    },
+                )
+            })
+            .collect();
         router.publish(routing_table_from(&assignments, &nodes), &nodes);
 
         let ingress = IngressRouter::new(router);
@@ -2684,29 +2715,7 @@ mod ownership_gate {
         let mut cache = HashMap::new();
         let mut key = String::new();
 
-        let handle = resolve_stream_cached(
-            &broker,
-            Some(&ingress),
-            &mut cache,
-            &mut key,
-            "t1",
-            "ns",
-            "stream",
-        )
-        .await;
-        assert!(handle.is_some(), "an owned, open shard must be servable");
-    }
-
-    /// The acceptance criterion, on the real path: a broker must not write a
-    /// shard it does not own, however healthy the stream is locally.
-    #[tokio::test]
-    async fn a_shard_owned_elsewhere_is_refused() {
-        let broker = broker_with_stream().await;
-        let ingress = ingress_for("broker-b", false);
-        let mut cache = HashMap::new();
-        let mut key = String::new();
-
-        let handle = resolve_stream_cached(
+        let route = resolve_route(
             &broker,
             Some(&ingress),
             &mut cache,
@@ -2717,9 +2726,35 @@ mod ownership_gate {
         )
         .await;
         assert!(
-            handle.is_none(),
-            "a shard owned by another broker must not resolve locally",
+            matches!(route, PublishRoute::Local(_)),
+            "an owned, open shard must be servable",
         );
+    }
+
+    /// The acceptance criterion, on the real path: a broker must not write a
+    /// shard it does not own, however healthy the stream is locally. It routes
+    /// the publish to the owner instead.
+    #[tokio::test]
+    async fn a_shard_owned_elsewhere_is_forwarded_not_served_locally() {
+        let broker = broker_with_stream().await;
+        let ingress = ingress_for("broker-b", false);
+        let mut cache = HashMap::new();
+        let mut key = String::new();
+
+        let route = resolve_route(
+            &broker,
+            Some(&ingress),
+            &mut cache,
+            &mut key,
+            "t1",
+            "ns",
+            "stream",
+        )
+        .await;
+        match route {
+            PublishRoute::Forward(target) => assert_eq!(target.node_id, "broker-b"),
+            other => panic!("must route to the owner, not serve locally: {other:?}"),
+        }
     }
 
     /// Owned but not yet opened. The stream exists locally, so only the gate
@@ -2731,7 +2766,7 @@ mod ownership_gate {
         let mut cache = HashMap::new();
         let mut key = String::new();
 
-        let handle = resolve_stream_cached(
+        let route = resolve_route(
             &broker,
             Some(&ingress),
             &mut cache,
@@ -2741,7 +2776,10 @@ mod ownership_gate {
             "stream",
         )
         .await;
-        assert!(handle.is_none(), "an unopened shard must not accept writes");
+        assert!(
+            matches!(route, PublishRoute::Refused),
+            "an unopened shard must not accept writes",
+        );
     }
 
     /// Ownership is checked outside the handle cache, so a reassignment takes
@@ -2754,34 +2792,39 @@ mod ownership_gate {
         let mut key = String::new();
 
         assert!(
-            resolve_stream_cached(
-                &broker,
-                Some(&ingress),
-                &mut cache,
-                &mut key,
-                "t1",
-                "ns",
-                "stream"
-            )
-            .await
-            .is_some(),
+            matches!(
+                resolve_route(
+                    &broker,
+                    Some(&ingress),
+                    &mut cache,
+                    &mut key,
+                    "t1",
+                    "ns",
+                    "stream"
+                )
+                .await,
+                PublishRoute::Local(_)
+            ),
             "warm the handle cache while the shard is ours",
         );
 
-        // The shard moves away. The stream handle is still cached and valid.
+        // The shard moves away. The stream handle is still cached and valid, so
+        // only the gate can notice.
         let moved = ingress_for("broker-b", false);
         assert!(
-            resolve_stream_cached(
-                &broker,
-                Some(&moved),
-                &mut cache,
-                &mut key,
-                "t1",
-                "ns",
-                "stream"
-            )
-            .await
-            .is_none(),
+            matches!(
+                resolve_route(
+                    &broker,
+                    Some(&moved),
+                    &mut cache,
+                    &mut key,
+                    "t1",
+                    "ns",
+                    "stream"
+                )
+                .await,
+                PublishRoute::Forward(_)
+            ),
             "a cached handle must not outlive ownership",
         );
     }
@@ -2793,8 +2836,7 @@ mod ownership_gate {
         let mut cache = HashMap::new();
         let mut key = String::new();
 
-        let handle =
-            resolve_stream_cached(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
-        assert!(handle.is_some());
+        let route = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+        assert!(matches!(route, PublishRoute::Local(_)));
     }
 }

--- a/services/broker/src/transport/quic/handlers/publish/uni.rs
+++ b/services/broker/src/transport/quic/handlers/publish/uni.rs
@@ -9,9 +9,9 @@ use felix_wire::Frame;
 use std::sync::atomic::Ordering;
 
 use crate::auth::AuthContext;
-use crate::transport::quic::handlers::publish::ingress::{PublishTarget, enqueue_publish};
+use crate::transport::quic::handlers::publish::ingress::enqueue_publish;
 use crate::transport::quic::handlers::publish::{
-    PublishContext, PublishJob, StreamHandleCache, resolve_stream_cached,
+    PublishContext, PublishJob, StreamHandleCache, publish_target, resolve_route,
 };
 use crate::transport::quic::telemetry::log_decode_error;
 
@@ -63,17 +63,25 @@ pub(crate) async fn handle_binary_publish_batch_uni(
             .pub_items_in_ok
             .fetch_add(batch.payloads.len() as u64, Ordering::Relaxed);
     }
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let Some(target) = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &batch.tenant_id,
+            &batch.namespace,
+            &batch.stream,
+        )
+        .await,
+        publish_ctx,
         &batch.tenant_id,
         &batch.namespace,
         &batch.stream,
-    )
-    .await
-    else {
+        // Fire-and-forget: the owner is told no acknowledgement is expected, the
+        // same contract the client gave this broker.
+        felix_wire::internal::AckMode::None,
+    ) else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
     };
@@ -85,7 +93,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
     match enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads,
             response: None,
             admission_permit: None,
@@ -127,17 +135,25 @@ pub(crate) async fn handle_publish_message_uni(
         counters.pub_batches_in_ok.fetch_add(1, Ordering::Relaxed);
         counters.pub_items_in_ok.fetch_add(1, Ordering::Relaxed);
     }
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let Some(target) = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &tenant_id,
+            &namespace,
+            &stream,
+        )
+        .await,
+        publish_ctx,
         &tenant_id,
         &namespace,
         &stream,
-    )
-    .await
-    else {
+        // Fire-and-forget: the owner is told no acknowledgement is expected, the
+        // same contract the client gave this broker.
+        felix_wire::internal::AckMode::None,
+    ) else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
     };
@@ -145,7 +161,7 @@ pub(crate) async fn handle_publish_message_uni(
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads: vec![Bytes::from(payload)],
             response: None,
             admission_permit: None,
@@ -190,17 +206,25 @@ pub(crate) async fn handle_publish_batch_message_uni(
             .pub_items_in_ok
             .fetch_add(payloads.len() as u64, Ordering::Relaxed);
     }
-    let Some(stream_handle) = resolve_stream_cached(
-        broker,
-        publish_ctx.ingress.as_deref(),
-        stream_cache,
-        stream_cache_key,
+    let Some(target) = publish_target(
+        resolve_route(
+            broker,
+            publish_ctx.ingress.as_deref(),
+            stream_cache,
+            stream_cache_key,
+            &tenant_id,
+            &namespace,
+            &stream,
+        )
+        .await,
+        publish_ctx,
         &tenant_id,
         &namespace,
         &stream,
-    )
-    .await
-    else {
+        // Fire-and-forget: the owner is told no acknowledgement is expected, the
+        // same contract the client gave this broker.
+        felix_wire::internal::AckMode::None,
+    ) else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         return Ok(true);
     };
@@ -209,7 +233,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
     let r = enqueue_publish(
         publish_ctx,
         PublishJob {
-            target: PublishTarget::Resolved(stream_handle),
+            target,
             payloads,
             response: None,
             admission_permit: None,

--- a/services/broker/src/transport/quic/mod.rs
+++ b/services/broker/src/transport/quic/mod.rs
@@ -33,5 +33,5 @@ pub(crate) static DECODE_ERROR_LOGS: AtomicUsize = AtomicUsize::new(0);
 pub(crate) const DECODE_ERROR_LOG_LIMIT: usize = 20;
 
 pub use codec::{read_frame_limited_into, read_message_limited, write_message};
-pub use conn::{serve, serve_with_shutdown};
+pub use conn::{ClusterContext, serve, serve_with_shutdown};
 pub use telemetry::{FrameCountersSnapshot, frame_counters_snapshot, reset_frame_counters};

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -553,6 +553,9 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
     tokio::spawn(async move {
         while let Some(job) = rx.recv().await {
             let result = match &job.target {
+                // This harness drives local publishes only; a forward would
+                // need a peer transport it does not build.
+                PublishTarget::Forward { .. } => unreachable!("no peers in this test"),
                 PublishTarget::Resolved(handle) => {
                     broker.publish_batch_to_handle(handle, &job.payloads).await
                 }
@@ -575,6 +578,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
     });
     PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3485,6 +3489,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
     drop(rx);
     let publish_ctx = PublishContext {
         ingress: None,
+        peers: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3661,6 +3666,7 @@ async fn handle_stream_drain_timeout_sleep_branch() -> Result<()> {
         });
         let publish_ctx = PublishContext {
             ingress: None,
+            peers: None,
             workers: Arc::new(vec![tx]),
             worker_count: 1,
             depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/services/broker/tests/cross_broker_forwarding.rs
+++ b/services/broker/tests/cross_broker_forwarding.rs
@@ -1,0 +1,590 @@
+//! A publish that arrives at the wrong broker, end to end.
+//!
+//! Real transports and a real broker on the owning side, so the two halves
+//! cannot drift: the ingress forwarder and the owner's handler are the pair
+//! under test, and a mismatch between what one sends and the other reads fails
+//! here rather than in a cluster.
+//!
+//! Run with `cargo test -p broker --test cross_broker_forwarding`.
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use broker::peer::{
+    ForwardError, ForwardKey, ForwardTarget, ForwardingHandler, PeerPool, PeerServer,
+    PeerTransportConfig, forward_publish,
+};
+use broker::shard_routing::{IngressRouter, routing_table_from};
+use broker::shard_watch::{ShardAssignment, ShardKey};
+use bytes::Bytes;
+use felix_broker::{Broker, StreamMetadata};
+use felix_router::{NodeRef, RegionRouter, ShardRouter};
+use felix_storage::EphemeralCache;
+use felix_wire::internal::{AckMode, ErrorCode, InternalMessage};
+use tokio_util::sync::CancellationToken;
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+const OWNER: &str = "broker-b";
+
+fn shard_key() -> ShardKey {
+    ShardKey {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard: 0,
+    }
+}
+
+fn forward_key() -> ForwardKey {
+    ForwardKey {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard: 0,
+    }
+}
+
+fn peer_config() -> PeerTransportConfig {
+    PeerTransportConfig {
+        bind: "127.0.0.1:0".parse().expect("addr"),
+        request_timeout: Duration::from_millis(500),
+        handshake_timeout: Duration::from_millis(500),
+        reconnect_base: Duration::from_millis(10),
+        reconnect_max: Duration::from_millis(20),
+        ..Default::default()
+    }
+}
+
+fn catalog(entries: &[(&str, SocketAddr)]) -> HashMap<String, NodeRef> {
+    entries
+        .iter()
+        .map(|(node_id, addr)| {
+            (
+                node_id.to_string(),
+                NodeRef {
+                    node_id: node_id.to_string(),
+                    advertise_addr: *addr,
+                    region: "us-west-2".to_string(),
+                    live: true,
+                },
+            )
+        })
+        .collect()
+}
+
+/// A broker that owns the shard, with the router and ingress view to match.
+struct Owner {
+    broker: Arc<Broker>,
+    ingress: Arc<IngressRouter>,
+    router: Arc<ShardRouter>,
+}
+
+impl Owner {
+    async fn new(node_id: &str, generation: u64, servable: bool) -> Self {
+        let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+        broker.register_tenant(TENANT).await.expect("tenant");
+        broker
+            .register_namespace(TENANT, NAMESPACE)
+            .await
+            .expect("namespace");
+        broker
+            .register_stream(TENANT, NAMESPACE, STREAM, StreamMetadata::default())
+            .await
+            .expect("stream");
+
+        let router = Arc::new(ShardRouter::new(
+            node_id,
+            "us-west-2",
+            RegionRouter::new("us-west-2".to_string()),
+        ));
+        let ingress = Arc::new(IngressRouter::new(Arc::clone(&router)));
+        let owner = Self {
+            broker,
+            ingress,
+            router,
+        };
+        owner.assign(node_id, generation, servable, &[]);
+        owner
+    }
+
+    /// Point the router at `leader` for this shard, and say whether this broker
+    /// has the shard open.
+    fn assign(&self, leader: &str, generation: u64, servable: bool, nodes: &[(&str, SocketAddr)]) {
+        let assignments: HashMap<ShardKey, ShardAssignment> = [(
+            shard_key(),
+            ShardAssignment {
+                key: shard_key(),
+                leader: leader.to_string(),
+                replicas: Vec::new(),
+                generation,
+                state: "active".to_string(),
+            },
+        )]
+        .into_iter()
+        .collect();
+        let nodes = catalog(nodes);
+        self.router
+            .publish(routing_table_from(&assignments, &nodes), &nodes);
+        self.ingress.publish_servable(if servable {
+            [(shard_key(), generation)].into_iter().collect()
+        } else {
+            HashMap::new()
+        });
+    }
+
+    fn handler(&self, advertise_addr: &str) -> Arc<ForwardingHandler> {
+        Arc::new(ForwardingHandler::new(
+            Arc::clone(&self.broker),
+            Arc::clone(&self.ingress),
+            Arc::clone(&self.router),
+            advertise_addr.to_string(),
+        ))
+    }
+}
+
+/// A running internal listener in front of a handler.
+struct Listener {
+    addr: SocketAddr,
+    shutdown: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Listener {
+    fn start(node_id: &str, handler: Arc<dyn broker::peer::PeerRequestHandler>) -> Self {
+        let server = PeerServer::bind(node_id.to_string(), &peer_config(), handler).expect("bind");
+        let addr = server.local_addr().expect("addr");
+        let shutdown = CancellationToken::new();
+        let task = tokio::spawn(server.serve(shutdown.clone()));
+        Self {
+            addr,
+            shutdown,
+            task,
+        }
+    }
+
+    async fn stop(self) {
+        self.shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(2), self.task).await;
+    }
+}
+
+fn pool() -> Arc<PeerPool> {
+    PeerPool::new(
+        "broker-a".to_string(),
+        peer_config(),
+        CancellationToken::new(),
+    )
+    .expect("pool")
+}
+
+fn target(addr: SocketAddr, generation: u64) -> ForwardTarget {
+    ForwardTarget {
+        node_id: OWNER.to_string(),
+        advertise_addr: addr,
+        generation,
+    }
+}
+
+/// The acceptance criterion: a publish sent to a non-owner is persisted by the
+/// owner and acknowledged back through the ingress broker.
+#[tokio::test]
+async fn a_forwarded_publish_is_written_by_the_owner() {
+    let owner = Owner::new(OWNER, 1, true).await;
+    // Subscribed before the forward, so a delivery proves the owner applied it
+    // rather than merely answering.
+    let mut subscription = owner
+        .broker
+        .subscribe(TENANT, NAMESPACE, STREAM)
+        .await
+        .expect("subscribe");
+    let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
+    let pool = pool();
+
+    let offsets = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"hello")],
+    )
+    .await
+    .expect("the owner must accept a publish for a shard it owns");
+
+    // Ephemeral stream: no log, so no offsets to report.
+    assert_eq!(offsets, Some((0, 0)));
+
+    let delivered = tokio::time::timeout(Duration::from_secs(2), subscription.recv())
+        .await
+        .expect("the owner never delivered the forwarded record")
+        .expect("subscription closed");
+    assert_eq!(delivered, Bytes::from_static(b"hello"));
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// The requester resolved against a newer assignment than the owner has seen.
+/// The owner must refuse: it may already have lost the shard.
+#[tokio::test]
+async fn an_owner_behind_the_requester_refuses_rather_than_writing() {
+    let owner = Owner::new(OWNER, 1, true).await;
+    let mut subscription = owner
+        .broker
+        .subscribe(TENANT, NAMESPACE, STREAM)
+        .await
+        .expect("subscribe");
+    let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
+    let pool = pool();
+
+    // Generation 5 against an owner still at 1.
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 5),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"too-new")],
+    )
+    .await
+    .expect_err("an owner behind the requester must not accept the write");
+
+    assert!(
+        matches!(err, ForwardError::Refused { .. }),
+        "nothing was written, so this is a refusal: {err:?}",
+    );
+    assert!(
+        subscription.try_recv().is_err(),
+        "a refused forward must not have been applied",
+    );
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// The shard moved. The owner answers with where it went rather than writing.
+#[tokio::test]
+async fn a_broker_that_no_longer_owns_the_shard_redirects() {
+    let owner = Owner::new(OWNER, 1, true).await;
+    let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
+    let pool = pool();
+
+    // The shard is reassigned to a broker this one knows the address of.
+    owner.assign(
+        "broker-c",
+        2,
+        false,
+        &[("broker-c", "127.0.0.1:9".parse().expect("addr"))],
+    );
+
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"moved")],
+    )
+    .await
+    .expect_err("broker-c is not reachable, so this cannot succeed");
+
+    // The failure has to name broker-c: that is the difference between
+    // following the redirect and simply being refused by broker-b.
+    assert!(
+        err.to_string().contains("broker-c"),
+        "the redirect was not followed: {err}",
+    );
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// A redirect that does not advance the generation would send the batch back
+/// where it came from. Bounded or not, that is a loop.
+#[tokio::test]
+async fn a_redirect_that_does_not_advance_the_generation_is_refused() {
+    use async_trait::async_trait;
+    use felix_wire::internal::NotLeader;
+
+    struct AlwaysRedirectsBackwards;
+
+    #[async_trait]
+    impl broker::peer::PeerRequestHandler for AlwaysRedirectsBackwards {
+        async fn handle(&self, request: InternalMessage) -> InternalMessage {
+            InternalMessage::NotLeader(NotLeader {
+                correlation_id: request.correlation_id(),
+                node_id: "broker-b".to_string(),
+                advertise_addr: "127.0.0.1:1".to_string(),
+                // The same generation the requester already had.
+                generation: 1,
+            })
+        }
+    }
+
+    let listener = Listener::start(OWNER, Arc::new(AlwaysRedirectsBackwards));
+    let pool = pool();
+
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"loop")],
+    )
+    .await
+    .expect_err("a backwards redirect must be refused, not followed");
+    assert!(
+        err.to_string().contains("not ahead of"),
+        "the error should say why the redirect was rejected: {err}",
+    );
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// A retryable refusal is retried, and converges when the owner becomes ready.
+#[tokio::test]
+async fn a_retryable_refusal_converges() {
+    use async_trait::async_trait;
+    use felix_wire::internal::{ForwardPublishError, ForwardPublishOk};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Refuses once with a retryable code, then accepts.
+    struct UnavailableOnce {
+        seen: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl broker::peer::PeerRequestHandler for UnavailableOnce {
+        async fn handle(&self, request: InternalMessage) -> InternalMessage {
+            if self.seen.fetch_add(1, Ordering::SeqCst) == 0 {
+                return InternalMessage::ForwardPublishError(ForwardPublishError {
+                    correlation_id: request.correlation_id(),
+                    code: ErrorCode::Unavailable,
+                    detail: "still opening the shard".to_string(),
+                });
+            }
+            InternalMessage::ForwardPublishOk(ForwardPublishOk {
+                correlation_id: request.correlation_id(),
+                first_offset: 7,
+                last_offset: 7,
+            })
+        }
+    }
+
+    let listener = Listener::start(
+        OWNER,
+        Arc::new(UnavailableOnce {
+            seen: AtomicUsize::new(0),
+        }),
+    );
+    let pool = pool();
+
+    let offsets = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"retry-me")],
+    )
+    .await
+    .expect("a retryable refusal must be retried");
+    assert_eq!(offsets, Some((7, 7)));
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// An owner that keeps refusing must fail explicitly within the attempt budget,
+/// not retry forever.
+#[tokio::test]
+async fn a_permanently_refusing_owner_fails_within_the_budget() {
+    use async_trait::async_trait;
+    use felix_wire::internal::ForwardPublishError;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct AlwaysUnavailable {
+        seen: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl broker::peer::PeerRequestHandler for AlwaysUnavailable {
+        async fn handle(&self, request: InternalMessage) -> InternalMessage {
+            self.seen.fetch_add(1, Ordering::SeqCst);
+            InternalMessage::ForwardPublishError(ForwardPublishError {
+                correlation_id: request.correlation_id(),
+                code: ErrorCode::Unavailable,
+                detail: "never ready".to_string(),
+            })
+        }
+    }
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let listener = Listener::start(
+        OWNER,
+        Arc::new(AlwaysUnavailable {
+            seen: Arc::clone(&seen),
+        }),
+    );
+    let pool = pool();
+
+    let started = std::time::Instant::now();
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"never")],
+    )
+    .await
+    .expect_err("a permanent refusal must fail, not loop");
+
+    assert!(matches!(err, ForwardError::Refused { .. }), "{err:?}");
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "the attempt budget did not bound this",
+    );
+    assert!(
+        seen.load(Ordering::SeqCst) <= 3,
+        "attempts must be bounded, saw {}",
+        seen.load(Ordering::SeqCst),
+    );
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// The duplicate-delivery case, and the reason the retry rule is what it is.
+///
+/// The owner applies the batch and the answer never arrives. Retrying would
+/// write it twice, and the ingress broker has no way to tell that from a batch
+/// that never landed — so it must not retry, and must say the outcome is
+/// unknown rather than claim failure.
+#[tokio::test]
+async fn a_lost_answer_is_reported_as_indeterminate_and_never_retried() {
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Applies the write, then never answers.
+    struct WritesThenGoesSilent {
+        broker: Arc<Broker>,
+        applied: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl broker::peer::PeerRequestHandler for WritesThenGoesSilent {
+        async fn handle(&self, request: InternalMessage) -> InternalMessage {
+            if let InternalMessage::ForwardPublish(publish) = &request {
+                self.broker
+                    .publish_batch(TENANT, NAMESPACE, STREAM, &publish.payloads)
+                    .await
+                    .expect("publish");
+                self.applied.fetch_add(1, Ordering::SeqCst);
+            }
+            // The answer is lost. This is the moment the requester cannot
+            // reason about.
+            std::future::pending::<()>().await;
+            unreachable!()
+        }
+    }
+
+    let owner = Owner::new(OWNER, 1, true).await;
+    let mut subscription = owner
+        .broker
+        .subscribe(TENANT, NAMESPACE, STREAM)
+        .await
+        .expect("subscribe");
+    let applied = Arc::new(AtomicUsize::new(0));
+    let listener = Listener::start(
+        OWNER,
+        Arc::new(WritesThenGoesSilent {
+            broker: Arc::clone(&owner.broker),
+            applied: Arc::clone(&applied),
+        }),
+    );
+    let pool = pool();
+
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"exactly-once")],
+    )
+    .await
+    .expect_err("a lost answer cannot be reported as success");
+
+    assert!(
+        matches!(err, ForwardError::Indeterminate { .. }),
+        "the outcome is unknown, and saying 'refused' would be a claim this \
+         broker cannot make: {err:?}",
+    );
+    assert_eq!(
+        applied.load(Ordering::SeqCst),
+        1,
+        "the batch must not have been sent a second time",
+    );
+
+    let delivered = tokio::time::timeout(Duration::from_secs(2), subscription.recv())
+        .await
+        .expect("nothing delivered")
+        .expect("subscription closed");
+    assert_eq!(delivered, Bytes::from_static(b"exactly-once"));
+    assert!(
+        subscription.try_recv().is_err(),
+        "the record must appear exactly once",
+    );
+
+    pool.shutdown().await;
+    listener.stop().await;
+}
+
+/// A peer that is not there fails without the batch ever being sent, so the
+/// caller is free to retry elsewhere.
+#[tokio::test]
+async fn an_unreachable_owner_fails_without_sending() {
+    let dead: SocketAddr = {
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind");
+        socket.local_addr().expect("addr")
+    };
+    let pool = pool();
+
+    let err = forward_publish(
+        &pool,
+        &target(dead, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"nowhere")],
+    )
+    .await
+    .expect_err("an unreachable owner must fail");
+    assert!(
+        matches!(err, ForwardError::Refused { .. }),
+        "nothing was sent, so this is not indeterminate: {err:?}",
+    );
+
+    pool.shutdown().await;
+}
+
+/// A broker that owns the shard but has not opened it must refuse rather than
+/// acknowledge a write against a log it has not recovered.
+#[tokio::test]
+async fn an_owner_that_has_not_opened_the_shard_refuses() {
+    let owner = Owner::new(OWNER, 1, false).await;
+    let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
+    let pool = pool();
+
+    let err = forward_publish(
+        &pool,
+        &target(listener.addr, 1),
+        &forward_key(),
+        AckMode::OnCommit,
+        vec![Bytes::from_static(b"not-yet")],
+    )
+    .await
+    .expect_err("an unopened shard must not accept writes");
+    assert!(matches!(err, ForwardError::Refused { .. }), "{err:?}");
+
+    pool.shutdown().await;
+    listener.stop().await;
+}

--- a/services/broker/tests/graceful_shutdown.rs
+++ b/services/broker/tests/graceful_shutdown.rs
@@ -74,7 +74,7 @@ async fn start_broker() -> Result<Harness> {
         auth,
         accept_shutdown.clone(),
         connections.clone(),
-        None,
+        Default::default(),
     ));
 
     Ok(Harness {


### PR DESCRIPTION
Closes #106. Depends on #105 (merged).

A publish that reaches the wrong broker is now sent to the one that owns its shard, instead of being refused.

### The address book had to come first

Shard assignments name an owner by node id and nothing turned that into an address — `spawn_feed` built its routing table with an empty catalog, so every remote shard resolved to "owner unavailable" rather than being forwardable. Brokers now poll `/v1/nodes` on the routing tick using the credential they already hold for assignments (both endpoints need `node.view:cluster:*`). A failed refresh keeps the previous catalog: a control-plane blip must not turn a healthy cluster into one that refuses every remote publish. `felix_broker_node_catalog_nodes` reading zero while assignments are known is exactly that failure.

### Two rules that are load-bearing

**The ingress broker cannot acknowledge before the owner has.** This overrides `ack_on_commit` — which is **off by default** and would otherwise send the ack right after enqueue. That setting is a statement about a *local* write ("accepted into this broker's queue is good enough"); for a forward this broker has accepted nothing. A forward always takes the commit-ack path.

**An ambiguous outcome is never retried.** One question decides it: could the owner already have applied this batch?

| Outcome | Applied? | Retried |
| --- | --- | --- |
| Shed, backoff, unreachable | No — nothing was sent | Yes |
| `NotLeader` | No — the refusal is the evidence | Yes, against the owner it names |
| `StaleRoute` / `Unavailable` / `Overload` | No | Yes |
| Connection dropped, request timed out | **Unknown** | **No** |

**I did not differentiate retry by `DeliveryGuarantee`, and want to flag that explicitly** since the issue asks for it. Never retrying an ambiguous outcome is compatible with both guarantees and satisfies "at-most-once streams are not blindly retried" strictly. Differentiating would mean retrying on `AtLeastOnce` — but the broker doesn't sync `delivery` today, and a duplicate produced *inside* the broker is invisible to the client, which holds the `request_id` and is the only layer that could deduplicate. If you want guarantee-aware retry instead, say so and I'll sync the field and add it.

### Shape

Forwarding runs on the publish worker as a new `PublishTarget::Forward`, not inline on the read loop. A slow peer therefore backs up the same queue a slow disk would, and the ack, backpressure and cancellation plumbing apply unchanged.

The owner re-checks ownership at the generation the requester named and answers rather than guesses — requester behind is `NotLeader` naming the current owner, requester ahead is `StaleRoute`. It **never relays onward**: a chain of brokers each forwarding to the next has unbounded latency and a failure mode nobody can reason about. A redirect that doesn't advance the generation is refused rather than followed, since it would send the batch back where it came from.

`publish_batch_with_outcome` reports the log offsets a batch was assigned, so the owner's ack is truthful rather than a fabricated zero. `publish_batch_to_handle` is now a thin wrapper — the hot path is unchanged.

### Tests

Nine cross-node tests in `cross_broker_forwarding.rs`, against real transports and a real broker on the owning side. The one that matters most:

`a_lost_answer_is_reported_as_indeterminate_and_never_retried` — the owner applies the batch and then goes silent. Asserts the record exists **exactly once**, the batch was never re-sent, and the outcome is reported as indeterminate rather than as a failure the broker cannot actually claim.

Per CLAUDE.md I reverted each mechanism and watched the test fail: the indeterminate rule, the generation check, and the backwards-redirect guard all fail their tests when removed. I also caught myself writing `contains("broker-c") || matches!(Refused)` in the redirect test — near-tautological — and tightened it, then verified it detects a redirect to the wrong node.

One test helper was building an empty node catalog, which is the exact gap this PR closes; it now carries real addresses, and `a_shard_owned_elsewhere_is_refused` is renamed to `..._is_forwarded_not_served_locally` because the behaviour changed.

### Verification

`task lint`, `task test`, `task demo:check` all clean. Two functions crossed clippy's argument limit; I grouped the parameters (`ClusterContext`, `FeedState`) rather than silencing the lint.

### Docs

`docs/internal-protocol.md` gains the ack rule, the retry table, and why chains are refused. `docs/control-plane.md` covers the node-catalog poll. The `what-felix-is-for` sharding row moves from "refused with the owner named" to "forwarded and acknowledged by the owner"; multi-node stays 🎯 Target because subscribe still isn't routed and there's no replication or failover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)