### PR TITLE
feat(cluster): drive the cluster by hand from a second terminal

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,6 +224,15 @@ tasks:
     cmds:
       - cargo build -p broker --bin felix-broker
       - cargo run -p felix-cluster -- smoke {{.CLI_ARGS}}
+  cluster:subscribe:
+    desc: Stream events from a running cluster (start one with cluster:up).
+    cmds: ["cargo run -q -p felix-cluster -- subscribe {{.CLI_ARGS}}"]
+  cluster:publish:
+    desc: Publish to a running cluster, through a broker that does not own the shard.
+    cmds: ["cargo run -q -p felix-cluster -- publish {{.CLI_ARGS}}"]
+  cluster:owners:
+    desc: Who leads each shard of a running cluster.
+    cmds: ["cargo run -q -p felix-cluster -- owners"]
   cluster:test:
     desc: Cross-broker integration tests against a real three-node cluster.
     cmds: ["cargo test -p felix-cluster"]

--- a/crates/felix-cluster/src/bin/felix-cluster.rs
+++ b/crates/felix-cluster/src/bin/felix-cluster.rs
@@ -1,81 +1,412 @@
-//! Start a local Felix cluster and inspect it.
+//! Start a local Felix cluster, and talk to it from another terminal.
 //!
 //! ```text
-//! cargo run -p felix-cluster -- up       # start, print addresses, hold until Ctrl-C
-//! cargo run -p felix-cluster -- status   # start, print membership and ownership, exit
-//! cargo run -p felix-cluster -- smoke    # publish through a non-owner, receive from the owner
+//! # window 1
+//! task cluster:up
+//!
+//! # window 2
+//! task cluster:subscribe
+//!
+//! # window 3
+//! task cluster:publish -- hello
 //! ```
 //!
-//! `--nodes N` sets the cluster size (default 3).
+//! `up` writes the addresses and a credential to a session file so the other
+//! commands need nothing copied into them.
+//!
+//! Every line names the broker it went through and whether the record crossed a
+//! node boundary, because that is the only part of this a cluster does
+//! differently from a single broker.
 use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
+use felix_cluster::session::{self, Session};
 use felix_cluster::{Cluster, ClusterConfig};
 
 const STREAM: &str = "orders";
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .init();
-
     let args: Vec<String> = std::env::args().skip(1).collect();
     let command = args.first().map(String::as_str).unwrap_or("up");
-    let nodes = parse_nodes(&args)?;
-
-    let config = ClusterConfig {
-        nodes,
-        streams: vec![(STREAM.to_string(), 1)],
-        // A cluster a person started should say what it is doing.
-        inherit_output: command == "up" || std::env::var("FELIX_CLUSTER_VERBOSE").is_ok(),
-        ..Default::default()
-    };
-
-    eprintln!("starting a {nodes}-node cluster...");
-    let mut cluster = Cluster::start(config).await?;
-    eprintln!("cluster up.\n");
-    print_topology(&cluster).await?;
 
     match command {
-        "up" => {
-            eprintln!("\nholding the cluster. press Ctrl-C to tear it down.");
-            tokio::signal::ctrl_c().await.context("wait for Ctrl-C")?;
-            eprintln!("\ntearing down...");
+        "up" => up(&args).await,
+        "status" => status(&args).await,
+        "smoke" => smoke_command(&args).await,
+        "subscribe" => subscribe(&args).await,
+        "publish" => publish(&args).await,
+        "owners" => owners().await,
+        "help" | "--help" | "-h" => {
+            print_help();
+            Ok(())
         }
-        "status" => {}
-        "smoke" => smoke(&mut cluster).await?,
-        other => bail!("unknown command {other}; expected up, status, or smoke"),
+        other => {
+            print_help();
+            bail!("unknown command {other}")
+        }
     }
+}
 
