### PR TITLE
fix(replication): stop retrying a follower that needs trimmed history

### DIFF
--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -198,6 +198,15 @@ Catch-up for a new or lagging follower is a bounded `read_range` from the leader
 with sealed-segment checksums to verify wholesale rather than record by record —
 the primitives the storage layer already exposes for this purpose.
 
+**This works only while the leader still holds what the follower is missing.**
+Once retention has trimmed past a follower's position, shipping cannot reach it:
+the records are not on the leader to send, and starting the follower at the
+surviving base offset would leave its log with a hole nothing downstream could
+detect. Such a follower is halted for bootstrap — it counts toward no quorum and
+is not shipped to again — and transferring its history is #114, which is not
+implemented. Until it is, a follower that falls that far behind needs its data
+directory rebuilt by hand.
+
 ### The `Leader` loss window, precisely
 
 For `ConsistencyLevel::Leader`, a record is acknowledged once it is durable on

--- a/services/broker/src/replication.rs
+++ b/services/broker/src/replication.rs
@@ -66,6 +66,11 @@ pub enum Halt {
     /// This broker is not the leader any more.
     #[error("this broker has been superseded as leader")]
     Fenced,
+    /// The follower wants records retention has already removed from the
+    /// leader, so shipping cannot reach it. It needs its history transferred
+    /// before live replication can resume.
+    #[error("the follower needs history this leader no longer holds")]
+    NeedsBootstrap,
 }
 
 impl FollowerCursor {
@@ -138,6 +143,28 @@ pub async fn ship_once<R: PeerRequester>(
 
     let records = match log.read_from(cursor.next_offset, max_batch_bytes).await {
         Ok(records) => records,
+        // The follower is asking for records this leader has already trimmed.
+        // Shipping cannot bridge that: the records are not here to send, and
+        // starting the follower at the surviving base would leave its log with
+        // a hole that nothing downstream could detect.
+        //
+        // Halting is the honest answer. It stops a retry that could never
+        // succeed, keeps the follower out of every quorum, and says plainly
+        // that the shard needs its history transferred -- which is #114's
+        // subject and is not implemented.
+        Err(felix_broker::BrokerError::CursorTooOld { oldest, requested }) => {
+            tracing::error!(
+                node_id = %cursor.node_id,
+                stream = %shard.stream,
+                shard = shard.shard,
+                requested,
+                oldest,
+                "replication stopped: the follower needs history retention has removed",
+            );
+            cursor.halted = Some(Halt::NeedsBootstrap);
+            metrics::record_shipped(metrics::OUTCOME_NEEDS_BOOTSTRAP);
+            return Progress::Halted(Halt::NeedsBootstrap);
+        }
         Err(err) => {
             // The leader could not read its own log. Nothing is wrong with the
             // follower, so this must not look like divergence.
@@ -204,6 +231,7 @@ pub async fn ship_once<R: PeerRequester>(
             metrics::record_shipped(match halt {
                 Halt::Diverged => metrics::OUTCOME_DIVERGED,
                 Halt::Fenced => metrics::OUTCOME_FENCED,
+                Halt::NeedsBootstrap => metrics::OUTCOME_NEEDS_BOOTSTRAP,
             });
         }
         Progress::Retry => metrics::record_shipped(metrics::OUTCOME_REFUSED),

--- a/services/broker/src/replication/metrics.rs
+++ b/services/broker/src/replication/metrics.rs
@@ -35,6 +35,9 @@ pub const OUTCOME_DISCONNECTED: &str = "disconnected";
 pub const OUTCOME_DIVERGED: &str = "diverged";
 /// The follower knows a newer generation than this broker is shipping at.
 pub const OUTCOME_FENCED: &str = "fenced";
+/// The follower needs records retention has removed from the leader. It cannot
+/// be caught up by shipping and needs its history transferred.
+pub const OUTCOME_NEEDS_BOOTSTRAP: &str = "needs_bootstrap";
 
 pub fn record_shipped(outcome: &'static str) {
     metrics::counter!(SHIPPED_TOTAL, "outcome" => outcome).increment(1);

--- a/services/broker/src/replication_tests.rs
+++ b/services/broker/src/replication_tests.rs
@@ -520,3 +520,116 @@ mod quorum {
         assert_eq!(quorum_offset(10, &[cursor(0), cursor(7)]), 7);
     }
 }
+
+/// A follower asking for records the leader has already trimmed.
+///
+/// Shipping cannot bridge this: the records are not on the leader to send.
+/// Before this was recognised, the read failed, the exchange reported a
+/// transient refusal, and the leader retried the same impossible read on every
+/// pass — forever, silently, with the follower never advancing.
+mod trimmed_history {
+    use super::*;
+
+    /// A leader whose retention has already removed the start of its log.
+    async fn trimmed_leader() -> (StreamLog, u64, TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let storage = DurableStorage::open(
+            dir.path(),
+            LogConfig {
+                // Tiny segments and a tight bound, so a handful of records
+                // forces the trim a long-lived stream would reach in time.
+                segment_size_bytes: 128,
+                index_spacing_bytes: 64,
+                fsync_mode: FsyncMode::None,
+                preallocate_segments: false,
+                retention_bytes: Some(256),
+                ..LogConfig::default()
+            },
+        )
+        .expect("storage");
+        let log = storage
+            .open_stream(TENANT, NAMESPACE, STREAM, 0)
+            .expect("open");
+        for i in 0..40 {
+            log.append(&[Bytes::from(format!("value-{i:03}"))])
+                .await
+                .expect("append");
+        }
+        log.enforce_retention_now().await.expect("retention");
+        let base = log.base_offset();
+        assert!(
+            base > 0,
+            "retention did not trim, so the case is not set up"
+        );
+        (log, base, dir)
+    }
+
+    /// **The leader stops rather than retrying a read that cannot succeed.**
+    #[tokio::test]
+    async fn a_follower_below_the_leaders_base_halts_for_bootstrap() {
+        let (log, base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([]);
+        let mut cursor = cursor(0);
+
+        let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        assert_eq!(progress, Progress::Halted(Halt::NeedsBootstrap));
+        assert_eq!(cursor.halted, Some(Halt::NeedsBootstrap));
+        assert!(
+            follower.sent().is_empty(),
+            "records were shipped from a range the leader no longer holds",
+        );
+        assert!(base > 0);
+    }
+
+    /// And it stays stopped, rather than trying again on the next pass.
+    #[tokio::test]
+    async fn it_stays_halted_across_passes() {
+        let (log, _base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([]);
+        let mut cursor = cursor(0);
+
+        for _ in 0..3 {
+            ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+        }
+
+        assert!(follower.sent().is_empty());
+    }
+
+    /// **A follower that cannot be caught up counts toward no quorum.** This is
+    /// what stops a replica being counted before it is eligible: it is not
+    /// merely behind, it can never arrive without a transfer.
+    #[tokio::test]
+    async fn a_follower_needing_bootstrap_counts_toward_no_quorum() {
+        let (log, _base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([]);
+        let mut cursor = cursor(0);
+        ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        let tail = log.tail_offset().await.expect("tail");
+        // A set of three: the leader plus this follower plus one healthy peer.
+        assert_eq!(
+            quorum_offset(tail, &[cursor.clone(), super::cursor(tail)]),
+            tail,
+        );
+        // And alone, it cannot make a majority of three with the leader.
+        assert_eq!(quorum_offset(tail, &[cursor.clone(), super::cursor(0)]), 0);
+    }
+
+    /// A follower at or above the leader's base is ordinary catch-up, not a
+    /// bootstrap. The line is exactly the base offset.
+    #[tokio::test]
+    async fn a_follower_at_the_base_is_ordinary_catch_up() {
+        let (log, base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([Ok(stored(base + 1))]);
+        let mut cursor = cursor(base);
+
+        let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        assert!(
+            matches!(progress, Progress::Stored { .. }),
+            "a follower at the surviving base was refused: {progress:?}",
+        );
+        assert!(cursor.halted.is_none());
+    }
+}


### PR DESCRIPTION
Groundwork for #114 — and a live bug found while scoping it.

## The bug

A follower asking for records retention has already removed from the leader **cannot** be caught up by shipping: the records are not on the leader to send.

`StreamLog::read_from` returns `CursorTooOld`, `ship_once` treated it as a transient read failure, and the leader retried the same impossible read on every pass. Forever. Silently. The follower never advanced, and nothing said why.

Reproduced before fixing — a leader trimmed to base offset 36, a follower at 0:

```
base before=0 after=36
progress with cursor at 0 vs base 36: Retry
sent: []
```

Every pass, unchanged.

## The fix

The follower is halted with its own reason, `NeedsBootstrap`. That:

- stops a retry that could never succeed,
- keeps the follower out of **every quorum** — it is not merely behind, it can never arrive without a transfer, which is #114's "a replica is never counted toward quorum before it is eligible",
- surfaces in a log line and in `felix_broker_replication_halted`, where any non-zero value is already worth investigating.

## Why not just start it at the surviving base

This is the tempting fix and it is wrong. Beginning the follower at the leader's base would leave a hole between what the follower holds and what it received — and **a log with a hole is one nothing downstream can detect**, because from the follower's own point of view the offsets it holds are still contiguous. The gap would only surface as missing records, much later, with nothing pointing at this decision.

Halting says "I cannot do this" instead of quietly doing the wrong thing.

## What this does not do

It does not close #114. Transferring history is the repair, and it is not implemented: `DiskLog` cannot create a log at a non-zero base offset, which is exactly what installing transferred segments requires. That is the real work in #114, and it is storage-layer work rather than replication-layer work.

Until then a follower that falls this far behind needs its data directory rebuilt by hand. `docs/replication-design.md` now says that plainly rather than implying catch-up always works.

## Tests

The halt is confirmed against a reverted check — treating the trimmed read as a transient refusal again fails `a_follower_below_the_leaders_base_halts_for_bootstrap`.

- a follower below the leader's base halts, and ships nothing
- it stays halted across passes rather than retrying
- it counts toward no quorum
- a follower **at** the base is ordinary catch-up, so the line is exactly the base offset and not one either side of it

`task lint`, `task test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)