### PR TITLE
feat(replication): ship committed records to followers (M5.3)

### DIFF
--- a/crates/felix-router/src/lib.rs
+++ b/crates/felix-router/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod shard;
 
 pub use shard::{
-    NodeRef, ReplicaRole, Resolution, RoutingTable, ShardKey, ShardRouter, Unavailable,
+    NodeRef, ReplicaRole, Resolution, Route, RoutingTable, ShardKey, ShardRouter, Unavailable,
 };
 
 use felix_common::ids::RegionId;

--- a/crates/felix-router/src/shard.rs
+++ b/crates/felix-router/src/shard.rs
@@ -168,6 +168,14 @@ impl RoutingTable {
         self.routes.get(key)
     }
 
+    /// Every route in the table.
+    ///
+    /// For a caller that has to visit shards rather than look one up -- the
+    /// replication driver walks the table to find the shards this node leads.
+    pub fn iter(&self) -> impl Iterator<Item = (&ShardKey, &Route)> {
+        self.routes.iter()
+    }
+
     pub fn len(&self) -> usize {
         self.routes.len()
     }

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -243,10 +243,23 @@ until records are actually replicated (#112) nothing reports being caught up, so
 promotion does not fire and placement behaves exactly as it did. The gate starts
 permitting failover at the moment replication starts working, and not before.
 
-The follower's half of this is implemented (#112): the exchange, the append
-rule, and the fence at the storing end. What ships records — the leader's side —
-is not, so nothing replicates yet and the promotion gate above still does not
-fire. The rule and its refusals are in `docs/internal-protocol.md`.
+Both halves of this are implemented (#112). The follower's side is the exchange,
+the append rule, and the fence at the storing end. The leader's side keeps one
+cursor per follower, ships bounded batches from its own log, and moves the
+cursor only on the follower's answer — so a follower that has fallen behind or
+been rebuilt is caught up by its own `LogGap`, with no separate negotiation and
+nothing kept on disk.
+
+Replication to a follower stops on `LogConflict` or `FencedEpoch`. Neither
+converges by retrying: the first means the two logs disagree about bytes both
+sides hold, the second that this broker is no longer the leader.
+
+The `Leader` loss window is exported as `felix_broker_replication_lag_records`:
+how far the slowest follower is behind, across every shard this broker leads. A
+halted follower is excluded from it — it has stopped rather than fallen behind,
+and `felix_broker_replication_halted` is where that shows.
+
+The rule and its refusals are in `docs/internal-protocol.md`.
 
 ## What this does to the other M5 issues
 
@@ -255,7 +268,10 @@ fire. The rule and its refusals are in `docs/internal-protocol.md`.
   routing and durable-append boundaries. **#239 is subsumed**: a stale ex-owner is
   a broker without a valid lease, and the same check refuses it.
 - **#112 (replicate records)** — append-only shipping, not a consensus log. The
-  catch-up path is `read_range` plus sealed-segment checksums.
+  catch-up path is `read_range` plus sealed-segment checksums. **Done**, both
+  halves. Catch-up currently re-reads from the offset the follower names rather
+  than verifying whole sealed segments by checksum; that is an optimisation for
+  #114, not a change to the rule.
 - **#113 (Leader and Quorum)** — the majority is over the replica set *of the
   current generation*, and an acknowledgement from a replica at an older
   generation does not count toward it.

--- a/services/broker/src/lib.rs
+++ b/services/broker/src/lib.rs
@@ -17,6 +17,7 @@ pub mod membership_metrics;
 pub mod node_catalog;
 pub mod peer;
 pub mod quic;
+pub mod replication;
 pub mod shard_lifecycle;
 pub mod shard_lifecycle_metrics;
 pub mod shard_routing;

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -36,6 +36,7 @@ mod test_support;
 use anyhow::{Context, Result};
 use broker::membership;
 use broker::peer;
+use broker::replication;
 use broker::{auth::BrokerAuth, config, durable_config::DurableStorageConfig, quic};
 use broker::{shard_lifecycle, shard_routing, shard_watch};
 use felix_broker::{Broker, DurableStorage};
@@ -457,6 +458,18 @@ where
                 Duration::from_millis(config.controlplane_sync_interval_ms),
                 sync_shutdown.clone(),
             );
+            // Shipping to followers, for the shards this broker leads. Only
+            // when there is a peer transport to ship over: without one the
+            // replica set is a plan nobody can act on.
+            if let Some(pool) = &peers {
+                replication::driver::spawn(
+                    Arc::clone(pool),
+                    Arc::clone(&broker),
+                    Arc::clone(router),
+                    Duration::from_millis(config.controlplane_sync_interval_ms),
+                    sync_shutdown.clone(),
+                );
+            }
             Some((watch, feed))
         }
         _ => None,

--- a/services/broker/src/peer/forward.rs
+++ b/services/broker/src/peer/forward.rs
@@ -81,7 +81,7 @@ pub trait PeerRequester {
         node_id: &str,
         addr: SocketAddr,
         message: InternalMessage,
-    ) -> impl std::future::Future<Output = std::result::Result<InternalMessage, PeerError>>;
+    ) -> impl std::future::Future<Output = std::result::Result<InternalMessage, PeerError>> + Send;
 }
 
 impl<T: PeerRequester> PeerRequester for std::sync::Arc<T> {
@@ -90,7 +90,8 @@ impl<T: PeerRequester> PeerRequester for std::sync::Arc<T> {
         node_id: &str,
         addr: SocketAddr,
         message: InternalMessage,
-    ) -> impl std::future::Future<Output = std::result::Result<InternalMessage, PeerError>> {
+    ) -> impl std::future::Future<Output = std::result::Result<InternalMessage, PeerError>> + Send
+    {
         T::request(self, node_id, addr, message)
     }
 }

--- a/services/broker/src/peer/mod.rs
+++ b/services/broker/src/peer/mod.rs
@@ -22,7 +22,7 @@ mod tls;
 
 pub use config::PeerTransportConfig;
 pub use dispatch::BrokerPeerHandler;
-pub use forward::{ForwardError, ForwardKey, ForwardTarget, forward_publish};
+pub use forward::{ForwardError, ForwardKey, ForwardTarget, PeerRequester, forward_publish};
 pub use handler::ForwardingHandler;
 pub use pool::{PeerError, PeerPool};
 pub use replica::ReplicaHandler;

