### PR TITLE
fix(docs): resolve the demo video under the site's base path

### DIFF
--- a/docs-site/src/content/docs/demos/cross-broker-cluster.mdx
+++ b/docs-site/src/content/docs/demos/cross-broker-cluster.mdx
@@ -11,12 +11,12 @@ client does nothing special: it connects to a broker and publishes.
   controls
   preload="metadata"
   playsInline
-  poster="/video/cluster-cross-broker-demo.jpg"
+  poster="/felix/video/cluster-cross-broker-demo.jpg"
   style={{ width: '100%', height: 'auto', borderRadius: '6px' }}
 >
-  <source src="/video/cluster-cross-broker-demo.mp4" type="video/mp4" />
+  <source src="/felix/video/cluster-cross-broker-demo.mp4" type="video/mp4" />
   Your browser cannot play this video.{' '}
-  <a href="/video/cluster-cross-broker-demo.mp4">Download it instead</a>.
+  <a href="/felix/video/cluster-cross-broker-demo.mp4">Download it instead</a>.
 </video>
 
 <p><small>45 seconds, no audio — the terminals carry the whole story.</small></p>


### PR DESCRIPTION
The video 404s on the deployed site. Reported from the browser console:

```
cluster-cross-broker-demo.jpg:1  Failed to load resource: 404
cluster-cross-broker-demo.mp4:1  Failed to load resource: 404
```

## Cause

The site is served from `base: '/felix'`. Astro base-prefixes its own components and markdown links, but **not raw JSX attributes** — so `src="/video/..."` stayed literal and resolved to `gabloe.github.io/video/...`.

All three references now carry the prefix explicitly, matching what `index.mdx` already does (`href="/felix/demos/..."`).

## The verification gap that let this ship

When I added the video in #249 I confirmed the `<video>` element rendered unescaped and that both files landed in `dist/video/`, and I called it verified. Neither of those checks the URL **resolves**. That's the whole bug, and I reported the weaker check as if it were the stronger one.

This time I served the built site and fetched them:

```
cluster-cross-broker-demo.mp4: HTTP 200, 2670606 bytes, video/mp4
cluster-cross-broker-demo.jpg: HTTP 200, 78171 bytes, image/jpeg
```

Pages maps `dist/` → `/felix/`, so `/felix/video/X` is `dist/video/X`, which those requests exercise.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)