### PR TITLE
feat(storage): let a shard's log begin at a non-zero offset (M5.5)

### DIFF
--- a/crates/felix-broker/src/durable.rs
+++ b/crates/felix-broker/src/durable.rs
@@ -65,6 +65,33 @@ impl DurableStorage {
     /// Repeated calls for the same shard return the same log, so re-registering
     /// a stream — which the control-plane watcher does on every restart and
     /// resync — never opens a second writer over the same files.
+    /// Open a shard's log, creating it to begin at `base_offset` if it is not
+    /// there yet.
+    ///
+    /// For a replica receiving a shard whose early history has already been
+    /// trimmed everywhere: its log begins where the surviving records do. An
+    /// existing shard keeps the base recorded in its own first segment.
+    pub fn open_stream_at(
+        &self,
+        tenant: &str,
+        namespace: &str,
+        stream: &str,
+        shard: u32,
+        base_offset: felix_storage::log::Offset,
+    ) -> Result<StreamLog> {
+        let key = ShardKey {
+            tenant: tenant.to_string(),
+            namespace: namespace.to_string(),
+            stream: stream.to_string(),
+            shard,
+        };
+        let log = self
+            .provider
+            .open_shard_at(&key, base_offset)
+            .map_err(storage_error)?;
+        Ok(StreamLog { log })
+    }
+
     pub fn open_stream(
         &self,
         tenant: &str,

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -431,10 +431,41 @@ impl DiskLog {
         label: impl Into<String>,
         config: LogConfig,
     ) -> Result<Self> {
-        config.validate()?;
-        let dir = dir.into();
-        let label = label.into();
+        Self::open_inner(dir.into(), label.into(), config, None)
+    }
 
+    /// Open a shard log, creating it to begin at `base_offset` if it does not
+    /// exist yet.
+    ///
+    /// For a replica receiving history that starts partway through a stream:
+    /// the records before `base_offset` are gone from every copy in the
+    /// cluster, so a log that begins there is complete rather than truncated,
+    /// and a read below it is `Trimmed` exactly as it would be on the leader.
+    ///
+    /// **An existing log is opened as it stands and `base_offset` is ignored.**
+    /// A restart must not reinterpret a shard that is already here, and the
+    /// base it was created at is recorded in its own first segment. Only an
+    /// empty directory is a shard being placed for the first time.
+    pub fn open_at(
+        dir: impl Into<PathBuf>,
+        label: impl Into<String>,
+        config: LogConfig,
+        base_offset: Offset,
+    ) -> Result<Self> {
+        Self::open_inner(dir.into(), label.into(), config, Some(base_offset))
+    }
+
+    fn open_inner(
+        dir: PathBuf,
+        label: String,
+        config: LogConfig,
+        base_offset: Option<Offset>,
+    ) -> Result<Self> {
+        config.validate()?;
+
+        if let Some(base_offset) = base_offset.filter(|base| *base > 0) {
+            recovery::place_empty_shard(&dir, &config, base_offset)?;
+        }
         let recovered = recovery::recover_shard(&dir, &label, &config)?;
         if recovered.truncated_bytes > 0 {
             tracing::warn!(
@@ -904,6 +935,27 @@ impl DiskLogProvider {
 
     pub fn config(&self) -> &LogConfig {
         &self.config
+    }
+
+    /// Open or return the cached log for `shard`, creating it to begin at
+    /// `base_offset` if it does not exist yet.
+    ///
+    /// For a replica being given a shard whose early history is already gone.
+    /// An existing shard keeps its own base, so this is safe to call on every
+    /// contact rather than only the first.
+    pub fn open_shard_at(&self, shard: &ShardKey, base_offset: Offset) -> Result<DiskLog> {
+        let mut open_logs = self.open_logs.lock();
+        if let Some(log) = open_logs.get(shard) {
+            return Ok(log.clone());
+        }
+        let log = DiskLog::open_at(
+            layout::shard_dir(&self.root, shard),
+            layout::shard_label(shard),
+            self.config.clone(),
+            base_offset,
+        )?;
+        open_logs.insert(shard.clone(), log.clone());
+        Ok(log)
     }
 
     /// Open or return the cached log for `shard`.

--- a/crates/felix-storage/src/disk_log/recovery.rs
+++ b/crates/felix-storage/src/disk_log/recovery.rs
@@ -84,6 +84,37 @@ pub fn discover_segment_ids(dir: &Path) -> Result<Vec<SegmentId>> {
 }
 
 /// Open, validate and repair every segment for one shard.
+/// Create a shard's first segment so its log begins at `base_offset`.
+///
+/// A no-op when the directory already holds segments: a shard that is already
+/// here keeps the base recorded in its own first segment, and a restart must
+/// not reinterpret it. Only an empty directory is a shard being placed.
+///
+/// The segment carries `base_offset` in its header, so recovery reads it back
+/// without needing to be told again.
+pub fn place_empty_shard(dir: &Path, config: &LogConfig, base_offset: Offset) -> Result<bool> {
+    std::fs::create_dir_all(dir)?;
+    if let Some(parent) = dir.parent() {
+        sync_dir(parent)?;
+    }
+    if !discover_segment_ids(dir)?.is_empty() {
+        return Ok(false);
+    }
+    let mut writer = SegmentWriter::create(
+        dir,
+        0,
+        base_offset,
+        now_micros(),
+        preallocate_bytes(config),
+        config.index_spacing_bytes,
+    )?;
+    // Flushed before anything can append to it: a base offset that did not
+    // survive a crash would leave the shard reading back as one starting at
+    // zero, which is a hole rather than a shorter log.
+    writer.sync()?;
+    Ok(true)
+}
+
 pub fn recover_shard(dir: &Path, label: &str, config: &LogConfig) -> Result<Recovered> {
     let started = std::time::Instant::now();
     std::fs::create_dir_all(dir)?;

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -994,3 +994,164 @@ async fn an_inline_rollover_does_not_park_every_worker() {
          appends parked their workers on the synchronous segment lock",
     );
 }
+
+/// A log that begins partway through a stream.
+///
+/// A replica receiving history that starts at an offset other than zero needs
+/// its log to *begin* there. The records before it are gone from every copy in
+/// the cluster, so such a log is complete rather than truncated, and it must
+/// read back that way after a restart as well.
+mod placed_at_a_base_offset {
+    use super::*;
+
+    const BASE: Offset = 5_000;
+
+    #[tokio::test]
+    async fn a_placed_log_starts_at_the_offset_it_was_given() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        assert_eq!(log.base_offset(), BASE);
+        assert_eq!(log.tail_offset().await.expect("tail"), BASE);
+    }
+
+    /// The first record takes the base offset, so the offsets a leader shipped
+    /// are the offsets this log stores them at.
+    #[tokio::test]
+    async fn the_first_record_takes_the_base_offset() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        let appended = log.append(&records(&["a", "b"])).await.expect("append");
+
+        assert_eq!(appended.first_offset, BASE);
+        assert_eq!(appended.last_offset, BASE + 1);
+        let read = log
+            .read_range(ReadRange {
+                start: BASE,
+                max_bytes: 1024,
+            })
+            .await
+            .expect("read");
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].offset, BASE);
+        assert_eq!(read[1].offset, BASE + 1);
+    }
+
+    /// **The base survives a restart.** It is recorded in the segment's own
+    /// header, so nothing has to remember it out of band — and a base that did
+    /// not survive would leave the log reading back as one starting at zero,
+    /// which is a hole rather than a shorter log.
+    #[tokio::test]
+    async fn the_base_survives_a_restart() {
+        let dir = tempdir().expect("dir");
+        {
+            let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+                .expect("place");
+            log.append(&records(&["a"])).await.expect("append");
+            log.shutdown().await.expect("shutdown");
+        }
+
+        let reopened =
+            DiskLog::open(dir.path(), "shard", config(FsyncMode::OnCommit)).expect("reopen");
+
+        assert_eq!(reopened.base_offset(), BASE);
+        assert_eq!(reopened.tail_offset().await.expect("tail"), BASE + 1);
+    }
+
+    /// **An existing log is never reinterpreted.** A restart that passed a
+    /// different base must open the shard that is there, not move it.
+    #[tokio::test]
+    async fn an_existing_log_keeps_its_own_base() {
+        let dir = tempdir().expect("dir");
+        {
+            let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+                .expect("place");
+            log.append(&records(&["a"])).await.expect("append");
+            log.shutdown().await.expect("shutdown");
+        }
+
+        let reopened = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), 99_999)
+            .expect("reopen");
+
+        assert_eq!(
+            reopened.base_offset(),
+            BASE,
+            "an existing shard was moved to a different base",
+        );
+        assert_eq!(reopened.tail_offset().await.expect("tail"), BASE + 1);
+    }
+
+    /// Below the base is `Trimmed`, exactly as on a leader whose retention has
+    /// removed the same records — the follower reports the same condition the
+    /// leader would.
+    #[tokio::test]
+    async fn a_read_below_the_base_is_trimmed() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+        log.append(&records(&["a"])).await.expect("append");
+
+        let err = log
+            .read_range(ReadRange {
+                start: BASE - 1,
+                max_bytes: 1024,
+            })
+            .await
+            .expect_err("a read below the base should be refused");
+
+        assert!(
+            matches!(err, crate::StorageError::Trimmed { .. }),
+            "expected Trimmed, got {err:?}",
+        );
+    }
+
+    /// A base of zero is an ordinary log, so the placing path costs nothing for
+    /// the shards that never needed it.
+    #[tokio::test]
+    async fn a_base_of_zero_is_an_ordinary_log() {
+        let dir = tempdir().expect("dir");
+        let log =
+            DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), 0).expect("place");
+
+        assert_eq!(log.base_offset(), 0);
+        let appended = log.append(&records(&["a"])).await.expect("append");
+        assert_eq!(appended.first_offset, 0);
+    }
+
+    /// Rollover keeps the offsets contiguous from a non-zero base, so a placed
+    /// log behaves like any other once it is being written to.
+    #[tokio::test]
+    async fn a_placed_log_rolls_over_without_breaking_the_offsets() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        for i in 0..200 {
+            log.append(&records(&[&format!("value-{i:04}")]))
+                .await
+                .expect("append");
+        }
+
+        assert!(
+            log.segments().len() > 1,
+            "the test did not force a rollover"
+        );
+        let read = log
+            .read_range(ReadRange {
+                start: BASE,
+                max_bytes: 64 * 1024,
+            })
+            .await
+            .expect("read");
+        for (index, record) in read.iter().enumerate() {
+            assert_eq!(
+                record.offset,
+                BASE + index as u64,
+                "offsets broke at {index}"
+            );
+        }
+    }
+}

