### PR TITLE
feat(cluster): add a local three-node cluster harness (#108)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,6 +1010,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,6 +997,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "felix-cluster"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "controlplane",
+ "felix-client",
+ "felix-wire",
+ "quinn",
+ "reqwest 0.12.28",
+ "rustls",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "felix-common"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/felix-authz",
   "crates/felix-client",
   "crates/felix-conformance",
+  "crates/felix-cluster",
   "services/controlplane",
   "services/agent",
   "services/broker",

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -15,6 +15,7 @@ service.
 | `crates/felix-conformance/` | Apache-2.0 | Conformance test runner and wire-format test vectors, so third-party client/server implementations can validate interop. (It links against the Elastic-2.0 crates below to run its checks against the reference broker — that's normal for a dev/CI tool and doesn't change its own license.) |
 | `crates/felix-broker/`, `felix-storage`, `felix-metadata`, `felix-authz`, `felix-crypto`, `felix-consensus`, `felix-router` | Elastic License 2.0 | Server-side core logic. |
 | `services/broker/`, `services/controlplane/`, `services/agent/` | Elastic License 2.0 | The runnable server binaries. |
+| `crates/felix-cluster/` | Elastic License 2.0 | Local multi-node cluster harness for integration and failure tests. It embeds the control plane and drives the broker, so unlike `felix-conformance` it is internal tooling rather than something a third-party implementer runs. Not published. |
 
 The root [`LICENSE`](LICENSE) file is Elastic License 2.0 (the license for
 the project as a whole / the deployable server). [`LICENSE-APACHE`](LICENSE-APACHE)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -209,5 +209,23 @@ tasks:
         "$PY" scripts/perf/normalize_and_aggregate.py
         "$PY" scripts/perf/make_charts.py --config scripts/perf/fast.yml
         "$PY" scripts/perf/render_markdown_snippets.py --config scripts/perf/fast.yml
+  cluster:up:
+    desc: Start a local three-node cluster and hold it until Ctrl-C.
+    cmds:
+      - cargo build -p broker --bin felix-broker
+      - cargo run -p felix-cluster -- up {{.CLI_ARGS}}
+  cluster:status:
+    desc: Start a cluster, print membership and shard ownership, then tear it down.
+    cmds:
+      - cargo build -p broker --bin felix-broker
+      - cargo run -p felix-cluster -- status {{.CLI_ARGS}}
+  cluster:smoke:
+    desc: Publish through a non-owner and receive from the owner.
+    cmds:
+      - cargo build -p broker --bin felix-broker
+      - cargo run -p felix-cluster -- smoke {{.CLI_ARGS}}
+  cluster:test:
+    desc: Cross-broker integration tests against a real three-node cluster.
+    cmds: ["cargo test -p felix-cluster"]
   conformance:
     cmds: ["cargo run -p felix-conformance"]

--- a/crates/felix-cluster/Cargo.toml
+++ b/crates/felix-cluster/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "felix-cluster"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+description = "Local multi-node Felix cluster harness for integration and failure testing"
+repository.workspace = true
+homepage.workspace = true
+readme.workspace = true
+# A test and development harness, not a library anyone consumes from a registry.
+publish = false
+
+[[bin]]
+name = "felix-cluster"
+path = "src/bin/felix-cluster.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+controlplane = { path = "../../services/controlplane", version = "0.2.0" }
+felix-client = { path = "../felix-client", version = "0.2.0" }
+felix-wire = { path = "../felix-wire", version = "0.2.0" }
+quinn = "0.11"
+rustls = "0.23"
+axum = "0.8"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tempfile = "3"
+tokio = { workspace = true }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/crates/felix-cluster/Cargo.toml
+++ b/crates/felix-cluster/Cargo.toml
@@ -31,3 +31,9 @@ tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+# These spawn several broker processes each. Run one cluster at a time: a CI
+# runner with two cores starting nine brokers at once starves them all, and the
+# ephemeral ports they were handed are more likely to collide.
+serial_test = "3"

--- a/crates/felix-cluster/LICENSE
+++ b/crates/felix-cluster/LICENSE
@@ -1,0 +1,94 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case
+subject to the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial
+set of the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key
+functionality in the software, and you may not remove or obscure any
+functionality in the software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other
+notices of the licensor in the software. Any use of the licensor's
+trademarks is subject to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer
+for sale, import and have imported the software, in each case subject to
+the limitations and conditions in this license. This license does not
+cover any patent claims that you cause to be infringed by modifications or
+additions to the software. If you or your company make any written claim
+that the software infringes or contributes to infringement of any patent,
+your patent license for the software granted under these terms ends
+immediately. If your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software
+from you also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted
+in these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not
+licensed, and your licenses will automatically terminate. If the licensor
+provides you with a notice of your violation, and you cease all violation
+of this license no later than 30 days after you receive that notice, your
+licenses will be reinstated retroactively. However, if you violate these
+terms after such reinstatement, any additional violation of these terms
+will cause your licenses to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty
+or condition, and the licensor will not be liable to you for any damages
+arising out of these terms or the use or nature of the software, under any
+kind of legal claim.*
+
+## Definitions
+
+The "licensor" is the entity offering these terms, and the "software" is
+the software the licensor makes available under these terms, including any
+portion of it.
+
+"you" refers to the individual or entity agreeing to these terms.
+
+"your company" is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control
+over, are under the control of, or are under common control with that
+organization. "Control" means ownership of substantially all the assets of
+an entity, or the power to direct its management and policies by vote,
+contract, or otherwise. Control can be direct or indirect.
+
+"your licenses" are all the licenses granted to you for the software under
+these terms.
+
+"use" means anything you do with the software requiring one of your
+licenses.
+
+"trademark" means trademarks, service marks, and similar rights.

--- a/crates/felix-cluster/src/bin/felix-cluster.rs
+++ b/crates/felix-cluster/src/bin/felix-cluster.rs
@@ -1,0 +1,135 @@
+//! Start a local Felix cluster and inspect it.
+//!
+//! ```text
+//! cargo run -p felix-cluster -- up       # start, print addresses, hold until Ctrl-C
+//! cargo run -p felix-cluster -- status   # start, print membership and ownership, exit
+//! cargo run -p felix-cluster -- smoke    # publish through a non-owner, receive from the owner
+//! ```
+//!
+//! `--nodes N` sets the cluster size (default 3).
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use felix_cluster::{Cluster, ClusterConfig};
+
+const STREAM: &str = "orders";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .init();
+
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let command = args.first().map(String::as_str).unwrap_or("up");
+    let nodes = parse_nodes(&args)?;
+
+    let config = ClusterConfig {
+        nodes,
+        streams: vec![(STREAM.to_string(), 1)],
+        // A cluster a person started should say what it is doing.
+        inherit_output: command == "up" || std::env::var("FELIX_CLUSTER_VERBOSE").is_ok(),
+        ..Default::default()
+    };
+
+    eprintln!("starting a {nodes}-node cluster...");
+    let mut cluster = Cluster::start(config).await?;
+    eprintln!("cluster up.\n");
+    print_topology(&cluster).await?;
+
+    match command {
+        "up" => {
+            eprintln!("\nholding the cluster. press Ctrl-C to tear it down.");
+            tokio::signal::ctrl_c().await.context("wait for Ctrl-C")?;
+            eprintln!("\ntearing down...");
+        }
+        "status" => {}
+        "smoke" => smoke(&mut cluster).await?,
+        other => bail!("unknown command {other}; expected up, status, or smoke"),
+    }
+
+    cluster.shutdown().await;
+    Ok(())
+}
+
+fn parse_nodes(args: &[String]) -> Result<usize> {
+    match args.iter().position(|arg| arg == "--nodes") {
+        Some(index) => args
+            .get(index + 1)
+            .ok_or_else(|| anyhow::anyhow!("--nodes needs a value"))?
+            .parse()
+            .context("parse --nodes"),
+        None => Ok(3),
+    }
+}
+
+async fn print_topology(cluster: &Cluster) -> Result<()> {
+    println!("control plane   {}", cluster.control_plane_url());
+    println!();
+    println!("{:<10} {:<22} {:<22} metrics", "node", "client", "internal");
+    for node in &cluster.nodes {
+        println!(
+            "{:<10} {:<22} {:<22} {}",
+            node.node_id,
+            node.client_addr.to_string(),
+            node.internal_addr.to_string(),
+            node.metrics_addr,
+        );
+    }
+    println!();
+    println!("placeable: {}", cluster.placeable_nodes().await?.join(", "));
+    println!("shard ownership:");
+    let mut owners: Vec<_> = cluster.shard_owners().await?.into_iter().collect();
+    owners.sort();
+    for (shard, leader) in owners {
+        println!("  {shard} -> {leader}");
+    }
+    Ok(())
+}
+
+/// The scenario the harness exists to make easy: a publish that arrives at a
+/// broker which does not own the shard still reaches a subscriber on the one
+/// that does.
+async fn smoke(cluster: &mut Cluster) -> Result<()> {
+    let (owner, non_owner) = cluster.owner_and_non_owner(STREAM).await?;
+    println!("\nsmoke: publishing via {non_owner}, subscribing on {owner}");
+
+    let (_client, mut subscription) = cluster.subscribe_on(&owner, STREAM).await?;
+    let payload = b"cross-broker".to_vec();
+    cluster
+        .publish_via(&non_owner, STREAM, payload.clone())
+        .await?;
+
+    // Assert the publish actually crossed a node boundary before waiting on
+    // delivery. Without this a local write on the wrong broker looks identical
+    // to a delivery that is merely slow.
+    let forwarded = cluster
+        .metric(&non_owner, "felix_broker_forwards_total")
+        .await?;
+    match forwarded {
+        Some(count) if count > 0.0 => println!("smoke: {non_owner} forwarded {count} publish(es)"),
+        _ => bail!(
+            "{non_owner} did not forward anything: the publish was served locally by a broker \
+             that does not own the shard"
+        ),
+    }
+
+    let event = tokio::time::timeout(Duration::from_secs(10), subscription.next_event())
+        .await
+        .context("timed out waiting for the forwarded record")?
+        .context("subscription failed")?
+        .context("subscription closed before the record arrived")?;
+
+    if event.payload != payload {
+        bail!(
+            "expected {:?}, received {:?}",
+            String::from_utf8_lossy(&payload),
+            String::from_utf8_lossy(&event.payload),
+        );
+    }
+    println!("smoke: ok — the record crossed the node boundary");
+    Ok(())
+}

