### PR TITLE
feat(cluster): drive the whole demo automatically, in one pane or three

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -230,6 +230,11 @@ tasks:
   cluster:publish:
     desc: Publish to a running cluster, through a broker that does not own the shard.
     cmds: ["cargo run -q -p felix-cluster -- publish {{.CLI_ARGS}}"]
+  cluster:demo:
+    desc: Run the whole cross-broker demo in one pane, start to finish.
+    cmds:
+      - cargo build -p broker --bin felix-broker
+      - cargo run -q -p felix-cluster -- demo {{.CLI_ARGS}}
   cluster:burst:
     desc: Publish a burst of messages to a running cluster, across every broker.
     cmds: ["scripts/cluster-publish-loop.sh"]

--- a/crates/felix-cluster/src/bin/felix-cluster.rs
+++ b/crates/felix-cluster/src/bin/felix-cluster.rs
@@ -34,6 +34,7 @@ async fn main() -> Result<()> {
         "up" => up(&args).await,
         "status" => status(&args).await,
         "smoke" => smoke_command(&args).await,
+        "demo" => demo(&args).await,
         "subscribe" => subscribe(&args).await,
         "publish" => publish(&args).await,
         "owners" => owners().await,
@@ -54,9 +55,10 @@ fn print_help() {
         "\
 felix-cluster — a local multi-node Felix cluster
 
-  up [--nodes N]            start a cluster and hold it until Ctrl-C
-  status [--nodes N]        start, print membership and ownership, exit
-  smoke [--nodes N]         publish through a non-owner, receive from the owner
+  up [--nodes N]                  start a cluster and hold it until Ctrl-C
+  status [--nodes N]              start, print membership and ownership, exit
+  smoke [--nodes N]               publish through a non-owner, receive from the owner
+  demo [--pace SECONDS]           the whole cross-broker story, start to finish
   nodes                           every broker in a running cluster, one per line
   owners                          who leads each shard of a running cluster
   subscribe STREAM [--on NODE]    stream events from a running cluster
@@ -120,6 +122,144 @@ async fn smoke_command(args: &[String]) -> Result<()> {
     let result = smoke(&mut cluster).await;
     cluster.shutdown().await;
     result
+}
+
+/// The whole demonstration, driven end to end in one terminal.
+///
+/// The three-panel version reads better, but it needs three windows and someone
+/// typing in them. This does the same story in one pane: the publisher's lines
+/// are flush left, and records arriving at the subscriber are indented with an
+/// arrow, so a viewer can still tell the two apart.
+///
+/// `--pace` is the gap between steps. Long enough to narrate over by default;
+/// `--pace 0` runs it flat out, which is what a test wants.
+async fn demo(args: &[String]) -> Result<()> {
+    init_tracing(false);
+    let nodes = flag_usize(args, "--nodes")?.unwrap_or(3);
+    let pace = Duration::from_millis(
+        (flag(args, "--pace")?
+            .map(|value| value.parse::<f64>())
+            .transpose()
+            .context("parse --pace")?
+            .unwrap_or(2.5)
+            * 1000.0) as u64,
+    );
+
+    step("Starting a three-node cluster");
+    println!("  Three brokers, each its own process, port, identity and data directory.");
+    let cluster = Cluster::start(cluster_config(nodes, false)).await?;
+    println!("  Ready — every broker registered, every shard assigned, a publish accepted.\n");
+    beat(pace).await;
+
+    step("Who owns what");
+    for node in &cluster.nodes {
+        println!("  {:<10} {}", node.node_id, node.client_addr);
+    }
+    let owner = cluster.owner(STREAM).await?;
+    println!();
+    for (shard, leader) in sorted(cluster.shard_owners().await?) {
+        println!("  {shard} -> {leader}");
+    }
+    println!("\n  {owner} leads the shard. The other brokers do not hold it at all,");
+    println!("  and nothing configured that — placement hashes the shard key.");
+    beat(pace).await;
+
+    step(&format!("Subscribing on {owner}"));
+    let (_client, subscription) = cluster.subscribe_on(&owner, STREAM).await?;
+    // Events print as they arrive, indented, so they read as a separate voice
+    // from the publisher's lines.
+    let reader = tokio::spawn(async move {
+        let mut subscription = subscription;
+        while let Ok(Some(event)) = subscription.next_event().await {
+            let offset = event
+                .offset
+                .map(|o| o.to_string())
+                .unwrap_or_else(|| "-".to_string());
+            println!(
+                "      ← [subscriber] offset {offset:>4}  {}",
+                String::from_utf8_lossy(&event.payload),
+            );
+        }
+    });
+    println!("  Attached. Nothing published yet.");
+    beat(pace).await;
+
+    let others: Vec<String> = cluster
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .filter(|id| id != &owner)
+        .collect();
+    let non_owner = others.first().cloned().unwrap_or_else(|| owner.clone());
+
+    step(&format!(
+        "Publishing through {non_owner}, which does not own the shard"
+    ));
+    let before = forward_count(&cluster, &non_owner).await;
+    cluster
+        .publish_via(&non_owner, STREAM, b"hello".to_vec())
+        .await?;
+    let after = forward_count(&cluster, &non_owner).await;
+    if after > before {
+        println!("  published \"hello\" via {non_owner} → forwarded to {owner} → acknowledged");
+    } else {
+        bail!("{non_owner} did not forward — it served a shard owned by {owner} locally");
+    }
+    beat(pace).await;
+
+    step(&format!("The same publish, through {owner}, which does"));
+    cluster
+        .publish_via(&owner, STREAM, b"direct".to_vec())
+        .await?;
+    println!("  published \"direct\" via {owner} (the owner) — written locally, no hop");
+    println!("\n  Same client, same call. The hop happens only when it has to.");
+    beat(pace).await;
+
+    step("A burst across every broker");
+    for index in 1..=9u32 {
+        let via = &cluster.nodes[(index as usize - 1) % cluster.nodes.len()].node_id;
+        cluster
+            .publish_via(via, STREAM, format!("msg-{index:03}").into_bytes())
+            .await?;
+    }
+    println!(
+        "  Nine records, round-robin across all {} brokers.",
+        cluster.nodes.len()
+    );
+    // Let the last deliveries land before the closing line.
+    tokio::time::sleep(Duration::from_millis(600)).await;
+    beat(pace).await;
+
+    step("Done");
+    println!("  Every record reached the subscriber, whichever broker it entered through.");
+    reader.abort();
+    cluster.shutdown().await;
+    Ok(())
+}
+
+fn step(title: &str) {
+    println!("\n\x1b[1m── {title}\x1b[0m");
+}
+
+async fn beat(pace: Duration) {
+    if !pace.is_zero() {
+        tokio::time::sleep(pace).await;
+    }
+}
+
+fn sorted(map: std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+    let mut rows: Vec<_> = map.into_iter().collect();
+    rows.sort();
+    rows
+}
+
+async fn forward_count(cluster: &Cluster, node_id: &str) -> f64 {
+    cluster
+        .metric(node_id, "felix_broker_forwards_total")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(0.0)
 }
 
 // ------------------------------------------------------------- attaching

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -160,6 +160,28 @@ Blocking a peer link without stopping the process is not supported yet; it needs
 either a proxy in front of the internal listener or platform firewall rules, and
 nothing in M4 required it.
 
+## Running it hands-free
+
+Two ways, depending on whether you want the three-panel view.
+
+```bash
+task cluster:demo          # one pane, drives itself, narrated headings
+scripts/cluster-demo-tmux.sh   # three panes, driven automatically
+```
+
+`cluster:demo` runs the whole sequence in a single process: the cluster comes
+up, a subscriber attaches to the owner, a record is published through a broker
+that does *not* own the shard, then through the one that does, then a burst
+across all of them. Records arriving at the subscriber are indented with an
+arrow so they read as a separate voice from the publisher's lines. `--pace 0`
+runs it flat out, which is what a test wants; the default leaves room to narrate.
+
+The tmux script does the same thing across three real panes, which reads better
+on camera. It needs `tmux`. Both wait on `owners` rather than `nodes` to decide
+the cluster is up: `nodes` only reads the session file, so a file left by a
+previous cluster satisfies it immediately and the pane then talks to a control
+plane that is gone.
+
 ## Running the tests
 
 They are `#[serial]`. Each starts three broker processes, and a two-core CI

--- a/scripts/cluster-demo-tmux.sh
+++ b/scripts/cluster-demo-tmux.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# The three-panel cross-broker demo, driven automatically.
+#
+#   scripts/cluster-demo-tmux.sh
+#
+# Opens a tmux session with the cluster top-left, a subscriber bottom-left, and
+# a publisher on the right that runs the sequence on its own. Record the whole
+# window; nothing needs typing.
+#
+# `PACE` is the gap between publishes, in seconds. Raise it to narrate over.
+set -euo pipefail
+
+PACE=${PACE:-4}
+STREAM=${STREAM:-orders}
+SESSION=${SESSION:-felix-demo}
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BIN="$REPO_ROOT/target/debug/felix-cluster"
+
+command -v tmux >/dev/null || { echo "tmux is not installed" >&2; exit 1; }
+[[ -x $BIN ]] || { echo "build first: cargo build -p felix-cluster -p broker" >&2; exit 1; }
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+# A session file from a previous cluster would otherwise be read by the panes
+# before this cluster overwrites it.
+rm -f "${TMPDIR:-/tmp}/felix-cluster.json"
+
+# Pane 0: the cluster. Everything else waits for it.
+tmux new-session -d -s "$SESSION" -x "${COLUMNS:-200}" -y "${LINES:-50}" \
+  "cd '$REPO_ROOT' && '$BIN' up"
+
+# Right half: the publisher. Bottom-left: the subscriber.
+tmux split-window -h -t "$SESSION:0.0" -c "$REPO_ROOT"
+tmux split-window -v -t "$SESSION:0.0" -c "$REPO_ROOT"
+
+# Both wait on the cluster actually being up rather than on a fixed sleep.
+#
+# `owners`, not `nodes`: `nodes` only reads the session file, so a file left by
+# a previous cluster satisfies it immediately and the pane then talks to a
+# control plane that is gone. `owners` has to reach the control plane, so it
+# fails until *this* cluster is answering.
+wait_for_cluster="until '$BIN' owners >/dev/null 2>&1; do sleep 0.3; done"
+
+tmux send-keys -t "$SESSION:0.1" \
+  "clear; $wait_for_cluster; '$BIN' subscribe $STREAM" C-m
+
+# The publisher narrates itself with `echo` so the pane reads as a sequence
+# rather than as bare output.
+tmux send-keys -t "$SESSION:0.2" "clear; $wait_for_cluster; sleep 2; \
+OWNER=\$('$BIN' owners | awk '{print \$3}'); \
+OTHER=\$('$BIN' nodes | grep -v \"\$OWNER\" | head -1); \
+echo \"owner of $STREAM is \$OWNER; publishing through \$OTHER\"; sleep $PACE; \
+'$BIN' publish $STREAM hello --via \$OTHER; sleep $PACE; \
+'$BIN' publish $STREAM direct --via \$OWNER; sleep $PACE; \
+echo; echo 'a burst across every broker'; sleep 1; \
+COUNT=9 GAP=0.4 '$REPO_ROOT/scripts/cluster-publish-loop.sh'; \
+echo; echo 'done — every record reached the subscriber'" C-m
+
+tmux select-pane -t "$SESSION:0.2"
+
+# ATTACH=0 sets the session up and returns, for scripted checks.
+if [[ ${ATTACH:-1} == 0 ]]; then
+  echo "session '$SESSION' running detached"
+  exit 0
+fi
+
+echo "attaching to tmux session '$SESSION' — Ctrl-B then D to detach, Ctrl-C in the cluster pane to stop"
+tmux attach -t "$SESSION"


### PR DESCRIPTION
**Stacked on #246** — merge that first; this targets its branch so the diff stays reviewable.

Two ways to run the cross-broker story without typing it.

## One pane

```bash
task cluster:demo              # narrated, paced for talking over
task cluster:demo -- --pace 0  # flat out
```

Runs the whole sequence in a single process: cluster comes up → subscriber attaches to the owner → a record published through a broker that does **not** own the shard → the same publish through the one that does → a burst across all of them.

Records arriving at the subscriber are indented with an arrow so they read as a separate voice from the publisher's lines:

```
── Publishing through broker-0, which does not own the shard
  published "hello" via broker-0 → forwarded to broker-2 → acknowledged

── The same publish, through broker-2, which does
      ← [subscriber] offset    1  hello
  published "direct" via broker-2 (the owner) — written locally, no hop

  Same client, same call. The hop happens only when it has to.
```

## Three panes

```bash
scripts/cluster-demo-tmux.sh     # PACE=6 to slow it down
```

Cluster top-left, subscriber bottom-left, publisher on the right running the sequence on its own. Needs tmux. Reads better on camera than the single pane; the single pane needs nothing installed and can be run in CI.

## The bug this cost, and it's worth stating

Both panes originally waited on `felix-cluster nodes` to decide the cluster was up. **`nodes` only reads the session file.** A file left by a previous cluster satisfied it instantly, and the subscriber pane then tried to reach a control plane that no longer existed — failing with `Connection refused` against a stale port while the publisher pane worked perfectly.

The gate is now `owners`, which has to reach the control plane and therefore fails until *this* cluster is answering. The tmux script also removes a stale session file before starting.

I only caught it because I captured all three panes rather than checking that the publisher looked right.

## Verification

Both paths run end to end. tmux run captured pane by pane: cluster shows its topology, subscriber receives all 11 records, publisher shows the forward, the no-hop, and the burst. No leftover processes after teardown. `task lint`, `task test`, mermaid clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)