--- a/docs/storage-format.md
+++ b/docs/storage-format.md
@@ -65,6 +65,14 @@ File names are zero-padded to 20 digits so lexicographic and numeric order agree
 Recovery still parses the number and sorts on it rather than trusting directory
 iteration order, which is filesystem-defined.
 
+A file name is a **segment id**, not an offset. The two coincide for the common
+log — segment 0 begins at offset 0 — but they are independent, and a shard's
+first segment may begin anywhere. That is what lets a replica be given a shard
+whose early history is already gone everywhere: its log *begins* at the oldest
+surviving offset, and the offset is read back from the segment's own header
+rather than inferred from its name. A read below that offset is `Trimmed`,
+exactly as it is on a leader whose retention removed the same records.
+
 ## Segment file
 
 A 32-byte header, then records back to back, with a sparse index in a companion


### PR DESCRIPTION
The blocker under #114, removed. Does not close it — see the end.

## Why this was in the way

A replica being given a shard whose early history is already gone everywhere needs its log to **begin** at the oldest surviving offset. Until now a log could only start at zero, so there was nowhere to put transferred history: the storage layer had no way to express *"this log is complete and starts at 5000"*.

That is why #260 had to halt such a follower rather than repair it.

## What this adds

`DiskLog::open_at` places a shard's first segment at a given base offset when the directory is empty.

