### PR TITLE
feat(replication): honour Leader and Quorum on the ack path (M5.4)

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -95,6 +95,26 @@ const _: () = {
     assert_send_sync::<Broker>();
 };
 
+/// How much of a shard's replica set must hold a record before the publish that
+/// wrote it is acknowledged.
+///
+/// The levels differ in what a client may conclude from an acknowledgement, and
+/// `docs/replication-design.md` states each precisely.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConsistencyLevel {
+    /// Durable on the leader. Exposes the leader-only loss window: records
+    /// acknowledged but not yet shipped are lost if the leader's storage is.
+    /// The window is bounded by the replication lag, which is exported.
+    ///
+    /// The default, so a stream created before replication existed — or by a
+    /// caller that does not ask — behaves exactly as it did.
+    #[default]
+    Leader,
+    /// Durable on a majority of the replica set, the leader included. No loss
+    /// window: any failure within that majority preserves the record.
+    Quorum,
+}
+
 #[derive(Debug, Clone)]
 pub struct StreamMetadata {
     /// When true, every publish is written to disk before it is fanned out or
@@ -102,6 +122,8 @@ pub struct StreamMetadata {
     /// [`Broker::with_durable_storage`].
     pub durable: bool,
     pub shards: u32,
+    /// What an acknowledgement of a publish to this stream means.
+    pub consistency: ConsistencyLevel,
 }
 
 /// What a publish did.
@@ -117,6 +139,13 @@ pub struct PublishOutcome {
 #[derive(Clone, Debug)]
 pub struct StreamHandle {
     pub(crate) state: Arc<StreamState>,
+}
+
+impl StreamHandle {
+    /// What an acknowledgement of a publish through this handle means.
+    pub fn consistency(&self) -> ConsistencyLevel {
+        self.state.consistency
+    }
 }
 
 impl StreamHandle {
@@ -137,6 +166,7 @@ impl Default for StreamMetadata {
         Self {
             durable: false,
             shards: 1,
+            consistency: ConsistencyLevel::Leader,
         }
     }
 }

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -35,8 +35,8 @@ mod subscription;
 pub mod timings;
 
 pub use broker::{
-    Broker, CacheMetadata, HistoryRange, PublishOutcome, ResumedSubscription, StartPosition,
-    StreamHandle, StreamMetadata,
+    Broker, CacheMetadata, ConsistencyLevel, HistoryRange, PublishOutcome, ResumedSubscription,
+    StartPosition, StreamHandle, StreamMetadata,
 };
 pub use config::SubQueuePolicy;
 pub use delivery::DeliveryEnvelope;

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -90,6 +90,7 @@ impl Broker {
                 self.topic_capacity,
                 self.subscriber_queue_policy,
                 durable,
+                metadata.consistency,
             ));
             self.hydrate_durable_stream(&state).await?;
 

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -59,6 +59,10 @@ pub(crate) struct StreamState {
     // replay and subscriber delivery agree with what is on disk. Only durable
     // streams use it; an ephemeral stream has no disk offsets to order by.
     pub(crate) commit_sequencer: CommitSequencer,
+    /// What an acknowledgement of a publish to this stream means. Carried on
+    /// the state so the publish path reads it from the handle it already has,
+    /// rather than looking the stream up again on the hot path.
+    pub(crate) consistency: crate::broker::ConsistencyLevel,
 }
 
 #[derive(Debug, Default)]
@@ -86,9 +90,11 @@ impl StreamState {
         subscriber_queue_capacity: usize,
         subscriber_queue_policy: SubQueuePolicy,
         durable: Option<StreamLog>,
+        consistency: crate::broker::ConsistencyLevel,
     ) -> Self {
         Self {
             handle_id,
+            consistency,
             active: AtomicBool::new(true),
             subscribers_snapshot: ArcSwap::from_pointee(Vec::new()),
             subscribers: Mutex::new(SubscriberRegistry::default()),

--- a/crates/felix-broker/src/tests.rs
+++ b/crates/felix-broker/src/tests.rs
@@ -85,7 +85,7 @@ async fn stream_delivers_in_order_to_single_subscriber() {
 
 #[test]
 fn append_batch_keeps_monotonic_sequences_and_trims_once() {
-    let stream = StreamState::new(1, 8, SubQueuePolicy::DropNew, None);
+    let stream = StreamState::new(1, 8, SubQueuePolicy::DropNew, None, Default::default());
     let first = vec![
         Bytes::from_static(b"a"),
         Bytes::from_static(b"b"),

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -47,7 +47,11 @@ async fn register(broker: &Broker, stream: &str, durable: bool) {
             "t1",
             "default",
             stream,
-            StreamMetadata { durable, shards: 1 },
+            StreamMetadata {
+                durable,
+                shards: 1,
+                ..Default::default()
+            },
         )
         .await
         .expect("register");
@@ -269,6 +273,7 @@ async fn upgrading_a_live_stream_to_durable_requires_recreation() {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await
@@ -314,6 +319,7 @@ async fn downgrading_a_live_durable_stream_requires_recreation() {
             StreamMetadata {
                 durable: false,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await
@@ -361,6 +367,7 @@ async fn registering_a_durable_stream_without_storage_is_rejected() {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await
@@ -772,6 +779,7 @@ async fn a_failed_hydration_leaves_no_registered_stream() {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await

--- a/demos/broker/durable_restart_demo.rs
+++ b/demos/broker/durable_restart_demo.rs
@@ -58,6 +58,7 @@ async fn boot(dir: &Path) -> Result<(Broker, DurableStorage)> {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -254,6 +254,28 @@ Replication to a follower stops on `LogConflict` or `FencedEpoch`. Neither
 converges by retrying: the first means the two logs disagree about bytes both
 sides hold, the second that this broker is no longer the leader.
 
+`Stream.consistency` is now wired into the acknowledgement path (#113). A
+`Leader` publish is acknowledged once the leader's own durability policy is
+satisfied, exactly as before. A `Quorum` publish is held until a majority of the
+replica set *of the generation it was written at* holds its records durably.
+
+The majority always counts the leader, so `replication_factor: 1` — the default
+— makes `Quorum` behave exactly like `Leader` rather than never acknowledging.
+A halted follower counts for nothing: it has stopped rather than fallen behind,
+and letting its last position count would make an acknowledgement mean less than
+it says.
+
+A wait that runs out is reported as a failure, and the distinction matters: the
+records *are* durable on the leader and may yet reach a majority. The broker is
+not saying the write failed, it is saying it cannot vouch for it at the level the
+stream asked for. `FELIX_PUBLISH_QUORUM_TIMEOUT_MS` sets the budget. Leadership
+moving mid-wait ends it the same way, immediately, rather than running the clock
+out on an answer that can no longer come.
+
+A control plane that sends a consistency level this broker does not recognise is
+refused rather than defaulted. Falling back to `Leader` would serve a stream the
+operator asked to be quorum-replicated at the weaker guarantee, silently.
+
 The `Leader` loss window is exported as `felix_broker_replication_lag_records`:
 how far the slowest follower is behind, across every shard this broker leads. A
 halted follower is excluded from it — it has stopped rather than fallen behind,

--- a/services/broker/src/config.rs
+++ b/services/broker/src/config.rs
@@ -146,6 +146,9 @@ pub struct BrokerConfig {
     pub sub_streams_per_conn: usize,
     // Strategy for mapping subscribers to streams.
     pub sub_stream_mode: SubStreamMode,
+    /// How long a publish to a `Quorum` stream waits for a majority before the
+    /// broker says it cannot vouch for the write.
+    pub publish_quorum_timeout_ms: u64,
 }
 
 impl Default for BrokerConfig {
@@ -191,6 +194,7 @@ impl Default for BrokerConfig {
             subscriber_max_bytes_per_write: DEFAULT_SUBSCRIBER_MAX_BYTES_PER_WRITE,
             sub_streams_per_conn: DEFAULT_SUB_STREAMS_PER_CONN,
             sub_stream_mode: DEFAULT_SUB_STREAM_MODE,
+            publish_quorum_timeout_ms: DEFAULT_PUBLISH_QUORUM_TIMEOUT_MS,
         }
     }
 }
@@ -332,6 +336,12 @@ const DEFAULT_CACHE_STREAM_RECV_WINDOW: u64 = 64 * 1024 * 1024;
 const DEFAULT_CACHE_SEND_WINDOW: u64 = 256 * 1024 * 1024;
 const DEFAULT_MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_PUBLISH_QUEUE_WAIT_TIMEOUT_MS: u64 = 2000;
+/// How long a publish to a `Quorum` stream waits for a majority.
+///
+/// Generous next to a healthy replication round trip, because being too short
+/// costs a publish the broker cannot vouch for even though the record is on its
+/// disk and about to reach a majority.
+const DEFAULT_PUBLISH_QUORUM_TIMEOUT_MS: u64 = 5_000;
 const DEFAULT_ACK_WAIT_TIMEOUT_MS: u64 = 2000;
 const DEFAULT_CONTROL_STREAM_DRAIN_TIMEOUT_MS: u64 = 50;
 // Total budget for draining in-flight work after a termination signal. Kubernetes
@@ -586,6 +596,11 @@ impl BrokerConfig {
             .and_then(|value| value.parse::<usize>().ok())
             .filter(|value| *value > 0)
             .unwrap_or(DEFAULT_SUB_STREAMS_PER_CONN);
+        let publish_quorum_timeout_ms = std::env::var("FELIX_PUBLISH_QUORUM_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_PUBLISH_QUORUM_TIMEOUT_MS);
         let sub_stream_mode = std::env::var("FELIX_SUB_STREAM_MODE")
             .ok()
             .and_then(|value| SubStreamMode::parse_env(value.as_str()))
@@ -631,6 +646,7 @@ impl BrokerConfig {
             subscriber_max_bytes_per_write,
             sub_streams_per_conn,
             sub_stream_mode,
+            publish_quorum_timeout_ms,
         })
     }
 

--- a/services/broker/src/controlplane.rs
+++ b/services/broker/src/controlplane.rs
@@ -23,8 +23,8 @@
 //!
 //! NOTE: This file is a *client* of the control-plane. Persisting control-plane data
 //! (e.g., in Postgres) is implemented on the **control-plane service**, not here.
-use anyhow::{Context, Result};
-use felix_broker::{Broker, BrokerError, CacheMetadata, StreamMetadata};
+use anyhow::{Context, Result, anyhow};
+use felix_broker::{Broker, BrokerError, CacheMetadata, ConsistencyLevel, StreamMetadata};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::Duration;
@@ -298,6 +298,27 @@ struct Stream {
     stream: String,
     shards: u32,
     durable: bool,
+    /// Absent from a control plane that predates replication, which reads as
+    /// `Leader` -- the behaviour every stream had before this existed.
+    #[serde(default)]
+    consistency: Option<String>,
+}
+
+/// Read a consistency level the control plane sent.
+///
+/// **An unrecognised level is refused, never defaulted.** Falling back to
+/// `Leader` would take a stream the operator asked to be quorum-replicated and
+/// serve it at the weaker guarantee, silently: the acknowledgement would keep
+/// its meaning on paper and lose it in fact. A broker that does not understand
+/// what it was asked for has to say so.
+fn read_consistency(value: Option<&str>) -> Result<ConsistencyLevel> {
+    match value {
+        None | Some("Leader") => Ok(ConsistencyLevel::Leader),
+        Some("Quorum") => Ok(ConsistencyLevel::Quorum),
+        Some(other) => Err(anyhow!(
+            "unknown consistency level {other:?}; this broker understands Leader and Quorum"
+        )),
+    }
 }
 
 /// Represents a cache as registered in the broker registry.
@@ -473,6 +494,7 @@ async fn sync_once(
                         StreamMetadata {
                             durable: stream.durable,
                             shards: stream.shards,
+                            consistency: read_consistency(stream.consistency.as_deref())?,
                         },
                     )
                     .await?;
@@ -615,6 +637,7 @@ async fn sync_once(
                                 StreamMetadata {
                                     durable: stream.durable,
                                     shards: stream.shards,
+                                    consistency: read_consistency(stream.consistency.as_deref())?,
                                 },
                             )
                             .await?;
@@ -1335,6 +1358,7 @@ mod tests {
                                     stream: "orders".to_string(),
                                     shards: 2,
                                     durable: true,
+                                    consistency: None,
                                 }),
                             }],
                             next_seq: 2,
@@ -1435,6 +1459,7 @@ mod tests {
             StreamMetadata {
                 durable: false,
                 shards: 2,
+                ..Default::default()
             },
         )
         .await?;
@@ -1450,6 +1475,7 @@ mod tests {
             StreamMetadata {
                 durable: false,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -1472,6 +1498,7 @@ mod tests {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -1486,6 +1513,7 @@ mod tests {
             StreamMetadata {
                 durable: false,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -1516,6 +1544,7 @@ mod tests {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -1684,6 +1713,7 @@ mod tests {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await
@@ -1720,6 +1750,7 @@ mod tests {
             StreamMetadata {
                 durable: false,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -1731,6 +1762,7 @@ mod tests {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await
@@ -1905,5 +1937,55 @@ mod tests {
         })
         .await
         .expect("test timeout")
+    }
+
+    /// What the control plane sends for `consistency`, and what this broker
+    /// makes of it.
+    mod consistency {
+        use super::*;
+
+        /// A control plane that predates replication sends no level at all, and
+        /// every stream written before this existed behaves as it did.
+        #[test]
+        fn an_absent_level_is_leader() {
+            assert_eq!(
+                read_consistency(None).expect("read"),
+                ConsistencyLevel::Leader
+            );
+        }
+
+        /// The exact strings the control plane serializes. Pinned on this side
+        /// too, because the two enums are compiled separately and nothing else
+        /// would catch them drifting apart.
+        #[test]
+        fn the_levels_are_read_by_their_wire_names() {
+            assert_eq!(
+                read_consistency(Some("Leader")).expect("read"),
+                ConsistencyLevel::Leader,
+            );
+            assert_eq!(
+                read_consistency(Some("Quorum")).expect("read"),
+                ConsistencyLevel::Quorum,
+            );
+        }
+
+        /// **An unrecognised level is refused, never defaulted.** Falling back
+        /// to `Leader` would serve a stream the operator asked to be
+        /// quorum-replicated at the weaker guarantee, and the acknowledgement
+        /// would keep its meaning on paper while losing it in fact.
+        #[test]
+        fn an_unknown_level_is_refused_rather_than_downgraded() {
+            let err = read_consistency(Some("Everywhere")).expect_err("should refuse");
+            assert!(err.to_string().contains("Everywhere"), "{err}");
+        }
+
+        /// Case matters: the wire form is what the control plane serializes, and
+        /// guessing at near-misses is how a downgrade slips through.
+        #[test]
+        fn a_near_miss_is_not_guessed_at() {
+            assert!(read_consistency(Some("quorum")).is_err());
+            assert!(read_consistency(Some("QUORUM")).is_err());
+            assert!(read_consistency(Some("")).is_err());
+        }
     }
 }

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -141,6 +141,9 @@ where
     // through it, and before the accept loop for the same reason the router is:
     // a publish must never arrive at a broker that can resolve a remote owner
     // and not reach it.
+    // Shared between the replication driver, which advances it, and the publish
+    // path, which waits on it for `Quorum` streams.
+    let quorum_marks = Arc::new(replication::quorum::QuorumMarks::new());
     let peer_shutdown = CancellationToken::new();
     let peers = match (&config.peer_transport, &config.membership) {
         (Some(peer_config), Some(membership_config)) => Some(
@@ -241,6 +244,7 @@ where
         let ingress_router = ingress_router.clone();
         let peers_for_accept = peers.clone();
         let lease_for_accept = lease.clone();
+        let marks_for_accept = Arc::clone(&quorum_marks);
         tokio::spawn(async move {
             // A durable broker does not accept until its streams exist.
             // Readiness alone only steers orchestrated traffic; a client with
@@ -271,6 +275,7 @@ where
                     ingress: ingress_router,
                     peers: peers_for_accept,
                     lease: lease_for_accept,
+                    marks: Some(Arc::clone(&marks_for_accept)),
                 },
             )
             .await
@@ -466,6 +471,7 @@ where
                     Arc::clone(pool),
                     Arc::clone(&broker),
                     Arc::clone(router),
+                    Arc::clone(&quorum_marks),
                     Duration::from_millis(config.controlplane_sync_interval_ms),
                     sync_shutdown.clone(),
                 );

--- a/services/broker/src/replication.rs
+++ b/services/broker/src/replication.rs
@@ -41,6 +41,7 @@ use crate::peer::{PeerError, PeerRequester};
 
 pub mod driver;
 pub mod metrics;
+pub mod quorum;
 
 /// How far a follower has got, as this leader understands it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -234,6 +235,45 @@ pub fn lag_records(tail: u64, followers: &[FollowerCursor]) -> Option<u64> {
         .filter(|follower| follower.halted.is_none())
         .map(|follower| tail.saturating_sub(follower.next_offset))
         .max()
+}
+
+/// How many copies must hold a record for a majority, the leader included.
+///
+/// `replicas` is the follower count, so the replica set is one larger. A set of
+/// three needs two, a set of five needs three — and a set of one needs one,
+/// which is the leader alone and is why `replication_factor: 1` costs nothing.
+pub fn majority_of(replicas: usize) -> usize {
+    replicas.div_ceil(2) + 1
+}
+
+/// The highest offset a majority of the replica set holds durably.
+///
+/// The leader is counted as holding everything up to `leader_tail`: it wrote the
+/// records, and a record it has not written is not a candidate for a quorum in
+/// the first place.
+///
+/// **A halted follower counts for nothing.** It is not slow, it has stopped —
+/// its log has diverged, or this broker has been superseded — and letting a
+/// stale position count toward a majority is how an acknowledgement comes to
+/// mean less than it says.
+///
+/// Cursors belong to one generation. The caller passes the set for the
+/// generation it is publishing at, which is what stops an older generation's
+/// acknowledgements satisfying a newer generation's quorum.
+pub fn quorum_offset(leader_tail: u64, followers: &[FollowerCursor]) -> u64 {
+    let needed = majority_of(followers.len());
+    // The leader is one of them, and it holds the most.
+    let mut held: Vec<u64> = std::iter::once(leader_tail)
+        .chain(
+            followers
+                .iter()
+                .filter(|follower| follower.halted.is_none())
+                .map(|follower| follower.next_offset.min(leader_tail)),
+        )
+        .collect();
+    // Descending, so the `needed`-th is the highest offset that many hold.
+    held.sort_unstable_by(|a, b| b.cmp(a));
+    held.get(needed - 1).copied().unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/services/broker/src/replication/driver.rs
+++ b/services/broker/src/replication/driver.rs
@@ -14,7 +14,8 @@ use felix_router::{Route, ShardKey, ShardRouter};
 use felix_wire::internal::ShardRef;
 use tokio_util::sync::CancellationToken;
 
-use super::{FollowerCursor, Progress, lag_records, metrics, ship_once};
+use super::quorum::QuorumMarks;
+use super::{FollowerCursor, Progress, lag_records, metrics, quorum_offset, ship_once};
 use crate::peer::PeerRequester;
 
 /// Cursors for one shard, valid only at `generation`.
@@ -36,6 +37,7 @@ pub async fn replicate_once<R: PeerRequester>(
     requester: &R,
     broker: &Arc<Broker>,
     router: &ShardRouter,
+    marks: &QuorumMarks,
     cursors: &mut HashMap<ShardKey, ShardCursors>,
 ) -> Option<u64> {
     let Some(storage) = broker.durable_storage() else {
@@ -101,6 +103,19 @@ pub async fn replicate_once<R: PeerRequester>(
             {}
         }
 
+        // Published after shipping, so a publish waiting on this shard sees the
+        // majority move as soon as this pass establishes it.
+        marks.publish(
+            &crate::shard_watch::ShardKey {
+                tenant_id: key.tenant_id.clone(),
+                namespace: key.namespace.clone(),
+                stream: key.stream.clone(),
+                shard: key.shard,
+            },
+            route.generation,
+            quorum_offset(tail, &entry.followers),
+        );
+
         halted += entry
             .followers
             .iter()
@@ -114,6 +129,20 @@ pub async fn replicate_once<R: PeerRequester>(
     // A shard this broker no longer leads keeps no cursors: they would be a
     // belief about a follower under a leadership that has ended.
     cursors.retain(|key, _| live_shards.contains(key));
+    // A shard this broker no longer leads stops promising a quorum. Dropping
+    // the mark ends any publish still waiting on it, rather than leaving it to
+    // run out its timeout for an answer that can no longer come.
+    marks.retain(
+        &live_shards
+            .iter()
+            .map(|key| crate::shard_watch::ShardKey {
+                tenant_id: key.tenant_id.clone(),
+                namespace: key.namespace.clone(),
+                stream: key.stream.clone(),
+                shard: key.shard,
+            })
+            .collect::<Vec<_>>(),
+    );
 
     metrics::record_halted(halted);
     if let Some(lag) = worst_lag {
@@ -152,6 +181,7 @@ pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
     requester: Arc<R>,
     broker: Arc<Broker>,
     router: Arc<ShardRouter>,
+    marks: Arc<QuorumMarks>,
     interval: Duration,
     shutdown: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
@@ -164,7 +194,7 @@ pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
                 _ = shutdown.cancelled() => return,
                 _ = ticker.tick() => {}
             }
-            replicate_once(requester.as_ref(), &broker, &router, &mut cursors).await;
+            replicate_once(requester.as_ref(), &broker, &router, &marks, &mut cursors).await;
         }
     })
 }

--- a/services/broker/src/replication/driver_tests.rs
+++ b/services/broker/src/replication/driver_tests.rs
@@ -145,9 +145,10 @@ async fn a_led_shard_is_shipped_to_each_follower() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &["broker-b", "broker-c"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     let mut shipped_to: Vec<String> = follower
         .batches()
@@ -165,9 +166,10 @@ async fn a_shard_led_elsewhere_is_not_shipped() {
     let (broker, _dir) = leader_with(3).await;
     let router = router("broker-b", &[LOCAL], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     assert!(
         follower.batches().is_empty(),
@@ -182,9 +184,10 @@ async fn a_shard_with_no_replicas_ships_nothing() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &[], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     assert!(follower.batches().is_empty());
 }
@@ -196,9 +199,10 @@ async fn one_pass_ships_until_the_follower_is_level() {
     let (broker, _dir) = leader_with(5).await;
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     let delivered: usize = follower.batches().iter().map(|(_, _, len)| len).sum();
     assert_eq!(delivered, 5, "the follower was left behind after a pass");
@@ -210,11 +214,12 @@ async fn a_second_pass_with_nothing_new_ships_nothing() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
     let after_first = follower.batches().len();
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     assert_eq!(
         follower.batches().len(),
@@ -231,13 +236,14 @@ async fn a_new_generation_starts_the_cursors_again() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
     let after_first = follower.batches().len();
 
     publish(&router, LOCAL, &["broker-b"], 5);
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     assert!(
         follower.batches().len() > after_first,
@@ -258,11 +264,12 @@ async fn a_replica_added_later_starts_from_the_beginning() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
     publish(&router, LOCAL, &["broker-b", "broker-c"], 4);
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     let from_c: Vec<(String, u64, usize)> = follower
         .batches()
@@ -282,9 +289,10 @@ async fn a_replica_removed_from_the_set_is_dropped() {
     let (broker, _dir) = leader_with(3).await;
     let router = router(LOCAL, &["broker-b", "broker-c"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
     publish(&router, LOCAL, &["broker-b"], 4);
     // Something new to ship, so a still-registered follower would show up.
     let storage = broker.durable_storage().expect("storage");
@@ -296,7 +304,7 @@ async fn a_replica_removed_from_the_set_is_dropped() {
         .expect("append");
 
     let before = follower.batches().len();
-    replicate_once(&follower, &broker, &router, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
 
     let after: Vec<String> = follower
         .batches()
@@ -317,10 +325,11 @@ async fn a_broker_without_durable_storage_ships_nothing() {
     let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &mut cursors).await,
+        replicate_once(&follower, &broker, &router, &marks, &mut cursors).await,
         None,
     );
     assert!(follower.batches().is_empty());
@@ -332,11 +341,12 @@ async fn the_reported_lag_is_the_distance_from_the_tail() {
     let (broker, _dir) = leader_with(4).await;
     let router = router(LOCAL, &["broker-b"], 4);
     let follower = AcceptingFollower::default();
+    let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
     // Caught up after a full pass.
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &mut cursors).await,
+        replicate_once(&follower, &broker, &router, &marks, &mut cursors).await,
         Some(0),
     );
 }

--- a/services/broker/src/replication/metrics.rs
+++ b/services/broker/src/replication/metrics.rs
@@ -47,3 +47,20 @@ pub fn record_lag(records: u64) {
 pub fn record_halted(count: usize) {
     metrics::gauge!(HALTED).set(count as f64);
 }
+
+/// Publishes to a `Quorum` stream that did not reach a majority, by `reason`.
+///
+/// The `ok` case is not counted here: an acknowledged publish is already
+/// counted on the publish path, and a second counter for the same event only
+/// invites the two to disagree.
+pub const QUORUM_FAILED_TOTAL: &str = "felix_broker_publish_quorum_failed_total";
+
+/// No majority within the budget. The records are durable on this broker and
+/// may yet reach one; this broker simply cannot say that they have.
+pub const QUORUM_TIMED_OUT: &str = "timed_out";
+/// Leadership moved before the batch reached a majority.
+pub const QUORUM_NOT_LEADING: &str = "not_leading";
+
+pub fn record_quorum(reason: &'static str) {
+    metrics::counter!(QUORUM_FAILED_TOTAL, "reason" => reason).increment(1);
+}

--- a/services/broker/src/replication/quorum.rs
+++ b/services/broker/src/replication/quorum.rs
@@ -1,0 +1,155 @@
+//! What a publish waits on before a `Quorum` stream acknowledges it.
+//!
+//! The replication driver owns the cursors; a publish must not. So the driver
+//! publishes one number per shard — the highest offset a majority of the
+//! replica set holds durably — and a publish waits for that number to reach
+//! past its own last offset.
+//!
+//! A `watch` channel rather than a lock and a condition variable: every waiter
+//! wants the same number, latest-wins is exactly right for a monotonic
+//! high-water mark, and a waiter that arrives after the mark has already passed
+//! sees the current value immediately rather than waiting for the next change.
+//!
+//! # Generations
+//!
+//! The mark is reset to zero when a shard's generation changes. An offset that
+//! a majority held under the previous leadership says nothing about the current
+//! one: the replica set may be different, and the design note is explicit that
+//! an acknowledgement from a replica at an older generation does not count
+//! toward a newer generation's quorum. Resetting is what enforces that here.
+use std::collections::HashMap;
+
+use crate::shard_watch::ShardKey;
+use parking_lot::Mutex;
+use tokio::sync::watch;
+
+/// The quorum-durable high-water mark for each shard this broker leads.
+#[derive(Debug, Default)]
+pub struct QuorumMarks {
+    shards: Mutex<HashMap<ShardKey, ShardMark>>,
+}
+
+#[derive(Debug)]
+struct ShardMark {
+    generation: u64,
+    offset: watch::Sender<u64>,
+}
+
+impl QuorumMarks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record how far the majority has got for `key` at `generation`.
+    ///
+    /// A generation change restarts the mark at zero rather than carrying the
+    /// old one forward.
+    pub fn publish(&self, key: &ShardKey, generation: u64, offset: u64) {
+        let mut shards = self.shards.lock();
+        match shards.get_mut(key) {
+            Some(mark) if mark.generation == generation => {
+                // Monotonic within a generation: the mark is a high-water mark,
+                // and a pass that saw less than the last one saw a follower
+                // mid-answer rather than a record becoming un-stored.
+                mark.offset.send_if_modified(|current| {
+                    if offset > *current {
+                        *current = offset;
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+            _ => {
+                shards.insert(
+                    key.clone(),
+                    ShardMark {
+                        generation,
+                        offset: watch::Sender::new(offset),
+                    },
+                );
+            }
+        }
+    }
+
+    /// Stop tracking a shard this broker no longer leads.
+    ///
+    /// Dropping the sender ends every wait on it, which is what turns a
+    /// leadership loss into a failed publish rather than one that hangs until
+    /// its timeout.
+    pub fn forget(&self, key: &ShardKey) {
+        self.shards.lock().remove(key);
+    }
+
+    /// Keep only the shards named, forgetting the rest.
+    pub fn retain(&self, live: &[ShardKey]) {
+        self.shards.lock().retain(|key, _| live.contains(key));
+    }
+
+    /// A receiver for `key` at `generation`, if this broker is tracking it.
+    fn watcher(&self, key: &ShardKey, generation: u64) -> Option<watch::Receiver<u64>> {
+        let shards = self.shards.lock();
+        let mark = shards.get(key)?;
+        (mark.generation == generation).then(|| mark.offset.subscribe())
+    }
+
+    /// Wait until a majority holds every offset below `offset`.
+    ///
+    /// `offset` is one past the last record of the batch, so this returns when
+    /// the batch itself is on a majority.
+    pub async fn wait_for(
+        &self,
+        key: &ShardKey,
+        generation: u64,
+        offset: u64,
+        timeout: std::time::Duration,
+    ) -> QuorumWait {
+        let Some(mut watcher) = self.watcher(key, generation) else {
+            // Nothing is tracking this shard at this generation: either this
+            // broker does not lead it, or the leadership has already moved.
+            // Either way it cannot promise a quorum for this write.
+            return QuorumWait::NotLeading;
+        };
+
+        if *watcher.borrow_and_update() >= offset {
+            return QuorumWait::Reached;
+        }
+
+        let reached = tokio::time::timeout(timeout, async {
+            // `changed` also errors when the sender is dropped, which is how a
+            // shard released mid-publish ends the wait instead of running it
+            // out.
+            while watcher.changed().await.is_ok() {
+                if *watcher.borrow_and_update() >= offset {
+                    return true;
+                }
+            }
+            false
+        })
+        .await;
+
+        match reached {
+            Ok(true) => QuorumWait::Reached,
+            Ok(false) => QuorumWait::NotLeading,
+            Err(_) => QuorumWait::TimedOut,
+        }
+    }
+}
+
+/// How a wait for a majority ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuorumWait {
+    /// A majority holds the batch. The publish may be acknowledged.
+    Reached,
+    /// No majority within the budget. The record may still be on disk here and
+    /// may yet reach a majority, so this is not "the write failed" — it is
+    /// "this broker cannot say that it succeeded", which is the honest answer
+    /// and the one the client can act on.
+    TimedOut,
+    /// This broker is not the leader of that shard at that generation any more.
+    NotLeading,
+}
+
+#[cfg(test)]
+#[path = "quorum_tests.rs"]
+mod tests;

--- a/services/broker/src/replication/quorum_tests.rs
+++ b/services/broker/src/replication/quorum_tests.rs
@@ -1,0 +1,185 @@
+//! Waiting for a majority, and the ways a wait ends other than success.
+use std::time::Duration;
+
+use super::*;
+
+const QUICK: Duration = Duration::from_millis(200);
+
+fn key(stream: &str) -> ShardKey {
+    ShardKey {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: stream.to_string(),
+        shard: 0,
+    }
+}
+
+/// A mark already past the batch returns at once rather than waiting for the
+/// next change — a publish that arrives after its records replicated must not
+/// wait for an unrelated one to move the mark.
+#[tokio::test]
+async fn a_mark_already_past_the_batch_returns_immediately() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 10);
+
+    assert_eq!(
+        marks.wait_for(&key("orders"), 4, 10, QUICK).await,
+        QuorumWait::Reached,
+    );
+}
+
+/// The wait ends when the mark reaches the batch, not before.
+#[tokio::test]
+async fn a_wait_ends_when_the_majority_reaches_the_batch() {
+    let marks = std::sync::Arc::new(QuorumMarks::new());
+    marks.publish(&key("orders"), 4, 0);
+
+    let waiting = {
+        let marks = std::sync::Arc::clone(&marks);
+        tokio::spawn(async move { marks.wait_for(&key("orders"), 4, 5, QUICK).await })
+    };
+
+    // Short of the batch: not enough.
+    marks.publish(&key("orders"), 4, 4);
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(!waiting.is_finished(), "the wait ended one record short");
+
+    marks.publish(&key("orders"), 4, 5);
+    assert_eq!(waiting.await.expect("join"), QuorumWait::Reached);
+}
+
+/// **A majority that never arrives times out rather than hanging.** A client
+/// waiting forever is worse than one told the broker cannot vouch for the write.
+#[tokio::test]
+async fn a_majority_that_never_arrives_times_out() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 0);
+
+    assert_eq!(
+        marks
+            .wait_for(&key("orders"), 4, 5, Duration::from_millis(50))
+            .await,
+        QuorumWait::TimedOut,
+    );
+}
+
+/// **An untracked shard is not a quorum.** If this broker is not tracking the
+/// shard it is not leading it, and it cannot promise a majority for a write.
+#[tokio::test]
+async fn a_shard_this_broker_does_not_lead_is_not_a_quorum() {
+    let marks = QuorumMarks::new();
+
+    assert_eq!(
+        marks.wait_for(&key("orders"), 4, 1, QUICK).await,
+        QuorumWait::NotLeading,
+    );
+}
+
+/// **An older generation's mark does not satisfy a newer generation's wait.**
+/// The replica set may be different, so what a majority held under the previous
+/// leadership says nothing about this one.
+#[tokio::test]
+async fn a_wait_at_a_newer_generation_ignores_the_old_mark() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 100);
+
+    assert_eq!(
+        marks.wait_for(&key("orders"), 5, 10, QUICK).await,
+        QuorumWait::NotLeading,
+    );
+}
+
+/// A generation change restarts the mark rather than carrying it forward.
+#[tokio::test]
+async fn a_new_generation_restarts_the_mark() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 100);
+    marks.publish(&key("orders"), 5, 0);
+
+    assert_eq!(
+        marks
+            .wait_for(&key("orders"), 5, 10, Duration::from_millis(50))
+            .await,
+        QuorumWait::TimedOut,
+        "the old generation's mark satisfied the new generation",
+    );
+}
+
+/// **Losing the shard ends the wait rather than running it out.** A publish
+/// held for its full timeout after leadership moved is a client kept waiting
+/// for an answer that can no longer come.
+#[tokio::test]
+async fn losing_the_shard_ends_a_wait_in_progress() {
+    let marks = std::sync::Arc::new(QuorumMarks::new());
+    marks.publish(&key("orders"), 4, 0);
+
+    let waiting = {
+        let marks = std::sync::Arc::clone(&marks);
+        tokio::spawn(async move {
+            marks
+                .wait_for(&key("orders"), 4, 5, Duration::from_secs(30))
+                .await
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    marks.forget(&key("orders"));
+
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(5), waiting)
+            .await
+            .expect("the wait should end when the shard is released")
+            .expect("join"),
+        QuorumWait::NotLeading,
+    );
+}
+
+/// The mark only goes forward within a generation. A pass that saw less than
+/// the last one saw a follower mid-answer, not a record becoming un-stored.
+#[tokio::test]
+async fn the_mark_does_not_go_backwards_within_a_generation() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 10);
+    marks.publish(&key("orders"), 4, 3);
+
+    assert_eq!(
+        marks.wait_for(&key("orders"), 4, 10, QUICK).await,
+        QuorumWait::Reached,
+        "the mark went backwards and un-acknowledged a batch",
+    );
+}
+
+/// Shards are tracked independently: one shard's majority says nothing about
+/// another's.
+#[tokio::test]
+async fn shards_do_not_share_a_mark() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 100);
+    marks.publish(&key("payments"), 4, 0);
+
+    assert_eq!(
+        marks
+            .wait_for(&key("payments"), 4, 10, Duration::from_millis(50))
+            .await,
+        QuorumWait::TimedOut,
+    );
+}
+
+/// Shards this broker no longer leads are forgotten in one pass.
+#[tokio::test]
+async fn retaining_the_live_shards_forgets_the_rest() {
+    let marks = QuorumMarks::new();
+    marks.publish(&key("orders"), 4, 10);
+    marks.publish(&key("payments"), 4, 10);
+
+    marks.retain(&[key("orders")]);
+
+    assert_eq!(
+        marks.wait_for(&key("orders"), 4, 10, QUICK).await,
+        QuorumWait::Reached,
+    );
+    assert_eq!(
+        marks.wait_for(&key("payments"), 4, 10, QUICK).await,
+        QuorumWait::NotLeading,
+    );
+}

--- a/services/broker/src/replication_tests.rs
+++ b/services/broker/src/replication_tests.rs
@@ -419,3 +419,104 @@ mod lag {
         assert_eq!(lag_records(100, &[]), None);
     }
 }
+
+/// The majority a `Quorum` acknowledgement rests on.
+mod quorum {
+    use super::*;
+
+    /// A majority always includes the leader, so a set of one is satisfied by
+    /// the leader alone — which is why `replication_factor: 1` costs nothing.
+    #[test]
+    fn a_majority_counts_the_leader() {
+        assert_eq!(majority_of(0), 1, "a set of one is the leader alone");
+        assert_eq!(majority_of(1), 2, "a set of two needs both");
+        assert_eq!(majority_of(2), 2, "a set of three needs two");
+        assert_eq!(majority_of(3), 3, "a set of four needs three");
+        assert_eq!(majority_of(4), 3, "a set of five needs three");
+    }
+
+    /// **A majority is more than half.** Half of an even set is not a majority:
+    /// two disjoint halves could each acknowledge a different record, and both
+    /// would believe they had a quorum.
+    #[test]
+    fn half_of_an_even_set_is_not_a_majority() {
+        for replicas in [1usize, 3, 5] {
+            let set = replicas + 1;
+            assert!(
+                majority_of(replicas) * 2 > set,
+                "a set of {set} accepted {} as a majority",
+                majority_of(replicas),
+            );
+        }
+    }
+
+    /// With no followers the leader's own tail is the quorum point, so a
+    /// `Quorum` stream on an unreplicated shard behaves exactly like `Leader`
+    /// rather than never acknowledging.
+    #[test]
+    fn the_leader_alone_is_a_quorum_of_one() {
+        assert_eq!(quorum_offset(10, &[]), 10);
+    }
+
+    /// Two of three: the quorum point is where the faster follower has got to,
+    /// not the slower one.
+    #[test]
+    fn a_set_of_three_advances_with_its_faster_follower() {
+        let followers = vec![cursor(8), cursor(3)];
+
+        assert_eq!(quorum_offset(10, &followers), 8);
+    }
+
+    /// All of two: the quorum point is the slower of the pair, because a set of
+    /// two needs both.
+    #[test]
+    fn a_set_of_two_waits_for_its_only_follower() {
+        assert_eq!(quorum_offset(10, &[cursor(4)]), 4);
+    }
+
+    /// A follower reporting past the leader's tail does not drag the quorum
+    /// point beyond what the leader actually holds.
+    #[test]
+    fn a_follower_ahead_of_the_leader_does_not_overstate_the_quorum() {
+        assert_eq!(quorum_offset(10, &[cursor(50), cursor(9)]), 10);
+    }
+
+    /// **A halted follower counts for nothing.** It has stopped rather than
+    /// fallen behind, and letting its last position count toward a majority
+    /// makes an acknowledgement mean less than it says.
+    #[test]
+    fn a_halted_follower_does_not_count_toward_the_majority() {
+        let mut halted = cursor(10);
+        halted.halted = Some(Halt::Diverged);
+        let followers = vec![halted, cursor(3)];
+
+        assert_eq!(
+            quorum_offset(10, &followers),
+            3,
+            "a diverged follower was counted toward the quorum",
+        );
+    }
+
+    /// Every follower halted leaves the leader alone, which is not a majority
+    /// of three — so nothing new reaches the quorum point.
+    #[test]
+    fn a_shard_with_every_follower_halted_stops_acknowledging() {
+        let mut a = cursor(10);
+        a.halted = Some(Halt::Diverged);
+        let mut b = cursor(10);
+        b.halted = Some(Halt::Fenced);
+
+        assert_eq!(
+            quorum_offset(10, &[a, b]),
+            0,
+            "a quorum was claimed with only the leader in a set of three",
+        );
+    }
+
+    /// A follower that has stored nothing holds offset zero, so a set of three
+    /// with one empty follower still has a quorum through the other.
+    #[test]
+    fn an_empty_follower_holds_nothing_but_still_counts_as_a_member() {
+        assert_eq!(quorum_offset(10, &[cursor(0), cursor(7)]), 7);
+    }
+}

--- a/services/broker/src/shard_routing.rs
+++ b/services/broker/src/shard_routing.rs
@@ -157,6 +157,21 @@ impl IngressRouter {
     /// it. Trusting only the router would serve writes during recovery;
     /// trusting only local state would keep serving a shard that has been
     /// reassigned.
+    /// The generation this broker currently leads `key` at, if it does.
+    ///
+    /// A publish waiting for a quorum needs it: the majority is over the
+    /// replica set of *that* generation, and an acknowledgement from an older
+    /// one does not count toward a newer one's quorum.
+    pub fn generation(&self, key: &ShardKey) -> Option<u64> {
+        match self.dispatch(key) {
+            Dispatch::Local => match self.router.resolve(&to_router_key(key)) {
+                Resolution::Local { generation } => Some(generation),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     pub fn dispatch(&self, key: &ShardKey) -> Dispatch {
         match self.router.resolve(&to_router_key(key)) {
             Resolution::Local { generation } => {

--- a/services/broker/src/transport/mod.rs
+++ b/services/broker/src/transport/mod.rs
@@ -59,6 +59,7 @@ mod tests {
             subscriber_max_bytes_per_write: 256 * 1024,
             sub_streams_per_conn: 4,
             sub_stream_mode: crate::config::SubStreamMode::PerSubscriber,
+            ..Default::default()
         };
 
         let base = TransportConfig::default();

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -158,6 +158,73 @@ pub struct ClusterContext {
     pub peers: Option<Arc<crate::peer::PeerPool>>,
     /// This broker's authority to serve the shards it leads.
     pub lease: Option<Arc<crate::lease::LeaseState>>,
+    /// How far a majority of each shard's replica set has got. Read by a
+    /// publish to a `Quorum` stream, which cannot acknowledge until the
+    /// majority holds its records.
+    pub marks: Option<Arc<crate::replication::quorum::QuorumMarks>>,
+}
+
+/// Hold a `Quorum` publish until a majority of the shard's replica set has it.
+///
+/// A `Leader` stream returns at once: local durability is the guarantee it
+/// offers, and it has already been reached by the time this is called.
+///
+/// The wait is bounded. A timeout is **not** "the write failed" — the records
+/// are on this broker's disk and may yet reach a majority — it is "this broker
+/// cannot say that it succeeded", which is the honest answer and the one a
+/// client can act on. Reporting success instead would make an acknowledgement
+/// mean less than the stream promises.
+async fn await_quorum(
+    handle: &felix_broker::StreamHandle,
+    shard: Option<&crate::shard_watch::ShardKey>,
+    outcome: &felix_broker::PublishOutcome,
+    marks: Option<&crate::replication::quorum::QuorumMarks>,
+    ingress: Option<&IngressRouter>,
+    timeout: std::time::Duration,
+) -> Result<(), anyhow::Error> {
+    use crate::replication::quorum::QuorumWait;
+
+    if handle.consistency() != felix_broker::ConsistencyLevel::Quorum {
+        return Ok(());
+    }
+    let (Some(shard), Some(marks), Some(ingress)) = (shard, marks, ingress) else {
+        // A single-node broker has no replica set. `Quorum` on a stream nobody
+        // replicates is satisfied by the leader alone, which has already
+        // written the record.
+        return Ok(());
+    };
+    // An ephemeral stream has no offsets, so there is nothing to replicate and
+    // nothing to wait for.
+    let Some((_, last_offset)) = outcome.offsets else {
+        return Ok(());
+    };
+    let Some(generation) = ingress.generation(shard) else {
+        anyhow::bail!("shard ownership changed before the batch could reach a quorum");
+    };
+
+    // `last_offset` is inclusive, and the mark is one past what is held.
+    match marks
+        .wait_for(shard, generation, last_offset + 1, timeout)
+        .await
+    {
+        QuorumWait::Reached => Ok(()),
+        QuorumWait::TimedOut => {
+            crate::replication::metrics::record_quorum(
+                crate::replication::metrics::QUORUM_TIMED_OUT,
+            );
+            Err(anyhow::anyhow!(
+                "the batch is durable here but did not reach a majority within {timeout:?}"
+            ))
+        }
+        QuorumWait::NotLeading => {
+            crate::replication::metrics::record_quorum(
+                crate::replication::metrics::QUORUM_NOT_LEADING,
+            );
+            Err(anyhow::anyhow!(
+                "shard leadership moved before the batch could reach a quorum"
+            ))
+        }
+    }
 }
 
 fn build_publish_context(
@@ -169,7 +236,9 @@ fn build_publish_context(
         ingress,
         peers,
         lease,
+        marks,
     } = cluster;
+    let quorum_timeout = std::time::Duration::from_millis(config.publish_quorum_timeout_ms.max(1));
     // NOTE: This is intentionally global for the process (not per-connection).
     // With per-connection worker pools, adding more publisher connections multiplied
     // concurrent broker.publish_batch callers and caused lock contention on shared broker state.
@@ -195,6 +264,8 @@ fn build_publish_context(
         let broker_for_worker = Arc::clone(&broker);
         let peers_for_worker = peers.clone();
         let lease_for_worker = lease.clone();
+        let marks_for_worker = marks.clone();
+        let ingress_for_worker = ingress.clone();
         let worker_task = async move {
             while let Some(job) = publish_rx.recv().await {
                 #[cfg(feature = "perf_debug")]
@@ -211,7 +282,7 @@ fn build_publish_context(
                 #[cfg(feature = "perf_debug")]
                 let worker_start = std::time::Instant::now();
                 let result: Result<(), anyhow::Error> = match &job.target {
-                    PublishTarget::Resolved(handle) => {
+                    PublishTarget::Resolved { handle, shard } => {
                         // The commit fence, and the authoritative one. Everything
                         // between admission and here can take arbitrarily long --
                         // a full queue, a slow fsync, a suspended process -- so a
@@ -227,11 +298,25 @@ fn build_publish_context(
                                     "lease lapsed before the record could be committed"
                                 ))
                             }
-                            _ => broker_for_worker
-                                .publish_batch_to_handle(handle, &job.payloads)
-                                .await
-                                .map(|_| ())
-                                .map_err(Into::into),
+                            _ => {
+                                match broker_for_worker
+                                    .publish_batch_with_outcome(handle, &job.payloads)
+                                    .await
+                                {
+                                    Ok(outcome) => {
+                                        await_quorum(
+                                            handle,
+                                            shard.as_ref(),
+                                            &outcome,
+                                            marks_for_worker.as_deref(),
+                                            ingress_for_worker.as_deref(),
+                                            quorum_timeout,
+                                        )
+                                        .await
+                                    }
+                                    Err(err) => Err(err.into()),
+                                }
+                            }
                         }
                     }
                     #[cfg(test)]

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -221,7 +221,17 @@ pub(crate) fn publish_target(
     ack: felix_wire::internal::AckMode,
 ) -> Option<PublishTarget> {
     match route {
-        PublishRoute::Local(handle) => Some(PublishTarget::Resolved(handle)),
+        PublishRoute::Local(handle) => Some(PublishTarget::Resolved {
+            handle,
+            // Built the same way `resolve_route` built the key it dispatched
+            // on, so the shard a publish waits for is the shard it landed on.
+            shard: publish_ctx.ingress.as_ref().map(|_| ShardKey {
+                tenant_id: tenant_id.to_string(),
+                namespace: namespace.to_string(),
+                stream: stream.to_string(),
+                shard: shard_for(1, None),
+            }),
+        }),
         PublishRoute::Forward(target) => {
             if publish_ctx.peers.is_none() {
                 t_counter!("felix_publish_requests_total", "result" => "not_owner").increment(1);

--- a/services/broker/src/transport/quic/handlers/publish/ingress.rs
+++ b/services/broker/src/transport/quic/handlers/publish/ingress.rs
@@ -18,7 +18,13 @@ use crate::transport::quic::handlers::publish::admission::AdmissionPermit;
 use crate::transport::quic::handlers::publish::{PublishContext, PublishJob};
 
 pub(crate) enum PublishTarget {
-    Resolved(StreamHandle),
+    Resolved {
+        handle: StreamHandle,
+        /// The shard this publish resolved to, when this broker is in a
+        /// cluster. `None` on a single-node broker, which has no replica set
+        /// and so nothing to wait for.
+        shard: Option<crate::shard_watch::ShardKey>,
+    },
     /// Another broker owns the shard. The batch is sent there and its answer
     /// relayed, from the same worker a local write would have used, so the ack
     /// path is identical either way.
@@ -112,7 +118,9 @@ pub(crate) async fn enqueue_publish(
     mut cancel: Option<watch::Receiver<bool>>,
 ) -> Result<bool> {
     let worker_index = match &job.target {
-        PublishTarget::Resolved(handle) => handle.id() as usize % publish_ctx.worker_count.max(1),
+        PublishTarget::Resolved { handle, .. } => {
+            handle.id() as usize % publish_ctx.worker_count.max(1)
+        }
         // Hashed by name, because there is no local handle to hash. Same
         // function the named path uses, so one stream's forwards stay on one
         // worker and keep their order.

--- a/services/broker/src/transport/quic/handlers/subscribe/replay_tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/replay_tests.rs
@@ -90,6 +90,7 @@ async fn durable_broker() -> (Arc<Broker>, TempDir) {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await

--- a/services/broker/src/transport/quic/handlers/subscribe/tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/tests.rs
@@ -77,6 +77,7 @@ fn test_config() -> crate::config::BrokerConfig {
         subscriber_max_bytes_per_write: 256 * 1024,
         sub_streams_per_conn: 4,
         sub_stream_mode: crate::config::SubStreamMode::PerSubscriber,
+        ..Default::default()
     }
 }
 

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -556,7 +556,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
                 // This harness drives local publishes only; a forward would
                 // need a peer transport it does not build.
                 PublishTarget::Forward { .. } => unreachable!("no peers in this test"),
-                PublishTarget::Resolved(handle) => {
+                PublishTarget::Resolved { handle, .. } => {
                     broker.publish_batch_to_handle(handle, &job.payloads).await
                 }
                 PublishTarget::Named {

--- a/services/broker/tests/quic_subscribe.rs
+++ b/services/broker/tests/quic_subscribe.rs
@@ -455,6 +455,7 @@ async fn quic_subscribe_resumes_from_a_checkpointed_offset() -> Result<()> {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;
@@ -590,6 +591,7 @@ async fn quic_subscribe_rejects_a_cursor_past_the_tail() -> Result<()> {
             StreamMetadata {
                 durable: true,
                 shards: 1,
+                ..Default::default()
             },
         )
         .await?;

--- a/services/controlplane/src/model/stream.rs
+++ b/services/controlplane/src/model/stream.rs
@@ -86,3 +86,47 @@ pub enum DeliveryGuarantee {
     AtMostOnce,
     AtLeastOnce,
 }
+
+#[cfg(test)]
+mod consistency_wire_tests {
+    use super::*;
+
+    /// The names these serialize under are what a broker parses. Pinned here as
+    /// well as in the broker, because the two are compiled separately and a
+    /// rename on this side would otherwise be found by a cluster rather than by
+    /// a test.
+    #[test]
+    fn the_levels_serialize_under_the_names_brokers_read() {
+        assert_eq!(
+            serde_json::to_string(&ConsistencyLevel::Leader).expect("serialize"),
+            "\"Leader\"",
+        );
+        assert_eq!(
+            serde_json::to_string(&ConsistencyLevel::Quorum).expect("serialize"),
+            "\"Quorum\"",
+        );
+    }
+
+    /// A stream serializes its level as a plain field, which is what lets a
+    /// broker read it without understanding the rest of the model.
+    #[test]
+    fn a_stream_carries_its_level_as_a_field() {
+        let stream = Stream {
+            tenant_id: "t1".to_string(),
+            namespace: "ns".to_string(),
+            stream: "orders".to_string(),
+            kind: StreamKind::Stream,
+            shards: 1,
+            replication_factor: 3,
+            retention: RetentionPolicy {
+                max_age_seconds: None,
+                max_size_bytes: None,
+            },
+            consistency: ConsistencyLevel::Quorum,
+            delivery: DeliveryGuarantee::AtLeastOnce,
+            durable: true,
+        };
+        let json: serde_json::Value = serde_json::to_value(&stream).expect("serialize");
+        assert_eq!(json["consistency"], "Quorum");
+    }
+}


### PR DESCRIPTION
Closes #113.

`Stream.consistency` existed in the control plane and reached nobody — the broker never read the field, so a stream asking for `Quorum` was served exactly like one asking for `Leader`. This wires it end to end.

## Reaching the broker

The control plane already serialised it; the broker now parses it. **An unrecognised level is refused, never defaulted.** Falling back to `Leader` would take a stream the operator asked to be quorum-replicated and serve it at the weaker guarantee, silently — the acknowledgement keeps its meaning on paper and loses it in fact.

The wire names are pinned by a test on *each* side, because the two enums compile separately and nothing else would catch them drifting apart.

An absent level reads as `Leader`, so a control plane predating replication — and every stream written before this existed — behaves exactly as it did.

## The majority

Over the replica set **of the generation the record was written at**, always counting the leader.

| Replica set | Needed |
|---|---|
| 1 (leader only) | 1 |
| 2 | 2 |
| 3 | 2 |
| 4 | 3 |
| 5 | 3 |

So `replication_factor: 1` — the default — is a quorum of one, and `Quorum` on an unreplicated stream behaves like `Leader` rather than never acknowledging. Half of an even set is explicitly not a majority; there's a test asserting that for every even size, because two disjoint halves could otherwise each believe they had one.

**A halted follower counts for nothing.** It has stopped rather than fallen behind, and letting its last position count is how an acknowledgement comes to mean less than it says.

## The wait

The replication driver owns the cursors, so a publish must not. The driver publishes one number per shard — the highest offset a majority holds durably — and a publish waits for that number to pass its own last offset.

A `watch` channel, because every waiter wants the same number, latest-wins is right for a monotonic high-water mark, and **a publish arriving after the mark has already passed returns immediately** rather than waiting for an unrelated change to wake it.

Two rules that are easy to get wrong, both tested:

- **The mark resets on a generation change.** What a majority held under the previous leadership says nothing about this one — the replica set may be different. This is what satisfies #113's "prevent an old generation's acknowledgements from satisfying a new generation's quorum".
- **Losing the shard ends the wait immediately.** Dropping the sender ends every waiter, rather than running the clock out on an answer that can no longer come.

## What a timeout means

Not "the write failed". The records *are* durable on this broker and may yet reach a majority. It is "this broker cannot say that it succeeded at the level the stream asked for" — the honest answer, and the one a client can act on. `FELIX_PUBLISH_QUORUM_TIMEOUT_MS` sets the budget, defaulting to 5s.

I'd flag this as the judgement call most worth a second opinion: failing on timeout means a single sustained-slow follower fails writes on a stream whose majority is otherwise healthy. The alternative — acknowledging anyway — makes `Quorum` a suggestion, so I took failing as the safe default and documented it.

## Verification

Both rules confirmed against a reverted check:

| Reverted | Fails |
|---|---|
| half a set counts as a majority | `a_majority_counts_the_leader`, `half_of_an_even_set_is_not_a_majority`, `a_set_of_two_waits_for_its_only_follower` |
| halted followers count toward the quorum | `a_halted_follower_does_not_count_toward_the_majority`, `a_shard_with_every_follower_halted_stops_acknowledging` |

`task lint`, `task test`, `task demo:check` all clean.

## Scope

Left for later, and called out rather than quietly skipped:

- **Metrics.** The issue asks for local-append / replication / quorum-wait latency to be distinguished. Quorum *failures* are counted by reason (`felix_broker_publish_quorum_failed_total`), and replication lag was added in #258, but the latency split is not here.
- **An end-to-end cluster test.** The rules are covered by unit tests against a real log and a scripted follower; a three-node test that fails a follower mid-publish belongs with #115's failure injection, which needs faults the harness cannot yet inject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)