+fn print_help() {
+    eprintln!(
+        "\
+felix-cluster — a local multi-node Felix cluster
+
+  up [--nodes N]            start a cluster and hold it until Ctrl-C
+  status [--nodes N]        start, print membership and ownership, exit
+  smoke [--nodes N]         publish through a non-owner, receive from the owner
+  owners                    who leads each shard of a running cluster
+  subscribe [--on NODE]     stream events from a running cluster
+  publish [--via NODE] MSG  publish to a running cluster
+
+`up` first; the rest attach to it."
+    );
+}
+
+// ---------------------------------------------------------------- lifecycle
+
+async fn up(args: &[String]) -> Result<()> {
+    init_tracing(true);
+    let nodes = flag_usize(args, "--nodes")?.unwrap_or(3);
+    eprintln!("starting a {nodes}-node cluster...");
+    let cluster = Cluster::start(cluster_config(nodes, true)).await?;
+
+    let path = session::default_path();
+    cluster.session().write(&path)?;
+
+    eprintln!("\ncluster up.\n");
+    print_topology(&cluster).await?;
+    println!("\nsession   {}", path.display());
+    println!("\n  felix-cluster subscribe        # in another window");
+    println!("  felix-cluster publish hello    # in a third");
+    eprintln!("\nholding the cluster. press Ctrl-C to tear it down.");
+
+    stop_signal().await?;
+    eprintln!("\ntearing down...");
+    let _ = std::fs::remove_file(&path);
     cluster.shutdown().await;
     Ok(())
 }
 