**An existing log is opened as it stands and the base is ignored.** A restart must not reinterpret a shard that is already here, and the base it was created at is recorded in its own first segment.

That last point is what keeps this from becoming a second source of truth. The offset travels in the segment header, which recovery already reads — so nothing has to remember it out of band, and a base that survives one restart survives every later one. The first segment is flushed before anything can append to it: **a base that did not survive a crash would leave the log reading back as one starting at zero, which is a hole rather than a shorter log.**

## A file name is a segment id, not an offset

The two coincide for the common log — segment 0 begins at offset 0 — and are independent in general. `docs/storage-format.md` now says so explicitly, because the assumption that they are the same is precisely what this change breaks for anyone reading segment files.

## Tests

- the placed base is where the first record lands
- **the base survives a restart** (read back from the segment header, not remembered elsewhere)
- an existing log keeps its own base when a different one is passed
- a read below the base is `Trimmed` — the same condition a leader reports for records its retention removed, so a follower and a leader answer alike
- rollover keeps offsets contiguous from a non-zero base
- a base of zero is an ordinary log, so the shards that never needed this pay nothing

`task lint`, `task test`, `task conformance` clean. Conformance matters here: it exercises the on-disk format this touches.

## What still remains in #114

Nothing transfers history yet. That needs two things:

1. A leader serving its surviving range to a bootstrapping follower.
2. A way for the follower to know the range it is being handed **starts where the leader's own log starts**. Without that it cannot distinguish "you are being given the whole surviving log" from "you are being sent a batch from the middle", and placing a base on the second would create exactly the undetectable hole #260 refuses to create.

(2) is a wire change, and not a free one: `ReplicateRecords` cannot carry the leader's base today, and `docs/internal-protocol.md` freezes existing body layouts — additive change happens by adding a `Kind`. I'd rather make that choice deliberately in its own slice than bolt a field on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)