### PR TITLE
feat(replication): accept records a shard leader ships (M5.3)

### DIFF
--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -42,10 +42,21 @@ env:
   # cores 0-1 alongside them: 6 threads on 4 CPUs, with two cores double-booked.
   # Measured net effect on these runners was a regression. Thread-per-core is worth
   # evaluating on dedicated many-core hardware, not a shared 4-vCPU runner.
-  # Shared target dir across the baseline and candidate worktrees below, so
-  # (usually-unchanged) third-party dependencies only compile once instead
-  # of twice.
-  CARGO_TARGET_DIR: /tmp/felix-perf-target
+  # One target directory per checkout, and NOT a shared one.
+  #
+  # Sharing looks like an easy win -- third-party dependencies compile once
+  # instead of twice -- but the baseline worktree and the PR checkout are two
+  # copies of the *same* workspace, and cargo derives a path dependency's
+  # metadata hash from its name and version, not from which checkout it came
+  # from. Both copies of `felix-router` therefore claim the same unit in the
+  # target dir, and whichever built last wins.
+  #
+  # The failure mode that matters is not the loud one. A PR that adds a
+  # cross-crate API fails to compile, which is at least obvious. A PR that only
+  # changes a function body compiles fine -- against the baseline's code -- and
+  # the job then benchmarks the merge-base twice and reports no change.
+  CARGO_TARGET_DIR_BASELINE: /tmp/felix-perf-target-baseline
+  CARGO_TARGET_DIR_CANDIDATE: /tmp/felix-perf-target-candidate
 
 jobs:
   perf-compare:
@@ -66,7 +77,9 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: ". -> /tmp/felix-perf-target"
+          workspaces: |
+            . -> /tmp/felix-perf-target-baseline
+            . -> /tmp/felix-perf-target-candidate
 
       - name: Determine merge-base
         id: mergebase
@@ -91,6 +104,8 @@ jobs:
         id: baseline
         continue-on-error: true
         working-directory: /tmp/felix-baseline