-fn parse_nodes(args: &[String]) -> Result<usize> {
-    match args.iter().position(|arg| arg == "--nodes") {
-        Some(index) => args
-            .get(index + 1)
-            .ok_or_else(|| anyhow::anyhow!("--nodes needs a value"))?
-            .parse()
-            .context("parse --nodes"),
-        None => Ok(3),
+async fn status(args: &[String]) -> Result<()> {
+    init_tracing(false);
+    let nodes = flag_usize(args, "--nodes")?.unwrap_or(3);
+    let cluster = Cluster::start(cluster_config(nodes, false)).await?;
+    print_topology(&cluster).await?;
+    cluster.shutdown().await;
+    Ok(())
+}
+
+async fn smoke_command(args: &[String]) -> Result<()> {
+    init_tracing(false);
+    let nodes = flag_usize(args, "--nodes")?.unwrap_or(3);
+    let mut cluster = Cluster::start(cluster_config(nodes, false)).await?;
+    print_topology(&cluster).await?;
+    let result = smoke(&mut cluster).await;
+    cluster.shutdown().await;
+    result
+}
+
+// ------------------------------------------------------------- attaching
+
+/// Who leads each shard, read from a running cluster.
+async fn owners() -> Result<()> {
+    let session = Session::read(&session::default_path())?;
+    let owners = shard_owners(&session).await?;
+    let mut rows: Vec<_> = owners.into_iter().collect();
+    rows.sort();
+    for (shard, leader) in rows {
+        println!("{shard} -> {leader}");
     }
+    Ok(())
+}
+
+/// Stream events until interrupted.
+async fn subscribe(args: &[String]) -> Result<()> {
+    init_tracing(false);
+    let session = Session::read(&session::default_path())?;
+    let stream = flag(args, "--stream")?.unwrap_or_else(|| STREAM.to_string());
+
+    // Defaults to the owner, because that is the only broker that serves a
+    // subscription today -- a non-owner has no copy to read from, and routing a
+    // subscribe is M6 (see docs/subscribe-routing.md).
+    let owner = owner_of(&session, &stream).await?;
+    let node_id = flag(args, "--on")?.unwrap_or_else(|| owner.clone());
+    let node = session
+        .node(&node_id)
+        .with_context(|| format!("unknown node {node_id}"))?;
+
+    let role = if node_id == owner {
+        "owner"
+    } else {
+        "NOT the owner"
+    };
+    println!("subscribing to {stream} on {node_id} ({role})");
+    if node_id != owner {
+        println!(
+            "  note: {node_id} does not own this shard, so it has nothing to deliver.\n\
+             \x20       subscribe routing is M6; see docs/subscribe-routing.md."
+        );
+    }
+    println!("waiting for events. Ctrl-C to stop.\n");
+
+    let client =
+        felix_cluster::client::connect(node.client_addr, &session.tenant_id, &session.client_token)
+            .await?;
+    let mut subscription = client
+        .subscribe(&session.tenant_id, &session.namespace, &stream)
+        .await
+        .context("subscribe")?;
+
+    loop {
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {
+                println!("\nstopped.");
+                return Ok(());
+            }
+            event = subscription.next_event() => {
+                match event.context("subscription failed")? {
+                    Some(event) => {
+                        let offset = event
+                            .offset
+                            .map(|o| o.to_string())
+                            .unwrap_or_else(|| "-".to_string());
+                        println!(
+                            "[{node_id}] offset {offset:>6}  {}",
+                            String::from_utf8_lossy(&event.payload),
+                        );
+                    }
+                    None => {
+                        println!("\nsubscription closed by the broker.");
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Publish one message, and say whether it crossed a node boundary.
+async fn publish(args: &[String]) -> Result<()> {
+    init_tracing(false);
+    let session = Session::read(&session::default_path())?;
+    let stream = flag(args, "--stream")?.unwrap_or_else(|| STREAM.to_string());
+    let message = positional(args).unwrap_or_else(|| "hello".to_string());
+
+    let owner = owner_of(&session, &stream).await?;
+    // Defaults to a broker that does *not* own the shard, because that is the
+    // interesting path: it is the one a single-node broker cannot show.
+    let node_id = match flag(args, "--via")? {
+        Some(explicit) => explicit,
+        None => session
+            .nodes
+            .iter()
+            .map(|node| node.node_id.clone())
+            .find(|id| id != &owner)
+            .unwrap_or_else(|| owner.clone()),
+    };
+    let node = session
+        .node(&node_id)
+        .with_context(|| format!("unknown node {node_id}"))?;
+
+    let before = forwards(&session, &node_id).await;
+    let client =
+        felix_cluster::client::connect(node.client_addr, &session.tenant_id, &session.client_token)
+            .await?;
+    let publisher = client.publisher().await.context("open publisher")?;
+    publisher
+        .publish(
+            &session.tenant_id,
+            &session.namespace,
+            &stream,
+            message.clone().into_bytes(),
+            felix_wire::AckMode::PerMessage,
+        )
+        .await
+        .with_context(|| format!("publish via {node_id}"))?;
+    let after = forwards(&session, &node_id).await;
+
+    // The acknowledgement already proves it was written. What a cluster adds is
+    // *where*, and the forward counter is how that is visible from outside.
+    if node_id == owner {
+        println!("published via {node_id} (the owner) — written locally, no hop");
+    } else if after > before {
+        println!("published via {node_id} → forwarded to {owner} → acknowledged");
+    } else {
+        println!(
+            "published via {node_id}, but it did not forward — it served a shard owned \
+             by {owner} locally"
+        );
+    }
+    Ok(())
+}
+
+/// Wait for Ctrl-C, or for a `kill`.
+///
+/// Both, because the brokers are child processes: this process dying without
+/// running its teardown orphans three of them, each holding a port and a data
+/// directory. SIGINT alone leaves `kill` and most process supervisors doing
+/// exactly that.
+#[cfg(unix)]
+async fn stop_signal() -> Result<()> {
+    use tokio::signal::unix::{SignalKind, signal};
+    let mut term = signal(SignalKind::terminate()).context("listen for SIGTERM")?;
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => result.context("wait for Ctrl-C")?,
+        _ = term.recv() => {}
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn stop_signal() -> Result<()> {
+    tokio::signal::ctrl_c().await.context("wait for Ctrl-C")
+}
+
+// ---------------------------------------------------------------- helpers
+
+fn cluster_config(nodes: usize, inherit_output: bool) -> ClusterConfig {
+    ClusterConfig {
+        nodes,
+        streams: vec![(STREAM.to_string(), 1)],
+        inherit_output: inherit_output && std::env::var("FELIX_CLUSTER_VERBOSE").is_ok(),
+        ..Default::default()
+    }
+}
+
+fn init_tracing(verbose: bool) {
+    let default = if verbose { "info" } else { "warn" };
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default)),
+        )
+        .try_init();
+}
+
+fn flag(args: &[String], name: &str) -> Result<Option<String>> {
+    match args.iter().position(|arg| arg == name) {
+        Some(index) => Ok(Some(
+            args.get(index + 1)
+                .cloned()
+                .with_context(|| format!("{name} needs a value"))?,
+        )),
+        None => Ok(None),
+    }
+}
+
+fn flag_usize(args: &[String], name: &str) -> Result<Option<usize>> {
+    match flag(args, name)? {
+        Some(value) => Ok(Some(
+            value.parse().with_context(|| format!("parse {name}"))?,
+        )),
+        None => Ok(None),
+    }
+}
+
+/// The first argument that is neither the subcommand nor a flag or its value.
+fn positional(args: &[String]) -> Option<String> {
+    let mut skip_next = false;
+    for arg in args.iter().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if arg.starts_with("--") {
+            skip_next = true;
+            continue;
+        }
+        return Some(arg.clone());
+    }
+    None
+}
+
+async fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .no_proxy()
+        .build()
+        .expect("build HTTP client")
+}
+
+async fn shard_owners(session: &Session) -> Result<std::collections::HashMap<String, String>> {
+    #[derive(serde::Deserialize)]
+    struct Response {
+        items: Vec<Row>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Row {
+        tenant_id: String,
+        namespace: String,
+        stream: String,
+        shard: u32,
+        leader: String,
+    }
+
+    let url = format!("{}/v1/shard-assignments", session.control_plane);
+    let response = http()
+        .await
+        .get(&url)
+        .bearer_auth(&session.admin_token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        bail!("GET {url}: {status}");
+    }
+    let response: Response = response.json().await.context("decode assignments")?;
+    Ok(response
+        .items
+        .into_iter()
+        .map(|row| {
+            (
+                format!(
+                    "{}/{}/{}/{}",
+                    row.tenant_id, row.namespace, row.stream, row.shard
+                ),
+                row.leader,
+            )
+        })
+        .collect())
+}
+
+async fn owner_of(session: &Session, stream: &str) -> Result<String> {
+    let key = format!("{}/{}/{}/0", session.tenant_id, session.namespace, stream);
+    shard_owners(session)
+        .await?
+        .remove(&key)
+        .with_context(|| format!("no owner for {key}"))
+}
+
+/// The broker's forward counter, or 0 if it has never forwarded.
+async fn forwards(session: &Session, node_id: &str) -> f64 {
+    let Some(node) = session.node(node_id) else {
+        return 0.0;
+    };
+    let url = format!("http://{}/metrics", node.metrics_addr);
+    let Ok(response) = http().await.get(&url).send().await else {
+        return 0.0;
+    };
+    let Ok(body) = response.text().await else {
+        return 0.0;
+    };
+    body.lines()
+        .filter(|line| line.starts_with("felix_broker_forwards_total"))
+        .filter_map(|line| line.rsplit(' ').next()?.parse::<f64>().ok())
+        .sum()
 }
 
 async fn print_topology(cluster: &Cluster) -> Result<()> {
     println!("control plane   {}", cluster.control_plane_url());
     println!();
-    println!("{:<10} {:<22} {:<22} metrics", "node", "client", "internal");
+    println!("{:<10} {:<22} metrics", "node", "client");
     for node in &cluster.nodes {
         println!(
-            "{:<10} {:<22} {:<22} {}",
+            "{:<10} {:<22} {}",
             node.node_id,
             node.client_addr.to_string(),
-            node.internal_addr.to_string(),
             node.metrics_addr,
         );
     }
@@ -103,9 +434,6 @@ async fn smoke(cluster: &mut Cluster) -> Result<()> {
         .publish_via(&non_owner, STREAM, payload.clone())
         .await?;
 
-    // Assert the publish actually crossed a node boundary before waiting on
-    // delivery. Without this a local write on the wrong broker looks identical
-    // to a delivery that is merely slow.
     let forwarded = cluster
         .metric(&non_owner, "felix_broker_forwards_total")
         .await?;

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -24,6 +24,7 @@ pub mod client;
 pub mod controlplane;
 pub mod ports;
 pub mod scenarios;
+pub mod session;
 pub mod wait;
 
 use std::collections::HashMap;
@@ -526,6 +527,26 @@ impl Cluster {
                 )
             })
             .collect())
+    }
+
+    /// Everything another process needs to talk to this cluster.
+    pub fn session(&self) -> session::Session {
+        session::Session {
+            control_plane: self.control_plane_url().to_string(),
+            tenant_id: self.tenant_id.clone(),
+            namespace: self.namespace.clone(),
+            client_token: self.client_token.clone(),
+            admin_token: self.admin_token.clone(),
+            nodes: self
+                .nodes
+                .iter()
+                .map(|node| session::SessionNode {
+                    node_id: node.node_id.clone(),
+                    client_addr: node.client_addr,
+                    metrics_addr: node.metrics_addr,
+                })
+                .collect(),
+        }
     }
 
     /// The node that owns `stream`'s shard 0.

--- a/crates/felix-cluster/src/session.rs
+++ b/crates/felix-cluster/src/session.rs
@@ -1,0 +1,81 @@
+//! How a second terminal finds a running cluster.
+//!
+//! `felix-cluster up` holds a cluster in one process. Everything it needs to be
+//! talked to — the broker addresses and a credential — lives in that process and
+//! nowhere else, so a `publish` or `subscribe` in another window has nothing to
+//! connect to. This writes it down.
+//!
+//! **The file contains a bearer token**, so it is written with owner-only
+//! permissions and lives in the temp directory. It is a local development
+//! harness whose brokers listen on loopback with dev certificates; the token is
+//! no more sensitive than the cluster it opens, and that cluster disappears when
+//! the process does.
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// A running cluster, as another process needs to see it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Session {
+    pub control_plane: String,
+    pub tenant_id: String,
+    pub namespace: String,
+    /// Publishes and subscribes. Stream permissions only.
+    pub client_token: String,
+    /// Reads membership and shard ownership, so a client can say which broker
+    /// owns what.
+    pub admin_token: String,
+    pub nodes: Vec<SessionNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionNode {
+    pub node_id: String,
+    pub client_addr: SocketAddr,
+    pub metrics_addr: SocketAddr,
+}
+
+/// Where `up` leaves the file and the other commands look for it.
+///
+/// A fixed path, so a second window needs nothing copied into it.
+pub fn default_path() -> PathBuf {
+    std::env::temp_dir().join("felix-cluster.json")
+}
+
+impl Session {
+    pub fn write(&self, path: &Path) -> Result<()> {
+        let body = serde_json::to_vec_pretty(self).context("encode session")?;
+        std::fs::write(path, body).with_context(|| format!("write {}", path.display()))?;
+        restrict(path)?;
+        Ok(())
+    }
+
+    pub fn read(path: &Path) -> Result<Self> {
+        let body = std::fs::read(path).with_context(|| {
+            format!(
+                "no cluster session at {} -- start one with `task cluster:up`",
+                path.display()
+            )
+        })?;
+        serde_json::from_slice(&body).context("decode session")
+    }
+
+    pub fn node(&self, node_id: &str) -> Option<&SessionNode> {
+        self.nodes.iter().find(|node| node.node_id == node_id)
+    }
+}
+
+/// Owner-only, because the file holds a bearer token.
+#[cfg(unix)]
+fn restrict(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("restrict {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn restrict(_path: &Path) -> Result<()> {
+    Ok(())
+}

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -12,6 +12,52 @@ task cluster:test     # the cross-broker integration tests
 `-- --nodes 5` sets the size. Nothing else is required: no compose file, no
 images, no ports to reserve, and no state left behind.
 
+## Driving it by hand
+
+`up` writes a session file — the broker addresses and a credential — so a second
+terminal has something to attach to. The other commands find it themselves.
+
+```bash
+# window 1
+task cluster:up
+
+# window 2
+task cluster:subscribe
+
+# window 3
+task cluster:publish -- hello
+```
+
+```text
+# window 2
+subscribing to orders on broker-2 (owner)
+[broker-2] offset      1  hello
+
+# window 3
+published via broker-0 → forwarded to broker-2 → acknowledged
+```
+
+That second line is the whole point of a cluster, and it is why the commands say
+which broker they went through. A single broker produces the same records; only
+the routing differs, so the routing is what the output shows.
+
+`publish` defaults to a broker that does **not** own the shard, because that is
+the path a single-node deployment cannot demonstrate. `--via broker-2` (the
+owner) prints `written locally, no hop` instead.
+
+`subscribe` defaults to the owner, because the owner is the only broker that
+serves a subscription today. `--on` a different broker is allowed and says
+plainly that nothing will arrive — subscribe routing is M6, decided in
+[subscribe routing](subscribe-routing.md).
+
+`task cluster:owners` prints who leads what, which is worth having on screen
+before publishing: the owner is chosen by rendezvous hash, so it differs between
+runs.
+
+The session file holds a bearer token. It is written owner-only into the temp
+directory and removed on teardown; the cluster it opens is loopback-only with dev
+certificates, and disappears with the process.
+
 ## What is real, and what is not
 
 **Brokers are real processes.** Each gets its own client-facing QUIC port,


### PR DESCRIPTION
Adds the interactive demo flow — a cluster you can drive from separate terminals and record.

## The flow

```bash
# window 1
task cluster:up

# window 2
task cluster:subscribe

# window 3
task cluster:publish -- hello
```

```text
# window 2
subscribing to orders on broker-2 (owner)
[broker-2] offset      1  hello

# window 3
published via broker-0 → forwarded to broker-2 → acknowledged
```

## Why it didn't work before

Two gaps, both mine: there was no `publish`/`subscribe` subcommand, and the credential never left the process. Brokers require a Felix token minted by the in-process control plane against a key generated at startup, so nothing outside could authenticate. `up` now writes a session file — addresses plus token — and the other commands find it themselves, so nothing has to be copied between windows.

## The output is the point

Every line names the broker it went through and whether the record crossed a node boundary. That is the **only** thing a cluster does differently from a single broker — the records are identical, the routing isn't — so the routing is what gets printed.

- `publish` defaults to a broker that does **not** own the shard, because that is the path a single-node deployment cannot demonstrate. `--via <owner>` prints `written locally, no hop`.
- `subscribe` defaults to the owner, because the owner is the only broker that serves a subscription today. Pointing it at another broker is allowed and says plainly that nothing will arrive, rather than appearing to hang — subscribe routing is M6 (#107).
- `task cluster:owners` prints who leads what, worth having on screen first since the owner is chosen by rendezvous hash and differs between runs.

## A real bug found while testing

`up` handled Ctrl-C but not SIGTERM. The brokers are child processes, so the process dying without running its teardown orphans three of them, each holding a port and a data directory — which is what `kill`, and most process supervisors, do.

Verified both ways from a clean baseline: without the handler a plain `kill` leaves all three behind; with it, 0 → 3 → 0 and the session file is removed.

I'll note I got there messily — my first process counts were wrong twice (the shell command line matched my own `grep`, and `pgrep -c` isn't a count flag on macOS), so I briefly reported orphans that weren't there and then a clean result that wasn't either. The numbers above are from a corrected counter.

## Security note

The session file holds a bearer token, so it is written owner-only into the temp directory and removed on teardown. The cluster it opens is loopback-only with dev certificates and disappears with the process.

`docs/cluster-harness.md` gains a "Driving it by hand" section with the recording flow.

`task lint`, `task test`, `task publish:check` clean; no leftover processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)