--- a/services/broker/src/replication.rs
+++ b/services/broker/src/replication.rs
@@ -1,0 +1,241 @@
+//! The leader's half of replication: shipping committed records to followers.
+//!
+//! # One cursor per follower
+//!
+//! A follower is a position in this shard's log, nothing more. The leader keeps
+//! the next offset it believes each follower wants, reads that range from its
+//! own log, and ships it. The follower's answer is what moves the cursor —
+//! never the send itself, because a batch that was sent is not a batch that was
+//! stored.
+//!
+//! That is why the cursor can go *backwards*. A follower that has lost records,
+//! or that was rebuilt, answers `LogGap` naming the offset it actually wants,
+//! and the leader resumes there. Resume needs no separate negotiation and no
+//! state on disk: the follower is the authority on its own position, and it
+//! says so in every refusal.
+//!
+//! # What stops, and what retries
+//!
+//! `LogConflict` and `FencedEpoch` stop this shard's replication to that
+//! follower. Neither converges by trying again: the first means the two logs
+//! disagree about bytes already stored, and the second means this broker is no
+//! longer the leader, so it has no business shipping anything. Everything else
+//! is transient and retried.
+//!
+//! # What bounds it
+//!
+//! One batch in flight per follower, and each batch is bounded by
+//! `max_batch_bytes` read from the log. So the memory a lagging follower costs
+//! the leader is one batch, not the distance it is behind — and a follower that
+//! stops answering stops consuming anything at all, because the next read does
+//! not start until the last answer arrives.
+use std::net::SocketAddr;
+
+use bytes::Bytes;
+use felix_broker::StreamLog;
+use felix_wire::internal::{
+    ErrorCode, InternalMessage, ReplicateRecords, ShardRef, batch_checksum,
+};
+
+use crate::peer::{PeerError, PeerRequester};
+
+pub mod driver;
+pub mod metrics;
+
+/// How far a follower has got, as this leader understands it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FollowerCursor {
+    pub node_id: String,
+    pub addr: SocketAddr,
+    /// The offset to send next. Moved only by the follower's own answers.
+    pub next_offset: u64,
+    /// Set once this follower has answered something that does not resolve by
+    /// retrying. Nothing more is shipped to it at this generation.
+    pub halted: Option<Halt>,
+}
+
+/// Why replication to a follower stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum Halt {
+    /// The follower holds different bytes at an offset both sides have. Records
+    /// are never rewritten, so there is no repair.
+    #[error("the follower's log has diverged from this one")]
+    Diverged,
+    /// The follower knows a newer generation than this broker is shipping at.
+    /// This broker is not the leader any more.
+    #[error("this broker has been superseded as leader")]
+    Fenced,
+}
+
+impl FollowerCursor {
+    pub fn new(node_id: impl Into<String>, addr: SocketAddr, next_offset: u64) -> Self {
+        Self {
+            node_id: node_id.into(),
+            addr,
+            next_offset,
+            halted: None,
+        }
+    }
+}
+
+/// What one exchange with a follower concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Progress {
+    /// The follower stored the batch and is now at this offset.
+    Stored { durable_offset: u64 },
+    /// The follower wants a different offset. Not an error: it is how a
+    /// follower that has fallen behind, or been rebuilt, is caught up.
+    Resume { offset: u64 },
+    /// Nothing to ship; the follower is level with this leader.
+    UpToDate,
+    /// Transient. The same batch may go again.
+    Retry,
+    /// Replication to this follower is over until the assignment changes.
+    Halted(Halt),
+}
+
+/// Read the follower's answer.
+///
+/// Separate from the exchange so the table in this module's documentation is
+/// testable without a follower on the other end.
+pub fn read_answer(answer: &InternalMessage) -> Progress {
+    match answer {
+        InternalMessage::ReplicateOk(ok) => Progress::Stored {
+            durable_offset: ok.durable_offset,
+        },
+        InternalMessage::ReplicateError(err) => match err.code {
+            ErrorCode::LogGap => Progress::Resume {
+                offset: err.expected_offset,
+            },
+            ErrorCode::LogConflict => Progress::Halted(Halt::Diverged),
+            ErrorCode::FencedEpoch => Progress::Halted(Halt::Fenced),
+            // Everything else is this moment rather than this pairing: the
+            // follower is behind, busy, or could not read the frame.
+            _ => Progress::Retry,
+        },
+        // Anything else is a peer that did not understand the request. Retrying
+        // is harmless and the alternative -- treating it as divergence -- would
+        // stop replication over a protocol confusion.
+        _ => Progress::Retry,
+    }
+}
+
+/// Ship one batch to one follower and apply its answer to the cursor.
+///
+/// Returns what the exchange concluded. The cursor is advanced, rewound, or
+/// halted here, so a caller only has to decide whether to go round again.
+pub async fn ship_once<R: PeerRequester>(
+    requester: &R,
+    log: &StreamLog,
+    shard: &ShardRef,
+    cursor: &mut FollowerCursor,
+    max_batch_bytes: usize,
+) -> Progress {
+    if let Some(halt) = cursor.halted {
+        return Progress::Halted(halt);
+    }
+
+    let records = match log.read_from(cursor.next_offset, max_batch_bytes).await {
+        Ok(records) => records,
+        Err(err) => {
+            // The leader could not read its own log. Nothing is wrong with the
+            // follower, so this must not look like divergence.
+            tracing::warn!(
+                node_id = %cursor.node_id,
+                offset = cursor.next_offset,
+                error = %err,
+                "could not read the local log to replicate",
+            );
+            metrics::record_shipped(metrics::OUTCOME_READ_FAILED);
+            return Progress::Retry;
+        }
+    };
+
+    if records.is_empty() {
+        return Progress::UpToDate;
+    }
+
+    let first_offset = records[0].offset;
+    let payloads: Vec<Bytes> = records.into_iter().map(|record| record.payload).collect();
+    let request = InternalMessage::ReplicateRecords(ReplicateRecords {
+        // The pool assigns the real id; it owns the connection this lands on.
+        correlation_id: 0,
+        shard: shard.clone(),
+        first_offset,
+        checksum: batch_checksum(&payloads),
+        payloads,
+    });
+
+    let answer = match requester
+        .request(&cursor.node_id, cursor.addr, request)
+        .await
+    {
+        Ok(answer) => answer,
+        Err(err) => {
+            metrics::record_shipped(unreachable_outcome(&err));
+            return Progress::Retry;
+        }
+    };
+
+    let progress = read_answer(&answer);
+    match progress {
+        Progress::Stored { durable_offset } => {
+            // The follower's own account of where it is. Trusted over the
+            // leader's arithmetic: it is the side that did the writing, and a
+            // partially applied batch would leave the two disagreeing.
+            cursor.next_offset = durable_offset;
+            metrics::record_shipped(metrics::OUTCOME_OK);
+        }
+        Progress::Resume { offset } => {
+            cursor.next_offset = offset;
+            metrics::record_shipped(metrics::OUTCOME_RESUMED);
+        }
+        Progress::Halted(halt) => {
+            cursor.halted = Some(halt);
+            tracing::error!(
+                node_id = %cursor.node_id,
+                stream = %shard.stream,
+                shard = shard.shard,
+                generation = shard.generation,
+                reason = %halt,
+                "replication to a follower stopped",
+            );
+            metrics::record_shipped(match halt {
+                Halt::Diverged => metrics::OUTCOME_DIVERGED,
+                Halt::Fenced => metrics::OUTCOME_FENCED,
+            });
+        }
+        Progress::Retry => metrics::record_shipped(metrics::OUTCOME_REFUSED),
+        Progress::UpToDate => {}
+    }
+    progress
+}
+
+fn unreachable_outcome(err: &PeerError) -> &'static str {
+    match err {
+        PeerError::Timeout { .. } => metrics::OUTCOME_TIMEOUT,
+        PeerError::Disconnected { .. } => metrics::OUTCOME_DISCONNECTED,
+        _ => metrics::OUTCOME_UNREACHABLE,
+    }
+}
+
+/// How far behind the slowest follower is, in records.
+///
+/// This is the `Leader` consistency level's loss window, and the design note is
+/// explicit that it has to be observable: an operator choosing `Leader` is
+/// choosing this window, and a bound nobody can see is not a bound.
+///
+/// A halted follower is excluded. It is not lagging, it has stopped, and
+/// folding "stopped" into a lag figure hides it behind a number that merely
+/// looks large.
+pub fn lag_records(tail: u64, followers: &[FollowerCursor]) -> Option<u64> {
+    followers
+        .iter()
+        .filter(|follower| follower.halted.is_none())
+        .map(|follower| tail.saturating_sub(follower.next_offset))
+        .max()
+}
+
+#[cfg(test)]
+#[path = "replication_tests.rs"]
+mod tests;