+        env:
+          CARGO_TARGET_DIR: ${{ env.CARGO_TARGET_DIR_BASELINE }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/felix-perf-results
@@ -112,6 +127,8 @@ jobs:
       - name: Run candidate benchmarks
         id: candidate
         continue-on-error: true
+        env:
+          CARGO_TARGET_DIR: ${{ env.CARGO_TARGET_DIR_CANDIDATE }}
         run: |
           set -euo pipefail
           mkdir -p /tmp/felix-perf-results

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 /target
 **/target
+# Cross-platform build trees (e.g. a Linux container reproducing a CI failure
+# against a bind-mounted checkout). These are cargo output like any other, and
+# 700MB of them showing as untracked is alarming in a way it should not be.
+/target-*
 **/*.rs.bk
 **/*.pdb
 **/*.dSYM/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
+ "crc32fast",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -28,6 +28,7 @@ pub mod durable;
 mod error;
 mod keys;
 mod registry;
+pub mod replication;
 mod stream_state;
 mod subscription;
 

--- a/crates/felix-broker/src/replication.rs
+++ b/crates/felix-broker/src/replication.rs
@@ -1,0 +1,187 @@
+//! The follower's half of replication: storing what a leader shipped.
+//!
+//! # The rule
+//!
+//! A follower stores a record at the **leader's** offset or not at all. That is
+//! what makes the two logs comparable by offset, and every other part of
+//! replication rests on it — the acknowledged mark, the catch-up range, the
+//! caught-up test that gates promotion.
+//!
+//! The log underneath appends at its own tail and cannot be told where to put a
+//! record. So the follower does not ask it to: it checks that the batch begins
+//! exactly at its tail, and refuses otherwise. Position is verified rather than
+//! commanded, which is stricter and needs nothing from the storage layer.
+//!
+//! # Why each refusal is its own answer
+//!
+//! | The batch | Meaning | What the leader does |
+//! | --- | --- | --- |
+//! | starts past the tail | records are missing in between | resume from `expected_offset` |
+//! | is entirely below the tail | a retry of something already stored | nothing; already acknowledged |
+//! | straddles the tail | a retry that overlaps | the new suffix is stored |
+//! | disagrees on stored bytes | the logs have diverged | stop |
+//!
+//! The middle two are why a retry is safe. Replication has to be able to resend
+//! a batch whose acknowledgement was lost, and resending must not duplicate a
+//! record: an overlap is resolved by position, and the bytes are checked rather
+//! than assumed.
+//!
+//! # Durable, not buffered
+//!
+//! [`apply`] returns only after the batch satisfies the log's fsync policy. A
+//! follower that acknowledged sooner would let the leader believe a record had
+//! survived a failure it would not have survived — and under
+//! `ConsistencyLevel::Quorum` that belief is the guarantee.
+use bytes::Bytes;
+
+use crate::durable::StreamLog;
+use crate::error::{BrokerError, Result};
+
+/// What applying a replication batch did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Applied {
+    /// One past the last record now durably stored. Both the acknowledgement
+    /// and the offset the leader should send next.
+    pub durable_offset: u64,
+    /// Records actually written. Zero for a batch that was entirely a retry.
+    pub appended: usize,
+}
+
+/// Why a batch was not applied.
+///
+/// Separate from [`BrokerError`] because these are answers about *position*,
+/// which the leader acts on, rather than failures of this broker.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum Divergence {
+    /// The batch starts past the follower's tail. Applying it would leave a
+    /// hole, and a log with a hole cannot be read back.
+    #[error("batch starts at {first_offset}, expected {expected}")]
+    Gap { expected: u64, first_offset: u64 },
+    /// The batch disagrees with bytes already stored. Records are never
+    /// rewritten, so there is no repair: progress stops here.
+    #[error("batch disagrees with the stored record at offset {offset}")]
+    Conflict { offset: u64, expected: u64 },
+    /// The batch did not survive the trip.
+    #[error("batch checksum mismatch (leader {leader:#x}, computed {computed:#x})")]
+    Corrupt { leader: u64, computed: u64 },
+}
+
+impl Divergence {
+    /// The offset the follower wants next, for the leader to resume from.
+    pub fn expected_offset(&self) -> u64 {
+        match self {
+            Self::Gap { expected, .. } => *expected,
+            Self::Conflict { expected, .. } => *expected,
+            Self::Corrupt { .. } => 0,
+        }
+    }
+}
+
+/// Store a batch the leader shipped, at the leader's offsets.
+///
+/// `first_offset` is where `payloads[0]` belongs. Returns once the batch is
+/// durable.
+pub async fn apply(
+    log: &StreamLog,
+    first_offset: u64,
+    checksum: u64,
+    payloads: &[Bytes],
+) -> Result<std::result::Result<Applied, Divergence>> {
+    let tail = log.tail_offset().await?;
+
+    // Checked before the tail is consulted for anything else: a batch that did
+    // not survive the trip says nothing reliable about position either.
+    let computed = felix_wire::internal::batch_checksum(payloads);
+    if computed != checksum {
+        return Ok(Err(Divergence::Corrupt {
+            leader: checksum,
+            computed,
+        }));
+    }
+
+    if payloads.is_empty() {
+        // Nothing to store, and nothing wrong: an empty batch is a position
+        // probe, and the tail is the answer.
+        return Ok(Ok(Applied {
+            durable_offset: tail,
+            appended: 0,
+        }));
+    }
+
+    if first_offset > tail {
+        return Ok(Err(Divergence::Gap {
+            expected: tail,
+            first_offset,
+        }));
+    }
+
+    // The batch reaches back into what is already stored. That is a retry, so
+    // the overlap is verified rather than trusted, and only the suffix past the
+    // tail is new.
+    let overlap = (tail - first_offset).min(payloads.len() as u64) as usize;
+    if overlap > 0
+        && let Some(divergence) = conflict_in(log, first_offset, &payloads[..overlap], tail).await?
+    {
+        return Ok(Err(divergence));
+    }
+
+    let fresh = &payloads[overlap..];
+    if fresh.is_empty() {
+        // Wholly a retry of records already held. Acknowledging the tail is
+        // what makes a lost acknowledgement cost nothing.
+        return Ok(Ok(Applied {
+            durable_offset: tail,
+            appended: 0,
+        }));
+    }
+
+    let pending = log.begin_append(fresh).await?;
+    log.commit(&pending).await?;
+
+    Ok(Ok(Applied {
+        durable_offset: tail + fresh.len() as u64,
+        appended: fresh.len(),
+    }))
+}
+
+/// Compare a batch's overlapping prefix against what is already stored.
+///
+/// Reads only the overlap, which is bounded by the batch, so a retry costs a
+/// read proportional to the resend rather than to the log.
+async fn conflict_in(
+    log: &StreamLog,
+    first_offset: u64,
+    overlapping: &[Bytes],
+    tail: u64,
+) -> Result<Option<Divergence>> {
+    let wanted: usize = overlapping.iter().map(|payload| payload.len() + 32).sum();
+    let stored = match log.read_from(first_offset, wanted.max(1)).await {
+        Ok(stored) => stored,
+        // Retention discarded the records this batch overlaps. There is nothing
+        // left to compare against, and refusing on that basis would stall a
+        // follower for a reason that is not divergence. The suffix past the
+        // tail is still appended, which is the part that matters.
+        Err(BrokerError::CursorTooOld { .. }) => return Ok(None),
+        Err(err) => return Err(err),
+    };
+
+    for (index, payload) in overlapping.iter().enumerate() {
+        let offset = first_offset + index as u64;
+        let Some(record) = stored.iter().find(|record| record.offset == offset) else {
+            // A short read, not a disagreement: the comparison simply cannot be
+            // made for the rest of this batch.
+            break;
+        };
+        if record.payload != *payload {
+            return Ok(Some(Divergence::Conflict {
+                offset,
+                expected: tail,
+            }));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+#[path = "replication_tests.rs"]
+mod tests;

--- a/crates/felix-broker/src/replication_tests.rs
+++ b/crates/felix-broker/src/replication_tests.rs
@@ -1,0 +1,257 @@
+//! The follower's append rule, against a real log on disk.
+//!
+//! Every case here is about *position*: where a batch claims to belong versus
+//! where the follower actually is. A fake log would decide that itself, so
+//! these use the same `DiskLog` a broker runs on and read the records back.
+use felix_storage::log::{FsyncMode, LogConfig};
+use tempfile::TempDir;
+
+use super::*;
+use crate::durable::DurableStorage;
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+
+/// A follower's log for one shard, with `OnCommit` so "durable" means the
+/// bytes reached the device rather than a buffer.
+async fn follower() -> (StreamLog, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage = DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::OnCommit,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+    let log = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open the shard log");
+    (log, dir)
+}
+
+fn payload(value: &str) -> Bytes {
+    Bytes::copy_from_slice(value.as_bytes())
+}
+
+fn batch(values: &[&str]) -> Vec<Bytes> {
+    values.iter().map(|value| payload(value)).collect()
+}
+
+/// Ship a batch the way a leader would, with a checksum it computed itself.
+async fn ship(
+    log: &StreamLog,
+    first_offset: u64,
+    values: &[&str],
+) -> std::result::Result<Applied, Divergence> {
+    let payloads = batch(values);
+    let checksum = felix_wire::internal::batch_checksum(&payloads);
+    apply(log, first_offset, checksum, &payloads)
+        .await
+        .expect("apply")
+}
+
+/// Everything the follower holds, in offset order.
+async fn stored(log: &StreamLog) -> Vec<String> {
+    log.read_from(0, 1024 * 1024)
+        .await
+        .expect("read")
+        .into_iter()
+        .map(|record| String::from_utf8(record.payload.to_vec()).expect("utf8"))
+        .collect()
+}
+
+/// The ordinary case: batches arrive in order and land at the leader's offsets.
+#[tokio::test]
+async fn batches_in_order_land_at_the_leaders_offsets() {
+    let (log, _dir) = follower().await;
+
+    let first = ship(&log, 0, &["a", "b"]).await.expect("applied");
+    assert_eq!(first.durable_offset, 2);
+    assert_eq!(first.appended, 2);
+
+    let second = ship(&log, 2, &["c"]).await.expect("applied");
+    assert_eq!(second.durable_offset, 3);
+    assert_eq!(second.appended, 1);
+
+    assert_eq!(stored(&log).await, vec!["a", "b", "c"]);
+}
+
+/// **A batch starting past the tail is refused, and says where to resume.**
+/// Applying it would leave a hole, and a log with a hole cannot be read back —
+/// the follower would report a durable offset covering records it does not have.
+#[tokio::test]
+async fn a_batch_that_would_leave_a_hole_is_refused() {
+    let (log, _dir) = follower().await;
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    let divergence = ship(&log, 5, &["f"]).await.expect_err("should be a gap");
+
+    assert_eq!(
+        divergence,
+        Divergence::Gap {
+            expected: 2,
+            first_offset: 5,
+        },
+    );
+    assert_eq!(
+        divergence.expected_offset(),
+        2,
+        "the leader must resume at 2"
+    );
+    assert_eq!(
+        stored(&log).await,
+        vec!["a", "b"],
+        "the hole was written anyway"
+    );
+}
+
+/// **A resent batch is not stored twice.** Replication has to be able to resend
+/// a batch whose acknowledgement was lost, and a duplicate record is invisible
+/// to a subscriber until the offsets stop matching the leader's.
+#[tokio::test]
+async fn a_resent_batch_is_acknowledged_without_being_stored_again() {
+    let (log, _dir) = follower().await;
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    let retry = ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    assert_eq!(
+        retry.durable_offset, 2,
+        "the retry moved the acknowledged mark"
+    );
+    assert_eq!(retry.appended, 0, "the retry stored the records again");
+    assert_eq!(stored(&log).await, vec!["a", "b"]);
+}
+
+/// A retry that overlaps the tail stores only the part the follower is missing.
+#[tokio::test]
+async fn a_retry_that_overlaps_the_tail_stores_only_the_new_suffix() {
+    let (log, _dir) = follower().await;
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    // The leader resends from 1, having not heard about 1 landing.
+    let applied = ship(&log, 1, &["b", "c", "d"]).await.expect("applied");
+
+    assert_eq!(applied.appended, 2, "the overlap was stored again");
+    assert_eq!(applied.durable_offset, 4);
+    assert_eq!(stored(&log).await, vec!["a", "b", "c", "d"]);
+}
+
+/// **Bytes that disagree with what is stored stop replication.** Records are
+/// never rewritten, so there is no repair — and continuing would leave two logs
+/// that agree on offsets while disagreeing on contents, which nothing
+/// downstream could detect.
+#[tokio::test]
+async fn a_batch_that_disagrees_with_stored_bytes_stops_progress() {
+    let (log, _dir) = follower().await;
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    let divergence = ship(&log, 0, &["a", "DIFFERENT", "c"])
+        .await
+        .expect_err("should conflict");
+
+    assert!(
+        matches!(divergence, Divergence::Conflict { offset: 1, .. }),
+        "{divergence:?}",
+    );
+    assert_eq!(
+        stored(&log).await,
+        vec!["a", "b"],
+        "a conflicting batch appended its suffix anyway",
+    );
+}
+
+/// A batch corrupted in transit is refused before anything is written, so a bad
+/// frame cannot become a stored record.
+#[tokio::test]
+async fn a_batch_that_did_not_survive_the_trip_is_refused() {
+    let (log, _dir) = follower().await;
+    let payloads = batch(&["a", "b"]);
+
+    let divergence = apply(&log, 0, 0xdead_beef, &payloads)
+        .await
+        .expect("apply")
+        .expect_err("should be corrupt");
+
+    assert!(
+        matches!(divergence, Divergence::Corrupt { .. }),
+        "{divergence:?}"
+    );
+    assert!(stored(&log).await.is_empty(), "a corrupt batch was stored");
+}
+
+/// **The checksum distinguishes a different split of the same bytes.** Without
+/// the length in the hash, `["ab", "c"]` and `["a", "bc"]` are the same input —
+/// and they are different records, which is exactly the divergence this exists
+/// to catch.
+#[test]
+fn the_checksum_separates_records_that_concatenate_alike() {
+    let one = felix_wire::internal::batch_checksum(&batch(&["ab", "c"]));
+    let other = felix_wire::internal::batch_checksum(&batch(&["a", "bc"]));
+
+    assert_ne!(one, other);
+}
+
+/// An empty batch is a position probe: it asks where the follower is without
+/// claiming anything, so it is answered rather than refused.
+#[tokio::test]
+async fn an_empty_batch_reports_the_tail() {
+    let (log, _dir) = follower().await;
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+
+    let applied = ship(&log, 2, &[]).await.expect("applied");
+
+    assert_eq!(applied.durable_offset, 2);
+    assert_eq!(applied.appended, 0);
+}
+
+/// A fresh follower starts at zero, so the leader's first batch has to start
+/// there too.
+#[tokio::test]
+async fn a_fresh_follower_expects_the_first_offset() {
+    let (log, _dir) = follower().await;
+
+    let divergence = ship(&log, 1, &["b"]).await.expect_err("should be a gap");
+
+    assert_eq!(divergence.expected_offset(), 0);
+}
+
+/// **The acknowledged offset is durable, not buffered.** Under `OnCommit` the
+/// records are readable back from disk the instant `apply` returns; a follower
+/// that acknowledged before its own fsync would let the leader count a record
+/// toward a quorum it would not survive.
+#[tokio::test]
+async fn the_acknowledged_offset_is_on_disk_before_it_is_reported() {
+    let (log, _dir) = follower().await;
+
+    let applied = ship(&log, 0, &["a", "b", "c"]).await.expect("applied");
+
+    assert_eq!(applied.durable_offset, 3);
+    assert_eq!(
+        log.durable_offset(),
+        3,
+        "the batch was acknowledged before it was durable",
+    );
+    assert_eq!(stored(&log).await, vec!["a", "b", "c"]);
+}
+
+/// Applying the same sequence twice, in any resend pattern, converges on the
+/// leader's log rather than accumulating.
+#[tokio::test]
+async fn resends_converge_rather_than_accumulate() {
+    let (log, _dir) = follower().await;
+
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+    ship(&log, 0, &["a", "b"]).await.expect("applied");
+    ship(&log, 1, &["b", "c"]).await.expect("applied");
+    ship(&log, 2, &["c"]).await.expect("applied");
+    let last = ship(&log, 3, &["d"]).await.expect("applied");
+
+    assert_eq!(last.durable_offset, 4);
+    assert_eq!(stored(&log).await, vec!["a", "b", "c", "d"]);
+}

--- a/crates/felix-router/src/lib.rs
+++ b/crates/felix-router/src/lib.rs
@@ -7,7 +7,9 @@
 //! together would make a placement decision look like a policy decision.
 pub mod shard;
 
-pub use shard::{NodeRef, Resolution, RoutingTable, ShardKey, ShardRouter, Unavailable};
+pub use shard::{
+    NodeRef, ReplicaRole, Resolution, RoutingTable, ShardKey, ShardRouter, Unavailable,
+};
 
 use felix_common::ids::RegionId;
 use std::collections::HashSet;

--- a/crates/felix-router/src/shard.rs
+++ b/crates/felix-router/src/shard.rs
@@ -225,7 +225,68 @@ impl ShardRouter {
     pub fn snapshot(&self) -> Arc<RoutingTable> {
         self.table.load_full()
     }
+}
 
+/// Whether this node may store records another broker replicates to it.
+///
+/// Separate from [`Resolution`], which answers "who serves reads and writes".
+/// A follower serves neither and still has to store, so the two questions have
+/// different answers for the same shard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplicaRole {
+    /// This node is in the shard's replica set at the epoch the leader named.
+    Follower,
+    /// The leader named an epoch older than this node's. It has been
+    /// superseded, and a superseded leader's records must not be stored: it may
+    /// have written them after losing the shard.
+    Fenced { have: u64, named: u64 },
+    /// This node's view is older than the epoch named. Its copy is behind, so
+    /// it cannot yet tell whether it is a replica at that epoch.
+    Behind { have: u64, named: u64 },
+    /// This node is not in the shard's replica set. Includes leading it: a
+    /// leader does not replicate to itself.
+    NotAReplica,
+}
+
+impl ShardRouter {
+    /// Whether this node should store records for `key` shipped at `generation`.
+    pub fn replica_role(&self, key: &ShardKey, generation: u64) -> ReplicaRole {
+        let table = self.table.load();
+        let Some(route) = table.get(key) else {
+            // Nothing known about the shard at all, so this node cannot confirm
+            // membership. Behind rather than NotAReplica: the assignment may
+            // simply not have arrived, and refusing permanently would strand a
+            // follower whose watch is a moment late.
+            return ReplicaRole::Behind {
+                have: 0,
+                named: generation,
+            };
+        };
+        if generation < route.generation {
+            return ReplicaRole::Fenced {
+                have: route.generation,
+                named: generation,
+            };
+        }
+        if generation > route.generation {
+            return ReplicaRole::Behind {
+                have: route.generation,
+                named: generation,
+            };
+        }
+        if route
+            .replicas
+            .iter()
+            .any(|replica| replica.node_id == self.local_node_id)
+        {
+            ReplicaRole::Follower
+        } else {
+            ReplicaRole::NotAReplica
+        }
+    }
+}
+
+impl ShardRouter {
     /// Resolve a shard against the current table.
     pub fn resolve(&self, key: &ShardKey) -> Resolution {
         self.resolve_in(&self.table.load(), key, None)

--- a/crates/felix-wire/Cargo.toml
+++ b/crates/felix-wire/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["network-programming", "encoding"]
 [dependencies]
 base64 = "0.23"
 bytes = { workspace = true }
+crc32fast = "1.5"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/felix-wire/src/internal.rs
+++ b/crates/felix-wire/src/internal.rs
@@ -53,6 +53,9 @@ pub enum Kind {
     NotLeader = 4,
     Hello = 5,
     HelloOk = 6,
+    ReplicateRecords = 7,
+    ReplicateOk = 8,
+    ReplicateError = 9,
 }
 
 impl Kind {
@@ -66,6 +69,9 @@ impl Kind {
             4 => Ok(Kind::NotLeader),
             5 => Ok(Kind::Hello),
             6 => Ok(Kind::HelloOk),
+            7 => Ok(Kind::ReplicateRecords),
+            8 => Ok(Kind::ReplicateOk),
+            9 => Ok(Kind::ReplicateError),
             other => Err(Error::UnsupportedInternalKind(other)),
         }
     }
@@ -93,6 +99,19 @@ pub enum ErrorCode {
     Malformed = 6,
     /// The owner accepted the request and the local write failed.
     StorageFailed = 7,
+    /// A replication batch starts past the follower's tail. Applying it would
+    /// leave a hole, and a log with a hole cannot be read back. The follower
+    /// reports the offset it does want; the leader resumes there.
+    LogGap = 8,
+    /// A replication batch disagrees with bytes the follower has already
+    /// stored. Records are never rewritten, so there is no repair for this:
+    /// the two logs have diverged and progress stops here.
+    LogConflict = 9,
+    /// The sender named an epoch older than the responder's. It has been
+    /// superseded and is no longer the leader, so its records must not be
+    /// stored: it may have written them after losing the shard. Not retryable —
+    /// the fence does not lift.
+    FencedEpoch = 10,
 }
 
 impl ErrorCode {
@@ -105,15 +124,25 @@ impl ErrorCode {
             5 => Ok(ErrorCode::ProtocolVersion),
             6 => Ok(ErrorCode::Malformed),
             7 => Ok(ErrorCode::StorageFailed),
+            8 => Ok(ErrorCode::LogGap),
+            9 => Ok(ErrorCode::LogConflict),
+            10 => Ok(ErrorCode::FencedEpoch),
             other => Err(Error::UnknownInternalErrorCode(other)),
         }
     }
 
     /// Whether a requester should try the same peer again.
+    ///
+    /// `LogGap` is retryable but not by re-sending the same batch: the follower
+    /// names the offset it wants, and the leader resumes from there. `LogConflict`
+    /// is absent deliberately — divergent logs do not converge by retrying.
     pub fn is_retryable(self) -> bool {
         matches!(
             self,
-            ErrorCode::StaleRoute | ErrorCode::Unavailable | ErrorCode::Overload
+            ErrorCode::StaleRoute
+                | ErrorCode::Unavailable
+                | ErrorCode::Overload
+                | ErrorCode::LogGap
         )
     }
 }
@@ -223,6 +252,54 @@ pub struct HelloOk {
     pub node_id: String,
 }
 
+/// Records the leader has committed, shipped to a follower.
+///
+/// Append-only, and identified by the offsets the *leader* assigned: a follower
+/// stores a record at the leader's offset or not at all. That is what makes the
+/// two logs comparable by offset, which every other part of replication relies
+/// on.
+///
+/// `shard.generation` is the leader's epoch. A follower that knows of a newer
+/// one refuses, because a leader at an older epoch may already have been
+/// replaced.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplicateRecords {
+    pub correlation_id: u64,
+    pub shard: ShardRef,
+    /// Offset of `payloads[0]`. Payload `i` belongs at `first_offset + i`.
+    pub first_offset: u64,
+    /// Over the payload bytes, in order. Checked before anything is written, so
+    /// a batch corrupted in transit is refused rather than stored.
+    pub checksum: u64,
+    pub payloads: Vec<Bytes>,
+}
+
+/// The follower stored the batch.
+///
+/// `durable_offset` is one past the last record the follower has on disk, so it
+/// is both an acknowledgement and the offset the leader should send next. It
+/// reports **durable** data, never buffered: a follower that acknowledged
+/// before its own fsync would let the leader believe a record survived a
+/// failure it would not have survived.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplicateOk {
+    pub correlation_id: u64,
+    pub durable_offset: u64,
+}
+
+/// The follower refused, and where it stands.
+///
+/// `expected_offset` is what the follower wants next. For `LogGap` it is how
+/// the leader repairs without a separate negotiation; for the rest it is
+/// diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplicateError {
+    pub correlation_id: u64,
+    pub code: ErrorCode,
+    pub expected_offset: u64,
+    pub detail: String,
+}
+
 /// A decoded internal message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InternalMessage {
@@ -232,6 +309,9 @@ pub enum InternalMessage {
     NotLeader(NotLeader),
     Hello(Hello),
     HelloOk(HelloOk),
+    ReplicateRecords(ReplicateRecords),
+    ReplicateOk(ReplicateOk),
+    ReplicateError(ReplicateError),
 }
 
 impl InternalMessage {
@@ -243,6 +323,9 @@ impl InternalMessage {
             Self::NotLeader(_) => Kind::NotLeader,
             Self::Hello(_) => Kind::Hello,
             Self::HelloOk(_) => Kind::HelloOk,
+            Self::ReplicateRecords(_) => Kind::ReplicateRecords,
+            Self::ReplicateOk(_) => Kind::ReplicateOk,
+            Self::ReplicateError(_) => Kind::ReplicateError,
         }
     }
 
@@ -259,6 +342,9 @@ impl InternalMessage {
             Self::NotLeader(m) => m.correlation_id,
             Self::Hello(m) => m.correlation_id,
             Self::HelloOk(m) => m.correlation_id,
+            Self::ReplicateRecords(m) => m.correlation_id,
+            Self::ReplicateOk(m) => m.correlation_id,
+            Self::ReplicateError(m) => m.correlation_id,
         }
     }
 
@@ -306,6 +392,34 @@ impl InternalMessage {
             Self::HelloOk(m) => {
                 body.put_u64(m.correlation_id);
                 put_str(&mut body, &m.node_id)?;
+            }
+            Self::ReplicateRecords(m) => {
+                body.put_u64(m.correlation_id);
+                put_str(&mut body, &m.shard.tenant_id)?;
+                put_str(&mut body, &m.shard.namespace)?;
+                put_str(&mut body, &m.shard.stream)?;
+                body.put_u32(m.shard.shard);
+                body.put_u64(m.shard.generation);
+                body.put_u64(m.first_offset);
+                body.put_u64(m.checksum);
+                if m.payloads.len() > MAX_BATCH_PAYLOADS {
+                    return Err(Error::FrameTooLarge);
+                }
+                body.put_u32(m.payloads.len() as u32);
+                for payload in &m.payloads {
+                    body.put_u32(u32::try_from(payload.len()).map_err(|_| Error::FrameTooLarge)?);
+                    body.extend_from_slice(payload);
+                }
+            }
+            Self::ReplicateOk(m) => {
+                body.put_u64(m.correlation_id);
+                body.put_u64(m.durable_offset);
+            }
+            Self::ReplicateError(m) => {
+                body.put_u64(m.correlation_id);
+                body.put_u16(m.code as u16);
+                body.put_u64(m.expected_offset);
+                put_str(&mut body, &m.detail)?;
             }
         }
 
@@ -426,8 +540,85 @@ impl InternalMessage {
                 expect_empty(&body)?;
                 Ok(Self::HelloOk(message))
             }
+            Kind::ReplicateRecords => {
+                let correlation_id = take_u64(&mut body)?;
+                let tenant_id = take_str(&mut body)?;
+                let namespace = take_str(&mut body)?;
+                let stream = take_str(&mut body)?;
+                let shard = take_u32(&mut body)?;
+                let generation = take_u64(&mut body)?;
+                let first_offset = take_u64(&mut body)?;
+                let checksum = take_u64(&mut body)?;
+
+                let declared = take_u32(&mut body)? as usize;
+                // Bounded against what the body could hold before it reaches
+                // `with_capacity`, exactly as `ForwardPublish` documents.
+                if declared > MAX_BATCH_PAYLOADS || declared > body.remaining() / LEN_PREFIX {
+                    return Err(Error::Incomplete);
+                }
+                let mut payloads = Vec::with_capacity(declared);
+                for _ in 0..declared {
+                    let len = take_u32(&mut body)? as usize;
+                    if len > body.remaining() {
+                        return Err(Error::Incomplete);
+                    }
+                    payloads.push(body.split_to(len));
+                }
+                expect_empty(&body)?;
+
+                Ok(Self::ReplicateRecords(ReplicateRecords {
+                    correlation_id,
+                    shard: ShardRef {
+                        tenant_id,
+                        namespace,
+                        stream,
+                        shard,
+                        generation,
+                    },
+                    first_offset,
+                    checksum,
+                    payloads,
+                }))
+            }
+            Kind::ReplicateOk => {
+                let message = ReplicateOk {
+                    correlation_id: take_u64(&mut body)?,
+                    durable_offset: take_u64(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::ReplicateOk(message))
+            }
+            Kind::ReplicateError => {
+                let message = ReplicateError {
+                    correlation_id: take_u64(&mut body)?,
+                    code: ErrorCode::from_u16(take_u16(&mut body)?)?,
+                    expected_offset: take_u64(&mut body)?,
+                    detail: take_str(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::ReplicateError(message))
+            }
         }
     }
+}
+
+/// The checksum a [`ReplicateRecords`] batch carries.
+///
+/// Defined once, here, so the leader and the follower cannot compute it
+/// differently — a checksum the two sides disagree about reports corruption on
+/// every healthy batch, which is worse than not having one.
+///
+/// It covers each payload's length and its bytes, in order. Including the
+/// length is what stops `["ab", "c"]` and `["a", "bc"]` hashing alike: they are
+/// different records, and a follower storing one where the leader has the other
+/// is exactly the divergence this is here to catch.
+pub fn batch_checksum(payloads: &[Bytes]) -> u64 {
+    let mut hasher = crc32fast::Hasher::new();
+    for payload in payloads {
+        hasher.update(&(payload.len() as u32).to_be_bytes());
+        hasher.update(payload);
+    }
+    u64::from(hasher.finalize())
 }
 
 /// Fixed-size header preceding every internal body.

--- a/crates/felix-wire/src/internal_tests.rs
+++ b/crates/felix-wire/src/internal_tests.rs
@@ -50,7 +50,29 @@ fn every_message() -> Vec<InternalMessage> {
             correlation_id: 42,
             node_id: "broker-b".to_string(),
         }),
+        replicate(),
+        InternalMessage::ReplicateOk(ReplicateOk {
+            correlation_id: 42,
+            durable_offset: 102,
+        }),
+        InternalMessage::ReplicateError(ReplicateError {
+            correlation_id: 42,
+            code: ErrorCode::LogGap,
+            expected_offset: 100,
+            detail: "batch starts at 105, expected 100".to_string(),
+        }),
     ]
+}
+
+fn replicate() -> InternalMessage {
+    let payloads = vec![Bytes::from_static(b"a"), Bytes::from_static(b"bb")];
+    InternalMessage::ReplicateRecords(ReplicateRecords {
+        correlation_id: 42,
+        shard: shard(),
+        first_offset: 100,
+        checksum: 0x0102_0304,
+        payloads,
+    })
 }
 
 #[test]
@@ -318,7 +340,9 @@ fn an_empty_batch_round_trips() {
 #[test]
 fn unknown_enum_values_are_rejected() {
     assert!(Kind::from_u16(0).is_err());
-    assert!(Kind::from_u16(7).is_err());
+    // One past the highest kind: an unknown kind must be rejected rather than
+    // skipped, because the kind is what selects how to read the body.
+    assert!(Kind::from_u16(10).is_err());
     assert!(ErrorCode::from_u16(0).is_err());
     assert!(ErrorCode::from_u16(999).is_err());
     assert!(AckMode::from_u8(9).is_err());
@@ -342,5 +366,122 @@ fn error_codes_say_whether_to_retry() {
         ErrorCode::StorageFailed,
     ] {
         assert!(!code.is_retryable(), "{code:?}");
+    }
+}
+
+#[test]
+fn replicate_records_matches_its_golden_vector() {
+    let encoded = replicate().encode().expect("encode");
+    let expected: Vec<u8> = [
+        // header: magic "FLXI", version 1, kind 7, length
+        &[0x46, 0x4C, 0x58, 0x49][..],
+        &[0x00, 0x01][..],
+        &[0x00, 0x07][..],
+        &[0x00, 0x00, 0x00, 0x49][..],
+        // correlation_id 42
+        &[0, 0, 0, 0, 0, 0, 0, 42][..],
+        // "t1", "ns", "orders"
+        &[0, 0, 0, 2][..],
+        b"t1",
+        &[0, 0, 0, 2][..],
+        b"ns",
+        &[0, 0, 0, 6][..],
+        b"orders",
+        // shard 3, generation 7
+        &[0, 0, 0, 3][..],
+        &[0, 0, 0, 0, 0, 0, 0, 7][..],
+        // first_offset 100, checksum 0x01020304
+        &[0, 0, 0, 0, 0, 0, 0, 100][..],
+        &[0, 0, 0, 0, 0x01, 0x02, 0x03, 0x04][..],
+        // two payloads
+        &[0, 0, 0, 2][..],
+        &[0, 0, 0, 1][..],
+        b"a",
+        &[0, 0, 0, 2][..],
+        b"bb",
+    ]
+    .concat();
+    assert_eq!(encoded.as_ref(), expected.as_slice());
+}
+
+/// **The checksum covers each payload's length as well as its bytes.** Without
+/// the length, a batch resplit in transit hashes the same as the original, and
+/// a resplit batch is a different set of records — exactly the divergence the
+/// checksum exists to catch.
+#[test]
+fn the_batch_checksum_separates_a_different_split_of_the_same_bytes() {
+    let one = batch_checksum(&[Bytes::from_static(b"ab"), Bytes::from_static(b"c")]);
+    let other = batch_checksum(&[Bytes::from_static(b"a"), Bytes::from_static(b"bc")]);
+
+    assert_ne!(one, other);
+}
+
+#[test]
+fn the_batch_checksum_is_stable_and_order_sensitive() {
+    let batch = [Bytes::from_static(b"a"), Bytes::from_static(b"bb")];
+    let reversed = [Bytes::from_static(b"bb"), Bytes::from_static(b"a")];
+
+    assert_eq!(batch_checksum(&batch), batch_checksum(&batch));
+    assert_ne!(batch_checksum(&batch), batch_checksum(&reversed));
+    assert_eq!(batch_checksum(&[]), batch_checksum(&[]));
+}
+
+/// The divergence codes say what a leader may do next, and getting these
+/// backwards is how a diverged follower gets hammered or a lagging one gets
+/// abandoned.
+#[test]
+fn a_gap_is_retryable_and_a_conflict_is_not() {
+    assert!(
+        ErrorCode::LogGap.is_retryable(),
+        "a follower that named the offset it wants was told not to retry",
+    );
+    assert!(
+        !ErrorCode::LogConflict.is_retryable(),
+        "diverged logs do not converge by retrying",
+    );
+    assert!(
+        !ErrorCode::FencedEpoch.is_retryable(),
+        "the fence does not lift",
+    );
+}
+
+/// Every code survives the wire as itself. A code that decoded as a neighbour
+/// would turn "stop, we have diverged" into "try again".
+#[test]
+fn every_error_code_round_trips() {
+    for code in [
+        ErrorCode::StaleRoute,
+        ErrorCode::Unavailable,
+        ErrorCode::Unauthorized,
+        ErrorCode::Overload,
+        ErrorCode::ProtocolVersion,
+        ErrorCode::Malformed,
+        ErrorCode::StorageFailed,
+        ErrorCode::LogGap,
+        ErrorCode::LogConflict,
+        ErrorCode::FencedEpoch,
+    ] {
+        assert_eq!(ErrorCode::from_u16(code as u16).expect("known"), code);
+    }
+}
+
+/// The kinds already on the wire keep their discriminants. A peer mid-upgrade
+/// decodes by number, so renumbering one silently reinterprets every frame of
+/// that kind.
+#[test]
+fn the_existing_kind_discriminants_are_unchanged() {
+    for (value, kind) in [
+        (1, Kind::ForwardPublish),
+        (2, Kind::ForwardPublishOk),
+        (3, Kind::ForwardPublishError),
+        (4, Kind::NotLeader),
+        (5, Kind::Hello),
+        (6, Kind::HelloOk),
+        (7, Kind::ReplicateRecords),
+        (8, Kind::ReplicateOk),
+        (9, Kind::ReplicateError),
+    ] {
+        assert_eq!(Kind::from_u16(value).expect("known"), kind);
+        assert_eq!(kind as u16, value);
     }
 }

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -1001,6 +1001,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
+ "crc32fast",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -1001,6 +1001,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
+ "crc32fast",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/demos/slow-consumer/Cargo.lock
+++ b/demos/slow-consumer/Cargo.lock
@@ -1026,6 +1026,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
+ "crc32fast",
  "serde",
  "serde_json",
  "thiserror 2.0.20",

--- a/demos/state-divergence/Cargo.lock
+++ b/demos/state-divergence/Cargo.lock
@@ -1026,6 +1026,7 @@ version = "0.2.0"
 dependencies = [
  "base64 0.23.1",
  "bytes",
+ "crc32fast",
  "serde",
  "serde_json",
  "thiserror 2.0.20",

--- a/docs/internal-protocol.md
+++ b/docs/internal-protocol.md
@@ -149,6 +149,53 @@ No relay kinds are defined, because nothing relays. Should proxying ever be
 added they are additive: an unknown kind is already a typed error rather than a
 misparse, so it needs no version bump.
 
+### Replication
+
+A shard leader ships records it has committed to the followers in the shard's
+replica set. `ReplicateRecords` carries the leader's epoch, the offset its first
+payload belongs at, a checksum over the batch, and the payloads.
+
+The offsets are the **leader's**. A follower stores a record at the leader's
+offset or not at all, which is what makes the two logs comparable by offset —
+the acknowledged mark, the catch-up range, and the caught-up test that gates
+promotion all rest on it.
+
+The follower cannot tell its log where to put a record; the log appends at its
+own tail. So position is *verified* rather than commanded: the batch must begin
+exactly at the follower's tail.
+
+| The batch | Answer | What the leader does |
+| --- | --- | --- |
+| begins at the tail | `ReplicateOk` | send the next batch from `durable_offset` |
+| begins past the tail | `LogGap`, with `expected_offset` | resume from `expected_offset` |
+| lies entirely below the tail | `ReplicateOk` | nothing; it was already stored |
+| straddles the tail | `ReplicateOk` | nothing; the new suffix was stored |
+| disagrees on stored bytes | `LogConflict` | **stop** |
+| fails its checksum | `Malformed` | resend the same records |
+| names an older epoch | `FencedEpoch` | stop; this broker is no longer the leader |
+| names a newer epoch than the follower knows | `StaleRoute` | retry shortly |
+
+The middle two rows are what make a resend safe. Replication has to be able to
+resend a batch whose acknowledgement was lost, and resending must not duplicate
+a record: an overlap is resolved by position, and the overlapping bytes are
+compared rather than assumed.
+
+`ReplicateOk.durable_offset` is one past the last record the follower holds **on
+disk**. It is both the acknowledgement and the offset to send next. It never
+reports buffered data: a follower acknowledging before its own fsync would let
+the leader believe a record had survived a failure it would not have survived,
+and under `Quorum` that belief is the guarantee.
+
+The batch checksum covers each payload's length as well as its bytes. Without
+the length, a batch resplit in transit hashes the same as the original — and a
+resplit batch is a different set of records, which is exactly the divergence the
+checksum is there to catch. `felix_wire::internal::batch_checksum` is the single
+definition, so the two sides cannot compute it differently.
+
+`LogConflict` has no repair. Records are never rewritten, so two logs that
+disagree at an offset do not converge by retrying; progress stops and the
+condition is surfaced.
+
 ## Errors
 
 Typed, because they need different responses:
@@ -163,6 +210,10 @@ Typed, because they need different responses:
 | `Overload` | the owner is shedding load | retry with backoff |
 | `ProtocolVersion` | version not understood | do not retry; close |
 | `Malformed` | the body did not decode | do not retry; close |
+| `StorageFailed` | the responder tried and its own disk failed | do not retry; nothing is wrong with the request |
+| `LogGap` | a replication batch starts past the follower's tail | resume from `expected_offset` |
+| `LogConflict` | a replication batch disagrees with stored bytes | do not retry; the logs have diverged |
+| `FencedEpoch` | the sender named an epoch older than the responder's | do not retry; it is no longer the leader |
 
 `NotLeader` is a distinct kind rather than an error code, because it carries a
 routing answer rather than only a reason.

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -243,6 +243,11 @@ until records are actually replicated (#112) nothing reports being caught up, so
 promotion does not fire and placement behaves exactly as it did. The gate starts
 permitting failover at the moment replication starts working, and not before.
 
+The follower's half of this is implemented (#112): the exchange, the append
+rule, and the fence at the storing end. What ships records — the leader's side —
+is not, so nothing replicates yet and the promotion gate above still does not
+fire. The rule and its refusals are in `docs/internal-protocol.md`.
+
 ## What this does to the other M5 issues
 
 - **#111 (fenced leadership)** — this is now specific: the epoch is the

--- a/scripts/perf/run_latency_matrix.py
+++ b/scripts/perf/run_latency_matrix.py
@@ -208,6 +208,21 @@ def effective_total(workload: dict, batch: int, payload: int) -> int:
     return max(total, min(needed, max_total))
 
 
+def tail_of(path, lines: int = 40) -> str:
+    """The last few lines of a failed run's captured output, for the log."""
+    try:
+        captured = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as err:
+        return f"  (could not read {path}: {err})"
+    if not captured:
+        return f"  (no output captured in {path})"
+    shown = captured[-lines:]
+    elided = len(captured) - len(shown)
+    header = f"  --- last {len(shown)} line(s) of {path.name}"
+    header += f", {elided} earlier line(s) elided ---" if elided else " ---"
+    return "\n".join([header] + [f"  {line}" for line in shown])
+
+
 def build_matrix(config: dict, trials: int, binary_override=None):
     workload = config["workload"]
     profiles = config["profiles"]
@@ -499,6 +514,11 @@ def main():
                         f"[{idx}/{len(matrix)}] {label} failed after {attempt} "
                         f"attempt(s): {record['parse_error']}"
                     )
+                    # The run's own output is the only thing that says *why*, and
+                    # in CI the file it was captured to is thrown away with the
+                    # runner. Printing the tail is what makes a failure here
+                    # diagnosable from the log alone.
+                    print(tail_of(stdout_path))
                     if args.fail_fast:
                         raise SystemExit(msg)
                     print(f"WARNING: {msg} -- recording as failed, continuing")

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -398,11 +398,14 @@ where
             let server = peer::PeerServer::bind(
                 membership_config.node_id.clone(),
                 peer_config,
-                Arc::new(peer::ForwardingHandler::new(
-                    Arc::clone(&broker),
-                    Arc::clone(ingress),
-                    Arc::clone(router),
-                    membership_config.advertise_addr.clone(),
+                Arc::new(peer::BrokerPeerHandler::new(
+                    peer::ForwardingHandler::new(
+                        Arc::clone(&broker),
+                        Arc::clone(ingress),
+                        Arc::clone(router),
+                        membership_config.advertise_addr.clone(),
+                    ),
+                    peer::ReplicaHandler::new(Arc::clone(&broker), Arc::clone(router)),
                 )),
             )
             .context("bind broker-internal listener")?;

--- a/services/broker/src/peer/dispatch.rs
+++ b/services/broker/src/peer/dispatch.rs
@@ -1,0 +1,46 @@
+//! Routing a peer request to the half of this broker that answers it.
+//!
+//! Two halves, because a broker plays two roles at once and they are not the
+//! same role for the same shard: it is the leader of some shards and a follower
+//! of others. A forwarded publish is a request to *order* a record, and only a
+//! leader may answer it; a replication batch is a request to *store* one
+//! already ordered, and only a follower should. Keeping them apart is what
+//! stops either check standing in for the other.
+use async_trait::async_trait;
+use felix_wire::internal::{ErrorCode, ForwardPublishError, InternalMessage};
+
+use super::handler::ForwardingHandler;
+use super::replica::ReplicaHandler;
+use super::server::PeerRequestHandler;
+
+/// Answers every request a peer may send this broker.
+pub struct BrokerPeerHandler {
+    forwarding: ForwardingHandler,
+    replica: ReplicaHandler,
+}
+
+impl BrokerPeerHandler {
+    pub fn new(forwarding: ForwardingHandler, replica: ReplicaHandler) -> Self {
+        Self {
+            forwarding,
+            replica,
+        }
+    }
+}
+
+#[async_trait]
+impl PeerRequestHandler for BrokerPeerHandler {
+    async fn handle(&self, request: InternalMessage) -> InternalMessage {
+        match request {
+            InternalMessage::ForwardPublish(publish) => self.forwarding.apply(publish).await,
+            InternalMessage::ReplicateRecords(batch) => self.replica.apply(batch).await,
+            // Responses have no business arriving as requests, and a broker that
+            // answered one would be inventing a request that was never made.
+            other => InternalMessage::ForwardPublishError(ForwardPublishError {
+                correlation_id: other.correlation_id(),
+                code: ErrorCode::Malformed,
+                detail: format!("{:?} is not a request", other.kind()),
+            }),
+        }
+    }
+}

--- a/services/broker/src/peer/handler.rs
+++ b/services/broker/src/peer/handler.rs
@@ -51,7 +51,7 @@ impl ForwardingHandler {
         }
     }
 
-    async fn apply(&self, publish: ForwardPublish) -> InternalMessage {
+    pub(super) async fn apply(&self, publish: ForwardPublish) -> InternalMessage {
         let correlation_id = publish.correlation_id;
         let key = ShardKey {
             tenant_id: publish.shard.tenant_id.clone(),

--- a/services/broker/src/peer/metrics.rs
+++ b/services/broker/src/peer/metrics.rs
@@ -102,3 +102,30 @@ pub fn record_forward(outcome: &'static str) {
 pub fn record_forward_retry() {
     metrics::counter!(FORWARD_RETRIES_TOTAL).increment(1);
 }
+
+/// Replication batches this broker stored as a follower, by `outcome`.
+///
+/// The failure outcomes are separated because they need different responses.
+/// `gap` is ordinary during catch-up and self-repairing. `conflict` and
+/// `fenced` are not: the first means two logs have diverged, the second that a
+/// superseded leader is still shipping. Either one standing is worth waking
+/// someone for.
+pub const REPLICATED_TOTAL: &str = "felix_broker_replicated_total";
+
+/// The sender named an epoch older than this broker's, so it is no longer the
+/// leader.
+pub const OUTCOME_FENCED: &str = "fenced";
+/// This broker's routing view has not caught up with the epoch the sender
+/// named. Transient by nature.
+pub const OUTCOME_BEHIND: &str = "behind";
+/// The batch starts past this broker's tail. The leader resumes from the offset
+/// in the answer.
+pub const OUTCOME_GAP: &str = "gap";
+/// The batch disagrees with bytes already stored.
+pub const OUTCOME_CONFLICT: &str = "conflict";
+/// The batch did not survive the trip.
+pub const OUTCOME_CORRUPT: &str = "corrupt";
+
+pub fn record_replicated(outcome: &'static str) {
+    metrics::counter!(REPLICATED_TOTAL, "outcome" => outcome).increment(1);
+}

--- a/services/broker/src/peer/mod.rs
+++ b/services/broker/src/peer/mod.rs
@@ -11,17 +11,21 @@
 //! consume this broker.
 pub mod codec;
 pub mod config;
+pub mod dispatch;
 pub mod forward;
 pub mod handler;
 pub mod metrics;
 pub mod pool;
+pub mod replica;
 pub mod server;
 mod tls;
 
 pub use config::PeerTransportConfig;
+pub use dispatch::BrokerPeerHandler;
 pub use forward::{ForwardError, ForwardKey, ForwardTarget, forward_publish};
 pub use handler::ForwardingHandler;
 pub use pool::{PeerError, PeerPool};
+pub use replica::ReplicaHandler;
 pub use server::{PeerRequestHandler, PeerServer, UnavailableHandler};
 
 #[cfg(test)]

--- a/services/broker/src/peer/pool.rs
+++ b/services/broker/src/peer/pool.rs
@@ -771,6 +771,20 @@ fn with_correlation(message: InternalMessage, correlation_id: u64) -> InternalMe
             correlation_id,
             ..m
         }),
+        InternalMessage::ReplicateRecords(m) => {
+            InternalMessage::ReplicateRecords(ReplicateRecords {
+                correlation_id,
+                ..m
+            })
+        }
+        InternalMessage::ReplicateOk(m) => InternalMessage::ReplicateOk(ReplicateOk {
+            correlation_id,
+            ..m
+        }),
+        InternalMessage::ReplicateError(m) => InternalMessage::ReplicateError(ReplicateError {
+            correlation_id,
+            ..m
+        }),
     }
 }
 

--- a/services/broker/src/peer/pool_tests.rs
+++ b/services/broker/src/peer/pool_tests.rs
@@ -352,6 +352,9 @@ mod correlation {
             InternalMessage::NotLeader(m) => m.correlation_id,
             InternalMessage::Hello(m) => m.correlation_id,
             InternalMessage::HelloOk(m) => m.correlation_id,
+            InternalMessage::ReplicateRecords(m) => m.correlation_id,
+            InternalMessage::ReplicateOk(m) => m.correlation_id,
+            InternalMessage::ReplicateError(m) => m.correlation_id,
         }
     }
 
@@ -397,6 +400,23 @@ mod correlation {
             InternalMessage::HelloOk(HelloOk {
                 correlation_id: 7,
                 node_id: "broker-b".to_string(),
+            }),
+            InternalMessage::ReplicateRecords(ReplicateRecords {
+                correlation_id: 7,
+                shard: shard(),
+                first_offset: 12,
+                checksum: 0xabcd,
+                payloads: vec![Bytes::from_static(b"hello")],
+            }),
+            InternalMessage::ReplicateOk(ReplicateOk {
+                correlation_id: 7,
+                durable_offset: 13,
+            }),
+            InternalMessage::ReplicateError(ReplicateError {
+                correlation_id: 7,
+                code: ErrorCode::LogGap,
+                expected_offset: 9,
+                detail: "behind".to_string(),
             }),
         ]
     }

--- a/services/broker/src/peer/replica.rs
+++ b/services/broker/src/peer/replica.rs
@@ -1,0 +1,167 @@
+//! The follower's side: storing records the shard's leader shipped.
+//!
+//! Two checks stand between a batch and this broker's disk, and they answer
+//! different questions:
+//!
+//! 1. **May this broker store these records at all?** Decided here, from the
+//!    routing view: is this node in the shard's replica set, at the epoch the
+//!    sender named? A sender at an older epoch has been superseded, and its
+//!    records must not be stored — it may have written them after losing the
+//!    shard. That is the fence, and it is the same one the durable-append check
+//!    applies on the leader.
+//! 2. **Do these records belong where the batch says?** Decided by
+//!    [`felix_broker::replication::apply`], against the log's own tail.
+//!
+//! The order matters. Position is only meaningful once the sender is
+//! established as the current leader: applying first and checking after would
+//! let a fenced leader's bytes reach the disk, and records are never rewritten.
+use std::sync::Arc;
+
+use felix_broker::Broker;
+use felix_broker::replication::{self, Divergence};
+use felix_router::{ReplicaRole, ShardRouter};
+use felix_wire::internal::{
+    ErrorCode, InternalMessage, ReplicateError, ReplicateOk, ReplicateRecords,
+};
+
+use super::metrics;
+
+/// Stores replicated records against this broker's local logs.
+pub struct ReplicaHandler {
+    broker: Arc<Broker>,
+    router: Arc<ShardRouter>,
+}
+
+impl ReplicaHandler {
+    pub fn new(broker: Arc<Broker>, router: Arc<ShardRouter>) -> Self {
+        Self { broker, router }
+    }
+
+    pub async fn apply(&self, batch: ReplicateRecords) -> InternalMessage {
+        let correlation_id = batch.correlation_id;
+        let key = felix_router::ShardKey {
+            tenant_id: batch.shard.tenant_id.clone(),
+            namespace: batch.shard.namespace.clone(),
+            stream: batch.shard.stream.clone(),
+            shard: batch.shard.shard,
+        };
+
+        match self.router.replica_role(&key, batch.shard.generation) {
+            ReplicaRole::Follower => {}
+            ReplicaRole::Fenced { have, named } => {
+                metrics::record_replicated(metrics::OUTCOME_FENCED);
+                return refused(
+                    correlation_id,
+                    ErrorCode::FencedEpoch,
+                    0,
+                    format!("this broker is at generation {have}, the sender at {named}"),
+                );
+            }
+            ReplicaRole::Behind { have, named } => {
+                // Not a refusal of the leader, only of this moment: the watch
+                // has not caught up. Retryable, and the leader will find us
+                // ready once it has.
+                metrics::record_replicated(metrics::OUTCOME_BEHIND);
+                return refused(
+                    correlation_id,
+                    ErrorCode::StaleRoute,
+                    0,
+                    format!("this broker is at generation {have}, the sender at {named}"),
+                );
+            }
+            ReplicaRole::NotAReplica => {
+                metrics::record_replicated(metrics::OUTCOME_REFUSED);
+                return refused(
+                    correlation_id,
+                    ErrorCode::Unauthorized,
+                    0,
+                    "this broker is not a replica of that shard".to_string(),
+                );
+            }
+        }
+
+        let Some(storage) = self.broker.durable_storage() else {
+            // A replica set naming a broker with no durable storage is a
+            // configuration error, not a transient one. Saying so beats
+            // accepting and silently keeping nothing.
+            metrics::record_replicated(metrics::OUTCOME_REFUSED);
+            return refused(
+                correlation_id,
+                ErrorCode::Unauthorized,
+                0,
+                "this broker has no durable storage".to_string(),
+            );
+        };
+
+        let log = match storage.open_stream(&key.tenant_id, &key.namespace, &key.stream, key.shard)
+        {
+            Ok(log) => log,
+            Err(err) => {
+                metrics::record_replicated(metrics::OUTCOME_ERROR);
+                return refused(correlation_id, ErrorCode::StorageFailed, 0, err.to_string());
+            }
+        };
+
+        match replication::apply(&log, batch.first_offset, batch.checksum, &batch.payloads).await {
+            Ok(Ok(applied)) => {
+                metrics::record_replicated(metrics::OUTCOME_OK);
+                InternalMessage::ReplicateOk(ReplicateOk {
+                    correlation_id,
+                    durable_offset: applied.durable_offset,
+                })
+            }
+            Ok(Err(divergence)) => {
+                metrics::record_replicated(divergence_outcome(&divergence));
+                refused(
+                    correlation_id,
+                    divergence_code(&divergence),
+                    divergence.expected_offset(),
+                    divergence.to_string(),
+                )
+            }
+            Err(err) => {
+                // This broker's own disk failed. Distinct from every refusal
+                // above: nothing is wrong with what the leader sent, so the
+                // leader must not treat it as divergence and stop.
+                metrics::record_replicated(metrics::OUTCOME_ERROR);
+                refused(correlation_id, ErrorCode::StorageFailed, 0, err.to_string())
+            }
+        }
+    }
+}
+
+fn divergence_code(divergence: &Divergence) -> ErrorCode {
+    match divergence {
+        Divergence::Gap { .. } => ErrorCode::LogGap,
+        Divergence::Conflict { .. } => ErrorCode::LogConflict,
+        // A batch that did not survive the trip is a transport problem, and
+        // resending the same records is the repair.
+        Divergence::Corrupt { .. } => ErrorCode::Malformed,
+    }
+}
+
+fn divergence_outcome(divergence: &Divergence) -> &'static str {
+    match divergence {
+        Divergence::Gap { .. } => metrics::OUTCOME_GAP,
+        Divergence::Conflict { .. } => metrics::OUTCOME_CONFLICT,
+        Divergence::Corrupt { .. } => metrics::OUTCOME_CORRUPT,
+    }
+}
+
+fn refused(
+    correlation_id: u64,
+    code: ErrorCode,
+    expected_offset: u64,
+    detail: String,
+) -> InternalMessage {
+    InternalMessage::ReplicateError(ReplicateError {
+        correlation_id,
+        code,
+        expected_offset,
+        detail,
+    })
+}
+
+#[cfg(test)]
+#[path = "replica_tests.rs"]
+mod tests;

--- a/services/broker/src/peer/replica_tests.rs
+++ b/services/broker/src/peer/replica_tests.rs
@@ -1,0 +1,252 @@
+//! The checks standing between a shipped batch and this broker's disk.
+//!
+//! These are about *authority* rather than position: whether the sender is
+//! still the leader, and whether this broker is a replica at all. Position is
+//! `felix_broker::replication`'s subject and is tested there.
+use bytes::Bytes;
+use felix_router::{NodeRef, RegionRouter, RoutingTable, ShardRouter};
+use felix_storage::EphemeralCache;
+use felix_storage::log::{FsyncMode, LogConfig};
+use felix_wire::internal::{ShardRef, batch_checksum};
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+use super::*;
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+const LOCAL: &str = "broker-b";
+
+fn node(node_id: &str, port: u16) -> NodeRef {
+    NodeRef {
+        node_id: node_id.to_string(),
+        advertise_addr: format!("10.0.0.1:{port}").parse().expect("addr"),
+        region: "us-west-2".to_string(),
+        live: true,
+    }
+}
+
+fn key() -> felix_router::ShardKey {
+    felix_router::ShardKey {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard: 0,
+    }
+}
+
+/// A router in which `LOCAL` is a follower of the shard at `generation`, unless
+/// `replicas` says otherwise.
+fn router_with(replicas: &[&str], generation: u64) -> Arc<ShardRouter> {
+    let router = Arc::new(ShardRouter::new(
+        LOCAL,
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let nodes: HashMap<String, NodeRef> = [
+        ("broker-a".to_string(), node("broker-a", 7001)),
+        (LOCAL.to_string(), node(LOCAL, 7002)),
+        ("broker-c".to_string(), node("broker-c", 7003)),
+    ]
+    .into_iter()
+    .collect();
+    let table = RoutingTable::build(
+        [(
+            key(),
+            "broker-a".to_string(),
+            replicas.iter().map(|r| r.to_string()).collect::<Vec<_>>(),
+            generation,
+        )],
+        &nodes,
+    );
+    router.publish(table, &nodes);
+    router
+}
+
+async fn broker_with_storage() -> (Arc<Broker>, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage = felix_broker::DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+    (
+        Arc::new(Broker::new(EphemeralCache::new().into()).with_durable_storage(storage)),
+        dir,
+    )
+}
+
+fn batch(generation: u64, first_offset: u64, values: &[&str]) -> ReplicateRecords {
+    let payloads: Vec<Bytes> = values
+        .iter()
+        .map(|v| Bytes::copy_from_slice(v.as_bytes()))
+        .collect();
+    ReplicateRecords {
+        correlation_id: 1,
+        shard: ShardRef {
+            tenant_id: TENANT.to_string(),
+            namespace: NAMESPACE.to_string(),
+            stream: STREAM.to_string(),
+            shard: 0,
+            generation,
+        },
+        first_offset,
+        checksum: batch_checksum(&payloads),
+        payloads,
+    }
+}
+
+fn refusal(answer: &InternalMessage) -> &ReplicateError {
+    match answer {
+        InternalMessage::ReplicateError(err) => err,
+        other => panic!("expected a refusal, got {:?}", other.kind()),
+    }
+}
+
+/// A follower at the leader's epoch stores the batch and reports its durable
+/// mark.
+#[tokio::test]
+async fn a_follower_at_the_leaders_epoch_stores_the_batch() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+
+    let answer = handler.apply(batch(4, 0, &["a", "b"])).await;
+
+    match answer {
+        InternalMessage::ReplicateOk(ok) => {
+            assert_eq!(ok.durable_offset, 2);
+            assert_eq!(ok.correlation_id, 1);
+        }
+        other => panic!("expected an acknowledgement, got {:?}", other.kind()),
+    }
+}
+
+/// **A superseded leader is refused.** Its records may have been written after
+/// it lost the shard, and a follower that stored them would hold bytes no
+/// current leader ever ordered. The fence does not lift, so this is not
+/// retryable.
+#[tokio::test]
+async fn a_leader_at_an_older_epoch_is_fenced() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 5));
+
+    let answer = handler.apply(batch(4, 0, &["a"])).await;
+
+    let refused = refusal(&answer);
+    assert_eq!(refused.code, ErrorCode::FencedEpoch);
+    assert!(
+        !refused.code.is_retryable(),
+        "a fenced leader was told to retry"
+    );
+}
+
+/// A follower whose watch is behind refuses *for now* — retryable, because the
+/// assignment is on its way and the leader is not at fault.
+#[tokio::test]
+async fn a_follower_behind_the_epoch_refuses_retryably() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 3));
+
+    let answer = handler.apply(batch(4, 0, &["a"])).await;
+
+    let refused = refusal(&answer);
+    assert_eq!(refused.code, ErrorCode::StaleRoute);
+    assert!(refused.code.is_retryable());
+}
+
+/// **A broker outside the replica set stores nothing.** Otherwise any peer
+/// could place bytes on any broker's disk by naming a shard.
+#[tokio::test]
+async fn a_broker_outside_the_replica_set_is_refused() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&["broker-c"], 4));
+
+    let answer = handler.apply(batch(4, 0, &["a"])).await;
+
+    assert_eq!(refusal(&answer).code, ErrorCode::Unauthorized);
+}
+
+/// A shard this broker has never heard of reads as "behind", not as a refusal:
+/// the assignment may simply not have arrived, and refusing permanently would
+/// strand a follower whose watch is a moment late.
+#[tokio::test]
+async fn an_unknown_shard_is_treated_as_a_late_watch() {
+    let (broker, _dir) = broker_with_storage().await;
+    let router = Arc::new(ShardRouter::new(
+        LOCAL,
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    let handler = ReplicaHandler::new(broker, router);
+
+    let answer = handler.apply(batch(4, 0, &["a"])).await;
+
+    let refused = refusal(&answer);
+    assert_eq!(refused.code, ErrorCode::StaleRoute);
+    assert!(refused.code.is_retryable());
+}
+
+/// A gap is reported with the offset the leader should resume from, so the
+/// repair needs no separate negotiation.
+#[tokio::test]
+async fn a_gap_names_the_offset_to_resume_from() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+    handler.apply(batch(4, 0, &["a", "b"])).await;
+
+    let answer = handler.apply(batch(4, 7, &["h"])).await;
+
+    let refused = refusal(&answer);
+    assert_eq!(refused.code, ErrorCode::LogGap);
+    assert_eq!(refused.expected_offset, 2);
+}
+
+/// A conflict is reported as its own code, and is not retryable: two logs that
+/// disagree do not converge by resending.
+#[tokio::test]
+async fn a_conflict_is_reported_as_divergence() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+    handler.apply(batch(4, 0, &["a", "b"])).await;
+
+    let answer = handler.apply(batch(4, 0, &["a", "DIFFERENT"])).await;
+
+    let refused = refusal(&answer);
+    assert_eq!(refused.code, ErrorCode::LogConflict);
+    assert!(!refused.code.is_retryable());
+}
+
+/// **A replica with nowhere to put records says so.** Accepting and keeping
+/// nothing would let the leader count this broker toward a quorum that does not
+/// exist.
+#[tokio::test]
+async fn a_replica_without_durable_storage_refuses() {
+    let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+
+    let answer = handler.apply(batch(4, 0, &["a"])).await;
+
+    assert_eq!(refusal(&answer).code, ErrorCode::Unauthorized);
+}
+
+/// The answer always carries the request's correlation id, whatever the
+/// outcome. A requester that could not match a refusal would wait out its
+/// timeout instead of acting on it.
+#[tokio::test]
+async fn every_answer_carries_the_requests_correlation_id() {
+    let (broker, _dir) = broker_with_storage().await;
+    let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+
+    for generation in [3, 4, 5] {
+        let mut request = batch(generation, 0, &["a"]);
+        request.correlation_id = 99;
+        assert_eq!(handler.apply(request).await.correlation_id(), 99);
+    }
+}


### PR DESCRIPTION
The follower's half of #112. Nothing ships records yet, so nothing replicates and #111's promotion gate still does not fire — it starts permitting failover when the leader's side lands, and not before. The leader's shipping loop, pipelining and backpressure, reconnect/resume, and the lag metric are the second slice.

## Offsets are the leader's

A follower stores a record at the leader's offset or not at all. That is what makes the two logs comparable by offset, and the acknowledged mark, the catch-up range, and the caught-up test that gates promotion all rest on it.

The log underneath appends at its own tail and cannot be told where to put a record. So the follower doesn't ask it to — it checks that the batch begins exactly at its tail and refuses otherwise. **Position is verified rather than commanded**, which is stricter and needs nothing new from the storage layer.

## Why a resend is safe

Replication has to be able to resend a batch whose acknowledgement was lost, and a resend must not duplicate a record.

| The batch | Answer | What the leader does |
|---|---|---|
| begins at the tail | `ReplicateOk` | send the next batch from `durable_offset` |
| begins past the tail | `LogGap` + `expected_offset` | resume from `expected_offset` |
| lies entirely below the tail | `ReplicateOk` | nothing; already stored |
| straddles the tail | `ReplicateOk` | nothing; the suffix was stored |
| disagrees on stored bytes | `LogConflict` | **stop** |
| fails its checksum | `Malformed` | resend the same records |
| names an older epoch | `FencedEpoch` | stop; no longer the leader |
| names a newer epoch than the follower knows | `StaleRoute` | retry shortly |

The middle rows are the ones that make a resend safe. The overlapping bytes are **compared against disk rather than assumed**, so a resend that is not actually a resend gets caught instead of appended.

## What each refusal means

`LogGap` names the offset the follower wants, so the repair needs no separate negotiation. `LogConflict` has no repair — records are never rewritten, so two logs that disagree at an offset do not converge by retrying. `FencedEpoch` refuses a superseded leader, which may have written those records *after* losing the shard. Only `LogGap` is retryable, and there's a test asserting exactly that, because getting it backwards either hammers a diverged follower or abandons a lagging one.

## Durable, not buffered

`ReplicateOk.durable_offset` is on disk before it is reported. A follower acknowledging before its own fsync would let the leader believe a record survived a failure it would not have — and under `Quorum` that belief *is* the guarantee. Tested under `FsyncMode::OnCommit` against the real `DiskLog`.

## The checksum

Covers each payload's length as well as its bytes. Without the length, `["ab","c"]` and `["a","bc"]` hash alike — and they are different records, which is exactly the divergence the checksum exists to catch. Defined once in `felix_wire::internal::batch_checksum` so the two sides cannot compute it differently.

## Two checks, in this order

`replica.rs` decides *may this broker store these at all* (replica set membership at the sender's epoch) before `replication::apply` decides *do they belong where the batch says*. Position is only meaningful once the sender is established as the current leader — applying first would let a fenced leader's bytes reach disk, and records are never rewritten.

## Verification

Every rule confirmed against a reverted check:

| Reverted | Fails |
|---|---|
| gap check | `a_batch_that_would_leave_a_hole_is_refused`, `a_fresh_follower_expects_the_first_offset` |
| overlap comparison | `a_batch_that_disagrees_with_stored_bytes_stops_progress` |
| suffix-only append | the three resend tests |
| `commit` before ack | `the_acknowledged_offset_is_on_disk_before_it_is_reported` |

The three new kinds join `every_message()`, which already drives round-trip, truncation at every byte, single-byte corruption, and trailing-byte rejection — so they inherit the malformed-input suite rather than needing a parallel one. A golden vector pins `ReplicateRecords`' bytes, and a test pins the existing kind discriminants, since a peer mid-upgrade decodes by number.

`task lint`, `task test`, `task conformance`, `task demo:check` all clean.

Closes part of #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also here: two CI fixes the perf failure on this branch turned up

These are unrelated to replication. They are here because this branch is where the failure surfaced; happy to split them out if you'd rather review them separately.

**The perf job was building two checkouts into one target directory.** It builds the merge-base worktree and the PR checkout back-to-back and shared `CARGO_TARGET_DIR` so third-party deps compile once. But they're two copies of the *same* workspace, and cargo derives a path dependency's metadata hash from name and version, not from which checkout it came from. The shared directory held exactly one `felix_router` rmeta and one fingerprint for the two source trees — whichever built last won.

The loud failure is not the one that matters. This branch adds a cross-crate API, so the candidate failed to compile and every trial reported "nonzero exit". **A PR that only changes a function body would compile fine against the baseline's code, and the job would benchmark the merge-base twice and report "no change" — which is exactly what a regression also looks like.** Each side now gets its own target directory.

Reproduced both directions locally before and after: shared directory → candidate fails to compile; separate directories → both clean.

**A failed benchmark run now prints its own output.** The harness captured the demo's stdout/stderr to `data/raw/stdout/` and printed only "nonzero exit". In CI that directory dies with the runner, so the log said a run failed and gave no way to find out why. The tail of the captured output now goes to the log — that is how the above got diagnosed at all.