--- a/crates/felix-cluster/src/client.rs
+++ b/crates/felix-cluster/src/client.rs
@@ -1,0 +1,85 @@
+//! Connecting a client to a broker in the harness.
+//!
+//! **Certificates are not verified.** Brokers generate a self-signed
+//! certificate at startup and publish it nowhere, so a client in a separate
+//! process has nothing to trust it against — the same gap the peer transport
+//! documents, and the same answer until a real PKI exists. That is acceptable
+//! here because every endpoint is loopback and started by this harness.
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use felix_client::{Client, ClientConfig};
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{DigitallySignedStruct, SignatureScheme};
+
+/// Connect to a broker's client-facing port as `tenant_id`.
+pub async fn connect(addr: SocketAddr, tenant_id: &str, token: &str) -> Result<Client> {
+    let mut tls = rustls::ClientConfig::builder_with_provider(provider())
+        .with_protocol_versions(rustls::ALL_VERSIONS)
+        .context("client protocol versions")?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(AcceptAnyBroker))
+        .with_no_client_auth();
+    // The client-facing role negotiates no ALPN, which is what keeps it out of
+    // the internal listener. Setting one here would change that.
+    tls.alpn_protocols.clear();
+
+    let quinn = quinn::ClientConfig::new(Arc::new(
+        quinn::crypto::rustls::QuicClientConfig::try_from(tls).context("client crypto")?,
+    ));
+    let mut config = ClientConfig::optimized_defaults(quinn);
+    config.auth_tenant_id = Some(tenant_id.to_string());
+    config.auth_token = Some(token.to_string());
+
+    Client::connect(addr, "localhost", config)
+        .await
+        .with_context(|| format!("connect to broker at {addr}"))
+}
+
+fn provider() -> Arc<rustls::crypto::CryptoProvider> {
+    // Both `ring` and `aws-lc-rs` are in the graph, so there is no unambiguous
+    // process default. This matches what quinn's own helpers pick.
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+#[derive(Debug)]
+struct AcceptAnyBroker;
+
+impl ServerCertVerifier for AcceptAnyBroker {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> std::result::Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &DigitallySignedStruct,
+    ) -> std::result::Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}