--- a/services/broker/src/replication/driver.rs
+++ b/services/broker/src/replication/driver.rs
@@ -1,0 +1,174 @@
+//! The task that keeps every shard this broker leads shipping.
+//!
+//! One pass visits each shard this node leads that has followers, ships what it
+//! can to each, and reports the lag. Cursors live for as long as the assignment
+//! does: a generation change discards them, because a cursor is a belief about
+//! a follower's position under a particular leadership, and a new generation
+//! invalidates the belief rather than the follower.
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use felix_broker::Broker;
+use felix_router::{Route, ShardKey, ShardRouter};
+use felix_wire::internal::ShardRef;
+use tokio_util::sync::CancellationToken;
+
+use super::{FollowerCursor, Progress, lag_records, metrics, ship_once};
+use crate::peer::PeerRequester;
+
+/// Cursors for one shard, valid only at `generation`.
+pub struct ShardCursors {
+    generation: u64,
+    followers: Vec<FollowerCursor>,
+}
+
+/// How much of the log one exchange may carry.
+///
+/// Bounds the leader's memory per follower. A follower far behind costs one
+/// batch, not the distance it is behind.
+const MAX_BATCH_BYTES: usize = 1024 * 1024;
+
+/// Ship for every shard this broker leads, once.
+///
+/// Returns the largest lag seen, so a caller can report it without recomputing.
+pub async fn replicate_once<R: PeerRequester>(
+    requester: &R,
+    broker: &Arc<Broker>,
+    router: &ShardRouter,
+    cursors: &mut HashMap<ShardKey, ShardCursors>,
+) -> Option<u64> {
+    let Some(storage) = broker.durable_storage() else {
+        // Nothing to replicate from. A broker without durable storage leads
+        // only ephemeral streams, which have no log to ship.
+        return None;
+    };
+
+    let table = router.snapshot();
+    let mut worst_lag: Option<u64> = None;
+    let mut halted = 0usize;
+    let mut live_shards = Vec::new();
+
+    for (key, route) in table.iter() {
+        if route.leader.node_id != router.local_node_id() || route.replicas.is_empty() {
+            continue;
+        }
+        live_shards.push(key.clone());
+
+        let entry = cursors.entry(key.clone()).or_insert_with(|| ShardCursors {
+            generation: route.generation,
+            followers: Vec::new(),
+        });
+        if entry.generation != route.generation {
+            // A new leadership, so every belief about where a follower stood
+            // under the old one is discarded rather than carried forward.
+            *entry = ShardCursors {
+                generation: route.generation,
+                followers: Vec::new(),
+            };
+        }
+        reconcile_followers(entry, route);
+
+        let log = match storage.open_stream(&key.tenant_id, &key.namespace, &key.stream, key.shard)
+        {
+            Ok(log) => log,
+            Err(err) => {
+                tracing::warn!(stream = %key.stream, error = %err, "could not open a shard to replicate");
+                continue;
+            }
+        };
+        let tail = match log.tail_offset().await {
+            Ok(tail) => tail,
+            Err(err) => {
+                tracing::warn!(stream = %key.stream, error = %err, "could not read a shard's tail");
+                continue;
+            }
+        };
+
+        let shard = ShardRef {
+            tenant_id: key.tenant_id.clone(),
+            namespace: key.namespace.clone(),
+            stream: key.stream.clone(),
+            shard: key.shard,
+            generation: route.generation,
+        };
+        for cursor in &mut entry.followers {
+            // Keep going while there is more to send, so a follower catching up
+            // is not limited to one batch per tick. It ends on the first answer
+            // that is not progress, which bounds the work per pass.
+            while let Progress::Stored { .. } =
+                ship_once(requester, &log, &shard, cursor, MAX_BATCH_BYTES).await
+            {}
+        }
+
+        halted += entry
+            .followers
+            .iter()
+            .filter(|follower| follower.halted.is_some())
+            .count();
+        if let Some(lag) = lag_records(tail, &entry.followers) {
+            worst_lag = Some(worst_lag.map_or(lag, |worst: u64| worst.max(lag)));
+        }
+    }
+
+    // A shard this broker no longer leads keeps no cursors: they would be a
+    // belief about a follower under a leadership that has ended.
+    cursors.retain(|key, _| live_shards.contains(key));
+
+    metrics::record_halted(halted);
+    if let Some(lag) = worst_lag {
+        metrics::record_lag(lag);
+    }
+    worst_lag
+}
+
+/// Add cursors for new replicas and drop those no longer in the set.
+///
+/// A follower added mid-generation starts at zero rather than at the tail: the
+/// leader does not know what it holds, and starting at the tail would silently
+/// declare it caught up. Starting at zero lets the follower's first `LogGap`
+/// say where it actually is.
+fn reconcile_followers(entry: &mut ShardCursors, route: &Route) {
+    entry
+        .followers
+        .retain(|cursor| route.replicas.iter().any(|r| r.node_id == cursor.node_id));
+    for replica in &route.replicas {
+        if !entry
+            .followers
+            .iter()
+            .any(|cursor| cursor.node_id == replica.node_id)
+        {
+            entry.followers.push(FollowerCursor::new(
+                replica.node_id.clone(),
+                replica.advertise_addr,
+                0,
+            ));
+        }
+    }
+}
+
+/// Run replication until cancelled.
+pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
+    requester: Arc<R>,
+    broker: Arc<Broker>,
+    router: Arc<ShardRouter>,
+    interval: Duration,
+    shutdown: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut cursors = HashMap::new();
+        loop {
+            tokio::select! {
+                _ = shutdown.cancelled() => return,
+                _ = ticker.tick() => {}
+            }
+            replicate_once(requester.as_ref(), &broker, &router, &mut cursors).await;
+        }
+    })
+}
+
+#[cfg(test)]
+#[path = "driver_tests.rs"]
+mod tests;

