### PR TITLE
feat: fenced shard leadership, replica sets, and gated promotion (#111)

### DIFF
--- a/crates/felix-cluster/src/controlplane.rs
+++ b/crates/felix-cluster/src/controlplane.rs
@@ -233,6 +233,12 @@ impl ControlPlane {
 
     pub async fn shutdown(self) {
         self.shutdown.cancel();
+        // Aborted, not drained. A graceful shutdown keeps serving the keep-alive
+        // connections brokers already hold, so their heartbeats would go on
+        // succeeding and the control plane would not be gone in any sense a
+        // broker could detect -- which is the whole point when this is used as a
+        // fault rather than a teardown.
+        self.task.abort();
         let _ = tokio::time::timeout(Duration::from_secs(5), self.task).await;
     }
 }

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -182,6 +182,9 @@ impl Cluster {
             .expect("control plane is only taken during shutdown")
     }
 
+    /// The control plane's address. Panics once it has been stopped, which is
+    /// deliberate: a caller reading this after `stop_control_plane` is asking
+    /// for a service that is gone.
     pub fn control_plane_url(&self) -> &str {
         &self.control_plane().base_url
     }
@@ -596,6 +599,24 @@ impl Cluster {
 
     pub fn node(&self, node_id: &str) -> Option<&BrokerNode> {
         self.nodes.iter().find(|node| node.node_id == node_id)
+    }
+
+    /// Stop the control plane, leaving the brokers running.
+    ///
+    /// A failure primitive rather than a teardown: brokers keep serving on the
+    /// authority they already hold, and lose it when their leases lapse. That is
+    /// the partition this cluster can produce without touching the network.
+    pub async fn stop_control_plane(&mut self) {
+        if let Some(control_plane) = self.control_plane.take() {
+            control_plane.shutdown().await;
+        }
+    }
+
+    /// Whether the control plane is still running. `false` once
+    /// [`Self::stop_control_plane`] has been called, after which the assignment
+    /// and node endpoints are unreachable.
+    pub fn control_plane_running(&self) -> bool {
+        self.control_plane.is_some()
     }
 
     /// Stop one broker, and wait until the control plane agrees it is gone.

--- a/crates/felix-cluster/tests/conformance.rs
+++ b/crates/felix-cluster/tests/conformance.rs
@@ -246,3 +246,49 @@ async fn a_moved_shard_converges_on_the_new_owner() -> Result<()> {
     cluster.shutdown().await;
     Ok(())
 }
+
+/// A broker that cannot renew its lease stops serving.
+///
+/// This is the fence from `docs/replication-design.md`, end to end, and it is
+/// what closes the write-loss path in #239: a broker whose authority has lapsed
+/// refuses rather than writing a shard someone else may already lead.
+///
+/// The control plane is stopped rather than the network cut, because that is the
+/// partition this harness can produce — and it is the same loss of authority
+/// from the broker's point of view.
+#[serial]
+#[tokio::test]
+async fn a_broker_that_cannot_renew_its_lease_stops_serving() -> Result<()> {
+    let mut cluster = Cluster::start(config(3)).await?;
+    let owner = cluster.owner(STREAM).await?;
+
+    // Serving normally, on a lease it is renewing.
+    cluster
+        .publish_via(&owner, STREAM, b"while-leased".to_vec())
+        .await
+        .expect("a leased broker must serve");
+
+    cluster.stop_control_plane().await;
+
+    // The lease outlives a brief outage — that is the point of a lease — and
+    // then lapses. Bounded: the harness runs a 1s expiry window.
+    let mut refused = false;
+    for _ in 0..200 {
+        if cluster
+            .publish_via(&owner, STREAM, b"after-expiry".to_vec())
+            .await
+            .is_err()
+        {
+            refused = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert!(
+        refused,
+        "{owner} kept accepting writes after it could no longer renew its lease",
+    );
+
+    cluster.shutdown().await;
+    Ok(())
+}

--- a/demos/cross_tenant_isolation/src/main.rs
+++ b/demos/cross_tenant_isolation/src/main.rs
@@ -682,6 +682,8 @@ async fn create_stream(
         stream: STREAM.to_string(),
         kind: StreamKind::Stream,
         shards: 1,
+        // Leader-only: this demo is about tenant isolation, not replication.
+        replication_factor: 1,
         retention: RetentionPolicy {
             max_age_seconds: None,
             max_size_bytes: None,

--- a/demos/rbac-live/src/main.rs
+++ b/demos/rbac-live/src/main.rs
@@ -466,6 +466,8 @@ async fn create_stream(http: &reqwest::Client, cp_base: &str) -> Result<StatusCo
         stream: STREAM.to_string(),
         kind: StreamKind::Stream,
         shards: 1,
+        // Leader-only: this demo is about authorization, not replication.
+        replication_factor: 1,
         retention: RetentionPolicy {
             max_age_seconds: None,
             max_size_bytes: None,

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -224,6 +224,25 @@ acknowledged record, so any failure within the configured majority preserves it.
 | Broker suspended past expiry | Refused at the durable-append check on waking. |
 | Stale broker after reassignment | Its lease has expired, so it refuses. This is what closes #239 by construction rather than by racing a watch. |
 
+## What is implemented so far
+
+`#111` builds the leadership half:
+
+- **Leases**, renewed by the heartbeat, with the duration taken from the control
+  plane's expiry window. Checked at admission (cheap, cached) and again at commit
+  (authoritative, reads the clock).
+- **Replica sets**, chosen by the same score as leadership so the whole set is a
+  deterministic function of the shard and the cluster. `replication_factor`
+  defaults to 1, so a stream that never asked for replication is unchanged.
+- **Promotion**, gated on a caught-up follower.
+
+The gate matters more than the promotion. A replica that holds no log can be
+promoted perfectly well and will then serve an empty shard — the failover *is*
+the data loss. So promotion requires a follower within the catch-up bound, and
+until records are actually replicated (#112) nothing reports being caught up, so
+promotion does not fire and placement behaves exactly as it did. The gate starts
+permitting failover at the moment replication starts working, and not before.
+
 ## What this does to the other M5 issues
 
 - **#111 (fenced leadership)** — this is now specific: the epoch is the

--- a/services/broker/src/lease.rs
+++ b/services/broker/src/lease.rs
@@ -1,0 +1,182 @@
+//! The broker's authority to serve the shards it leads.
+//!
+//! An assignment says who *should* lead a shard. A lease says who may still act
+//! on that, and it expires on its own. The difference matters because a
+//! revocation cannot be delivered to a broker that is partitioned — which is
+//! exactly the case where it is needed. See `docs/replication-design.md`.
+//!
+//! # The lease is the heartbeat
+//!
+//! No separate protocol. A broker renews by heartbeating, which it already
+//! does, and the control plane grants by keeping the node live, which it already
+//! decides. The lease is the time since the last *accepted* heartbeat, measured
+//! on the broker's own monotonic clock — so the two ends never compare wall
+//! clocks, and no clock synchronisation is assumed.
+//!
+//! # Two checks, and why they differ
+//!
+//! `docs/replication-design.md` requires the lease be checked when a request is
+//! admitted and again before its record is committed. They are not the same
+//! check:
+//!
+//! - **Admission** ([`LeaseState::looks_valid`]) reads one atomic and may be
+//!   stale by up to the refresh interval. It sheds early and cheaply, on a path
+//!   that prides itself on costing two atomic loads.
+//! - **Commit** ([`LeaseState::is_valid_now`]) reads the clock. It is the
+//!   authoritative one, and it is the reason a process suspended past its expiry
+//!   cannot write on waking: the cached flag would still say yes, and the clock
+//!   says no. It sits behind an fsync, so its cost is not measurable.
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+/// How much of the lease is given up as safety margin.
+///
+/// The broker stops serving this long before the control plane could possibly
+/// regrant, which is the gap that makes two leaders impossible. Expressed as a
+/// fraction because it has to scale with the lease: a fixed margin is either
+/// most of a short lease or negligible against a long one.
+const SAFETY_MARGIN_FRACTION: u32 = 4;
+
+/// How often the cached admission flag is refreshed, as a fraction of the
+/// margin. Frequent enough that the cached answer is never far behind, cheap
+/// enough to be invisible.
+const REFRESH_FRACTION: u32 = 4;
+
+/// Whether this broker may currently serve the shards it leads.
+pub struct LeaseState {
+    /// Millis since `base` of the last accepted heartbeat, **plus one**.
+    ///
+    /// Zero means never renewed. The offset is what keeps that sentinel from
+    /// colliding with a real renewal in the first millisecond of the process,
+    /// which is otherwise a broker that heartbeats immediately and reads as
+    /// holding no lease.
+    renewed_at_millis: AtomicU64,
+    /// The admission-path answer. Refreshed on a timer; authoritative only in
+    /// the negative direction, since it can lag a renewal but is re-derived
+    /// from the clock before any commit.
+    looks_valid: AtomicBool,
+    /// Monotonic origin. `Instant` has no representation to store, so
+    /// everything is kept as a duration from here.
+    base: Instant,
+    /// How long a lease lasts without renewal, already net of the margin, in
+    /// millis. Atomic because the control plane owns this cadence and can change
+    /// it, exactly as it owns the heartbeat interval.
+    usable_millis: AtomicU64,
+}
+
+impl LeaseState {
+    /// A lease of `lease` duration, of which a quarter is held back as margin.
+    ///
+    /// Starts **invalid**: a broker has no authority until its first heartbeat
+    /// is accepted. Starting valid would let a broker that never successfully
+    /// registered serve for a full lease period.
+    pub fn new(lease: Duration) -> Self {
+        Self {
+            renewed_at_millis: AtomicU64::new(0),
+            looks_valid: AtomicBool::new(false),
+            base: Instant::now(),
+            usable_millis: AtomicU64::new(usable_millis(lease)),
+        }
+    }
+
+    /// Adopt the control plane's expiry window.
+    ///
+    /// The lease must never outlive it: a broker still serving after the control
+    /// plane has declared it down is the split this exists to prevent. Taken
+    /// from the heartbeat response for the same reason the interval is — the
+    /// cadence belongs to the control plane, not to broker configuration.
+    pub fn adopt(&self, expiry_timeout: Duration) {
+        self.usable_millis
+            .store(usable_millis(expiry_timeout), Ordering::Release);
+    }
+
+    /// How long a renewal is good for, net of the margin.
+    pub fn usable(&self) -> Duration {
+        Duration::from_millis(self.usable_millis.load(Ordering::Acquire))
+    }
+
+    /// Record an accepted heartbeat.
+    pub fn renew(&self) {
+        let stamp = self.base.elapsed().as_millis() as u64 + 1;
+        // `fetch_max`, not `store`: two heartbeat responses can race, and an
+        // out-of-order one must not move the anchor backwards and shorten the
+        // lease.
+        self.renewed_at_millis.fetch_max(stamp, Ordering::Release);
+        self.looks_valid.store(true, Ordering::Release);
+    }
+
+    /// Give up the lease immediately.
+    ///
+    /// For a broker that has been told it is no longer a member: it should stop
+    /// serving now rather than run out the remaining margin.
+    pub fn surrender(&self) {
+        self.looks_valid.store(false, Ordering::Release);
+        self.renewed_at_millis.store(0, Ordering::Release);
+    }
+
+    /// The cheap admission check. One relaxed load.
+    #[inline]
+    pub fn looks_valid(&self) -> bool {
+        self.looks_valid.load(Ordering::Relaxed)
+    }
+
+    /// The authoritative check, against the clock.
+    ///
+    /// Called before a record is committed. A broker suspended past its expiry
+    /// fails here even though the cached flag still says otherwise, which is the
+    /// entire reason this exists separately.
+    pub fn is_valid_now(&self) -> bool {
+        let stamp = self.renewed_at_millis.load(Ordering::Acquire);
+        if stamp == 0 {
+            return false;
+        }
+        let elapsed = self.base.elapsed().as_millis() as u64 + 1;
+        Duration::from_millis(elapsed.saturating_sub(stamp)) < self.usable()
+    }
+
+    /// Keep the cached flag in step with the clock.
+    ///
+    /// Only ever moves it to `false`; a renewal is what moves it back. That
+    /// asymmetry is deliberate — this task being late must not extend a lease.
+    pub fn spawn_refresh(
+        self: Arc<Self>,
+        shutdown: CancellationToken,
+    ) -> tokio::task::JoinHandle<()> {
+        let period = (self.usable() / (SAFETY_MARGIN_FRACTION * REFRESH_FRACTION))
+            .max(Duration::from_millis(10));
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(period);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                tokio::select! {
+                    _ = shutdown.cancelled() => return,
+                    _ = ticker.tick() => {}
+                }
+                if !self.is_valid_now() && self.looks_valid.swap(false, Ordering::AcqRel) {
+                    tracing::warn!(
+                        usable_ms = self.usable().as_millis() as u64,
+                        "lease expired; this broker is no longer serving the shards it led",
+                    );
+                    crate::lease_metrics::record_expiry();
+                }
+                crate::lease_metrics::set_held(self.is_valid_now());
+            }
+        })
+    }
+}
+
+/// A lease is only usable for part of its life; the rest is the safety margin
+/// the control plane's regrant wait is measured against.
+fn usable_millis(lease: Duration) -> u64 {
+    lease
+        .saturating_sub(lease / SAFETY_MARGIN_FRACTION)
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+#[path = "lease_tests.rs"]
+mod tests;

--- a/services/broker/src/lease_metrics.rs
+++ b/services/broker/src/lease_metrics.rs
@@ -1,0 +1,30 @@
+//! Lease metrics.
+//!
+//! `felix_broker_lease_held` is the one to alert on. A broker that is up,
+//! answering `/ready`, and holding no lease is a broker serving nothing — which
+//! looks identical to a healthy idle broker from every other signal.
+
+/// 1 while this broker may serve the shards it leads, 0 otherwise.
+pub const LEASE_HELD: &str = "felix_broker_lease_held";
+/// Times a lease lapsed. Each one is a window in which this broker's shards were
+/// unavailable here and not yet reassigned elsewhere.
+pub const LEASE_EXPIRIES_TOTAL: &str = "felix_broker_lease_expiries_total";
+/// Publishes refused because the lease was invalid, by `boundary`: `admission`
+/// or `commit`. A non-zero `commit` count means requests are outliving their
+/// lease inside the broker — the queue is deeper than the margin.
+pub const LEASE_REFUSALS_TOTAL: &str = "felix_broker_lease_refusals_total";
+
+pub const BOUNDARY_ADMISSION: &str = "admission";
+pub const BOUNDARY_COMMIT: &str = "commit";
+
+pub fn set_held(held: bool) {
+    metrics::gauge!(LEASE_HELD).set(if held { 1.0 } else { 0.0 });
+}
+
+pub fn record_expiry() {
+    metrics::counter!(LEASE_EXPIRIES_TOTAL).increment(1);
+}
+
+pub fn record_refusal(boundary: &'static str) {
+    metrics::counter!(LEASE_REFUSALS_TOTAL, "boundary" => boundary).increment(1);
+}

--- a/services/broker/src/lease_tests.rs
+++ b/services/broker/src/lease_tests.rs
@@ -1,0 +1,141 @@
+//! Lease expiry, deterministically.
+//!
+//! `start_paused` gives tokio's clock to the test, so expiry is driven by
+//! advancing time rather than by sleeping through it. That is what makes these
+//! exact rather than approximate, and it is why `LeaseState` reads
+//! `tokio::time::Instant` rather than `std::time::Instant`.
+use super::*;
+
+const LEASE: Duration = Duration::from_secs(4);
+
+/// A quarter is held back, so a 4s lease is usable for 3s.
+#[test]
+fn a_quarter_of_the_lease_is_surrendered_as_margin() {
+    let lease = LeaseState::new(LEASE);
+    assert_eq!(lease.usable(), Duration::from_secs(3));
+}
+
+/// A broker has no authority until its first heartbeat is accepted.
+///
+/// Starting valid would let one that never successfully registered serve for a
+/// full lease period.
+#[tokio::test(start_paused = true)]
+async fn a_lease_starts_invalid() {
+    let lease = LeaseState::new(LEASE);
+    assert!(!lease.looks_valid());
+    assert!(!lease.is_valid_now());
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_renewed_lease_is_valid_until_its_usable_life_elapses() {
+    let lease = LeaseState::new(LEASE);
+    lease.renew();
+    assert!(lease.is_valid_now());
+
+    // Just inside.
+    tokio::time::advance(Duration::from_millis(2_999)).await;
+    assert!(lease.is_valid_now(), "still inside the usable window");
+
+    // Just past.
+    tokio::time::advance(Duration::from_millis(2)).await;
+    assert!(!lease.is_valid_now(), "the usable window has elapsed");
+}
+
+/// The case the commit-boundary check exists for.
+///
+/// A broker suspended past its expiry wakes with the cached flag still saying
+/// yes. Only the clock knows otherwise, and a write must not be committed on the
+/// strength of the stale flag.
+#[tokio::test(start_paused = true)]
+async fn a_broker_suspended_past_expiry_fails_the_commit_check_while_admission_still_passes() {
+    let lease = LeaseState::new(LEASE);
+    lease.renew();
+
+    // Nothing refreshes the cached flag: this is the suspension.
+    tokio::time::advance(Duration::from_secs(10)).await;
+
+    assert!(
+        lease.looks_valid(),
+        "the cached flag is stale by construction here -- that is the premise",
+    );
+    assert!(
+        !lease.is_valid_now(),
+        "the clock check must refuse, or a suspended broker writes after losing its lease",
+    );
+}
+
+/// Renewal extends the lease, which is what a heartbeat is for.
+#[tokio::test(start_paused = true)]
+async fn renewing_extends_the_lease() {
+    let lease = LeaseState::new(LEASE);
+    lease.renew();
+
+    for _ in 0..5 {
+        tokio::time::advance(Duration::from_secs(2)).await;
+        lease.renew();
+        assert!(lease.is_valid_now(), "a renewed lease must not expire");
+    }
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    assert!(
+        !lease.is_valid_now(),
+        "renewal stopped, so the lease lapses"
+    );
+}
+
+/// A late renewal must not resurrect an expired lease into the past.
+#[tokio::test(start_paused = true)]
+async fn renewal_never_moves_backwards() {
+    let lease = LeaseState::new(LEASE);
+    tokio::time::advance(Duration::from_secs(10)).await;
+    lease.renew();
+    let late = lease.is_valid_now();
+
+    // A renewal recorded out of order -- two heartbeat responses racing -- must
+    // not move the anchor backwards and shorten the lease.
+    lease.renewed_at_millis.fetch_max(1, Ordering::Release);
+    assert_eq!(
+        lease.is_valid_now(),
+        late,
+        "an out-of-order renewal must not shorten the lease",
+    );
+}
+
+/// Surrender is immediate, for a broker told it is no longer a member.
+#[tokio::test(start_paused = true)]
+async fn surrender_takes_effect_at_once() {
+    let lease = LeaseState::new(LEASE);
+    lease.renew();
+    assert!(lease.is_valid_now());
+
+    lease.surrender();
+    assert!(!lease.looks_valid());
+    assert!(
+        !lease.is_valid_now(),
+        "surrender must not wait out the margin"
+    );
+}
+
+/// The refresh task moves the cached flag to false on its own, so the admission
+/// path stops accepting without needing a publish to discover it.
+#[tokio::test(start_paused = true)]
+async fn the_refresh_task_invalidates_the_cached_flag() {
+    let lease = Arc::new(LeaseState::new(LEASE));
+    lease.renew();
+    let shutdown = CancellationToken::new();
+    let task = Arc::clone(&lease).spawn_refresh(shutdown.clone());
+
+    tokio::time::advance(Duration::from_secs(4)).await;
+    // Let the ticker run at the advanced time.
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_millis(200)).await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        !lease.looks_valid(),
+        "the admission path should stop accepting without waiting for a publish",
+    );
+
+    shutdown.cancel();
+    let _ = task.await;
+}

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -10,6 +10,8 @@ pub mod config;
 pub mod controlplane;
 pub mod core_shards;
 pub mod durable_config;
+pub mod lease;
+pub mod lease_metrics;
 pub mod membership;
 pub mod membership_metrics;
 pub mod node_catalog;

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -127,6 +127,15 @@ where
         .as_ref()
         .map(|(_, ingress, _, _)| Arc::clone(ingress));
 
+    // This broker's authority to serve the shards it leads. Created here rather
+    // than inside the membership task because the accept loop is built first and
+    // the publish path reads it. Starts conservative and invalid: authority
+    // arrives with the first accepted heartbeat, never before.
+    let lease = config
+        .membership
+        .as_ref()
+        .map(|_| Arc::new(peer_lease_state()));
+
     // Outbound peer connections. Built here because the publish path forwards
     // through it, and before the accept loop for the same reason the router is:
     // a publish must never arrive at a broker that can resolve a remote owner
@@ -230,6 +239,7 @@ where
         let seeded = seeded.clone();
         let ingress_router = ingress_router.clone();
         let peers_for_accept = peers.clone();
+        let lease_for_accept = lease.clone();
         tokio::spawn(async move {
             // A durable broker does not accept until its streams exist.
             // Readiness alone only steers orchestrated traffic; a client with
@@ -259,6 +269,7 @@ where
                 quic::ClusterContext {
                     ingress: ingress_router,
                     peers: peers_for_accept,
+                    lease: lease_for_accept,
                 },
             )
             .await
@@ -358,12 +369,19 @@ where
                 now.cancel();
                 now
             };
+            let lease = Arc::clone(lease.as_ref().expect("a cluster member has a lease"));
+            // Keeps the cheap admission flag in step with the clock, so a broker
+            // that loses its lease stops accepting without waiting for a publish
+            // to discover it.
+            let refresh = Arc::clone(&lease).spawn_refresh(sync_shutdown.clone());
+            drop(refresh);
             Some(membership::spawn(
                 membership_client.clone(),
                 base_url.clone(),
                 membership_config.clone(),
                 serving,
                 sync_shutdown.clone(),
+                lease,
             ))
         }
         _ => {
@@ -625,6 +643,15 @@ where
 /// This is convenient for local development but **not appropriate for production**.
 /// Production should load a real certificate chain and private key (and should avoid
 /// regenerating keys on each start).
+/// The initial lease: conservative, and invalid until the first heartbeat.
+///
+/// The real duration comes from the control plane's expiry window on the first
+/// accepted heartbeat, so this value only bounds how long a broker could serve
+/// if that window ever stopped being reported.
+fn peer_lease_state() -> broker::lease::LeaseState {
+    broker::lease::LeaseState::new(Duration::from_secs(10))
+}
+
 fn build_server_config() -> Result<ServerConfig> {
     // Dev-only self-signed TLS config for QUIC endpoints.
     let cert = generate_simple_self_signed(vec!["localhost".into()])?;

--- a/services/broker/src/membership.rs
+++ b/services/broker/src/membership.rs
@@ -70,6 +70,15 @@ struct HeartbeatRequest {
 struct HeartbeatResponse {
     lifecycle: String,
     heartbeat_interval_ms: u64,
+    /// How long the control plane will wait before declaring this node down.
+    /// The broker's lease is derived from it, so the two ends cannot disagree
+    /// about when authority to serve ends.
+    ///
+    /// Defaulted rather than required: a control plane predating this field
+    /// leaves the broker on its conservative initial lease instead of failing to
+    /// parse the response and losing membership entirely.
+    #[serde(default)]
+    expiry_timeout_ms: Option<u64>,
 }
 
 /// A registered identity, and what the control plane told us about it.
@@ -201,6 +210,7 @@ pub async fn run_heartbeat(
     registration: Registration,
     shutdown: CancellationToken,
     consecutive_failures: Arc<AtomicU64>,
+    lease: Arc<crate::lease::LeaseState>,
 ) {
     let base_url = base_url.trim_end_matches('/').to_string();
     let url = format!("{base_url}/v1/nodes/{}/heartbeat", registration.node_id);
@@ -224,6 +234,15 @@ pub async fn run_heartbeat(
             Ok(response) => {
                 consecutive_failures.store(0, Ordering::Release);
                 last_success = std::time::Instant::now();
+                // The heartbeat *is* the lease renewal. Renewed only on an
+                // accepted response, so a control plane that answers "you are
+                // not live" does not extend the authority to serve.
+                if response.lifecycle == "live" || response.lifecycle == "draining" {
+                    if let Some(expiry) = response.expiry_timeout_ms {
+                        lease.adopt(Duration::from_millis(expiry.max(1)));
+                    }
+                    lease.renew();
+                }
                 mm::record_heartbeat_success();
                 // The control plane owns the cadence, so a change to it takes
                 // effect without touching broker configuration.
@@ -235,10 +254,15 @@ pub async fn run_heartbeat(
                 let placeable = response.lifecycle == "live" || response.lifecycle == "draining";
                 mm::record_membership_live(placeable);
                 if !placeable {
+                    // Told outright that it is not a member. Waiting out the
+                    // remaining margin would serve a shard the control plane may
+                    // already have reassigned.
+                    lease.surrender();
                     tracing::warn!(
                         node_id = %registration.node_id,
                         lifecycle = %response.lifecycle,
-                        "the control plane no longer considers this broker live",
+                        "the control plane no longer considers this broker live; \
+                         surrendering the lease",
                     );
                 }
             }
@@ -372,6 +396,9 @@ pub struct MembershipTask {
     /// Consecutive heartbeat failures, exposed so shutdown and metrics can see
     /// whether membership is currently healthy.
     pub consecutive_failures: Arc<AtomicU64>,
+    /// This broker's authority to serve the shards it leads. Renewed by the
+    /// heartbeat below; read by the publish path.
+    pub lease: Arc<crate::lease::LeaseState>,
 }
 
 /// Register once the broker can serve, then report health until shutdown.
@@ -385,13 +412,14 @@ pub fn spawn(
     config: MembershipConfig,
     serving: CancellationToken,
     shutdown: CancellationToken,
+    lease: Arc<crate::lease::LeaseState>,
 ) -> MembershipTask {
     let fatal = CancellationToken::new();
     let consecutive_failures = Arc::new(AtomicU64::new(0));
-
     let handle = tokio::spawn({
         let fatal = fatal.clone();
         let consecutive_failures = Arc::clone(&consecutive_failures);
+        let lease = Arc::clone(&lease);
         async move {
             tokio::select! {
                 _ = shutdown.cancelled() => return,
@@ -437,6 +465,7 @@ pub fn spawn(
                 registration,
                 shutdown,
                 consecutive_failures,
+                lease,
             )
             .await;
         }
@@ -446,6 +475,7 @@ pub fn spawn(
         handle,
         fatal,
         consecutive_failures,
+        lease,
     }
 }
 

--- a/services/broker/src/membership_tests.rs
+++ b/services/broker/src/membership_tests.rs
@@ -178,6 +178,9 @@ async fn heartbeats_carry_the_registered_incarnation() {
         registration,
         shutdown.clone(),
         Arc::clone(&failures),
+        Arc::new(crate::lease::LeaseState::new(
+            std::time::Duration::from_secs(30),
+        )),
     ));
 
     // Wait for a few beats rather than a fixed sleep.
@@ -224,6 +227,9 @@ async fn heartbeat_failures_are_counted_and_then_recovered_from() {
         registration,
         shutdown.clone(),
         Arc::clone(&failures),
+        Arc::new(crate::lease::LeaseState::new(
+            std::time::Duration::from_secs(30),
+        )),
     ));
 
     for _ in 0..400 {

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -156,6 +156,8 @@ pub async fn serve_with_shutdown(
 pub struct ClusterContext {
     pub ingress: Option<Arc<IngressRouter>>,
     pub peers: Option<Arc<crate::peer::PeerPool>>,
+    /// This broker's authority to serve the shards it leads.
+    pub lease: Option<Arc<crate::lease::LeaseState>>,
 }
 
 fn build_publish_context(
@@ -163,7 +165,11 @@ fn build_publish_context(
     config: &BrokerConfig,
     cluster: ClusterContext,
 ) -> PublishContext {
-    let ClusterContext { ingress, peers } = cluster;
+    let ClusterContext {
+        ingress,
+        peers,
+        lease,
+    } = cluster;
     // NOTE: This is intentionally global for the process (not per-connection).
     // With per-connection worker pools, adding more publisher connections multiplied
     // concurrent broker.publish_batch callers and caused lock contention on shared broker state.
@@ -188,6 +194,7 @@ fn build_publish_context(
         let queue_depth_worker = Arc::clone(&queue_depth);
         let broker_for_worker = Arc::clone(&broker);
         let peers_for_worker = peers.clone();
+        let lease_for_worker = lease.clone();
         let worker_task = async move {
             while let Some(job) = publish_rx.recv().await {
                 #[cfg(feature = "perf_debug")]
@@ -204,11 +211,29 @@ fn build_publish_context(
                 #[cfg(feature = "perf_debug")]
                 let worker_start = std::time::Instant::now();
                 let result: Result<(), anyhow::Error> = match &job.target {
-                    PublishTarget::Resolved(handle) => broker_for_worker
-                        .publish_batch_to_handle(handle, &job.payloads)
-                        .await
-                        .map(|_| ())
-                        .map_err(Into::into),
+                    PublishTarget::Resolved(handle) => {
+                        // The commit fence, and the authoritative one. Everything
+                        // between admission and here can take arbitrarily long --
+                        // a full queue, a slow fsync, a suspended process -- so a
+                        // lease that was valid on the way in may have lapsed. A
+                        // broker that writes here after losing its lease is a
+                        // broker writing a shard someone else may already lead.
+                        match &lease_for_worker {
+                            Some(lease) if !lease.is_valid_now() => {
+                                crate::lease_metrics::record_refusal(
+                                    crate::lease_metrics::BOUNDARY_COMMIT,
+                                );
+                                Err(anyhow::anyhow!(
+                                    "lease lapsed before the record could be committed"
+                                ))
+                            }
+                            _ => broker_for_worker
+                                .publish_batch_to_handle(handle, &job.payloads)
+                                .await
+                                .map(|_| ())
+                                .map_err(Into::into),
+                        }
+                    }
                     #[cfg(test)]
                     PublishTarget::Named {
                         tenant_id,
@@ -274,6 +299,7 @@ fn build_publish_context(
     PublishContext {
         ingress,
         peers,
+        lease,
         workers: Arc::new(worker_txs),
         worker_count,
         depth: queue_depth,

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -139,6 +139,11 @@ pub(crate) struct PublishContext {
     /// the handlers can tell "forwardable" from "cannot forward" before
     /// enqueueing rather than after.
     pub(crate) peers: Option<Arc<crate::peer::PeerPool>>,
+    /// This broker's authority to serve the shards it leads.
+    ///
+    /// `None` on a single-node broker, which leads by construction and has
+    /// nobody to lose a shard to.
+    pub(crate) lease: Option<Arc<crate::lease::LeaseState>>,
     pub(crate) workers: Arc<Vec<mpsc::Sender<PublishJob>>>,
     pub(crate) worker_count: usize,
     pub(crate) depth: Arc<AtomicUsize>,
@@ -174,11 +179,11 @@ impl PublishContext {
     /// the worker queues, the shared budget, and **the cluster view** — is
     /// carried through.
     ///
-    /// The cluster view is the part worth stating. `ingress` and `peers` decide
-    /// whether a publish is served here, refused, or forwarded, and dropping
-    /// them here disables shard ownership for every client connection: the gate
-    /// keeps passing its own tests while no broker ever refuses or forwards a
-    /// shard it does not own.
+    /// The cluster view is the part worth stating. `ingress`, `peers`, and
+    /// `lease` decide whether a publish is served here, refused, or forwarded,
+    /// and dropping any of them here disables shard ownership for every client
+    /// connection: the gate keeps passing its own tests while no broker ever
+    /// refuses or forwards a shard it does not own.
     pub(crate) fn for_connection(&self, config: &crate::config::BrokerConfig) -> Self {
         Self {
             conn_admission: Arc::new(PublishAdmission::new(config.pub_conn_inflight_bytes)),
@@ -257,6 +262,27 @@ pub(crate) fn internal_ack(ack: Option<felix_wire::AckMode>) -> felix_wire::inte
     }
 }
 
+/// What decides whether this broker may serve a publish at all.
+///
+/// The two travel together because they answer halves of one question — the
+/// router says whether this broker *should* hold the shard, the lease says
+/// whether it still *may* act on that. Separating them at a call site is how one
+/// gets forgotten.
+#[derive(Clone, Copy)]
+pub(crate) struct Authority<'a> {
+    pub(crate) ingress: Option<&'a IngressRouter>,
+    pub(crate) lease: Option<&'a crate::lease::LeaseState>,
+}
+
+impl PublishContext {
+    pub(crate) fn authority(&self) -> Authority<'_> {
+        Authority {
+            ingress: self.ingress.as_deref(),
+            lease: self.lease.as_deref(),
+        }
+    }
+}
+
 /// Where a publish should be applied.
 #[derive(Debug)]
 pub(crate) enum PublishRoute {
@@ -280,7 +306,7 @@ pub(crate) enum PublishRoute {
 /// loads, so paying it per publish costs less than reasoning about staleness.
 pub(crate) async fn resolve_route(
     broker: &Broker,
-    ingress: Option<&IngressRouter>,
+    authority: Authority<'_>,
     cache: &mut StreamHandleCache,
     key_scratch: &mut String,
     tenant_id: &str,
@@ -289,6 +315,24 @@ pub(crate) async fn resolve_route(
 ) -> PublishRoute {
     // Single-node brokers short-circuit on a null check; a cluster member pays
     // two loads. Either way there is no lock and no await.
+    let Authority { ingress, lease } = authority;
+
+    // The admission fence. Cheap and possibly stale, so it only sheds early --
+    // the authoritative check happens again before the record is committed. See
+    // `crate::lease`.
+    if let Some(lease) = lease
+        && !lease.looks_valid()
+    {
+        crate::lease_metrics::record_refusal(crate::lease_metrics::BOUNDARY_ADMISSION);
+        tracing::debug!(
+            tenant_id,
+            namespace,
+            stream,
+            "publish refused: this broker no longer holds a lease on the shards it led",
+        );
+        return PublishRoute::Refused;
+    }
+
     if ingress.is_some() {
         let key = ShardKey {
             tenant_id: tenant_id.to_string(),

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -84,7 +84,7 @@ pub(crate) async fn handle_binary_publish_batch_control(
     let Some(target) = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &batch.tenant_id,
@@ -401,7 +401,7 @@ pub(crate) async fn handle_publish_message(
     let target = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &tenant_id,
@@ -780,7 +780,7 @@ pub(crate) async fn handle_publish_batch_message(
     let target = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &tenant_id,

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -31,6 +31,7 @@ fn make_publish_context(
     let context = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -83,6 +84,7 @@ async fn enqueue_publish_drop_sheds_load_when_byte_budget_exhausted() {
     let ctx = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -109,6 +111,7 @@ async fn enqueue_publish_drop_sheds_load_when_conn_byte_budget_exhausted() {
     let ctx = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -136,6 +139,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     let ctx_a = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx.clone()]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -149,6 +153,7 @@ async fn enqueue_publish_conn_budget_does_not_starve_other_connections() {
     let ctx_b = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         conn_admission: Arc::new(PublishAdmission::new(4)),
         subscriptions: Arc::new(SubscriptionLimiter::new()),
         lane_manager: test_lane_manager(),
@@ -289,6 +294,7 @@ async fn enqueue_publish_wait_times_out_when_queue_full() {
     let ctx = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -312,6 +318,7 @@ async fn enqueue_publish_returns_error_when_queue_closed() {
     let ctx = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(AtomicUsize::new(0)),
@@ -1753,7 +1760,19 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
     let mut cache = HashMap::new();
     let mut key = String::new();
 
-    let handle = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let handle = resolve_route(
+        &broker,
+        Authority {
+            ingress: None,
+            lease: None,
+        },
+        &mut cache,
+        &mut key,
+        "t1",
+        "ns",
+        "stream",
+    )
+    .await;
     assert!(
         matches!(handle, PublishRoute::Refused),
         "no tenant/namespace yet"
@@ -1774,14 +1793,38 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         .await
         .expect("stream");
 
-    let cached = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let cached = resolve_route(
+        &broker,
+        Authority {
+            ingress: None,
+            lease: None,
+        },
+        &mut cache,
+        &mut key,
+        "t1",
+        "ns",
+        "stream",
+    )
+    .await;
     assert!(
         matches!(cached, PublishRoute::Refused),
         "cached miss should be returned until cache expires or clears"
     );
 
     cache.clear();
-    let refreshed = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+    let refreshed = resolve_route(
+        &broker,
+        Authority {
+            ingress: None,
+            lease: None,
+        },
+        &mut cache,
+        &mut key,
+        "t1",
+        "ns",
+        "stream",
+    )
+    .await;
     assert!(
         matches!(refreshed, PublishRoute::Local(_)),
         "cache refresh should see stream"
@@ -2743,7 +2786,10 @@ mod ownership_gate {
 
         let route = resolve_route(
             &broker,
-            Some(&ingress),
+            Authority {
+                ingress: Some(&ingress),
+                lease: None,
+            },
             &mut cache,
             &mut key,
             "t1",
@@ -2769,7 +2815,10 @@ mod ownership_gate {
 
         let route = resolve_route(
             &broker,
-            Some(&ingress),
+            Authority {
+                ingress: Some(&ingress),
+                lease: None,
+            },
             &mut cache,
             &mut key,
             "t1",
@@ -2794,7 +2843,10 @@ mod ownership_gate {
 
         let route = resolve_route(
             &broker,
-            Some(&ingress),
+            Authority {
+                ingress: Some(&ingress),
+                lease: None,
+            },
             &mut cache,
             &mut key,
             "t1",
@@ -2821,7 +2873,10 @@ mod ownership_gate {
             matches!(
                 resolve_route(
                     &broker,
-                    Some(&ingress),
+                    Authority {
+                        ingress: Some(&ingress),
+                        lease: None
+                    },
                     &mut cache,
                     &mut key,
                     "t1",
@@ -2841,7 +2896,10 @@ mod ownership_gate {
             matches!(
                 resolve_route(
                     &broker,
-                    Some(&moved),
+                    Authority {
+                        ingress: Some(&moved),
+                        lease: None
+                    },
                     &mut cache,
                     &mut key,
                     "t1",
@@ -2862,7 +2920,19 @@ mod ownership_gate {
         let mut cache = HashMap::new();
         let mut key = String::new();
 
-        let route = resolve_route(&broker, None, &mut cache, &mut key, "t1", "ns", "stream").await;
+        let route = resolve_route(
+            &broker,
+            Authority {
+                ingress: None,
+                lease: None,
+            },
+            &mut cache,
+            &mut key,
+            "t1",
+            "ns",
+            "stream",
+        )
+        .await;
         assert!(matches!(route, PublishRoute::Local(_)));
     }
 }

--- a/services/broker/src/transport/quic/handlers/publish/uni.rs
+++ b/services/broker/src/transport/quic/handlers/publish/uni.rs
@@ -66,7 +66,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
     let Some(target) = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &batch.tenant_id,
@@ -138,7 +138,7 @@ pub(crate) async fn handle_publish_message_uni(
     let Some(target) = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &tenant_id,
@@ -209,7 +209,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
     let Some(target) = publish_target(
         resolve_route(
             broker,
-            publish_ctx.ingress.as_deref(),
+            publish_ctx.authority(),
             stream_cache,
             stream_cache_key,
             &tenant_id,

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -579,6 +579,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
     PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3490,6 +3491,7 @@ async fn uni_loop_breaks_on_enqueue_error() -> Result<()> {
     let publish_ctx = PublishContext {
         ingress: None,
         peers: None,
+        lease: None,
         workers: Arc::new(vec![tx]),
         worker_count: 1,
         depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
@@ -3667,6 +3669,7 @@ async fn handle_stream_drain_timeout_sleep_branch() -> Result<()> {
         let publish_ctx = PublishContext {
             ingress: None,
             peers: None,
+            lease: None,
             workers: Arc::new(vec![tx]),
             worker_count: 1,
             depth: Arc::new(std::sync::atomic::AtomicUsize::new(0)),

--- a/services/broker/tests/membership_lifecycle.rs
+++ b/services/broker/tests/membership_lifecycle.rs
@@ -288,6 +288,7 @@ async fn heartbeats_keep_a_broker_live_past_its_expiry_window() {
         config("broker-a", 7001, &cluster.token),
         serving,
         shutdown.clone(),
+        std::sync::Arc::new(broker::lease::LeaseState::new(Duration::from_secs(30))),
     );
 
     // Wait for registration to land.

--- a/services/broker/tests/shard_watch_integration.rs
+++ b/services/broker/tests/shard_watch_integration.rs
@@ -130,6 +130,7 @@ impl Cluster {
                 stream: "orders".to_string(),
                 kind: StreamKind::Stream,
                 shards: 4,
+                replication_factor: 1,
                 retention: RetentionPolicy {
                     max_age_seconds: None,
                     max_size_bytes: None,

--- a/services/controlplane/migrations/0007_stream_replication_factor.sql
+++ b/services/controlplane/migrations/0007_stream_replication_factor.sql
@@ -1,0 +1,7 @@
+-- How many brokers hold a copy of each shard, leader included.
+--
+-- Defaulted to 1 rather than made NOT NULL without one: every stream that
+-- existed before replication was leader-only, and reading them back as anything
+-- else would claim copies that do not exist.
+ALTER TABLE streams
+    ADD COLUMN IF NOT EXISTS replication_factor INTEGER NOT NULL DEFAULT 1;

--- a/services/controlplane/src/api/streams.rs
+++ b/services/controlplane/src/api/streams.rs
@@ -69,6 +69,7 @@ pub(crate) async fn create_stream(
         stream: body.stream,
         kind: body.kind,
         shards: body.shards,
+        replication_factor: body.replication_factor,
         retention: body.retention,
         consistency: body.consistency,
         delivery: body.delivery,

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -65,6 +65,9 @@ pub struct StreamCreateRequest {
     pub stream: String,
     pub kind: StreamKind,
     pub shards: u32,
+    /// Brokers holding each shard, leader included. Defaults to leader-only.
+    #[serde(default = "crate::model::stream::default_replication_factor")]
+    pub replication_factor: u32,
     pub retention: RetentionPolicy,
     pub consistency: ConsistencyLevel,
     pub delivery: DeliveryGuarantee,

--- a/services/controlplane/src/model/mod.rs
+++ b/services/controlplane/src/model/mod.rs
@@ -6,7 +6,7 @@ mod cache;
 mod namespace;
 mod node;
 mod shard;
-mod stream;
+pub mod stream;
 mod tenant;
 
 pub use cache::{Cache, CacheChange, CacheChangeOp, CacheKey, CachePatchRequest};

--- a/services/controlplane/src/model/stream.rs
+++ b/services/controlplane/src/model/stream.rs
@@ -19,10 +19,23 @@ pub struct Stream {
     pub stream: String,
     pub kind: StreamKind,
     pub shards: u32,
+    /// How many brokers hold a copy of each shard, leader included.
+    ///
+    /// `1` is leader-only and is the default, so a stream created before this
+    /// existed — or by a caller that does not set it — behaves exactly as it did.
+    /// A `Quorum` stream needs at least 3 for a majority to mean anything.
+    #[serde(default = "default_replication_factor")]
+    pub replication_factor: u32,
     pub retention: RetentionPolicy,
     pub consistency: ConsistencyLevel,
     pub delivery: DeliveryGuarantee,
     pub durable: bool,
+}
+
+/// Leader-only. The value a stream has unless it asks for more, and the value
+/// every stream written before replication existed reads back as.
+pub(crate) fn default_replication_factor() -> u32 {
+    1
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]

--- a/services/controlplane/src/placement.rs
+++ b/services/controlplane/src/placement.rs
@@ -46,8 +46,9 @@ impl std::fmt::Display for Unplaceable {
 pub enum Decision {
     /// The existing assignment is still valid. Nothing to write.
     Kept,
-    /// This shard needs an assignment written, to this leader.
-    Place(String),
+    /// This shard needs an assignment written: a leader, and the followers that
+    /// will hold a copy of it.
+    Place(String, Vec<String>),
     Unplaceable(Unplaceable),
 }
 
@@ -65,9 +66,11 @@ pub struct Plan {
 }
 
 impl Plan {
-    pub fn to_place(&self) -> impl Iterator<Item = (&ShardKey, &str)> {
+    pub fn to_place(&self) -> impl Iterator<Item = (&ShardKey, &str, &[String])> {
         self.shards.iter().filter_map(|plan| match &plan.decision {
-            Decision::Place(leader) => Some((&plan.key, leader.as_str())),
+            Decision::Place(leader, replicas) => {
+                Some((&plan.key, leader.as_str(), replicas.as_slice()))
+            }
             _ => None,
         })
     }
@@ -92,7 +95,36 @@ impl Plan {
 /// Independent of the order `streams`, `nodes`, and `existing` arrive in: shards
 /// are planned in sorted order and candidates are chosen by score, so two
 /// control-plane instances reading the same rows agree without coordinating.
-pub fn plan(streams: &[Stream], nodes: &[Node], existing: &[ShardAssignment]) -> Plan {
+/// Which replicas hold enough of a shard's log to lead it.
+///
+/// Promotion is gated on this, and the gate is the difference between a failover
+/// and data loss: a replica that holds nothing can be promoted perfectly well
+/// and will serve an empty shard.
+pub trait CaughtUp {
+    /// Whether `node_id` is within the catch-up bound for `key`.
+    fn is_caught_up(&self, key: &ShardKey, node_id: &str) -> bool;
+}
+
+/// Nothing is caught up.
+///
+/// What the cluster can honestly report until records are actually replicated
+/// (#112). With this, promotion never fires and placement behaves exactly as it
+/// did — which is correct, because a promotion today would hand the shard to a
+/// broker holding none of it.
+pub struct NothingCaughtUp;
+
+impl CaughtUp for NothingCaughtUp {
+    fn is_caught_up(&self, _key: &ShardKey, _node_id: &str) -> bool {
+        false
+    }
+}
+
+pub fn plan(
+    streams: &[Stream],
+    nodes: &[Node],
+    existing: &[ShardAssignment],
+    caught_up: &dyn CaughtUp,
+) -> Plan {
     let eligible: Vec<&Node> = {
         let mut live: Vec<&Node> = nodes
             .iter()
@@ -117,6 +149,21 @@ pub fn plan(streams: &[Stream], nodes: &[Node], existing: &[ShardAssignment]) ->
             *load.entry(assignment.leader.as_str()).or_default() += 1;
         }
     }
+
+    // Keyed by the same string `stream_of` builds, so the lookup below cannot
+    // disagree with the key it is derived from.
+    let factors: HashMap<String, u32> = streams
+        .iter()
+        .map(|stream| {
+            (
+                format!(
+                    "{}/{}/{}",
+                    stream.tenant_id, stream.namespace, stream.stream
+                ),
+                stream.replication_factor.max(1),
+            )
+        })
+        .collect();
 
     let mut keys: Vec<ShardKey> = streams
         .iter()
@@ -146,10 +193,44 @@ pub fn plan(streams: &[Stream], nodes: &[Node], existing: &[ShardAssignment]) ->
             continue;
         }
 
+        let replication_factor = factors.get(stream_of(&key).as_str()).copied().unwrap_or(1);
+
+        // The leader is gone. Prefer one of its followers -- but only one that
+        // actually holds the log, or the failover is the data loss.
+        if let Some(previous) = current.get(&key)
+            && let Some(promoted) = promote(&key, previous, &eligible, caught_up)
+        {
+            *load.entry(promoted).or_default() += 1;
+            let replicas = choose_replicas(
+                &key,
+                &eligible,
+                &mut load,
+                promoted,
+                replication_factor.saturating_sub(1),
+            );
+            shards.push(ShardPlan {
+                key,
+                decision: Decision::Place(promoted.to_string(), replicas),
+            });
+            continue;
+        }
+
         let decision = match choose(&key, &eligible, &load) {
             Some(leader) => {
                 *load.entry(leader).or_default() += 1;
-                Decision::Place(leader.to_string())
+                // Followers are the next best-scoring nodes for this shard,
+                // excluding the leader. Chosen by the same score so the whole
+                // replica set is a deterministic function of the shard key and
+                // the cluster -- two control-plane instances planning the same
+                // cluster produce the same set.
+                let replicas = choose_replicas(
+                    &key,
+                    &eligible,
+                    &mut load,
+                    leader,
+                    replication_factor.saturating_sub(1),
+                );
+                Decision::Place(leader.to_string(), replicas)
             }
             None if eligible.is_empty() => Decision::Unplaceable(Unplaceable::NoEligibleNode),
             None => Decision::Unplaceable(Unplaceable::AllNodesAtCapacity),
@@ -158,6 +239,72 @@ pub fn plan(streams: &[Stream], nodes: &[Node], existing: &[ShardAssignment]) ->
     }
 
     Plan { shards }
+}
+
+/// The best eligible follower that is caught up, if any.
+///
+/// Ties break on score then node id, the same way leadership does, so the choice
+/// is a deterministic function of the shard and the cluster.
+fn promote<'a>(
+    key: &ShardKey,
+    previous: &ShardAssignment,
+    eligible: &[&'a Node],
+    caught_up: &dyn CaughtUp,
+) -> Option<&'a str> {
+    eligible
+        .iter()
+        .filter(|node| previous.replicas.iter().any(|r| r == &node.node_id))
+        .filter(|node| caught_up.is_caught_up(key, &node.node_id))
+        .max_by(|a, b| {
+            score(key, &a.node_id)
+                .cmp(&score(key, &b.node_id))
+                .then_with(|| a.node_id.cmp(&b.node_id))
+        })
+        .map(|node| node.node_id.as_str())
+}
+
+/// The stream a shard belongs to, as `tenant/namespace/stream`.
+fn stream_of(key: &ShardKey) -> String {
+    format!("{}/{}/{}", key.tenant_id, key.namespace, key.stream)
+}
+
+/// The next best-scoring nodes for a shard, after the leader.
+///
+/// Fewer than `wanted` is normal and not an error: a three-node cluster cannot
+/// hold four copies. Placement records what it could achieve rather than
+/// claiming a replica set it did not create, because an assignment that names a
+/// node holding nothing is exactly the lie failover would act on.
+fn choose_replicas<'a>(
+    key: &ShardKey,
+    eligible: &[&'a Node],
+    load: &mut HashMap<&'a str, u32>,
+    leader: &str,
+    wanted: u32,
+) -> Vec<String> {
+    let mut chosen = Vec::new();
+    for _ in 0..wanted {
+        let Some(node) = eligible
+            .iter()
+            .filter(|node| node.node_id != leader)
+            .filter(|node| !chosen.iter().any(|taken: &String| taken == &node.node_id))
+            .filter(|node| match node.spec.capacity.max_shards {
+                // A replica holds a copy, so it counts against capacity just as
+                // leadership does.
+                Some(max) => load.get(node.node_id.as_str()).copied().unwrap_or(0) < max,
+                None => true,
+            })
+            .max_by(|a, b| {
+                score(key, &a.node_id)
+                    .cmp(&score(key, &b.node_id))
+                    .then_with(|| a.node_id.cmp(&b.node_id))
+            })
+        else {
+            break;
+        };
+        *load.entry(node.node_id.as_str()).or_default() += 1;
+        chosen.push(node.node_id.clone());
+    }
+    chosen
 }
 
 /// Highest-scoring node with capacity left.
@@ -242,11 +389,11 @@ fn order(key: &ShardKey) -> (&str, &str, &str, u32) {
 ///
 /// New assignments start `Assigning`: placement has decided, and the broker has
 /// not yet confirmed it is serving. Generation is the store's.
-pub fn assignment_for(key: &ShardKey, leader: &str) -> ShardAssignment {
+pub fn assignment_for(key: &ShardKey, leader: &str, replicas: Vec<String>) -> ShardAssignment {
     ShardAssignment {
         key: key.clone(),
         leader: leader.to_string(),
-        replicas: Vec::new(),
+        replicas,
         generation: 0,
         state: ShardState::Assigning,
     }
@@ -270,15 +417,17 @@ pub async fn reconcile_once(store: &dyn crate::store::ControlPlaneStore) -> Reco
         }
     };
 
-    let plan = plan(&streams, &nodes, &existing);
+    // Nothing is caught up until records are replicated (#112), so promotion
+    // does not yet fire and placement behaves as it did.
+    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
     let mut outcome = ReconcileOutcome {
         kept: plan.kept(),
         ..ReconcileOutcome::default()
     };
 
-    for (key, leader) in plan.to_place() {
+    for (key, leader, replicas) in plan.to_place() {
         match store
-            .put_shard_assignment(assignment_for(key, leader))
+            .put_shard_assignment(assignment_for(key, leader, replicas.to_vec()))
             .await
         {
             Ok(assignment) => {
@@ -287,6 +436,7 @@ pub async fn reconcile_once(store: &dyn crate::store::ControlPlaneStore) -> Reco
                     stream = %key.stream,
                     shard = key.shard,
                     leader = %leader,
+                    replicas = replicas.len(),
                     generation = assignment.generation,
                     "shard placed",
                 );

--- a/services/controlplane/src/placement_tests.rs
+++ b/services/controlplane/src/placement_tests.rs
@@ -7,12 +7,18 @@ use crate::model::{
 use std::collections::{BTreeMap, BTreeSet};
 
 fn stream(name: &str, shards: u32) -> Stream {
+    replicated_stream(name, shards, 1)
+}
+
+/// A stream that keeps `replication_factor` copies of each shard.
+fn replicated_stream(name: &str, shards: u32, replication_factor: u32) -> Stream {
     Stream {
         tenant_id: "t1".to_string(),
         namespace: "ns".to_string(),
         stream: name.to_string(),
         kind: StreamKind::Stream,
         shards,
+        replication_factor,
         retention: RetentionPolicy {
             max_age_seconds: None,
             max_size_bytes: None,
@@ -54,7 +60,9 @@ fn placements(plan: &Plan) -> BTreeMap<(String, u32), String> {
     plan.shards
         .iter()
         .filter_map(|p| match &p.decision {
-            Decision::Place(leader) => Some(((p.key.stream.clone(), p.key.shard), leader.clone())),
+            Decision::Place(leader, _) => {
+                Some(((p.key.stream.clone(), p.key.shard), leader.clone()))
+            }
             _ => None,
         })
         .collect()
@@ -67,9 +75,9 @@ fn placement_is_deterministic() {
     let streams = vec![stream("orders", 8), stream("payments", 5)];
     let nodes = live(&["broker-a", "broker-b", "broker-c"]);
 
-    let first = plan(&streams, &nodes, &[]);
+    let first = plan(&streams, &nodes, &[], &NothingCaughtUp);
     for _ in 0..20 {
-        assert_eq!(plan(&streams, &nodes, &[]), first);
+        assert_eq!(plan(&streams, &nodes, &[], &NothingCaughtUp), first);
     }
 }
 
@@ -79,7 +87,7 @@ fn placement_is_deterministic() {
 fn placement_does_not_depend_on_input_order() {
     let streams = vec![stream("orders", 8), stream("payments", 5)];
     let nodes = live(&["broker-a", "broker-b", "broker-c"]);
-    let expected = placements(&plan(&streams, &nodes, &[]));
+    let expected = placements(&plan(&streams, &nodes, &[], &NothingCaughtUp));
 
     let mut reversed_streams = streams.clone();
     reversed_streams.reverse();
@@ -87,18 +95,29 @@ fn placement_does_not_depend_on_input_order() {
     reversed_nodes.reverse();
 
     assert_eq!(
-        placements(&plan(&reversed_streams, &reversed_nodes, &[])),
+        placements(&plan(
+            &reversed_streams,
+            &reversed_nodes,
+            &[],
+            &NothingCaughtUp
+        )),
         expected,
     );
-    assert_eq!(placements(&plan(&streams, &reversed_nodes, &[])), expected);
-    assert_eq!(placements(&plan(&reversed_streams, &nodes, &[])), expected);
+    assert_eq!(
+        placements(&plan(&streams, &reversed_nodes, &[], &NothingCaughtUp)),
+        expected
+    );
+    assert_eq!(
+        placements(&plan(&reversed_streams, &nodes, &[], &NothingCaughtUp)),
+        expected
+    );
 }
 
 #[test]
 fn every_shard_gets_exactly_one_leader() {
     let streams = vec![stream("orders", 8), stream("payments", 5)];
     let nodes = live(&["broker-a", "broker-b", "broker-c"]);
-    let plan = plan(&streams, &nodes, &[]);
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
 
     assert_eq!(plan.shards.len(), 13);
     let keys: BTreeSet<(String, u32)> = plan
@@ -110,7 +129,7 @@ fn every_shard_gets_exactly_one_leader() {
     assert!(
         plan.shards
             .iter()
-            .all(|p| matches!(p.decision, Decision::Place(_))),
+            .all(|p| matches!(p.decision, Decision::Place(..))),
         "every shard should be placeable with three live nodes",
     );
 }
@@ -122,10 +141,10 @@ fn every_shard_gets_exactly_one_leader() {
 fn placement_skew_stays_bounded() {
     let streams = vec![stream("orders", 300)];
     let nodes = live(&["broker-a", "broker-b", "broker-c", "broker-d"]);
-    let plan = plan(&streams, &nodes, &[]);
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
 
     let mut counts: BTreeMap<String, usize> = BTreeMap::new();
-    for (_, leader) in plan.to_place() {
+    for (_, leader, _) in plan.to_place() {
         *counts.entry(leader.to_string()).or_default() += 1;
     }
 
@@ -150,13 +169,13 @@ fn reconciliation_is_idempotent() {
     let streams = vec![stream("orders", 8)];
     let nodes = live(&["broker-a", "broker-b", "broker-c"]);
 
-    let first = plan(&streams, &nodes, &[]);
+    let first = plan(&streams, &nodes, &[], &NothingCaughtUp);
     let applied: Vec<ShardAssignment> = first
         .to_place()
-        .map(|(key, leader)| assignment_for(key, leader))
+        .map(|(key, leader, replicas)| assignment_for(key, leader, replicas.to_vec()))
         .collect();
 
-    let second = plan(&streams, &nodes, &applied);
+    let second = plan(&streams, &nodes, &applied, &NothingCaughtUp);
     assert_eq!(second.kept(), 8, "a second pass should keep everything");
     assert_eq!(second.to_place().count(), 0, "and write nothing");
 }
@@ -184,7 +203,7 @@ fn a_valid_assignment_is_kept_even_if_the_hash_disagrees() {
         })
         .collect();
 
-    let plan = plan(&streams, &nodes, &pinned);
+    let plan = plan(&streams, &nodes, &pinned, &NothingCaughtUp);
     assert_eq!(plan.kept(), 4);
     assert_eq!(plan.to_place().count(), 0, "no reshuffling");
 }
@@ -195,15 +214,15 @@ fn losing_a_node_moves_only_its_shards() {
     let streams = vec![stream("orders", 30)];
     let all = live(&["broker-a", "broker-b", "broker-c"]);
 
-    let initial = plan(&streams, &all, &[]);
+    let initial = plan(&streams, &all, &[], &NothingCaughtUp);
     let applied: Vec<ShardAssignment> = initial
         .to_place()
-        .map(|(key, leader)| assignment_for(key, leader))
+        .map(|(key, leader, replicas)| assignment_for(key, leader, replicas.to_vec()))
         .collect();
 
     let mut degraded = all.clone();
     degraded[0].status.lifecycle = NodeLifecycle::Down;
-    let after = plan(&streams, &degraded, &applied);
+    let after = plan(&streams, &degraded, &applied, &NothingCaughtUp);
 
     let lost = applied.iter().filter(|a| a.leader == "broker-a").count();
     assert!(lost > 0, "the test needs broker-a to have held something");
@@ -214,7 +233,7 @@ fn losing_a_node_moves_only_its_shards() {
     );
     assert_eq!(after.kept(), 30 - lost);
     assert!(
-        after.to_place().all(|(_, leader)| leader != "broker-a"),
+        after.to_place().all(|(_, leader, _)| leader != "broker-a"),
         "nothing may be placed on a node that is down",
     );
 }
@@ -233,9 +252,9 @@ fn only_live_nodes_are_eligible() {
             node("broker-a", lifecycle, None),
             node("broker-b", NodeLifecycle::Live, None),
         ];
-        let plan = plan(&streams, &nodes, &[]);
+        let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
         assert!(
-            plan.to_place().all(|(_, leader)| leader == "broker-b"),
+            plan.to_place().all(|(_, leader, _)| leader == "broker-b"),
             "{lifecycle:?} must not receive placement",
         );
     }
@@ -259,14 +278,15 @@ fn an_assignment_on_an_ineligible_node_is_replaced() {
                     shard,
                 },
                 "broker-a",
+                Vec::new(),
             )
         })
         .collect();
 
-    let plan = plan(&streams, &nodes, &stale);
+    let plan = plan(&streams, &nodes, &stale, &NothingCaughtUp);
     assert_eq!(plan.kept(), 0);
     assert_eq!(plan.to_place().count(), 2);
-    assert!(plan.to_place().all(|(_, leader)| leader == "broker-b"));
+    assert!(plan.to_place().all(|(_, leader, _)| leader == "broker-b"));
 }
 
 #[test]
@@ -274,7 +294,7 @@ fn with_no_live_nodes_every_shard_says_why() {
     let streams = vec![stream("orders", 3)];
     let nodes = vec![node("broker-a", NodeLifecycle::Down, None)];
 
-    let plan = plan(&streams, &nodes, &[]);
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
     assert_eq!(plan.unplaceable().count(), 3);
     assert!(
         plan.unplaceable()
@@ -292,7 +312,7 @@ fn capacity_is_respected_and_exhaustion_is_distinguishable() {
         node("broker-b", NodeLifecycle::Live, Some(1)),
     ];
 
-    let plan = plan(&streams, &nodes, &[]);
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
     assert_eq!(plan.to_place().count(), 2, "two nodes, one shard each");
 
     let unplaceable: Vec<&Unplaceable> = plan.unplaceable().map(|(_, r)| r).collect();
@@ -319,9 +339,10 @@ fn existing_assignments_count_towards_capacity() {
             shard: 0,
         },
         "broker-a",
+        Vec::new(),
     )];
 
-    let plan = plan(&streams, &nodes, &existing);
+    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
     assert_eq!(plan.kept(), 1);
     assert_eq!(
         plan.to_place().count(),
@@ -368,7 +389,12 @@ fn scores_are_stable_across_runs() {
 
 #[test]
 fn a_stream_with_no_shards_plans_nothing() {
-    let plan = plan(&[stream("orders", 0)], &live(&["broker-a"]), &[]);
+    let plan = plan(
+        &[stream("orders", 0)],
+        &live(&["broker-a"]),
+        &[],
+        &NothingCaughtUp,
+    );
     assert!(plan.shards.is_empty());
 }
 
@@ -504,4 +530,242 @@ mod reconcile {
                 .is_empty()
         );
     }
+}
+
+/// A replicated stream gets followers, and they are not the leader.
+#[test]
+fn a_replicated_shard_is_given_followers() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, None),
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
+
+    let (_, leader, replicas) = plan.to_place().next().expect("placed");
+    assert_eq!(replicas.len(), 2, "three copies means the leader plus two");
+    assert!(
+        !replicas.contains(&leader.to_string()),
+        "the leader must not also be listed as its own follower",
+    );
+    let unique: BTreeSet<_> = replicas.iter().collect();
+    assert_eq!(
+        unique.len(),
+        replicas.len(),
+        "a node cannot hold two copies"
+    );
+}
+
+/// Fewer nodes than copies is not an error. Placement records what it achieved,
+/// because an assignment naming a node that holds nothing is the lie failover
+/// would act on.
+#[test]
+fn asking_for_more_copies_than_nodes_records_what_exists() {
+    let streams = vec![replicated_stream("orders", 1, 5)];
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, None),
+        node("broker-b", NodeLifecycle::Live, None),
+    ];
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
+
+    let (_, leader, replicas) = plan.to_place().next().expect("placed");
+    assert_eq!(replicas.len(), 1, "two nodes can hold two copies, not five");
+    assert!(!replicas.contains(&leader.to_string()));
+}
+
+/// The default is leader-only, so a stream that never asked for replication
+/// behaves exactly as it did before replication existed.
+#[test]
+fn an_unreplicated_stream_gets_no_followers() {
+    let streams = vec![stream("orders", 1)];
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, None),
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
+
+    let (_, _, replicas) = plan.to_place().next().expect("placed");
+    assert!(replicas.is_empty(), "replication_factor 1 is leader-only");
+}
+
+/// The whole replica set is a deterministic function of the shard key and the
+/// cluster, so two control-plane instances planning the same cluster agree.
+#[test]
+fn replica_selection_is_deterministic() {
+    let streams = vec![replicated_stream("orders", 4, 3)];
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, None),
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+        node("broker-d", NodeLifecycle::Live, None),
+    ];
+
+    let first: Vec<_> = plan(&streams, &nodes, &[], &NothingCaughtUp)
+        .to_place()
+        .map(|(k, l, r)| (k.clone(), l.to_string(), r.to_vec()))
+        .collect();
+
+    // Same cluster, nodes presented in a different order.
+    let mut shuffled = nodes.clone();
+    shuffled.reverse();
+    let second: Vec<_> = plan(&streams, &shuffled, &[], &NothingCaughtUp)
+        .to_place()
+        .map(|(k, l, r)| (k.clone(), l.to_string(), r.to_vec()))
+        .collect();
+
+    assert_eq!(first, second, "placement must not depend on input order");
+}
+
+/// A replica holds a copy, so it consumes capacity exactly as leadership does.
+#[test]
+fn replicas_count_against_node_capacity() {
+    let streams = vec![replicated_stream("orders", 2, 2)];
+    // Room for one copy each, of any kind.
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, Some(1)),
+        node("broker-b", NodeLifecycle::Live, Some(1)),
+    ];
+
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
+    let placed: Vec<_> = plan.to_place().collect();
+
+    // Two nodes with room for one copy each can hold one shard's leader and one
+    // follower, and nothing more.
+    let total_copies: usize = placed.iter().map(|(_, _, r)| 1 + r.len()).sum();
+    assert!(
+        total_copies <= 2,
+        "capacity was exceeded: {total_copies} copies across two single-slot nodes",
+    );
+}
+
+/// A follower that holds the log, for the promotion tests.
+struct CaughtUpNodes(BTreeSet<String>);
+
+impl CaughtUp for CaughtUpNodes {
+    fn is_caught_up(&self, _key: &ShardKey, node_id: &str) -> bool {
+        self.0.contains(node_id)
+    }
+}
+
+fn assigned(stream: &str, leader: &str, replicas: &[&str]) -> ShardAssignment {
+    ShardAssignment {
+        key: ShardKey {
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            stream: stream.to_string(),
+            shard: 0,
+        },
+        leader: leader.to_string(),
+        replicas: replicas.iter().map(|r| r.to_string()).collect(),
+        generation: 3,
+        state: ShardState::Active,
+    }
+}
+
+/// A lost leader is replaced by a follower that holds the log.
+#[test]
+fn a_caught_up_follower_is_promoted() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    // broker-a is gone.
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+    let caught_up = CaughtUpNodes(["broker-c".to_string()].into_iter().collect());
+
+    let plan = plan(&streams, &nodes, &existing, &caught_up);
+    let (_, leader, _) = plan.to_place().next().expect("placed");
+    assert_eq!(
+        leader, "broker-c",
+        "the caught-up follower must be promoted, not the other one",
+    );
+}
+
+/// **The gate.** A follower that holds nothing is not promoted, however
+/// eligible it looks: promoting it would serve an empty shard, which is the data
+/// loss a failover is supposed to prevent.
+///
+/// Asserted against a baseline with no replica set recorded, because "did not
+/// promote" and "promoted the node it would have chosen anyway" are otherwise
+/// the same outcome. Both single-node replica sets are tried, so at least one
+/// names a follower that scoring would *not* have picked — without that, the
+/// two paths coincide and the assertion proves nothing.
+#[test]
+fn a_follower_that_holds_nothing_is_not_promoted() {
+    let streams = vec![replicated_stream("orders", 1, 2)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+
+    let baseline = plan(
+        &streams,
+        &nodes,
+        &[assigned("orders", "broker-a", &[])],
+        &NothingCaughtUp,
+    );
+    let expected: Vec<_> = baseline
+        .to_place()
+        .map(|(k, l, _)| (k.clone(), l.to_string()))
+        .collect();
+
+    for replica in ["broker-b", "broker-c"] {
+        let existing = vec![assigned("orders", "broker-a", &[replica])];
+        let chosen: Vec<_> = plan(&streams, &nodes, &existing, &NothingCaughtUp)
+            .to_place()
+            .map(|(k, l, _)| (k.clone(), l.to_string()))
+            .collect();
+        assert_eq!(
+            chosen, expected,
+            "a replica ({replica}) holding nothing was promoted; with no caught-up \
+             follower, placement must ignore the replica set entirely",
+        );
+    }
+}
+
+/// A node that was never a replica is never promoted, even if it reports being
+/// caught up. Only the recorded replica set is promotable.
+#[test]
+fn only_a_recorded_replica_is_promotable() {
+    let streams = vec![replicated_stream("orders", 1, 2)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-z", NodeLifecycle::Live, None),
+    ];
+    // broker-z is not in the replica set, but claims to be caught up.
+    let existing = vec![assigned("orders", "broker-a", &["broker-b"])];
+    let caught_up = CaughtUpNodes(
+        ["broker-b".to_string(), "broker-z".to_string()]
+            .into_iter()
+            .collect(),
+    );
+
+    let plan = plan(&streams, &nodes, &existing, &caught_up);
+    let (_, leader, _) = plan.to_place().next().expect("placed");
+    assert_eq!(
+        leader, "broker-b",
+        "promotion must come from the recorded replica set",
+    );
+}
+
+/// A promoted follower is not left listed as its own follower.
+#[test]
+fn promotion_rebuilds_the_replica_set_without_the_new_leader() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+    let caught_up = CaughtUpNodes(["broker-b".to_string(), "broker-c".to_string()].into());
+
+    let plan = plan(&streams, &nodes, &existing, &caught_up);
+    let (_, leader, replicas) = plan.to_place().next().expect("placed");
+    assert!(
+        !replicas.contains(&leader.to_string()),
+        "{leader} was promoted and is still listed as a follower of itself",
+    );
 }

--- a/services/controlplane/src/store/memory.rs
+++ b/services/controlplane/src/store/memory.rs
@@ -1441,6 +1441,7 @@ mod tests {
                 stream: "orders".to_string(),
                 kind: StreamKind::Stream,
                 shards: 1,
+                replication_factor: 1,
                 retention: RetentionPolicy {
                     max_age_seconds: Some(3600),
                     max_size_bytes: None,

--- a/services/controlplane/src/store/postgres.rs
+++ b/services/controlplane/src/store/postgres.rs
@@ -94,6 +94,7 @@ struct DbStream {
     stream: String,
     kind: String,
     shards: i32,
+    replication_factor: i32,
     retention_max_age_seconds: Option<i64>,
     retention_max_size_bytes: Option<i64>,
     consistency: String,
@@ -434,7 +435,7 @@ impl ControlPlaneStore for PostgresStore {
         .await?;
 
         let streams = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
                FROM streams WHERE tenant_id = $1"#,
         )
         .bind(tenant_id)
@@ -495,6 +496,7 @@ impl ControlPlaneStore for PostgresStore {
                 stream: stream.stream,
                 kind: parse_stream_kind(&stream.kind)?,
                 shards: stream.shards as u32,
+                replication_factor: stream.replication_factor as u32,
                 retention: RetentionPolicy {
                     max_age_seconds: stream.retention_max_age_seconds.map(|v| v as u64),
                     max_size_bytes: stream.retention_max_size_bytes.map(|v| v as u64),
@@ -676,7 +678,7 @@ impl ControlPlaneStore for PostgresStore {
         });
 
         let streams = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
                FROM streams WHERE tenant_id = $1 AND namespace = $2"#,
         )
         .bind(&key.tenant_id)
@@ -737,6 +739,7 @@ impl ControlPlaneStore for PostgresStore {
                 stream: stream.stream,
                 kind: parse_stream_kind(&stream.kind)?,
                 shards: stream.shards as u32,
+                replication_factor: stream.replication_factor as u32,
                 retention: RetentionPolicy {
                     max_age_seconds: stream.retention_max_age_seconds.map(|v| v as u64),
                     max_size_bytes: stream.retention_max_size_bytes.map(|v| v as u64),
@@ -832,7 +835,7 @@ impl ControlPlaneStore for PostgresStore {
 
     async fn list_streams(&self, tenant_id: &str, namespace: &str) -> StoreResult<Vec<Stream>> {
         let rows = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
                FROM streams WHERE tenant_id = $1 AND namespace = $2 ORDER BY stream"#,
         )
         .bind(tenant_id)
@@ -847,7 +850,7 @@ impl ControlPlaneStore for PostgresStore {
 
     async fn get_stream(&self, key: &StreamKey) -> StoreResult<Stream> {
         let row = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
                FROM streams WHERE tenant_id = $1 AND namespace = $2 AND stream = $3"#,
         )
         .bind(&key.tenant_id)
@@ -877,14 +880,15 @@ impl ControlPlaneStore for PostgresStore {
         }
 
         let insert = sqlx::query(
-            r#"INSERT INTO streams (tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
+            r#"INSERT INTO streams (tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)"#,
         )
         .bind(&stream.tenant_id)
         .bind(&stream.namespace)
         .bind(&stream.stream)
         .bind(stream_kind_to_str(&stream.kind))
         .bind(stream.shards as i32)
+        .bind(stream.replication_factor as i32)
         .bind(stream.retention.max_age_seconds.map(|v| v as i64))
         .bind(stream.retention.max_size_bytes.map(|v| v as i64))
         .bind(consistency_to_str(&stream.consistency))
@@ -924,7 +928,7 @@ impl ControlPlaneStore for PostgresStore {
     ) -> StoreResult<Stream> {
         let mut tx = self.pool.begin().await?;
         let current = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable
                FROM streams WHERE tenant_id = $1 AND namespace = $2 AND stream = $3 FOR UPDATE"#,
         )
         .bind(&key.tenant_id)
@@ -953,11 +957,12 @@ impl ControlPlaneStore for PostgresStore {
         }
 
         sqlx::query(
-            r#"UPDATE streams SET kind = $1, shards = $2, retention_max_age_seconds = $3, retention_max_size_bytes = $4, consistency = $5, delivery = $6, durable = $7, updated_at = now()
-                WHERE tenant_id = $8 AND namespace = $9 AND stream = $10"#,
+            r#"UPDATE streams SET kind = $1, shards = $2, replication_factor = $3, retention_max_age_seconds = $4, retention_max_size_bytes = $5, consistency = $6, delivery = $7, durable = $8, updated_at = now()
+                WHERE tenant_id = $9 AND namespace = $10 AND stream = $11"#,
         )
         .bind(stream_kind_to_str(&updated.kind))
         .bind(updated.shards as i32)
+        .bind(updated.replication_factor as i32)
         .bind(updated.retention.max_age_seconds.map(|v| v as i64))
         .bind(updated.retention.max_size_bytes.map(|v| v as i64))
         .bind(consistency_to_str(&updated.consistency))
@@ -1021,7 +1026,7 @@ impl ControlPlaneStore for PostgresStore {
 
     async fn stream_snapshot(&self) -> StoreResult<Snapshot<Stream>> {
         let rows = sqlx::query_as::<_, DbStream>(
-            r#"SELECT tenant_id, namespace, stream, kind, shards, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable FROM streams ORDER BY tenant_id, namespace, stream"#,
+            r#"SELECT tenant_id, namespace, stream, kind, shards, replication_factor, retention_max_age_seconds, retention_max_size_bytes, consistency, delivery, durable FROM streams ORDER BY tenant_id, namespace, stream"#,
         )
         .fetch_all(&self.pool)
         .await
@@ -2184,6 +2189,7 @@ fn stream_from_db(row: DbStream) -> StoreResult<Stream> {
         stream: row.stream,
         kind: parse_stream_kind(&row.kind)?,
         shards: row.shards as u32,
+        replication_factor: 1,
         retention: RetentionPolicy {
             max_age_seconds: row.retention_max_age_seconds.map(|v| v as u64),
             max_size_bytes: row.retention_max_size_bytes.map(|v| v as u64),
@@ -2658,6 +2664,7 @@ mod tests {
             stream: "s1".to_string(),
             kind: "Stream".to_string(),
             shards: 2,
+            replication_factor: 1,
             retention_max_age_seconds: Some(3600),
             retention_max_size_bytes: Some(2048),
             consistency: "Leader".to_string(),

--- a/services/controlplane/src/store/postgres_tests.rs
+++ b/services/controlplane/src/store/postgres_tests.rs
@@ -511,6 +511,7 @@ async fn postgres_store_full_roundtrip() -> anyhow::Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,

--- a/services/controlplane/src/store/shard_contract.rs
+++ b/services/controlplane/src/store/shard_contract.rs
@@ -59,6 +59,7 @@ async fn seed(store: &dyn ControlPlaneStore) {
             stream: STREAM.to_string(),
             kind: StreamKind::Stream,
             shards: SHARDS,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,

--- a/services/controlplane/tests/node_admin_api.rs
+++ b/services/controlplane/tests/node_admin_api.rs
@@ -362,6 +362,7 @@ async fn seed_shards(store: &InMemoryStore) {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 3,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,

--- a/services/controlplane/tests/pg_store.rs
+++ b/services/controlplane/tests/pg_store.rs
@@ -188,6 +188,7 @@ async fn pg_stream_sequences_monotonic() {
         stream: "orders".to_string(),
         kind: StreamKind::Stream,
         shards: 1,
+        replication_factor: 1,
         retention: RetentionPolicy {
             max_age_seconds: Some(3600),
             max_size_bytes: None,
@@ -266,6 +267,7 @@ async fn pg_delete_namespace_emits_cascades() {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -531,6 +533,7 @@ async fn pg_store_stream_conflict_and_not_found() {
             stream: "updates".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -549,6 +552,7 @@ async fn pg_store_stream_conflict_and_not_found() {
         stream: "updates".to_string(),
         kind: StreamKind::Stream,
         shards: 1,
+        replication_factor: 1,
         retention: RetentionPolicy {
             max_age_seconds: None,
             max_size_bytes: None,
@@ -725,6 +729,7 @@ async fn pg_store_list_get_and_exists_roundtrip() {
             stream: "updates".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -845,6 +850,7 @@ async fn pg_delete_tenant_emits_stream_retention_max_size() {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(60),
                 max_size_bytes: Some(4096),

--- a/services/controlplane/tests/pg_store_e2e.rs
+++ b/services/controlplane/tests/pg_store_e2e.rs
@@ -508,6 +508,7 @@ async fn pg_store_core_crud_and_auth() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,
@@ -524,6 +525,7 @@ async fn pg_store_core_crud_and_auth() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,
@@ -841,6 +843,7 @@ async fn pg_store_additional_paths() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -1017,6 +1020,7 @@ async fn pg_store_list_and_change_roundtrip() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 2,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: Some(1024),
@@ -1033,6 +1037,7 @@ async fn pg_store_list_and_change_roundtrip() -> Result<()> {
             stream: "events".to_string(),
             kind: StreamKind::Queue,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -1164,6 +1169,7 @@ async fn pg_store_not_found_and_noop_paths() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: None,
                 max_size_bytes: None,
@@ -1278,6 +1284,7 @@ async fn pg_store_delete_tenant_with_dependents() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,
@@ -1422,6 +1429,7 @@ async fn pg_store_full_surface_area() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,
@@ -1708,6 +1716,7 @@ async fn pg_changes_monotonic_and_delete_not_found() -> Result<()> {
             stream: "orders".to_string(),
             kind: StreamKind::Stream,
             shards: 1,
+            replication_factor: 1,
             retention: RetentionPolicy {
                 max_age_seconds: Some(3600),
                 max_size_bytes: None,


### PR DESCRIPTION
Closes #111. Also closes #239. Implements the leadership half of the design in #110.

## Leases, and the fence

A broker may serve only while it holds an unexpired lease, and **the lease is the heartbeat it already sends**. No new protocol: the control plane grants by keeping the node live, the broker renews by heartbeating, and the duration is the control plane's own expiry window taken from the heartbeat response — the same rule the interval already follows. Measured on the broker's own monotonic clock, so the two ends never compare wall clocks.

**Checked twice, and the two checks are not the same:**

- **Admission** reads one atomic and may lag a refresh. It sheds early on a path that prides itself on costing two atomic loads.
- **Commit** reads the clock immediately before the write. It is authoritative, and it is why a process suspended past its expiry cannot write on waking: the cached flag still says yes and the clock does not.

**The safety interval already existed.** The broker surrenders a quarter of the lease as margin, so it stops at 0.75× the expiry window while the control plane will not reassign before the full window — and the broker's window starts later, since it records success on *receipt*. No new control-plane code; worth stating rather than building.

**This closes #239.** A stale ex-owner is a broker whose lease has lapsed, and it refuses rather than racing its watch.

## Replica sets are real

`Stream.replication_factor` defaults to 1, so a stream that never asked for replication is leader-only exactly as before, and rows written before the column existed read back that way. Followers are the next best-scoring nodes, chosen by the same function as leadership, so the whole set is deterministic — two control-plane instances agree. A replica holds a copy, so it counts against `max_shards`.

Fewer nodes than copies is recorded rather than refused: an assignment naming a node that holds nothing is the lie failover would act on.

## The promotion gate is the important part

Promotion prefers a follower when the leader is gone — **gated on that follower being caught up**. A replica holding no log can be promoted perfectly well and will then serve an empty shard: the failover *is* the data loss.

Nothing reports being caught up until records are replicated (#112), so promotion does not fire today and placement behaves as it did. The gate starts permitting failover the moment replication starts working, and not before. That is deliberate, not dead code.

## Tests, and two I had to fix

Deterministic throughout: `LeaseState` reads `tokio::time::Instant`, so expiry is driven by advancing a paused clock rather than sleeping.

That immediately found a real defect — `0` was both my "never renewed" sentinel and a genuine renewal in the process's first millisecond. With a real clock that is a 1ms startup window; paused, it is every time.

Per CLAUDE.md I reverted each mechanism and watched its test fail:

- Both fences disabled → the end-to-end test fails with *"kept accepting writes after it could no longer renew its lease"*.
- Catch-up gate removed → both promotion tests fail.

**One of those promotion tests initially did not fail**, and I want to flag why: promotion and ordinary placement pick by the same score over the same candidates, so with the gate removed they coincided and the assertion proved nothing. It now asserts against a no-replica baseline across *both* single-node replica sets, so at least one names a follower scoring would not have chosen.

## Harness

`Cluster::stop_control_plane` is a fault primitive #115 needs. It **aborts rather than drains**: a graceful shutdown keeps serving the keep-alive connections brokers already hold, so their heartbeats go on succeeding and the control plane is not gone in any sense a broker can detect. That cost me a debugging cycle and is now commented.

## Verification

`task lint`, `task test`, `task demo:check`, `task publish:check`, mermaid — all clean. Includes a Postgres migration (`0007`), where shifting the binds also required fixing the `UPDATE`/`INSERT` placeholder numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)