### PR TITLE
fix(broker): stop a skipped batch ending a subscription (#253)

### DIFF
--- a/crates/felix-broker/src/subscription.rs
+++ b/crates/felix-broker/src/subscription.rs
@@ -52,24 +52,38 @@ pub struct Subscription {
 }
 
 impl Subscription {
+    /// The next record, or `None` once the subscription has ended.
+    ///
+    /// **`None` means the channel closed, and nothing else.** Every caller
+    /// treats it as the end of the stream, so a batch that happens to yield no
+    /// records must not produce one: a batch landing entirely below
+    /// [`Self::skip_below`] is ordinary during a resume, and reporting it as an
+    /// end of stream loses every record after the cursor.
     pub async fn recv(&mut self) -> Option<Bytes> {
-        if let Some(payload) = self.pending.pop_front() {
-            return Some(payload);
+        loop {
+            if let Some(payload) = self.pending.pop_front() {
+                return Some(payload);
+            }
+            // Terminates: each turn consumes one envelope from a finite
+            // channel, and a closed one ends the loop through `?`.
+            let envelope = self.receiver.recv().await?;
+            self.extend_pending(&envelope);
         }
-        let envelope = self.receiver.recv().await?;
-        self.extend_pending(&envelope);
-        self.pending.pop_front()
     }
 
+    /// The next record if one is already queued.
+    ///
+    /// `Empty` means nothing is waiting, so — as in [`Self::recv`] — a batch
+    /// that yielded no records is skipped rather than reported: the queue may
+    /// still hold the record the caller is after.
     pub fn try_recv(&mut self) -> std::result::Result<Bytes, mpsc::error::TryRecvError> {
-        if let Some(payload) = self.pending.pop_front() {
-            return Ok(payload);
+        loop {
+            if let Some(payload) = self.pending.pop_front() {
+                return Ok(payload);
+            }
+            let envelope = self.receiver.try_recv()?;
+            self.extend_pending(&envelope);
         }
-        let envelope = self.receiver.try_recv()?;
-        self.extend_pending(&envelope);
-        self.pending
-            .pop_front()
-            .ok_or(mpsc::error::TryRecvError::Empty)
     }
 
     /// Queue an envelope's payloads, dropping any below the resume point.
@@ -141,3 +155,7 @@ impl Drop for SubscriptionReceiver {
         self.receiver.close();
     }
 }
+
+#[cfg(test)]
+#[path = "subscription_tests.rs"]
+mod tests;

--- a/crates/felix-broker/src/subscription_tests.rs
+++ b/crates/felix-broker/src/subscription_tests.rs
@@ -1,0 +1,143 @@
+//! What `recv` reports, and what a caller is entitled to conclude from it.
+//!
+//! `None` is the end of the subscription. Every caller treats it that way — the
+//! broker's subscribe handler, the client, and the benchmarks all stop when
+//! they see it. So `None` must mean the channel closed and nothing else.
+use super::*;
+use crate::delivery::DeliveryEnvelope;
+use std::sync::Arc;
+
+fn payload(value: &str) -> Bytes {
+    Bytes::copy_from_slice(value.as_bytes())
+}
+
+/// A subscription resuming at `skip_below`, with a sender to feed it.
+fn resuming_at(skip_below: u64) -> (mpsc::Sender<QueuedDelivery>, Subscription) {
+    let (tx, rx) = mpsc::channel(16);
+    let subscription = Subscription {
+        receiver: SubscriptionReceiver::new(rx),
+        // No stream to unregister from; the guard's `Weak` simply never
+        // upgrades, which is the same thing it does after a stream is dropped.
+        guard: SubscriptionGuard {
+            stream_state: Weak::new(),
+            subscriber_id: 0,
+        },
+        pending: VecDeque::new(),
+        skip_below: Some(skip_below),
+    };
+    (tx, subscription)
+}
+
+fn deliver(tx: &mpsc::Sender<QueuedDelivery>, base_offset: u64, values: &[&str]) {
+    let payloads: Vec<Bytes> = values.iter().map(|v| payload(v)).collect();
+    let envelope = DeliveryEnvelope::with_base_offset(&payloads, Some(base_offset));
+    tx.try_send(QueuedDelivery::new(
+        envelope,
+        Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+    ))
+    .expect("queue the delivery");
+}
+
+/// **A batch entirely below the resume point is skipped, not an end of stream.**
+///
+/// A publish claims its disk offsets before the record reaches the replay ring,
+/// so a cursor taken from the durable tail can name an offset the ring has not
+/// seen, and the records in between arrive live and below the cursor. Dropping
+/// them is correct — the caller already has them. Reporting `None` is not: every
+/// caller reads that as "the broker closed my subscription" and stops, losing
+/// every record after the cursor.
+#[tokio::test]
+async fn a_batch_wholly_below_the_resume_point_is_skipped_rather_than_ending_the_stream() {
+    let (tx, mut subscription) = resuming_at(105);
+
+    // Offsets 100-102: all below the resume point, so nothing to deliver.
+    deliver(&tx, 100, &["a", "b", "c"]);
+    // And then the record the caller is actually waiting for.
+    deliver(&tx, 105, &["f"]);
+
+    assert_eq!(
+        subscription.recv().await,
+        Some(payload("f")),
+        "a skipped batch was reported as the end of the subscription",
+    );
+}
+
+/// Several skipped batches in a row are still not an end of stream.
+#[tokio::test]
+async fn consecutive_skipped_batches_do_not_end_the_stream() {
+    let (tx, mut subscription) = resuming_at(105);
+
+    deliver(&tx, 100, &["a"]);
+    deliver(&tx, 101, &["b"]);
+    deliver(&tx, 102, &["c"]);
+    deliver(&tx, 105, &["f"]);
+
+    assert_eq!(subscription.recv().await, Some(payload("f")));
+}
+
+/// A batch straddling the resume point yields only the part at or above it.
+#[tokio::test]
+async fn a_batch_straddling_the_resume_point_yields_only_its_tail() {
+    let (tx, mut subscription) = resuming_at(102);
+
+    deliver(&tx, 100, &["a", "b", "c", "d"]);
+
+    assert_eq!(subscription.recv().await, Some(payload("c")));
+    assert_eq!(subscription.recv().await, Some(payload("d")));
+}
+
+/// Once past the resume point the filter retires, so later batches are
+/// delivered whole.
+#[tokio::test]
+async fn the_filter_retires_once_the_resume_point_is_reached() {
+    let (tx, mut subscription) = resuming_at(100);
+
+    deliver(&tx, 100, &["a"]);
+    deliver(&tx, 101, &["b"]);
+
+    assert_eq!(subscription.recv().await, Some(payload("a")));
+    assert_eq!(subscription.recv().await, Some(payload("b")));
+}
+
+/// **`None` still means the channel closed.** The fix must not turn an ended
+/// subscription into a hang.
+#[tokio::test]
+async fn a_closed_channel_still_reports_the_end_of_the_stream() {
+    let (tx, mut subscription) = resuming_at(105);
+    deliver(&tx, 100, &["a"]);
+    drop(tx);
+
+    assert_eq!(
+        subscription.recv().await,
+        None,
+        "a closed channel must still end the subscription",
+    );
+}
+
+/// `try_recv` has the same trap: a skipped batch is not "nothing queued".
+#[tokio::test]
+async fn try_recv_sees_past_a_skipped_batch() {
+    let (tx, mut subscription) = resuming_at(105);
+    deliver(&tx, 100, &["a", "b"]);
+    deliver(&tx, 105, &["f"]);
+
+    assert_eq!(
+        subscription
+            .try_recv()
+            .expect("the record above the cursor"),
+        payload("f"),
+    );
+}
+
+/// And `try_recv` still reports an empty queue as empty rather than blocking or
+/// inventing a record.
+#[tokio::test]
+async fn try_recv_reports_an_empty_queue_as_empty() {
+    let (tx, mut subscription) = resuming_at(105);
+    deliver(&tx, 100, &["a"]);
+
+    assert!(matches!(
+        subscription.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty),
+    ));
+}


### PR DESCRIPTION
Fixes #253.

## The bug

`Subscription::recv` read one envelope, filtered it, and returned whatever that one envelope produced:

```rust
let envelope = self.receiver.recv().await?;
self.extend_pending(&envelope);
self.pending.pop_front()          // ← None when the batch yielded nothing
```

`extend_pending` drops payloads below `skip_below`. A batch landing **entirely** below it produces nothing, so `pop_front` returns `None` — and `None` is the value that means *the channel closed*. Every caller reads it that way: the broker's subscribe handler, the client, and the latency demo all stop when they see it.

A subscriber that did nothing wrong is told its stream ended, and loses every record after the cursor.

## Why the batch is below the cursor in the first place

Not exotic — the field's own documentation says it:

> A publish claims its disk offsets before the record reaches the replay ring, so a cursor taken from the durable tail can name an offset the ring has not seen.

So those records arrive **live and below the cursor**. Dropping them is correct: the caller already has them. Ending the subscription is not.

## Why this is #253

The signature matches exactly:

| #253 reported | Cause |
|---|---|
| `seen` empty — backlog empty and nothing delivered | first live envelope was wholly below the cursor |
| exited via `Ok(None)` | `pop_front()` on an empty `pending` |
| the `timed_out` assertion did **not** fire | it genuinely wasn't slowness |
| only on loaded Linux CI, never on a fast machine | needs an in-flight publish below the cursor; a wider window makes it likelier |

That last row also explains why the issue's own reproduction attempts failed: 30 plain runs and 12 under CPU saturation on a fast machine is exactly where this is hardest to hit.

## The fix

Both `recv` and `try_recv` now consume envelopes until they have a record or the channel really ends. Each turn consumes one envelope from a finite channel, so neither can spin.

## Tests

All three of these fail on `main`:

- a batch wholly below the resume point does not end the stream
- several such batches in a row do not end the stream
- `try_recv` sees past a skipped batch

And these guard the fix from overshooting:

- a closed channel **still** reports the end of the stream
- an empty queue **still** reports empty rather than blocking
- a batch straddling the resume point still yields only its tail
- the filter still retires once the cursor is reached

## What I did not prove

I did not witness #253 itself. 60 runs of `the_backlog_to_live_handoff_loses_nothing_under_concurrent_publishes` on two pinned CPUs under Linux passed **both with and without** the fix, matching the issue's own attempts. The defect is proven deterministically by the unit tests, and its signature matches the reported failure in every detail — but tying it to that specific occurrence is inference, not a reproduction. Worth keeping an eye on CI for a recurrence.

## Also found, filed separately

#256 — reaping a closed subscriber can remove a live one, because `Slab` recycles ids and `remove_subscribers` removes purely by index from a snapshot that may be stale. A different defect with a different signature; not fixed here.

`task lint`, `task test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)