### PR TITLE
ci: authenticate the tool installs so they stop hitting the anonymous rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v3
+        with:
+          # Authenticated, so this reads the repo's 1000/hr budget rather than
+          # the 60/hr GitHub allows an unauthenticated IP. Runners share their
+          # IP, so the anonymous budget is routinely spent by other jobs and the
+          # install fails with "API rate limit exceeded" before any code runs.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         run: task lint

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,9 +42,18 @@ jobs:
 
       - name: Install Task
         uses: arduino/setup-task@v3
+        with:
+          # Authenticated, so this reads the repo's 1000/hr budget rather than
+          # the 60/hr GitHub allows an unauthenticated IP. Runners share their
+          # IP, so the anonymous budget is routinely spent by other jobs and the
+          # install fails with "API rate limit exceeded" before any code runs.
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+        env:
+          # Same reason as above: this resolves a release through the API.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for Postgres service
         run: |


### PR DESCRIPTION
`coverage` failed on #251 in **34 seconds**, before any code ran:

```
Install Task
##[error]API rate limit exceeded for 135.232.216.64.
```

## Cause

`arduino/setup-task` and `taiki-e/install-action` resolve a release through the GitHub API. Unauthenticated, that budget is **60 requests an hour per IP** — and hosted runners share their IP with everything else scheduled on it, so the anonymous budget is routinely already spent by jobs belonging to other people. Nothing about this repo's activity controls it.

## Fix

Both now pass `GITHUB_TOKEN`, moving them onto the repository's 1000/hr budget. `secrets.GITHUB_TOKEN` needs only `contents: read`, which is the default; the coverage job already declares `contents: write` for its badge.

## Worth noting

This is the **same failure** an earlier `main` coverage run hit. At the time I checked whether it was caused by the branch it appeared on, concluded it wasn't, and left it there. That conclusion was right and insufficient — "not caused by this branch" is not the same as "not worth fixing", and the flake has now cost two more CI runs.

## Verification

A workflow change only proves itself on CI, so this needs its own run to confirm. What I can check locally: both files parse, no tabs, the token is wired into all three install steps, and the required permissions are already granted.

## The other two PRs

- **#251** — its `test` job **passed** (7m1s), so the harness fix works. Only `coverage` failed, for this reason.
- **#248** — still showing the run from before #251 existed. It needs re-running once #251 lands; nothing is wrong with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)