--- a/crates/felix-cluster/src/controlplane.rs
+++ b/crates/felix-cluster/src/controlplane.rs
@@ -1,0 +1,205 @@
+//! The control plane the harness runs.
+//!
+//! In process, on a real TCP port, so the brokers it starts reach it over HTTP
+//! exactly as they would in a deployment. It is in process for one reason: a
+//! broker needs a credential, and the only way to obtain one today is an OIDC
+//! token exchange against a real identity provider. Holding the store here lets
+//! the harness mint node and client tokens directly with the tenant's signing
+//! keys — the same thing `services/broker/tests/membership_lifecycle.rs` does,
+//! and the same reason.
+//!
+//! The consequence is worth stating plainly: **the control plane is not under
+//! test as a process.** Its router, store, placement, and HTTP contract all are.
+//! What is not exercised is its `main`, its own configuration, and its shutdown.
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use controlplane::api::types::{FeatureFlags, Region};
+use controlplane::app::{AppState, build_router};
+use controlplane::auth::felix_token::TenantSigningKeys;
+use controlplane::config::NodeLivenessConfig;
+use controlplane::store::memory::InMemoryStore;
+use controlplane::store::{AuthStore, StoreConfig};
+use tokio_util::sync::CancellationToken;
+
+use crate::ports;
+
+/// Liveness tuned for a harness: brokers are local, so a lapsed heartbeat means
+/// a broker that actually stopped rather than a slow network. Short windows make
+/// a stopped broker observable in seconds instead of tens of seconds, which is
+/// what failure tests wait on.
+const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
+    heartbeat_interval_ms: 200,
+    expiry_timeout_ms: 1_000,
+    sweep_interval_ms: 100,
+    // Placement is driven explicitly by the harness, so this only matters as a
+    // backstop for anything the harness does not step itself.
+    shard_reconcile_interval_ms: 500,
+};
+
+/// A running control plane, and the keys to mint credentials against it.
+pub struct ControlPlane {
+    pub base_url: String,
+    pub store: Arc<InMemoryStore>,
+    keys: TenantSigningKeys,
+    shutdown: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ControlPlane {
+    /// Start the control plane, holding the signing keys it will issue against.
+    pub async fn start(tenant_id: &str) -> Result<Self> {
+        let store = Arc::new(InMemoryStore::new(StoreConfig {
+            changes_limit: controlplane::config::DEFAULT_CHANGES_LIMIT,
+            change_retention_max_rows: Some(10_000),
+        }));
+        let keys = controlplane::auth::keys::generate_signing_keys()
+            .context("generate tenant signing keys")?;
+        store
+            .set_tenant_signing_keys(tenant_id, keys.clone())
+            .await
+            .context("seed tenant signing keys")?;
+
+        let state = AppState {
+            region: Region {
+                region_id: "local".to_string(),
+                display_name: "Local".to_string(),
+            },
+            api_version: "v1".to_string(),
+            features: FeatureFlags {
+                durable_storage: false,
+                tiered_storage: false,
+                bridges: false,
+            },
+            store: Arc::clone(&store)
+                as Arc<dyn controlplane::store::ControlPlaneAuthStore + Send + Sync>,
+            oidc_validator: controlplane::auth::oidc::UpstreamOidcValidator::default(),
+            bootstrap_enabled: false,
+            bootstrap_token: None,
+            node_liveness: LIVENESS,
+        };
+
+        let addr = ports::free_tcp()?;
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .with_context(|| format!("bind control plane on {addr}"))?;
+        let addr = listener
+            .local_addr()
+            .context("read control plane address")?;
+        let shutdown = CancellationToken::new();
+        let serve_shutdown = shutdown.clone();
+        let task = tokio::spawn(async move {
+            let _ = axum::serve(listener, build_router(state).into_make_service())
+                .with_graceful_shutdown(async move { serve_shutdown.cancelled().await })
+                .await;
+        });
+
+        // Expiry has to run, or a stopped broker stays `live` forever and no
+        // failure test can observe it leaving.
+        let expiry = controlplane::membership::spawn_expiry_sweep(
+            Arc::clone(&store) as Arc<dyn controlplane::store::ControlPlaneStore + Send + Sync>,
+            LIVENESS,
+            shutdown.clone(),
+        );
+        // Owned by the same token; nothing waits on it separately.
+        drop(expiry);
+
+        Ok(Self {
+            base_url: format!("http://{addr}"),
+            store,
+            keys,
+            shutdown,
+            task,
+        })
+    }
+
+    /// Associate this control plane's signing keys with `tenant_id`.
+    ///
+    /// Called again after the tenant is created through the API: keys set for a
+    /// tenant that does not exist yet do not survive its creation, and every
+    /// token minted here verifies against whatever the store holds at the time
+    /// the request arrives.
+    pub async fn seed_tenant_keys(&self, tenant_id: &str) -> Result<()> {
+        self.store
+            .set_tenant_signing_keys(tenant_id, self.keys.clone())
+            .await
+            .context("seed tenant signing keys")
+    }
+
+    /// A credential for one broker: manage its own membership, and read the
+    /// cluster's assignments and node catalog.
+    ///
+    /// Scoped to `node:{node_id}` on purpose, which is what a real deployment
+    /// would hand it — a broker presenting this for another node is refused.
+    pub fn node_token(&self, tenant_id: &str, node_id: &str) -> Result<String> {
+        controlplane::auth::felix_token::mint_token(
+            &self.keys,
+            tenant_id,
+            &format!("p:{node_id}"),
+            vec![
+                format!("node.manage:node:{node_id}"),
+                // Assignments and `/v1/nodes` both require this; without it a
+                // broker cannot learn who owns what, or where they are.
+                "node.view:cluster:*".to_string(),
+            ],
+            Duration::from_secs(3600),
+        )
+        .context("mint node token")
+    }
+
+    /// A credential for a client publishing and subscribing in `tenant_id`.
+    ///
+    /// Stream permissions only. A broker validates every action in a token it is
+    /// presented, and rejects the whole token if one is not a client-facing
+    /// action — so a cluster-scoped permission here would make this credential
+    /// unusable for its actual purpose.
+    pub fn client_token(&self, tenant_id: &str) -> Result<String> {
+        controlplane::auth::felix_token::mint_token(
+            &self.keys,
+            tenant_id,
+            "p:harness-client",
+            vec![
+                format!("stream.publish:stream:{tenant_id}/*/*"),
+                format!("stream.subscribe:stream:{tenant_id}/*/*"),
+            ],
+            Duration::from_secs(3600),
+        )
+        .context("mint client token")
+    }
+
+    /// A credential for the harness itself, against the control plane's HTTP
+    /// API: create metadata, and read membership and ownership.
+    ///
+    /// Separate from [`Self::client_token`] because the two are presented to
+    /// different services, which accept different actions.
+    pub fn admin_token(&self, tenant_id: &str) -> Result<String> {
+        controlplane::auth::felix_token::mint_token(
+            &self.keys,
+            tenant_id,
+            "p:harness-admin",
+            vec![
+                format!("tenant.manage:tenant:{tenant_id}"),
+                format!("ns.manage:namespace:{tenant_id}/*"),
+                format!("stream.manage:stream:{tenant_id}/*/*"),
+                "node.view:cluster:*".to_string(),
+            ],
+            Duration::from_secs(3600),
+        )
+        .context("mint admin token")
+    }
+
+    /// Place any unassigned shard onto a live broker.
+    ///
+    /// Driven explicitly rather than waited for: the reconciler runs on a timer,
+    /// and a harness that slept for one would be timing-dependent in exactly the
+    /// way the acceptance criteria rule out.
+    pub async fn place_shards(&self) -> controlplane::placement::ReconcileOutcome {
+        controlplane::placement::reconcile_once(self.store.as_ref()).await
+    }
+
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(5), self.task).await;
+    }
+}

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -55,6 +55,15 @@ impl BrokerNode {
     pub fn is_running(&self) -> bool {
         self.process.is_some()
     }
+
+    /// The exit status if this broker has already stopped.
+    ///
+    /// A broker that refuses its configuration exits within milliseconds. Left
+    /// unchecked, that becomes a readiness timeout tens of seconds later that
+    /// says nothing about why.
+    fn exited(&mut self) -> Option<std::process::ExitStatus> {
+        self.process.as_mut()?.try_wait().ok().flatten()
+    }
 }
 
 /// A running cluster.
@@ -133,7 +142,7 @@ impl Cluster {
             );
         }
 
