### PR TITLE
feat(cluster): make the tmux demo discoverable, and show concurrency in it

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -231,10 +231,16 @@ tasks:
     desc: Publish to a running cluster, through a broker that does not own the shard.
     cmds: ["cargo run -q -p felix-cluster -- publish {{.CLI_ARGS}}"]
   cluster:demo:
-    desc: Run the whole cross-broker demo in one pane, start to finish.
+    desc: "Cross-broker demo in ONE pane, start to finish (see cluster:demo:tmux for three)."
     cmds:
       - cargo build -p broker --bin felix-broker
       - cargo run -q -p felix-cluster -- demo {{.CLI_ARGS}}
+  cluster:demo:tmux:
+    desc: The same demo across THREE tmux panes - cluster, subscriber, publisher.
+    cmds:
+      - cargo build -p broker --bin felix-broker
+      - cargo build -p felix-cluster
+      - scripts/cluster-demo-tmux.sh
   cluster:burst:
     desc: Publish a burst of messages to a running cluster, across every broker.
     cmds: ["scripts/cluster-publish-loop.sh"]

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -165,8 +165,8 @@ nothing in M4 required it.
 Two ways, depending on whether you want the three-panel view.
 
 ```bash
-task cluster:demo          # one pane, drives itself, narrated headings
-scripts/cluster-demo-tmux.sh   # three panes, driven automatically
+task cluster:demo         # ONE pane, drives itself, narrated headings
+task cluster:demo:tmux    # THREE panes: cluster, subscriber, publisher
 ```
 
 `cluster:demo` runs the whole sequence in a single process: the cluster comes
@@ -176,8 +176,9 @@ across all of them. Records arriving at the subscriber are indented with an
 arrow so they read as a separate voice from the publisher's lines. `--pace 0`
 runs it flat out, which is what a test wants; the default leaves room to narrate.
 
-The tmux script does the same thing across three real panes, which reads better
-on camera. It needs `tmux`. Both wait on `owners` rather than `nodes` to decide
+`cluster:demo:tmux` does the same thing across three real panes, which reads
+better on camera. It needs `tmux`, and `PACE=6 task cluster:demo:tmux` slows it
+down to narrate over. Both wait on `owners` rather than `nodes` to decide
 the cluster is up: `nodes` only reads the session file, so a file left by a
 previous cluster satisfies it immediately and the pane then talks to a control
 plane that is gone.

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -178,7 +178,14 @@ runs it flat out, which is what a test wants; the default leaves room to narrate
 
 `cluster:demo:tmux` does the same thing across three real panes, which reads
 better on camera. It needs `tmux`, and `PACE=6 task cluster:demo:tmux` slows it
-down to narrate over. Both wait on `owners` rather than `nodes` to decide
+down to narrate over.
+
+The tmux version ends with two bursts rather than one: six records sent one at a
+time, which arrive in order, then twenty-four sent twelve at a time, which do
+not. Both prefixes are distinct (`seq-`, `par-`) so the subscriber's panel shows
+which is which. The second burst is the interesting one — it makes visible that
+concurrent publishes through different brokers have no relative order, which is
+a property worth showing rather than a defect worth hiding. Both wait on `owners` rather than `nodes` to decide
 the cluster is up: `nodes` only reads the session file, so a file left by a
 previous cluster satisfies it immediately and the pane then talks to a control
 plane that is gone.

--- a/scripts/cluster-demo-publisher.sh
+++ b/scripts/cluster-demo-publisher.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# The publisher half of the three-panel demo.
+#
+# Run by `cluster-demo-tmux.sh` in its own pane. A separate file rather than a
+# long `tmux send-keys` string: the shell echoes whatever it is sent, and a
+# thirty-line command fills the pane with itself before printing anything.
+set -euo pipefail
+
+STREAM=${STREAM:-orders}
+PACE=${PACE:-4}
+BURST_PARALLEL=${BURST_PARALLEL:-12}
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BIN="$REPO_ROOT/target/debug/felix-cluster"
+
+# `owners` has to reach the control plane, so this waits for the cluster rather
+# than for a session file a previous run may have left behind.
+until "$BIN" owners >/dev/null 2>&1; do sleep 0.3; done
+sleep 2
+
+OWNER=$("$BIN" owners | awk '{print $3}')
+OTHER=$("$BIN" nodes | grep -v "^${OWNER}$" | head -1)
+
+echo "owner of $STREAM is $OWNER"
+echo
+sleep "$PACE"
+
+echo "publishing through $OTHER, which does not own it"
+"$BIN" publish "$STREAM" hello --via "$OTHER"
+sleep "$PACE"
+
+echo
+echo "the same publish, through $OWNER, which does"
+"$BIN" publish "$STREAM" direct --via "$OWNER"
+sleep "$PACE"
+
+echo
+echo "a burst across every broker, one at a time"
+PREFIX=seq COUNT=6 GAP=0.35 PARALLEL=1 "$REPO_ROOT/scripts/cluster-publish-loop.sh"
+sleep "$PACE"
+
+echo
+echo "now $BURST_PARALLEL at once, through all three brokers."
+echo "arrival order is no longer guaranteed to match the send order --"
+echo "concurrent publishes through different brokers have no relative order."
+sleep 1
+PREFIX=par COUNT=24 GAP=0 PARALLEL="$BURST_PARALLEL" "$REPO_ROOT/scripts/cluster-publish-loop.sh"
+
+echo
+echo "done — every record reached the subscriber"