--- a/services/broker/src/replication/driver_tests.rs
+++ b/services/broker/src/replication/driver_tests.rs
@@ -1,0 +1,342 @@
+//! Which shards get shipped, and how long a cursor is believed.
+//!
+//! The engine's rules are tested next door; these are about the decisions
+//! around it — leading versus following, a replica set that changes, and a
+//! generation that moves.
+use std::collections::HashMap as Map;
+use std::net::SocketAddr;
+use std::sync::Mutex;
+
+use bytes::Bytes;
+use felix_broker::{Broker, DurableStorage};
+use felix_router::{NodeRef, RegionRouter, RoutingTable};
+use felix_storage::EphemeralCache;
+use felix_storage::log::{FsyncMode, LogConfig};
+use felix_wire::internal::{InternalMessage, ReplicateOk, ReplicateRecords};
+use tempfile::TempDir;
+
+use super::*;
+use crate::peer::PeerError;
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+const LOCAL: &str = "broker-a";
+
+/// A follower that stores everything and records which shard it was for.
+#[derive(Default)]
+struct AcceptingFollower {
+    sent: Mutex<Vec<(String, ReplicateRecords)>>,
+}
+
+impl AcceptingFollower {
+    fn batches(&self) -> Vec<(String, u64, usize)> {
+        self.sent
+            .lock()
+            .expect("lock")
+            .iter()
+            .map(|(node, batch)| (node.clone(), batch.first_offset, batch.payloads.len()))
+            .collect()
+    }
+}
+
+impl PeerRequester for AcceptingFollower {
+    async fn request(
+        &self,
+        node_id: &str,
+        _addr: SocketAddr,
+        message: InternalMessage,
+    ) -> std::result::Result<InternalMessage, PeerError> {
+        let InternalMessage::ReplicateRecords(batch) = message else {
+            panic!("the driver sent something other than a replication batch");
+        };
+        let durable_offset = batch.first_offset + batch.payloads.len() as u64;
+        self.sent
+            .lock()
+            .expect("lock")
+            .push((node_id.to_string(), batch));
+        Ok(InternalMessage::ReplicateOk(ReplicateOk {
+            correlation_id: 0,
+            durable_offset,
+        }))
+    }
+}
+
+fn node(node_id: &str, port: u16) -> NodeRef {
+    NodeRef {
+        node_id: node_id.to_string(),
+        advertise_addr: format!("10.0.0.1:{port}").parse().expect("addr"),
+        region: "us-west-2".to_string(),
+        live: true,
+    }
+}
+
+fn key() -> ShardKey {
+    ShardKey {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard: 0,
+    }
+}
+
+fn nodes() -> Map<String, NodeRef> {
+    ["broker-a", "broker-b", "broker-c"]
+        .into_iter()
+        .enumerate()
+        .map(|(i, id)| (id.to_string(), node(id, 7001 + i as u16)))
+        .collect()
+}
+
+/// A router where `leader` leads the shard with `replicas` behind it.
+fn router(leader: &str, replicas: &[&str], generation: u64) -> Arc<ShardRouter> {
+    let router = Arc::new(ShardRouter::new(
+        LOCAL,
+        "us-west-2",
+        RegionRouter::new("us-west-2".to_string()),
+    ));
+    publish(&router, leader, replicas, generation);
+    router
+}
+
+fn publish(router: &ShardRouter, leader: &str, replicas: &[&str], generation: u64) {
+    let nodes = nodes();
+    let table = RoutingTable::build(
+        [(
+            key(),
+            leader.to_string(),
+            replicas.iter().map(|r| r.to_string()).collect::<Vec<_>>(),
+            generation,
+        )],
+        &nodes,
+    );
+    router.publish(table, &nodes);
+}
+
+/// A broker leading the shard, with `count` records already on disk.
+async fn leader_with(count: usize) -> (Arc<Broker>, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage = DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+    let log = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open");
+    for i in 0..count {
+        log.append(&[Bytes::from(format!("v{i}"))])
+            .await
+            .expect("append");
+    }
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage);
+    (Arc::new(broker), dir)
+}
+
+/// The shard this broker leads is shipped to every follower in its set.
+#[tokio::test]
+async fn a_led_shard_is_shipped_to_each_follower() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &["broker-b", "broker-c"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    let mut shipped_to: Vec<String> = follower
+        .batches()
+        .into_iter()
+        .map(|(node, _, _)| node)
+        .collect();
+    shipped_to.sort();
+    assert_eq!(shipped_to, vec!["broker-b", "broker-c"]);
+}
+
+/// **A shard this broker only follows is not shipped from here.** Two brokers
+/// both shipping the same shard would each be writing the other's log.
+#[tokio::test]
+async fn a_shard_led_elsewhere_is_not_shipped() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router("broker-b", &[LOCAL], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    assert!(
+        follower.batches().is_empty(),
+        "a follower shipped a shard it does not lead",
+    );
+}
+
+/// A shard with no replicas has nowhere to ship, which is the unreplicated
+/// default and must cost nothing.
+#[tokio::test]
+async fn a_shard_with_no_replicas_ships_nothing() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &[], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    assert!(follower.batches().is_empty());
+}
+
+/// A pass ships until the follower is level, so catching up is not rationed to
+/// one batch per tick.
+#[tokio::test]
+async fn one_pass_ships_until_the_follower_is_level() {
+    let (broker, _dir) = leader_with(5).await;
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    let delivered: usize = follower.batches().iter().map(|(_, _, len)| len).sum();
+    assert_eq!(delivered, 5, "the follower was left behind after a pass");
+}
+
+/// A second pass with nothing new ships nothing: the cursor is remembered.
+#[tokio::test]
+async fn a_second_pass_with_nothing_new_ships_nothing() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    let after_first = follower.batches().len();
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    assert_eq!(
+        follower.batches().len(),
+        after_first,
+        "the cursor was forgotten between passes",
+    );
+}
+
+/// **A new generation discards the cursors.** A cursor is a belief about where
+/// a follower stood under a particular leadership; a new one invalidates the
+/// belief, not the follower.
+#[tokio::test]
+async fn a_new_generation_starts_the_cursors_again() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    let after_first = follower.batches().len();
+
+    publish(&router, LOCAL, &["broker-b"], 5);
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    assert!(
+        follower.batches().len() > after_first,
+        "a new generation reused the old generation's cursor",
+    );
+    let (_, batch) = &follower.sent.lock().expect("lock")[after_first];
+    assert_eq!(
+        batch.shard.generation, 5,
+        "the old epoch was still being sent"
+    );
+}
+
+/// A replica added to the set starts from zero rather than from the tail. The
+/// leader does not know what it holds, and starting at the tail would declare
+/// it caught up while it held nothing.
+#[tokio::test]
+async fn a_replica_added_later_starts_from_the_beginning() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    publish(&router, LOCAL, &["broker-b", "broker-c"], 4);
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    let from_c: Vec<(String, u64, usize)> = follower
+        .batches()
+        .into_iter()
+        .filter(|(node, _, _)| node == "broker-c")
+        .collect();
+    assert_eq!(
+        from_c.first().map(|(_, first, _)| *first),
+        Some(0),
+        "a newly added replica was assumed to be caught up",
+    );
+}
+
+/// A replica dropped from the set stops being shipped to.
+#[tokio::test]
+async fn a_replica_removed_from_the_set_is_dropped() {
+    let (broker, _dir) = leader_with(3).await;
+    let router = router(LOCAL, &["broker-b", "broker-c"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    publish(&router, LOCAL, &["broker-b"], 4);
+    // Something new to ship, so a still-registered follower would show up.
+    let storage = broker.durable_storage().expect("storage");
+    let log = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open");
+    log.append(&[Bytes::from_static(b"more")])
+        .await
+        .expect("append");
+
+    let before = follower.batches().len();
+    replicate_once(&follower, &broker, &router, &mut cursors).await;
+
+    let after: Vec<String> = follower
+        .batches()
+        .into_iter()
+        .skip(before)
+        .map(|(node, _, _)| node)
+        .collect();
+    assert!(
+        !after.contains(&"broker-c".to_string()),
+        "a replica removed from the set was still shipped to",
+    );
+}
+
+/// A broker with no durable storage leads only ephemeral streams, which have no
+/// log to ship.
+#[tokio::test]
+async fn a_broker_without_durable_storage_ships_nothing() {
+    let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    assert_eq!(
+        replicate_once(&follower, &broker, &router, &mut cursors).await,
+        None,
+    );
+    assert!(follower.batches().is_empty());
+}
+
+/// The lag reported is the distance the slowest follower is behind the tail.
+#[tokio::test]
+async fn the_reported_lag_is_the_distance_from_the_tail() {
+    let (broker, _dir) = leader_with(4).await;
+    let router = router(LOCAL, &["broker-b"], 4);
+    let follower = AcceptingFollower::default();
+    let mut cursors = HashMap::new();
+
+    // Caught up after a full pass.
+    assert_eq!(
+        replicate_once(&follower, &broker, &router, &mut cursors).await,
+        Some(0),
+    );
+}

--- a/services/broker/src/replication/metrics.rs
+++ b/services/broker/src/replication/metrics.rs
@@ -1,0 +1,49 @@
+//! Metrics for the leader's side of replication.
+//!
+//! Unlabelled by shard on purpose. A label per shard is a label per stream per
+//! tenant, which is unbounded by design in a multi-tenant broker; these answer
+//! "is replication healthy on this node" and the shard in question is in the
+//! log line that accompanies a halt.
+
+/// Replication batches this broker shipped as a leader, by `outcome`.
+pub const SHIPPED_TOTAL: &str = "felix_broker_replication_shipped_total";
+
+/// How far the slowest follower is behind, in records, across every shard this
+/// broker leads.
+///
+/// This is the `ConsistencyLevel::Leader` loss window. Records acknowledged to
+/// a client but not yet on a follower are the ones a total loss of this broker
+/// would take with it.
+pub const LAG_RECORDS: &str = "felix_broker_replication_lag_records";
+
+/// Followers replication has stopped for, because their log diverged or this
+/// broker was superseded. Not a rate -- any non-zero value is worth waking
+/// someone for.
+pub const HALTED: &str = "felix_broker_replication_halted";
+
+pub const OUTCOME_OK: &str = "ok";
+/// The follower asked to be sent a different offset. Ordinary during catch-up.
+pub const OUTCOME_RESUMED: &str = "resumed";
+/// The follower refused for a reason that resolves on its own.
+pub const OUTCOME_REFUSED: &str = "refused";
+/// The leader could not read its own log.
+pub const OUTCOME_READ_FAILED: &str = "read_failed";
+pub const OUTCOME_UNREACHABLE: &str = "unreachable";
+pub const OUTCOME_TIMEOUT: &str = "timeout";
+pub const OUTCOME_DISCONNECTED: &str = "disconnected";
+/// The two logs disagree about bytes both sides hold.
+pub const OUTCOME_DIVERGED: &str = "diverged";
+/// The follower knows a newer generation than this broker is shipping at.
+pub const OUTCOME_FENCED: &str = "fenced";
+
+pub fn record_shipped(outcome: &'static str) {
+    metrics::counter!(SHIPPED_TOTAL, "outcome" => outcome).increment(1);
+}
+
+pub fn record_lag(records: u64) {
+    metrics::gauge!(LAG_RECORDS).set(records as f64);
+}
+
+pub fn record_halted(count: usize) {
+    metrics::gauge!(HALTED).set(count as f64);
+}

--- a/services/broker/src/replication_tests.rs
+++ b/services/broker/src/replication_tests.rs
@@ -1,0 +1,421 @@
+//! Shipping, against a follower that answers on command and a real log.
+//!
+//! The subject is the cursor: where the leader believes a follower is, and what
+//! is allowed to move that belief. A real cluster produces the interesting
+//! answers rarely and never on demand, so they come from a script.
+use std::sync::Mutex;
+
+use felix_broker::DurableStorage;
+use felix_storage::log::{FsyncMode, LogConfig};
+use felix_wire::internal::{ReplicateError, ReplicateOk};
+use tempfile::TempDir;
+
+use super::*;
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+const GENERATION: u64 = 4;
+
+/// A follower that answers from a script and records what it was sent.
+struct ScriptedFollower {
+    answers: Mutex<std::collections::VecDeque<std::result::Result<InternalMessage, PeerError>>>,
+    sent: Mutex<Vec<ReplicateRecords>>,
+}
+
+impl ScriptedFollower {
+    fn new(
+        answers: impl IntoIterator<Item = std::result::Result<InternalMessage, PeerError>>,
+    ) -> Self {
+        Self {
+            answers: Mutex::new(answers.into_iter().collect()),
+            sent: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// The offsets and payloads of every batch this follower was sent.
+    fn sent(&self) -> Vec<(u64, Vec<String>)> {
+        self.sent
+            .lock()
+            .expect("lock")
+            .iter()
+            .map(|batch| {
+                (
+                    batch.first_offset,
+                    batch
+                        .payloads
+                        .iter()
+                        .map(|p| String::from_utf8(p.to_vec()).expect("utf8"))
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+}
+
+impl PeerRequester for ScriptedFollower {
+    async fn request(
+        &self,
+        _node_id: &str,
+        _addr: SocketAddr,
+        message: InternalMessage,
+    ) -> std::result::Result<InternalMessage, PeerError> {
+        match message {
+            InternalMessage::ReplicateRecords(batch) => self.sent.lock().expect("lock").push(batch),
+            other => panic!("shipping sent a {:?}", other.kind()),
+        }
+        self.answers
+            .lock()
+            .expect("lock")
+            .pop_front()
+            .unwrap_or(Err(PeerError::Unavailable {
+                node_id: "broker-b".to_string(),
+                detail: "the script ran out".to_string(),
+            }))
+    }
+}
+
+fn shard() -> ShardRef {
+    ShardRef {
+        tenant_id: TENANT.to_string(),
+        namespace: NAMESPACE.to_string(),
+        stream: STREAM.to_string(),
+        shard: 0,
+        generation: GENERATION,
+    }
+}
+
+fn cursor(next_offset: u64) -> FollowerCursor {
+    FollowerCursor::new(
+        "broker-b",
+        "10.0.0.4:7002".parse().expect("addr"),
+        next_offset,
+    )
+}
+
+fn stored(durable_offset: u64) -> InternalMessage {
+    InternalMessage::ReplicateOk(ReplicateOk {
+        correlation_id: 0,
+        durable_offset,
+    })
+}
+
+fn refused(code: ErrorCode, expected_offset: u64) -> InternalMessage {
+    InternalMessage::ReplicateError(ReplicateError {
+        correlation_id: 0,
+        code,
+        expected_offset,
+        detail: "no".to_string(),
+    })
+}
+
+/// A leader's log holding `values` at offsets 0..n.
+async fn leader_log(values: &[&str]) -> (StreamLog, TempDir) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let storage = DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+    let log = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open");
+    for value in values {
+        log.append(&[Bytes::copy_from_slice(value.as_bytes())])
+            .await
+            .expect("append");
+    }
+    (log, dir)
+}
+
+const BATCH_BYTES: usize = 1024 * 1024;
+
+/// The ordinary case: ship from where the follower is, and move the cursor to
+/// where the follower says it got to.
+#[tokio::test]
+async fn a_stored_batch_advances_the_cursor_to_what_the_follower_reported() {
+    let (log, _dir) = leader_log(&["a", "b", "c"]).await;
+    let follower = ScriptedFollower::new([Ok(stored(3))]);
+    let mut cursor = cursor(0);
+
+    let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(progress, Progress::Stored { durable_offset: 3 });
+    assert_eq!(cursor.next_offset, 3);
+    assert_eq!(follower.sent(), vec![(0, vec_of(&["a", "b", "c"]))]);
+}
+
+/// **The follower's number wins, not the leader's arithmetic.** The follower
+/// did the writing, and a partially applied batch would otherwise leave the two
+/// sides disagreeing about what is stored.
+#[tokio::test]
+async fn the_cursor_follows_the_follower_rather_than_the_batch_size() {
+    let (log, _dir) = leader_log(&["a", "b", "c"]).await;
+    // Sent three, but the follower reports holding only two.
+    let follower = ScriptedFollower::new([Ok(stored(2))]);
+    let mut cursor = cursor(0);
+
+    ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(cursor.next_offset, 2, "the leader trusted its own count");
+}
+
+/// **A gap rewinds the cursor.** A follower that lost records, or was rebuilt,
+/// names the offset it wants and the leader resumes there — no separate
+/// negotiation, and nothing kept on disk.
+#[tokio::test]
+async fn a_gap_rewinds_the_cursor_and_the_next_batch_starts_there() {
+    let (log, _dir) = leader_log(&["a", "b", "c", "d"]).await;
+    let follower = ScriptedFollower::new([Ok(refused(ErrorCode::LogGap, 1)), Ok(stored(4))]);
+    let mut cursor = cursor(3);
+
+    let first = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+    assert_eq!(first, Progress::Resume { offset: 1 });
+    assert_eq!(cursor.next_offset, 1);
+
+    ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(
+        follower.sent(),
+        vec![(3, vec_of(&["d"])), (1, vec_of(&["b", "c", "d"])),],
+        "the resend did not start where the follower asked",
+    );
+}
+
+/// **Divergence stops this follower.** Two logs that disagree about stored
+/// bytes do not converge by retrying, and continuing would ship records on top
+/// of a log that is already wrong.
+#[tokio::test]
+async fn divergence_halts_the_follower_and_nothing_more_is_sent() {
+    let (log, _dir) = leader_log(&["a", "b"]).await;
+    let follower = ScriptedFollower::new([Ok(refused(ErrorCode::LogConflict, 0))]);
+    let mut cursor = cursor(0);
+
+    let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+    assert_eq!(progress, Progress::Halted(Halt::Diverged));
+    assert_eq!(cursor.halted, Some(Halt::Diverged));
+
+    // A halted follower is not shipped to again, even when asked.
+    let again = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(again, Progress::Halted(Halt::Diverged));
+    assert_eq!(follower.sent().len(), 1, "a halted follower was shipped to");
+}
+
+/// **A fenced leader stops shipping.** The follower knows a newer generation,
+/// so this broker is not the leader and has no business sending anything.
+#[tokio::test]
+async fn being_fenced_halts_the_follower() {
+    let (log, _dir) = leader_log(&["a"]).await;
+    let follower = ScriptedFollower::new([Ok(refused(ErrorCode::FencedEpoch, 0))]);
+    let mut cursor = cursor(0);
+
+    let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(progress, Progress::Halted(Halt::Fenced));
+    assert_eq!(cursor.halted, Some(Halt::Fenced));
+}
+
+/// A refusal that resolves on its own leaves the cursor where it was, so the
+/// same batch goes again.
+#[tokio::test]
+async fn a_transient_refusal_leaves_the_cursor_alone() {
+    let (log, _dir) = leader_log(&["a", "b"]).await;
+    let follower = ScriptedFollower::new([Ok(refused(ErrorCode::StaleRoute, 0)), Ok(stored(2))]);
+    let mut cursor = cursor(0);
+
+    assert_eq!(
+        ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await,
+        Progress::Retry,
+    );
+    assert_eq!(
+        cursor.next_offset, 0,
+        "a transient refusal moved the cursor"
+    );
+
+    ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+    assert_eq!(
+        follower.sent(),
+        vec![(0, vec_of(&["a", "b"])), (0, vec_of(&["a", "b"]))],
+    );
+}
+
+/// An unreachable follower is retried, and — importantly — is not mistaken for
+/// one that refused. Nothing was stored, so the cursor stays put.
+#[tokio::test]
+async fn an_unreachable_follower_is_retried_without_moving_the_cursor() {
+    let (log, _dir) = leader_log(&["a"]).await;
+    let follower = ScriptedFollower::new([Err(PeerError::Timeout {
+        node_id: "broker-b".to_string(),
+        timeout: std::time::Duration::from_secs(5),
+    })]);
+    let mut cursor = cursor(0);
+
+    assert_eq!(
+        ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await,
+        Progress::Retry,
+    );
+    assert_eq!(cursor.next_offset, 0);
+    assert!(cursor.halted.is_none(), "a timeout halted replication");
+}
+
+/// A follower level with the leader is not shipped an empty batch.
+#[tokio::test]
+async fn a_follower_that_is_level_is_not_shipped_to() {
+    let (log, _dir) = leader_log(&["a", "b"]).await;
+    let follower = ScriptedFollower::new([]);
+    let mut cursor = cursor(2);
+
+    let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    assert_eq!(progress, Progress::UpToDate);
+    assert!(follower.sent().is_empty(), "an empty batch was shipped");
+}
+
+/// **A batch is bounded, so a follower far behind costs one batch of memory
+/// rather than the distance it is behind.**
+#[tokio::test]
+async fn a_batch_is_bounded_rather_than_the_whole_backlog() {
+    let (log, _dir) = leader_log(&["a", "b", "c", "d", "e", "f"]).await;
+    let follower = ScriptedFollower::new([Ok(stored(2))]);
+    let mut cursor = cursor(0);
+
+    // A budget smaller than the backlog's payload bytes, so the read has to
+    // stop short of the tail.
+    ship_once(&follower, &log, &shard(), &mut cursor, 2).await;
+
+    let (_, payloads) = follower.sent().into_iter().next().expect("a batch");
+    assert!(
+        !payloads.is_empty(),
+        "a budget smaller than one record shipped nothing at all",
+    );
+    assert!(
+        payloads.len() < 6,
+        "the whole backlog was read into one batch: {payloads:?}",
+    );
+}
+
+/// The batch carries the checksum the follower will recompute. If these ever
+/// disagreed, every healthy batch would be reported as corrupt.
+#[tokio::test]
+async fn the_batch_carries_the_checksum_the_follower_will_verify() {
+    let (log, _dir) = leader_log(&["a", "b"]).await;
+    let follower = ScriptedFollower::new([Ok(stored(2))]);
+    let mut cursor = cursor(0);
+
+    ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+    let batch = follower.sent.lock().expect("lock")[0].clone();
+    assert_eq!(batch.checksum, batch_checksum(&batch.payloads));
+    assert_eq!(
+        batch.shard.generation, GENERATION,
+        "the epoch was not carried"
+    );
+}
+
+fn vec_of(values: &[&str]) -> Vec<String> {
+    values.iter().map(|v| v.to_string()).collect()
+}
+
+/// Reading an answer, on its own. Getting one of these backwards either
+/// hammers a diverged follower or abandons a healthy one.
+mod answers {
+    use super::*;
+
+    #[test]
+    fn each_answer_means_one_thing() {
+        assert_eq!(
+            read_answer(&stored(9)),
+            Progress::Stored { durable_offset: 9 },
+        );
+        assert_eq!(
+            read_answer(&refused(ErrorCode::LogGap, 4)),
+            Progress::Resume { offset: 4 },
+        );
+        assert_eq!(
+            read_answer(&refused(ErrorCode::LogConflict, 0)),
+            Progress::Halted(Halt::Diverged),
+        );
+        assert_eq!(
+            read_answer(&refused(ErrorCode::FencedEpoch, 0)),
+            Progress::Halted(Halt::Fenced),
+        );
+    }
+
+    /// Everything else is this moment rather than this pairing.
+    #[test]
+    fn the_recoverable_refusals_are_retried() {
+        for code in [
+            ErrorCode::StaleRoute,
+            ErrorCode::Unavailable,
+            ErrorCode::Overload,
+            ErrorCode::Malformed,
+            ErrorCode::StorageFailed,
+            ErrorCode::Unauthorized,
+        ] {
+            assert_eq!(read_answer(&refused(code, 0)), Progress::Retry, "{code:?}");
+        }
+    }
+
+    /// An answer that is not part of this exchange is retried rather than read
+    /// as divergence — stopping replication over a protocol confusion would be
+    /// the worse mistake.
+    #[test]
+    fn an_unexpected_answer_is_retried() {
+        assert_eq!(
+            read_answer(&InternalMessage::HelloOk(felix_wire::internal::HelloOk {
+                correlation_id: 0,
+                node_id: "broker-b".to_string(),
+            })),
+            Progress::Retry,
+        );
+    }
+}
+
+/// The lag figure an operator reads to size the `Leader` loss window.
+mod lag {
+    use super::*;
+
+    #[test]
+    fn lag_is_measured_against_the_slowest_follower() {
+        let mut behind = cursor(10);
+        behind.node_id = "broker-c".to_string();
+        let followers = vec![cursor(90), behind];
+
+        assert_eq!(lag_records(100, &followers), Some(90));
+    }
+
+    #[test]
+    fn a_caught_up_follower_reports_no_lag() {
+        assert_eq!(lag_records(100, &[cursor(100)]), Some(0));
+    }
+
+    /// A follower ahead of this leader's tail is not negative lag. It happens
+    /// while an answer is in flight, and wrapping would report an enormous one.
+    #[test]
+    fn a_follower_ahead_of_the_tail_does_not_wrap() {
+        assert_eq!(lag_records(100, &[cursor(105)]), Some(0));
+    }
+
+    /// **A halted follower is not lagging, it has stopped.** Folding the two
+    /// together hides a stopped follower behind a number that merely looks
+    /// large, and the two need different responses.
+    #[test]
+    fn a_halted_follower_is_left_out_of_the_lag() {
+        let mut halted = cursor(0);
+        halted.halted = Some(Halt::Diverged);
+
+        assert_eq!(lag_records(100, &[cursor(95), halted]), Some(5));
+    }
+
+    #[test]
+    fn no_followers_means_no_lag_to_report() {
+        assert_eq!(lag_records(100, &[]), None);
+    }
+}


### PR DESCRIPTION
The leader's half of #112, completing it. The follower's half landed in #255.

## One cursor per follower

A follower is a position in the shard's log and nothing more. The leader keeps the next offset it believes each follower wants, reads that range from its own log, and ships it.

**The follower's answer moves the cursor, never the send.** A batch that was sent is not a batch that was stored, and the follower is the side that did the writing — so if it reports holding two records out of a three-record batch, the cursor goes to two.

That is also why the cursor can go *backwards*. A follower that lost records, or was rebuilt, answers `LogGap` naming the offset it actually wants, and the leader resumes there. **Resume needs no separate negotiation and nothing kept on disk** — the follower is the authority on its own position and says so in every refusal.

## What stops and what retries

| Answer | Effect |
|---|---|
| `ReplicateOk` | cursor moves to the follower's `durable_offset` |
| `LogGap` | cursor rewinds to `expected_offset`; next batch starts there |
| `LogConflict` | **halt** — two logs disagreeing about stored bytes do not converge |
| `FencedEpoch` | **halt** — this broker is no longer the leader |
| anything else | retry; the cursor does not move |

An answer this broker does not recognise is retried rather than treated as divergence: stopping replication over a protocol confusion is the worse mistake.

## What bounds it

One batch in flight per follower, each bounded by a byte budget read from the log. A follower far behind costs the leader **one batch**, not the distance it is behind — and a follower that stops answering stops consuming anything at all, because the next read does not start until the last answer arrives.

A pass ships until the follower is level, so catching up is not rationed to one batch per tick.

## Cursor lifetime

Cursors last as long as the assignment does. A generation change **discards** them: a cursor is a belief about where a follower stood under a particular leadership, and a new generation invalidates the belief rather than the follower.

A replica added mid-generation starts at **zero**, not at the tail. The leader does not know what it holds, and starting at the tail would silently declare it caught up while it held nothing; starting at zero lets its first `LogGap` say where it actually is.

## The loss window is observable

`felix_broker_replication_lag_records` — how far the slowest follower is behind, across every shard this broker leads. The design note is explicit about why this has to exist:

> An operator choosing `Leader` is choosing this window, and must be able to see how large it currently is.

A halted follower is **excluded** from the lag. It has stopped rather than fallen behind, and folding the two together hides a stopped follower behind a number that merely looks large. `felix_broker_replication_halted` is where that shows, and any non-zero value is worth waking someone for.

Metrics are unlabelled by shard deliberately — a label per shard is a label per stream per tenant, which is unbounded by design in a multi-tenant broker. The shard is in the log line that accompanies a halt.

## Verification

Every rule confirmed against a reverted check:

| Reverted | Fails |
|---|---|
| trust the leader's own count, not the follower's | `the_cursor_follows_the_follower_rather_than_the_batch_size`, `a_stored_batch_advances_the_cursor_to_what_the_follower_reported` |
| ignore a gap's requested offset | `a_gap_rewinds_the_cursor_and_the_next_batch_starts_there` |
| keep shipping to a halted follower | `divergence_halts_the_follower_and_nothing_more_is_sent` |
| count a halted follower in the lag | `a_halted_follower_is_left_out_of_the_lag` |

28 tests over the engine, the answer table, the lag figure, and the driver's shard selection and cursor lifetime — all against a real `DiskLog` and a scripted follower, reusing the `PeerRequester` seam from #255 so no network is involved.

`task lint`, `task test`, `task demo:check` all clean.

## Scope

Deferred deliberately, and not needed for #113/#114 to start:

- **Pipelining.** The issue says "pipeline *or* batch"; this batches, with one request in flight per follower. Bounded memory and backpressure come from that directly.
- **Sealed-segment checksum catch-up.** Catch-up re-reads from the offset the follower names. Verifying whole sealed segments by checksum is an optimisation for #114, not a change to the rule.

Closes #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)