-        let cluster = Self {
+        let mut cluster = Self {
             control_plane: Some(control_plane),
             nodes,
             tenant_id: config.tenant_id.clone(),
@@ -144,7 +153,10 @@ impl Cluster {
             _root: root,
         };
 
-        cluster.await_ready(&config).await?;
+        // Two phases: the first needs the child handles, to tell "not ready yet"
+        // from "already exited"; the rest only observes the cluster.
+        cluster.await_brokers_ready().await?;
+        cluster.await_cluster_ready(&config).await?;
         Ok(cluster)
     }
 
@@ -158,20 +170,39 @@ impl Cluster {
         &self.control_plane().base_url
     }
 
-    /// Wait for every broker to be ready, registered, and serving its shards.
-    async fn await_ready(&self, config: &ClusterConfig) -> Result<()> {
-        for node in &self.nodes {
-            let url = format!("http://{}/ready", node.metrics_addr);
-            wait::until(READY_TIMEOUT, &format!("broker {} ready", node.node_id), || {
-                let http = self.http.clone();
-                let url = url.clone();
-                async move {
-                    matches!(http.get(&url).send().await, Ok(response) if response.status().is_success())
+    /// Wait for every broker process to report ready.
+    async fn await_brokers_ready(&mut self) -> Result<()> {
+        // Written as a loop rather than through `wait::until` so a broker that
+        // has already exited can be reported as such, with its status, instead
+        // of timing out.
+        for index in 0..self.nodes.len() {
+            let url = format!("http://{}/ready", self.nodes[index].metrics_addr);
+            let deadline = std::time::Instant::now() + READY_TIMEOUT;
+            loop {
+                if let Some(status) = self.nodes[index].exited() {
+                    let node_id = &self.nodes[index].node_id;
+                    bail!("{node_id} exited before becoming ready ({status})");
                 }
-            })
-            .await?;
+                let ok = matches!(
+                    self.http.get(&url).send().await,
+                    Ok(response) if response.status().is_success()
+                );
+                if ok {
+                    break;
+                }
+                if std::time::Instant::now() >= deadline {
+                    let node_id = &self.nodes[index].node_id;
+                    bail!("timed out after {READY_TIMEOUT:?} waiting for {node_id} to be ready");
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
         }
+        Ok(())
+    }
 
+    /// Wait until the cluster as a whole can serve: every broker registered and
+    /// placeable, every shard led, and a publish accepted.
+    async fn await_cluster_ready(&self, config: &ClusterConfig) -> Result<()> {
         let expected: Vec<String> = self.nodes.iter().map(|n| n.node_id.clone()).collect();
         wait::until(
             READY_TIMEOUT,

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -1,0 +1,658 @@
+//! A local multi-node Felix cluster, for integration and failure tests.
+//!
+//! Starts one control plane and N broker processes, waits for each of them to
+//! actually be usable, and tears everything down when the [`Cluster`] is
+//! dropped.
+//!
+//! # What is real
+//!
+//! **Brokers are real processes.** Each has its own client-facing QUIC port,
+//! internal peer port, metrics port, node identity, credential, and data
+//! directory, and they reach each other over the internal transport exactly as
+//! they would in a deployment. Stopping one is a real process exit.
+//!
+//! **The control plane is in process.** See [`controlplane`] for why, and for
+//! what that does and does not exercise.
+//!
+//! # Waiting
+//!
+//! Nothing here sleeps for a fixed duration and hopes. Every wait polls a real
+//! signal — a readiness endpoint, a node's placement eligibility in the catalog,
+//! an assignment naming a leader — and fails with what it was still waiting for
+//! rather than proceeding into a confusing failure later.
+pub mod client;
+pub mod controlplane;
+pub mod ports;
+pub mod wait;
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+pub use controlplane::ControlPlane;
+
+/// How long any single start-up wait may take before the harness gives up.
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// One broker process.
+pub struct BrokerNode {
+    pub node_id: String,
+    /// Where clients publish and subscribe.
+    pub client_addr: SocketAddr,
+    /// Where peer brokers forward to. This is what the catalog advertises.
+    pub internal_addr: SocketAddr,
+    pub metrics_addr: SocketAddr,
+    pub data_dir: PathBuf,
+    /// `None` once the node has been stopped.
+    process: Option<Child>,
+}
+
+impl BrokerNode {
+    pub fn is_running(&self) -> bool {
+        self.process.is_some()
+    }
+}
+
+/// A running cluster.
+pub struct Cluster {
+    pub control_plane: Option<ControlPlane>,
+    pub nodes: Vec<BrokerNode>,
+    pub tenant_id: String,
+    pub namespace: String,
+    /// Presented to brokers over QUIC.
+    pub client_token: String,
+    /// Presented to the control plane's HTTP API.
+    pub admin_token: String,
+    http: reqwest::Client,
+    /// Held so the data directories outlive the brokers and are removed with
+    /// the cluster.
+    _root: tempfile::TempDir,
+}
+
+/// How to build a cluster.
+pub struct ClusterConfig {
+    pub nodes: usize,
+    pub tenant_id: String,
+    pub namespace: String,
+    /// Streams to create, and how many shards each has.
+    pub streams: Vec<(String, u32)>,
+    /// Inherit the parent's stdout/stderr rather than discarding it. Useful when
+    /// running the harness by hand; noisy inside a test.
+    pub inherit_output: bool,
+}
+
+impl Default for ClusterConfig {
+    fn default() -> Self {
+        Self {
+            nodes: 3,
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            streams: vec![("orders".to_string(), 1)],
+            inherit_output: false,
+        }
+    }
+}
+
+impl Cluster {
+    /// Start a cluster and wait until every part of it is usable.
+    ///
+    /// "Usable" means each broker answers `/ready`, the control plane considers
+    /// each one placeable, every stream's shards have a leader, and the leader
+    /// has opened them. A publish issued the moment this returns is expected to
+    /// succeed.
+    pub async fn start(config: ClusterConfig) -> Result<Self> {
+        if config.nodes == 0 {
+            bail!("a cluster needs at least one broker");
+        }
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .no_proxy()
+            .build()
+            .context("build harness HTTP client")?;
+
+        let control_plane = ControlPlane::start(&config.tenant_id).await?;
+        let client_token = control_plane.client_token(&config.tenant_id)?;
+        let admin_token = control_plane.admin_token(&config.tenant_id)?;
+
+        // Metadata first: a broker syncs streams at startup, and one that starts
+        // before its streams exist has to wait for the next sync to become
+        // useful. Creating them up front means readiness means what it says.
+        seed_metadata(&http, &control_plane, &config, &admin_token).await?;
+
+        let root = tempfile::tempdir().context("create cluster data root")?;
+        let binary = broker_binary()?;
+        let mut nodes = Vec::with_capacity(config.nodes);
+        for index in 0..config.nodes {
+            nodes.push(
+                spawn_broker(&binary, &control_plane, &config, root.path(), index)
+                    .with_context(|| format!("start broker {index}"))?,
+            );
+        }
+
+        let cluster = Self {
+            control_plane: Some(control_plane),
+            nodes,
+            tenant_id: config.tenant_id.clone(),
+            namespace: config.namespace.clone(),
+            client_token,
+            admin_token,
+            http,
+            _root: root,
+        };
+
+        cluster.await_ready(&config).await?;
+        Ok(cluster)
+    }
+
+    fn control_plane(&self) -> &ControlPlane {
+        self.control_plane
+            .as_ref()
+            .expect("control plane is only taken during shutdown")
+    }
+
+    pub fn control_plane_url(&self) -> &str {
+        &self.control_plane().base_url
+    }
+
+    /// Wait for every broker to be ready, registered, and serving its shards.
+    async fn await_ready(&self, config: &ClusterConfig) -> Result<()> {
+        for node in &self.nodes {
+            let url = format!("http://{}/ready", node.metrics_addr);
+            wait::until(READY_TIMEOUT, &format!("broker {} ready", node.node_id), || {
+                let http = self.http.clone();
+                let url = url.clone();
+                async move {
+                    matches!(http.get(&url).send().await, Ok(response) if response.status().is_success())
+                }
+            })
+            .await?;
+        }
+
+        let expected: Vec<String> = self.nodes.iter().map(|n| n.node_id.clone()).collect();
+        wait::until(
+            READY_TIMEOUT,
+            "every broker registered and placeable",
+            || {
+                let this = self;
+                let expected = expected.clone();
+                async move {
+                    match this.placeable_nodes().await {
+                        Ok(live) => expected.iter().all(|id| live.contains(id)),
+                        Err(_) => false,
+                    }
+                }
+            },
+        )
+        .await?;
+
+        // Placement is stepped rather than waited on, then the result is
+        // verified: a leader for every shard of every stream.
+        let total_shards: usize = config.streams.iter().map(|(_, s)| *s as usize).sum();
+        wait::until(
+            READY_TIMEOUT,
+            "every shard assigned a leader",
+            || async move {
+                self.control_plane().place_shards().await;
+                match self.shard_owners().await {
+                    Ok(owners) => owners.len() >= total_shards,
+                    Err(_) => false,
+                }
+            },
+        )
+        .await?;
+
+        // An assignment is not the same as a broker that has opened the shard.
+        // That gap is exactly where a publish is refused as `NotReady`, and no
+        // control-plane state distinguishes the two — so the only honest check
+        // is a publish that succeeds.
+        for (stream, _) in &config.streams {
+            let stream = stream.clone();
+            wait::until(
+                READY_TIMEOUT,
+                &format!("a publish to {stream} to be accepted"),
+                || {
+                    let stream = stream.clone();
+                    async move { self.probe_publish(&stream).await.is_ok() }
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Publish one record through an arbitrary broker.
+    ///
+    /// Deliberately not through the owner: routing a publish from a non-owner is
+    /// the thing that has to work, so the readiness check exercises it rather
+    /// than the easy path.
+    async fn probe_publish(&self, stream: &str) -> Result<()> {
+        let node = self
+            .nodes
+            .iter()
+            .find(|node| node.is_running())
+            .ok_or_else(|| anyhow!("no running broker"))?;
+        self.publish_via(&node.node_id, stream, b"harness-probe".to_vec())
+            .await
+    }
+
+    /// Publish one record through a named broker, whether or not it owns the
+    /// shard.
+    pub async fn publish_via(&self, node_id: &str, stream: &str, payload: Vec<u8>) -> Result<()> {
+        let node = self
+            .node(node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let client = client::connect(node.client_addr, &self.tenant_id, &self.client_token).await?;
+        let publisher = client.publisher().await.context("open publisher")?;
+        // Acked, because an unacked publish would make every failure look like
+        // success and the wait above would pass instantly.
+        publisher
+            .publish(
+                &self.tenant_id,
+                &self.namespace,
+                stream,
+                payload,
+                felix_wire::AckMode::PerMessage,
+            )
+            .await
+            .with_context(|| format!("publish to {stream} via {node_id}"))
+    }
+
+    /// Subscribe on a named broker and return the client and subscription.
+    ///
+    /// Both are returned because dropping the client closes the connection the
+    /// subscription is delivered on.
+    pub async fn subscribe_on(
+        &self,
+        node_id: &str,
+        stream: &str,
+    ) -> Result<(felix_client::Client, felix_client::Subscription)> {
+        let node = self
+            .node(node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let client = client::connect(node.client_addr, &self.tenant_id, &self.client_token).await?;
+        let subscription = client
+            .subscribe(&self.tenant_id, &self.namespace, stream)
+            .await
+            .with_context(|| format!("subscribe to {stream} on {node_id}"))?;
+        Ok((client, subscription))
+    }
+
+    /// Node ids the control plane currently considers placeable.
+    pub async fn placeable_nodes(&self) -> Result<Vec<String>> {
+        #[derive(serde::Deserialize)]
+        struct Response {
+            items: Vec<Item>,
+        }
+        #[derive(serde::Deserialize)]
+        struct Item {
+            node: Node,
+            placement: Placement,
+        }
+        #[derive(serde::Deserialize)]
+        struct Node {
+            node_id: String,
+        }
+        #[derive(serde::Deserialize)]
+        struct Placement {
+            eligible: bool,
+        }
+
+        let response: Response = self
+            .get(&format!("{}/v1/nodes", self.control_plane_url()))
+            .await?;
+        Ok(response
+            .items
+            .into_iter()
+            .filter(|item| item.placement.eligible)
+            .map(|item| item.node.node_id)
+            .collect())
+    }
+
+    /// Which broker leads each shard, keyed by `tenant/namespace/stream/shard`.
+    pub async fn shard_owners(&self) -> Result<HashMap<String, String>> {
+        #[derive(serde::Deserialize)]
+        struct Response {
+            items: Vec<Assignment>,
+        }
+        // `ShardAssignment` flattens its key, so the JSON is flat too.
+        #[derive(serde::Deserialize)]
+        struct Assignment {
+            tenant_id: String,
+            namespace: String,
+            stream: String,
+            shard: u32,
+            leader: String,
+        }
+
+        let response: Response = self
+            .get(&format!(
+                "{}/v1/shard-assignments",
+                self.control_plane_url()
+            ))
+            .await?;
+        Ok(response
+            .items
+            .into_iter()
+            .map(|a| {
+                (
+                    format!("{}/{}/{}/{}", a.tenant_id, a.namespace, a.stream, a.shard),
+                    a.leader,
+                )
+            })
+            .collect())
+    }
+
+    /// The node that owns `stream`'s shard 0, and one that does not.
+    ///
+    /// This pair is the whole point of a multi-node harness: it is what lets a
+    /// test publish somewhere the data does not belong.
+    pub async fn owner_and_non_owner(&self, stream: &str) -> Result<(String, String)> {
+        let owners = self.shard_owners().await?;
+        let key = format!("{}/{}/{}/0", self.tenant_id, self.namespace, stream);
+        let owner = owners
+            .get(&key)
+            .ok_or_else(|| anyhow!("no owner for {key}"))?
+            .clone();
+        let other = self
+            .nodes
+            .iter()
+            .find(|node| node.node_id != owner && node.is_running())
+            .ok_or_else(|| anyhow!("no running broker other than the owner {owner}"))?
+            .node_id
+            .clone();
+        Ok((owner, other))
+    }
+
+    /// Read one counter or gauge from a broker's `/metrics`.
+    ///
+    /// `None` when the metric has never been recorded, which for a counter is
+    /// the difference between "zero so far" and "this code path never ran" —
+    /// the distinction a cross-broker test is usually making.
+    pub async fn metric(&self, node_id: &str, name: &str) -> Result<Option<f64>> {
+        let node = self
+            .node(node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let body = self
+            .http
+            .get(format!("http://{}/metrics", node.metrics_addr))
+            .send()
+            .await
+            .context("scrape metrics")?
+            .text()
+            .await
+            .context("read metrics body")?;
+
+        let mut total = None;
+        for line in body.lines() {
+            if line.starts_with('#') {
+                continue;
+            }
+            // `name`, `name{labels}`, then the value. Summed across label sets,
+            // because a caller asking "did this happen" does not care which
+            // label it happened under.
+            let Some(rest) = line.strip_prefix(name) else {
+                continue;
+            };
+            if !(rest.starts_with(' ') || rest.starts_with('{')) {
+                continue;
+            }
+            if let Some(value) = rest.rsplit(' ').next().and_then(|v| v.parse::<f64>().ok()) {
+                *total.get_or_insert(0.0) += value;
+            }
+        }
+        Ok(total)
+    }
+
+    pub fn node(&self, node_id: &str) -> Option<&BrokerNode> {
+        self.nodes.iter().find(|node| node.node_id == node_id)
+    }
+
+    /// Stop one broker, and wait until the control plane agrees it is gone.
+    ///
+    /// The wait is the useful half: a test that kills a broker and immediately
+    /// asserts is racing the expiry sweep.
+    pub async fn stop_node(&mut self, node_id: &str) -> Result<()> {
+        let node = self
+            .nodes
+            .iter_mut()
+            .find(|node| node.node_id == node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let Some(mut process) = node.process.take() else {
+            return Ok(());
+        };
+        let _ = process.kill();
+        let _ = process.wait();
+
+        let node_id = node_id.to_string();
+        wait::until(
+            READY_TIMEOUT,
+            &format!("control plane to notice {node_id} is gone"),
+            || {
+                let this = &*self;
+                let node_id = node_id.clone();
+                async move {
+                    match this.placeable_nodes().await {
+                        Ok(live) => !live.contains(&node_id),
+                        Err(_) => false,
+                    }
+                }
+            },
+        )
+        .await
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(&self, url: &str) -> Result<T> {
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(&self.admin_token)
+            .send()
+            .await
+            .with_context(|| format!("GET {url}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            bail!("GET {url}: {status}: {body}");
+        }
+        response.json().await.context("decode response")
+    }
+
+    /// Stop everything. Called by `Drop` too, so an aborted test leaves nothing
+    /// behind — this exists for the case where a caller wants to wait for it.
+    pub async fn shutdown(mut self) {
+        self.kill_brokers();
+        if let Some(control_plane) = self.control_plane.take() {
+            control_plane.shutdown().await;
+        }
+    }
+
+    fn kill_brokers(&mut self) {
+        for node in &mut self.nodes {
+            if let Some(mut process) = node.process.take() {
+                let _ = process.kill();
+                let _ = process.wait();
+            }
+        }
+    }
+}
+
+impl Drop for Cluster {
+    fn drop(&mut self) {
+        // A panicking test must not leave broker processes running. The data
+        // root is a `TempDir`, so it goes with this too — but only after the
+        // processes holding it are gone.
+        self.kill_brokers();
+    }
+}
+
+/// Create the tenant, namespace, and streams the cluster serves.
+async fn seed_metadata(
+    http: &reqwest::Client,
+    control_plane: &ControlPlane,
+    config: &ClusterConfig,
+    token: &str,
+) -> Result<()> {
+    let base = &control_plane.base_url;
+    post(
+        http,
+        &format!("{base}/v1/tenants"),
+        token,
+        serde_json::json!({
+            "tenant_id": config.tenant_id,
+            "display_name": config.tenant_id,
+        }),
+    )
+    .await
+    .context("create tenant")?;
+    // The tenant now exists; bind the signing keys to it so every token this
+    // harness mints verifies.
+    control_plane.seed_tenant_keys(&config.tenant_id).await?;
+
+    post(
+        http,
+        &format!("{base}/v1/tenants/{}/namespaces", config.tenant_id),
+        token,
+        serde_json::json!({
+            "tenant_id": config.tenant_id,
+            "namespace": config.namespace,
+            "display_name": config.namespace,
+        }),
+    )
+    .await
+    .context("create namespace")?;
+
+    for (stream, shards) in &config.streams {
+        post(
+            http,
+            &format!(
+                "{base}/v1/tenants/{}/namespaces/{}/streams",
+                config.tenant_id, config.namespace
+            ),
+            token,
+            serde_json::json!({
+                "tenant_id": config.tenant_id,
+                "namespace": config.namespace,
+                "stream": stream,
+                "kind": "Stream",
+                "shards": shards,
+                "retention": { "max_age_seconds": null, "max_size_bytes": null },
+                "consistency": "Leader",
+                "delivery": "AtLeastOnce",
+                // Durable, so the brokers gate readiness on having actually
+                // recovered their logs. An ephemeral stream would let a broker
+                // report ready before it could serve anything.
+                "durable": true,
+            }),
+        )
+        .await
+        .with_context(|| format!("create stream {stream}"))?;
+    }
+    Ok(())
+}
+
+async fn post(
+    http: &reqwest::Client,
+    url: &str,
+    token: &str,
+    body: serde_json::Value,
+) -> Result<()> {
+    let response = http
+        .post(url)
+        .bearer_auth(token)
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = response.status();
+    // Idempotent by design: a harness restarted against a warm control plane
+    // should not fail because the tenant already exists.
+    if status.is_success() || status == reqwest::StatusCode::CONFLICT {
+        return Ok(());
+    }
+    let detail = response.text().await.unwrap_or_default();
+    bail!("POST {url}: {status}: {detail}")
+}
+
+/// Start one broker process.
+fn spawn_broker(
+    binary: &PathBuf,
+    control_plane: &ControlPlane,
+    config: &ClusterConfig,
+    root: &std::path::Path,
+    index: usize,
+) -> Result<BrokerNode> {
+    let node_id = format!("broker-{index}");
+    let client_addr = ports::free_udp()?;
+    let internal_addr = ports::free_udp()?;
+    let metrics_addr = ports::free_tcp()?;
+    let data_dir = root.join(&node_id);
+    std::fs::create_dir_all(&data_dir)
+        .with_context(|| format!("create data dir {}", data_dir.display()))?;
+
+    let token = control_plane.node_token(&config.tenant_id, &node_id)?;
+    let mut command = Command::new(binary);
+    command
+        .env("FELIX_NODE_ID", &node_id)
+        // The advertised address is the internal listener's: it is what peers
+        // forward to, not what clients connect to.
+        .env("FELIX_NODE_ADVERTISE_ADDR", internal_addr.to_string())
+        .env("FELIX_NODE_TOKEN", &token)
+        .env("FELIX_CONTROLPLANE_URL", &control_plane.base_url)
+        .env("FELIX_REGION_ID", "local")
+        .env("FELIX_QUIC_BIND", client_addr.to_string())
+        .env("FELIX_INTERNAL_BIND", internal_addr.to_string())
+        .env("FELIX_BROKER_METRICS_BIND", metrics_addr.to_string())
+        .env("FELIX_DURABLE_STORAGE_DIR", &data_dir)
+        // Fast enough that ownership converges while a person is watching, and
+        // still a real poll rather than a fixed wait.
+        .env("FELIX_CONTROLPLANE_SYNC_INTERVAL_MS", "200")
+        .env(
+            "RUST_LOG",
+            std::env::var("RUST_LOG").as_deref().unwrap_or("info"),
+        );
+
+    if config.inherit_output {
+        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    } else {
+        command.stdout(Stdio::null()).stderr(Stdio::null());
+    }
+
+    let process = command
+        .spawn()
+        .with_context(|| format!("spawn {}", binary.display()))?;
+
+    Ok(BrokerNode {
+        node_id,
+        client_addr,
+        internal_addr,
+        metrics_addr,
+        data_dir,
+        process: Some(process),
+    })
+}
+
+/// Locate the `felix-broker` binary built alongside this harness.
+///
+/// Taken from this executable's own directory rather than by running cargo: the
+/// harness is often already inside a cargo invocation, and a nested one would
+/// deadlock on the build lock.
+fn broker_binary() -> Result<PathBuf> {
+    let mut dir = std::env::current_exe().context("locate the running executable")?;
+    dir.pop();
+    // Integration test binaries live in `target/<profile>/deps`.
+    if dir.ends_with("deps") {
+        dir.pop();
+    }
+    let candidate = dir.join("felix-broker");
+    if candidate.exists() {
+        return Ok(candidate);
+    }
+    Err(anyhow!(
+        "felix-broker not found at {}; build it first with `cargo build -p broker --bin felix-broker`",
+        candidate.display()
+    ))
+}

--- a/crates/felix-cluster/src/ports.rs
+++ b/crates/felix-cluster/src/ports.rs
@@ -1,0 +1,22 @@
+//! Picking addresses that are free right now.
+//!
+//! Every process the harness starts binds a port it was told to bind, so the
+//! harness has to choose them. It asks the OS for an ephemeral port, notes it,
+//! and closes the socket — which leaves a window where something else could take
+//! it. That window is why callers get a fresh port per attempt rather than a
+//! cached one, and why start-up retries.
+use std::net::{SocketAddr, TcpListener, UdpSocket};
+
+use anyhow::{Context, Result};
+
+/// A free TCP port on loopback, for the HTTP listeners.
+pub fn free_tcp() -> Result<SocketAddr> {
+    let listener = TcpListener::bind("127.0.0.1:0").context("bind ephemeral TCP port")?;
+    listener.local_addr().context("read TCP port")
+}
+
+/// A free UDP port on loopback, for the QUIC listeners.
+pub fn free_udp() -> Result<SocketAddr> {
+    let socket = UdpSocket::bind("127.0.0.1:0").context("bind ephemeral UDP port")?;
+    socket.local_addr().context("read UDP port")
+}

--- a/crates/felix-cluster/src/wait.rs
+++ b/crates/felix-cluster/src/wait.rs
@@ -1,0 +1,31 @@
+//! Polling for a real condition, with a deadline.
+//!
+//! The acceptance criterion this exists for: the harness waits on real readiness
+//! rather than fixed sleeps. A timeout says what it was waiting for, because a
+//! harness that fails with "timed out" tells a contributor nothing.
+use std::future::Future;
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, bail};
+
+/// How often a condition is re-checked. Short enough that start-up is not
+/// dominated by the poll interval, long enough not to spin.
+const POLL: Duration = Duration::from_millis(50);
+
+/// Poll `condition` until it is true, or fail saying what never happened.
+pub async fn until<F, Fut>(timeout: Duration, what: &str, mut condition: F) -> Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if condition().await {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out after {timeout:?} waiting for {what}");
+        }
+        tokio::time::sleep(POLL).await;
+    }
+}

--- a/crates/felix-cluster/tests/cross_broker.rs
+++ b/crates/felix-cluster/tests/cross_broker.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use felix_cluster::{Cluster, ClusterConfig};
+use serial_test::serial;
 
 const STREAM: &str = "orders";
 
@@ -23,6 +24,7 @@ fn config() -> ClusterConfig {
 
 /// The milestone signal. A publish that arrives at a broker which does not own
 /// the shard reaches a subscriber on the one that does.
+#[serial]
 #[tokio::test]
 async fn a_publish_through_a_non_owner_is_delivered_by_the_owner() {
     let cluster = Cluster::start(config()).await.expect("start cluster");
@@ -66,6 +68,7 @@ async fn a_publish_through_a_non_owner_is_delivered_by_the_owner() {
 
 /// The owner serves its own shard without forwarding, which is what makes the
 /// test above about routing rather than about publishing at all.
+#[serial]
 #[tokio::test]
 async fn a_publish_through_the_owner_is_not_forwarded() {
     let cluster = Cluster::start(config()).await.expect("start cluster");
@@ -102,6 +105,7 @@ async fn a_publish_through_the_owner_is_not_forwarded() {
 ///
 /// This is the primitive the M5-M10 failure tests need: without it every such
 /// test races the expiry sweep.
+#[serial]
 #[tokio::test]
 async fn a_stopped_broker_leaves_the_cluster() {
     let mut cluster = Cluster::start(config()).await.expect("start cluster");

--- a/crates/felix-cluster/tests/cross_broker.rs
+++ b/crates/felix-cluster/tests/cross_broker.rs
@@ -1,0 +1,124 @@
+//! M4's completion signal: a three-node cluster delivers across node boundaries.
+//!
+//! These start real broker processes, so they are slower than a unit test and
+//! deliberately few. What they cover is the seam nothing else can: the wiring
+//! between a broker's configuration, its cluster view, and the publish path a
+//! real client actually takes.
+//!
+//! Run with `cargo test -p felix-cluster` (or `task cluster:test`), which builds
+//! the `felix-broker` binary these need.
+use std::time::Duration;
+
+use felix_cluster::{Cluster, ClusterConfig};
+
+const STREAM: &str = "orders";
+
+fn config() -> ClusterConfig {
+    ClusterConfig {
+        nodes: 3,
+        streams: vec![(STREAM.to_string(), 1)],
+        ..Default::default()
+    }
+}
+
+/// The milestone signal. A publish that arrives at a broker which does not own
+/// the shard reaches a subscriber on the one that does.
+#[tokio::test]
+async fn a_publish_through_a_non_owner_is_delivered_by_the_owner() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+    let (owner, non_owner) = cluster
+        .owner_and_non_owner(STREAM)
+        .await
+        .expect("resolve owner");
+
+    let (_client, mut subscription) = cluster
+        .subscribe_on(&owner, STREAM)
+        .await
+        .expect("subscribe on the owner");
+
+    let payload = b"across-the-boundary".to_vec();
+    cluster
+        .publish_via(&non_owner, STREAM, payload.clone())
+        .await
+        .expect("publish through a non-owner");
+
+    // Asserted before the delivery wait: a broker that served the publish
+    // locally would look exactly like one whose delivery is merely slow, and
+    // this is the difference the whole milestone is about.
+    let forwarded = cluster
+        .metric(&non_owner, "felix_broker_forwards_total")
+        .await
+        .expect("read metrics");
+    assert!(
+        forwarded.is_some_and(|count| count > 0.0),
+        "{non_owner} did not forward: it served a shard owned by {owner} locally",
+    );
+
+    let event = tokio::time::timeout(Duration::from_secs(10), subscription.next_event())
+        .await
+        .expect("timed out waiting for the record")
+        .expect("subscription failed")
+        .expect("subscription closed");
+    assert_eq!(event.payload, payload);
+
+    cluster.shutdown().await;
+}
+
+/// The owner serves its own shard without forwarding, which is what makes the
+/// test above about routing rather than about publishing at all.
+#[tokio::test]
+async fn a_publish_through_the_owner_is_not_forwarded() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+    let (owner, _) = cluster
+        .owner_and_non_owner(STREAM)
+        .await
+        .expect("resolve owner");
+
+    let before = cluster
+        .metric(&owner, "felix_broker_forwards_total")
+        .await
+        .expect("read metrics")
+        .unwrap_or(0.0);
+
+    cluster
+        .publish_via(&owner, STREAM, b"local".to_vec())
+        .await
+        .expect("publish through the owner");
+
+    let after = cluster
+        .metric(&owner, "felix_broker_forwards_total")
+        .await
+        .expect("read metrics")
+        .unwrap_or(0.0);
+    assert_eq!(
+        before, after,
+        "the owner forwarded a shard it owns; ownership resolution is wrong",
+    );
+
+    cluster.shutdown().await;
+}
+
+/// A stopped broker leaves the cluster, and the harness can tell when.
+///
+/// This is the primitive the M5-M10 failure tests need: without it every such
+/// test races the expiry sweep.
+#[tokio::test]
+async fn a_stopped_broker_leaves_the_cluster() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let victim = cluster.nodes[1].node_id.clone();
+    assert!(
+        cluster
+            .placeable_nodes()
+            .await
+            .expect("list nodes")
+            .contains(&victim),
+    );
+
+    cluster.stop_node(&victim).await.expect("stop the broker");
+
+    let live = cluster.placeable_nodes().await.expect("list nodes");
+    assert!(!live.contains(&victim), "{victim} is still placeable");
+    assert_eq!(live.len(), 2, "the survivors must stay placeable: {live:?}");
+
+    cluster.shutdown().await;
+}

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -1,0 +1,93 @@
+# The local cluster harness
+
+A three-node Felix cluster on one machine, for integration and failure tests.
+
+```bash
+task cluster:status   # start, print membership and ownership, tear down
+task cluster:smoke    # publish through a non-owner, receive from the owner
+task cluster:up       # start and hold until Ctrl-C
+task cluster:test     # the cross-broker integration tests
+```
+
+`-- --nodes 5` sets the size. Nothing else is required: no compose file, no
+images, no ports to reserve, and no state left behind.
+
+## What is real, and what is not
+
+**Brokers are real processes.** Each gets its own client-facing QUIC port,
+internal peer port, metrics port, node identity, credential, and data directory.
+They register with the control plane, forward to each other over the internal
+transport, and stopping one is a real process exit.
+
+**The control plane runs in the harness process.** Not for convenience: a broker
+needs a credential, and the only way to obtain one today is an OIDC token
+exchange against a real identity provider. Holding the store in process lets the
+harness mint node and client tokens against the tenant's signing keys, which is
+what `services/broker/tests/membership_lifecycle.rs` already does for the same
+reason.
+
+The consequence, stated plainly: the control plane's router, store, placement,
+and HTTP contract are all exercised; its `main`, its own configuration, and its
+shutdown are not. A harness that ran it as a process would need a fake IdP, or a
+way to issue a first credential without one — the latter is worth having on its
+own, and would let this become a fully out-of-process cluster.
+
+## Waiting
+
+Nothing here sleeps for a fixed duration and hopes. Start-up returns only once:
+
+1. every broker answers `/ready`,
+2. the control plane considers every broker placeable,
+3. every shard has a leader — placement is *stepped*, not waited for, so it does
+   not depend on a reconcile timer, and
+4. **a publish succeeds**.
+
+The last one is the only honest check for the gap between "assigned" and
+"servable": a broker can hold an assignment it has not finished opening, no
+control-plane state distinguishes the two, and a publish in that window is
+refused. The probe deliberately publishes through an arbitrary broker rather
+than the owner, so the routing path is covered by start-up itself.
+
+A wait that times out says what it was still waiting for.
+
+## Two tokens
+
+The harness mints two credentials, and they are not interchangeable:
+
+- A **client token** carrying only `stream.publish` and `stream.subscribe`,
+  presented to brokers over QUIC.
+- An **admin token** carrying tenant, namespace, and `node.view:cluster:*`,
+  presented to the control plane's HTTP API.
+
+A broker validates every action in a token it is given and rejects the whole
+token if one is not a client-facing action, so a single credential carrying
+`node.view` cannot publish at all.
+
+## Faults
+
+`stop_node` kills a broker and waits until the control plane no longer considers
+it placeable, which is the primitive a failure test needs — without it, every
+such test races the expiry sweep. Liveness windows are tuned short (a 1s expiry
+timeout) because every process is local, so a stopped broker is observable in
+about a second.
+
+Blocking a peer link without stopping the process is not supported yet; it needs
+either a proxy in front of the internal listener or platform firewall rules, and
+nothing in M4 required it.
+
+## Using it from a test
+
+```rust
+let cluster = Cluster::start(ClusterConfig::default()).await?;
+let (owner, non_owner) = cluster.owner_and_non_owner("orders").await?;
+cluster.publish_via(&non_owner, "orders", payload).await?;
+```
+
+`Cluster::metric` reads a counter or gauge from one broker's `/metrics`, and
+returns `None` when it was never recorded — which for a counter is the
+difference between "zero so far" and "this code path never ran". That
+distinction is usually what a cross-broker assertion is making: a publish served
+locally by the wrong broker looks exactly like one whose delivery is slow.
+
+Dropping a `Cluster` kills its brokers, so a panicking test leaves nothing
+running.

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -75,6 +75,18 @@ Blocking a peer link without stopping the process is not supported yet; it needs
 either a proxy in front of the internal listener or platform firewall rules, and
 nothing in M4 required it.
 
+## Running the tests
+
+They are `#[serial]`. Each starts three broker processes, and a two-core CI
+runner asked to start nine at once starves them all — the first symptom is a
+readiness timeout that looks like a bug in the broker rather than in the test
+setup. Serial runs also narrow the window in which two clusters can be handed
+the same ephemeral port.
+
+A broker that exits during start-up is reported with its exit status
+immediately, rather than as a readiness timeout tens of seconds later that says
+nothing about why.
+
 ## Using it from a test
 
 ```rust

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -107,6 +107,9 @@ emptying it, because a control-plane blip must not turn a healthy cluster into
 one that refuses every remote publish. `felix_broker_node_catalog_nodes` reading
 zero while assignments are known is exactly that failure.
 
+A three-node cluster can be run locally with
+[the cluster harness](cluster-harness.md).
+
 The internal transport is described in
 [the broker-internal forwarding protocol](internal-protocol.md); its remaining
 settings (`FELIX_INTERNAL_CONNS_PER_PEER`, `FELIX_INTERNAL_STREAMS_PER_CONN`,

--- a/scripts/check_publish_metadata.py
+++ b/scripts/check_publish_metadata.py
@@ -43,15 +43,22 @@ ELASTIC = {
     "felix-crypto",
     "felix-consensus",
     "felix-router",
+    "felix-cluster",
     "broker",
     "controlplane",
     "agent",
 }
 
-# Service binaries and a dev/CI tool with hard Elastic-2.0 dependencies. Nobody
+# Service binaries and dev/CI tools with hard Elastic-2.0 dependencies. Nobody
 # consumes these from a registry, and `broker`/`controlplane`/`agent` are generic
 # names that would collide besides.
-NOT_PUBLISHABLE = {"broker", "controlplane", "agent", "felix-conformance"}
+NOT_PUBLISHABLE = {
+    "broker",
+    "controlplane",
+    "agent",
+    "felix-conformance",
+    "felix-cluster",
+}
 
 # crates.io hard requirement is `description`; the rest are discoverability
 # fields we want set before a first publish rather than bolted on after.

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -332,15 +332,11 @@ pub(crate) async fn handle_connection_with_shutdown(
     // exhaust the process-wide publish budget (`publish_ctx.admission`), open unbounded
     // subscriptions, or (via a stale/colliding cache) share subscription delivery state with
     // an unrelated connection. `workers`/`admission`/`depth` stay the shared, process-wide
-    // instances from `build_publish_context` — only `conn_admission`, `subscriptions`, and
-    // `lane_manager` are fresh per connection.
-    let publish_ctx = PublishContext {
-        ingress: None,
-        conn_admission: Arc::new(PublishAdmission::new(config.pub_conn_inflight_bytes)),
-        subscriptions: Arc::new(SubscriptionLimiter::new()),
-        lane_manager: WriterLaneManager::new(&config),
-        ..publish_ctx
-    };
+    // instances from `build_publish_context`. What is and is not carried through
+    // is `PublishContext::for_connection`'s to decide, in one place, because
+    // dropping the cluster view here silently disabled shard ownership for every
+    // client connection once already.
+    let publish_ctx = publish_ctx.for_connection(&config);
     // Tracks the per-stream handler tasks so shutdown can wait for in-flight
     // work instead of dropping it.
     let streams = TaskTracker::new();

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -167,6 +167,27 @@ pub(crate) struct PublishContext {
 }
 
 impl PublishContext {
+    /// Derive this connection's context from the process-wide one.
+    ///
+    /// Only the per-connection limits are fresh: its slice of the publish byte
+    /// budget, its subscription limiter, and its writer lanes. Everything else —
+    /// the worker queues, the shared budget, and **the cluster view** — is
+    /// carried through.
+    ///
+    /// The cluster view is the part worth stating. `ingress` and `peers` decide
+    /// whether a publish is served here, refused, or forwarded, and dropping
+    /// them here disables shard ownership for every client connection: the gate
+    /// keeps passing its own tests while no broker ever refuses or forwards a
+    /// shard it does not own.
+    pub(crate) fn for_connection(&self, config: &crate::config::BrokerConfig) -> Self {
+        Self {
+            conn_admission: Arc::new(PublishAdmission::new(config.pub_conn_inflight_bytes)),
+            subscriptions: Arc::new(SubscriptionLimiter::new()),
+            lane_manager: WriterLaneManager::new(config),
+            ..self.clone()
+        }
+    }
+
     /// Overflow policy for publishes that carry no ack (fire-and-forget).
     /// Unacked publishes get `Backpressure`, never `Wait`: with no ack there is no
     /// channel on which to report a timeout, so a bounded wait could only end in a

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -1721,6 +1721,32 @@ async fn handle_publish_batch_message_uni_drop_returns_true() {
     assert!(result);
 }
 
+/// A connection's context must keep the cluster view.
+///
+/// This exact field was overridden to `None` when the ownership gate shipped,
+/// which left every broker writing shards it did not own — the gate's own unit
+/// tests passed throughout, because they call it directly. The invariant only
+/// shows up at the seam.
+#[tokio::test]
+async fn a_connections_context_keeps_the_cluster_view() {
+    use crate::shard_routing::IngressRouter;
+    use felix_router::{RegionRouter, ShardRouter};
+
+    let (mut context, _rx, _tx) = make_publish_context(1);
+    let router = Arc::new(ShardRouter::new(
+        "broker-a",
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    context.ingress = Some(Arc::new(IngressRouter::new(router)));
+
+    let derived = context.for_connection(&crate::config::BrokerConfig::default());
+    assert!(
+        derived.ingress.is_some(),
+        "a connection that loses the router serves every shard locally",
+    );
+}
+
 #[tokio::test]
 async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
     let broker = Broker::new(EphemeralCache::new().into());


### PR DESCRIPTION
Closes #108. This is M4's milestone-completion signal — and running it immediately found that the milestone did not actually hold.

## It found a serious bug

**The shard-ownership gate has been inert for all real client traffic since it shipped in #231.**

The per-connection `PublishContext` set `ingress: None`, so every client connection lost the cluster view. Consequences:

- Every broker wrote every shard **locally, including shards it does not own**.
- #106's forwarding never ran once in production. `felix_broker_forwards_total` was never incremented.

The gate's unit tests passed the whole time, because they call `resolve_route` directly with a router in hand. The bug lives at the seam between the process-wide context and the per-connection one, and only a real client through a real broker process reaches it. `..publish_ctx` would have carried the field correctly; the explicit `ingress: None` overrode it.

The fix is `PublishContext::for_connection`, which puts the "what does a connection inherit" decision in one documented place, plus a unit test that fails the moment the cluster view is dropped. I verified both the unit test and the harness test fail with the bug reintroduced:

```
broker-0 did not forward: it served a shard owned by broker-2 locally
```

I introduced this in #231, and I want to be direct about the lesson rather than bury it: three PRs of ownership routing and cross-broker forwarding shipped with tests that all passed and a feature that never once executed on the real path. The harness is what closed that gap.

## The harness

```bash
task cluster:smoke    # publish through a non-owner, receive from the owner
task cluster:status   # membership and shard ownership
task cluster:up       # hold until Ctrl-C
task cluster:test     # the cross-broker integration tests
```

**Brokers are real processes** with their own client/internal/metrics ports, identities, credentials, and data directories.

**The control plane runs in process**, and I want to flag that as the one real compromise. A broker's only route to a credential today is an OIDC exchange against a real identity provider, so an out-of-process control plane would need a fake IdP — or a way to issue a first credential without one, which is arguably a genuine gap worth its own issue. `docs/cluster-harness.md` says plainly what that does and does not exercise.

**Nothing sleeps for a fixed duration.** Start-up returns once every broker answers `/ready`, every broker is placeable, every shard has a leader (placement is *stepped*, not waited for), and **a publish succeeds**. That last check is the only honest one for the window where a broker holds an assignment it has not finished opening — no control-plane state distinguishes it, and a publish there is refused. It deliberately publishes through an arbitrary broker, so the routing path is covered by start-up itself.

**Two credentials**, because they are not interchangeable: a client token with only stream permissions for brokers over QUIC, and an admin token with `node.view:cluster:*` for the control plane. A broker rejects an entire token containing an action it does not recognise, so a single combined credential cannot publish at all — which cost me a debugging cycle and is now documented.

## Tests

Three integration tests, ~1.7s total: the milestone signal, its converse (the owner does *not* forward its own shard), and stopping a broker until the control plane agrees it is gone — the primitive M5–M10 failure tests need, since without it every such test races the expiry sweep.

`Cluster::metric` returns `None` for a never-recorded counter, which is the distinction these assertions rest on: a publish served locally by the wrong broker looks exactly like one whose delivery is merely slow.

## Not done

Blocking a peer link without killing the process. It needs a proxy in front of the internal listener or platform firewall rules, and nothing in M4 required it. Noted in the docs rather than left implied.

## Verification

`task lint`, `task test`, `task demo:check`, `task deny` all clean, and no stale broker processes after the runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)