--- a/scripts/cluster-demo-tmux.sh
+++ b/scripts/cluster-demo-tmux.sh
@@ -12,6 +12,9 @@ set -euo pipefail
 
 PACE=${PACE:-4}
 STREAM=${STREAM:-orders}
+# The second burst runs concurrently, so the panel shows records arriving out of
+# the order they were sent -- which is the point of showing it.
+BURST_PARALLEL=${BURST_PARALLEL:-12}
 SESSION=${SESSION:-felix-demo}
 
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -45,17 +48,10 @@ wait_for_cluster="until '$BIN' owners >/dev/null 2>&1; do sleep 0.3; done"
 tmux send-keys -t "$SESSION:0.1" \
   "clear; $wait_for_cluster; '$BIN' subscribe $STREAM" C-m
 
-# The publisher narrates itself with `echo` so the pane reads as a sequence
-# rather than as bare output.
-tmux send-keys -t "$SESSION:0.2" "clear; $wait_for_cluster; sleep 2; \
-OWNER=\$('$BIN' owners | awk '{print \$3}'); \
-OTHER=\$('$BIN' nodes | grep -v \"\$OWNER\" | head -1); \
-echo \"owner of $STREAM is \$OWNER; publishing through \$OTHER\"; sleep $PACE; \
-'$BIN' publish $STREAM hello --via \$OTHER; sleep $PACE; \
-'$BIN' publish $STREAM direct --via \$OWNER; sleep $PACE; \
-echo; echo 'a burst across every broker'; sleep 1; \
-COUNT=9 GAP=0.4 '$REPO_ROOT/scripts/cluster-publish-loop.sh'; \
-echo; echo 'done — every record reached the subscriber'" C-m
+# The publisher runs from a file so the pane shows its output rather than a
+# screenful of the command that produced it.
+tmux send-keys -t "$SESSION:0.2" \
+  "clear; STREAM=$STREAM PACE=$PACE BURST_PARALLEL=$BURST_PARALLEL '$REPO_ROOT/scripts/cluster-demo-publisher.sh'" C-m
 
 tmux select-pane -t "$SESSION:0.2"
 

--- a/scripts/cluster-publish-loop.sh
+++ b/scripts/cluster-publish-loop.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 
 STREAM=${STREAM:-orders}
 COUNT=${COUNT:-30}
+PREFIX=${PREFIX:-msg}
 PARALLEL=${PARALLEL:-1}
 GAP=${GAP:-0}
 
@@ -64,7 +65,7 @@ echo "publishing $COUNT messages to $STREAM across $BROKER_COUNT broker(s), para
 
 for i in $(seq 1 "$COUNT"); do
   via=${BROKERS[$(( (i - 1) % BROKER_COUNT ))]}
-  "$BIN" publish "$STREAM" "$(printf 'msg-%03d' "$i")" --via "$via" >/dev/null &
+  "$BIN" publish "$STREAM" "$(printf '%s-%03d' "$PREFIX" "$i")" --via "$via" >/dev/null &
 
   # Hold in-flight publishes at PARALLEL. Polled rather than `wait -n`, which
   # macOS's bash 3.2 does not have.


### PR DESCRIPTION
Two problems you hit, plus the one they exposed.

## `task cluster:demo` gave one pane

The three-pane version was a bare script with no task entry, so the obvious command ran the single-pane version and nothing pointed at the other. Now:

```bash
task cluster:demo         # ONE pane
task cluster:demo:tmux    # THREE panes: cluster, subscriber, publisher
```

Both descriptions say which they are.

## The burst ran at parallel=1

It showed records arriving, but not the thing worth showing. It now runs **twice**: six one at a time, then twenty-four twelve at a time, with distinct prefixes so the subscriber panel says which is which.

```
hello direct seq-001 seq-002 seq-003 seq-004 seq-005 seq-006
par-001 par-002 par-003 par-004 par-006 par-005 par-008 par-007 par-010 par-009 …
```

Sequential arrives in order; concurrent does not. That's the interesting property — concurrent publishes through different brokers have no relative order — and it's worth showing rather than hiding.

**The narration asserts that, so the assertion had to be true rather than likely.** At my first sizing (12 records, parallel=6) it arrived *in order*, and the pane would have claimed otherwise on camera. Measured at 24/parallel=12: reordered in 3 of 3 runs.

## The publisher sequence moved into its own script

A shell echoes whatever `tmux send-keys` gives it, so a thirty-line command filled the publisher pane with itself before printing any output. `scripts/cluster-demo-publisher.sh` now holds the sequence and the pane shows results.

## Verification

Full tmux run captured pane by pane: cluster topology, publisher showing the forward / the no-hop / both bursts, subscriber receiving all 32 records with the ordered and interleaved sections visible. No leftover processes. `task lint`, `task test`, mermaid clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)