### PR TITLE
feat(replication): bootstrap a follower whose history is gone (M5.5)

### DIFF
--- a/crates/felix-broker/src/durable.rs
+++ b/crates/felix-broker/src/durable.rs
@@ -65,6 +65,33 @@ impl DurableStorage {
     /// Repeated calls for the same shard return the same log, so re-registering
     /// a stream — which the control-plane watcher does on every restart and
     /// resync — never opens a second writer over the same files.
+    /// Open a shard's log, creating it to begin at `base_offset` if it is not
+    /// there yet.
+    ///
+    /// For a replica receiving a shard whose early history has already been
+    /// trimmed everywhere: its log begins where the surviving records do. An
+    /// existing shard keeps the base recorded in its own first segment.
+    pub fn open_stream_at(
+        &self,
+        tenant: &str,
+        namespace: &str,
+        stream: &str,
+        shard: u32,
+        base_offset: felix_storage::log::Offset,
+    ) -> Result<StreamLog> {
+        let key = ShardKey {
+            tenant: tenant.to_string(),
+            namespace: namespace.to_string(),
+            stream: stream.to_string(),
+            shard,
+        };
+        let log = self
+            .provider
+            .open_shard_at(&key, base_offset)
+            .map_err(storage_error)?;
+        Ok(StreamLog { log })
+    }
+
     pub fn open_stream(
         &self,
         tenant: &str,

--- a/crates/felix-storage/src/disk_log/mod.rs
+++ b/crates/felix-storage/src/disk_log/mod.rs
@@ -431,10 +431,41 @@ impl DiskLog {
         label: impl Into<String>,
         config: LogConfig,
     ) -> Result<Self> {
-        config.validate()?;
-        let dir = dir.into();
-        let label = label.into();
+        Self::open_inner(dir.into(), label.into(), config, None)
+    }
 
+    /// Open a shard log, creating it to begin at `base_offset` if it does not
+    /// exist yet.
+    ///
+    /// For a replica receiving history that starts partway through a stream:
+    /// the records before `base_offset` are gone from every copy in the
+    /// cluster, so a log that begins there is complete rather than truncated,
+    /// and a read below it is `Trimmed` exactly as it would be on the leader.
+    ///
+    /// **An existing log is opened as it stands and `base_offset` is ignored.**
+    /// A restart must not reinterpret a shard that is already here, and the
+    /// base it was created at is recorded in its own first segment. Only an
+    /// empty directory is a shard being placed for the first time.
+    pub fn open_at(
+        dir: impl Into<PathBuf>,
+        label: impl Into<String>,
+        config: LogConfig,
+        base_offset: Offset,
+    ) -> Result<Self> {
+        Self::open_inner(dir.into(), label.into(), config, Some(base_offset))
+    }
+
+    fn open_inner(
+        dir: PathBuf,
+        label: String,
+        config: LogConfig,
+        base_offset: Option<Offset>,
+    ) -> Result<Self> {
+        config.validate()?;
+
+        if let Some(base_offset) = base_offset.filter(|base| *base > 0) {
+            recovery::place_empty_shard(&dir, &config, base_offset)?;
+        }
         let recovered = recovery::recover_shard(&dir, &label, &config)?;
         if recovered.truncated_bytes > 0 {
             tracing::warn!(
@@ -904,6 +935,27 @@ impl DiskLogProvider {
 
     pub fn config(&self) -> &LogConfig {
         &self.config
+    }
+
+    /// Open or return the cached log for `shard`, creating it to begin at
+    /// `base_offset` if it does not exist yet.
+    ///
+    /// For a replica being given a shard whose early history is already gone.
+    /// An existing shard keeps its own base, so this is safe to call on every
+    /// contact rather than only the first.
+    pub fn open_shard_at(&self, shard: &ShardKey, base_offset: Offset) -> Result<DiskLog> {
+        let mut open_logs = self.open_logs.lock();
+        if let Some(log) = open_logs.get(shard) {
+            return Ok(log.clone());
+        }
+        let log = DiskLog::open_at(
+            layout::shard_dir(&self.root, shard),
+            layout::shard_label(shard),
+            self.config.clone(),
+            base_offset,
+        )?;
+        open_logs.insert(shard.clone(), log.clone());
+        Ok(log)
     }
 
     /// Open or return the cached log for `shard`.

--- a/crates/felix-storage/src/disk_log/recovery.rs
+++ b/crates/felix-storage/src/disk_log/recovery.rs
@@ -84,6 +84,37 @@ pub fn discover_segment_ids(dir: &Path) -> Result<Vec<SegmentId>> {
 }
 
 /// Open, validate and repair every segment for one shard.
+/// Create a shard's first segment so its log begins at `base_offset`.
+///
+/// A no-op when the directory already holds segments: a shard that is already
+/// here keeps the base recorded in its own first segment, and a restart must
+/// not reinterpret it. Only an empty directory is a shard being placed.
+///
+/// The segment carries `base_offset` in its header, so recovery reads it back
+/// without needing to be told again.
+pub fn place_empty_shard(dir: &Path, config: &LogConfig, base_offset: Offset) -> Result<bool> {
+    std::fs::create_dir_all(dir)?;
+    if let Some(parent) = dir.parent() {
+        sync_dir(parent)?;
+    }
+    if !discover_segment_ids(dir)?.is_empty() {
+        return Ok(false);
+    }
+    let mut writer = SegmentWriter::create(
+        dir,
+        0,
+        base_offset,
+        now_micros(),
+        preallocate_bytes(config),
+        config.index_spacing_bytes,
+    )?;
+    // Flushed before anything can append to it: a base offset that did not
+    // survive a crash would leave the shard reading back as one starting at
+    // zero, which is a hole rather than a shorter log.
+    writer.sync()?;
+    Ok(true)
+}
+
 pub fn recover_shard(dir: &Path, label: &str, config: &LogConfig) -> Result<Recovered> {
     let started = std::time::Instant::now();
     std::fs::create_dir_all(dir)?;

--- a/crates/felix-storage/src/disk_log/tests.rs
+++ b/crates/felix-storage/src/disk_log/tests.rs
@@ -994,3 +994,164 @@ async fn an_inline_rollover_does_not_park_every_worker() {
          appends parked their workers on the synchronous segment lock",
     );
 }
+
+/// A log that begins partway through a stream.
+///
+/// A replica receiving history that starts at an offset other than zero needs
+/// its log to *begin* there. The records before it are gone from every copy in
+/// the cluster, so such a log is complete rather than truncated, and it must
+/// read back that way after a restart as well.
+mod placed_at_a_base_offset {
+    use super::*;
+
+    const BASE: Offset = 5_000;
+
+    #[tokio::test]
+    async fn a_placed_log_starts_at_the_offset_it_was_given() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        assert_eq!(log.base_offset(), BASE);
+        assert_eq!(log.tail_offset().await.expect("tail"), BASE);
+    }
+
+    /// The first record takes the base offset, so the offsets a leader shipped
+    /// are the offsets this log stores them at.
+    #[tokio::test]
+    async fn the_first_record_takes_the_base_offset() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        let appended = log.append(&records(&["a", "b"])).await.expect("append");
+
+        assert_eq!(appended.first_offset, BASE);
+        assert_eq!(appended.last_offset, BASE + 1);
+        let read = log
+            .read_range(ReadRange {
+                start: BASE,
+                max_bytes: 1024,
+            })
+            .await
+            .expect("read");
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].offset, BASE);
+        assert_eq!(read[1].offset, BASE + 1);
+    }
+
+    /// **The base survives a restart.** It is recorded in the segment's own
+    /// header, so nothing has to remember it out of band — and a base that did
+    /// not survive would leave the log reading back as one starting at zero,
+    /// which is a hole rather than a shorter log.
+    #[tokio::test]
+    async fn the_base_survives_a_restart() {
+        let dir = tempdir().expect("dir");
+        {
+            let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+                .expect("place");
+            log.append(&records(&["a"])).await.expect("append");
+            log.shutdown().await.expect("shutdown");
+        }
+
+        let reopened =
+            DiskLog::open(dir.path(), "shard", config(FsyncMode::OnCommit)).expect("reopen");
+
+        assert_eq!(reopened.base_offset(), BASE);
+        assert_eq!(reopened.tail_offset().await.expect("tail"), BASE + 1);
+    }
+
+    /// **An existing log is never reinterpreted.** A restart that passed a
+    /// different base must open the shard that is there, not move it.
+    #[tokio::test]
+    async fn an_existing_log_keeps_its_own_base() {
+        let dir = tempdir().expect("dir");
+        {
+            let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+                .expect("place");
+            log.append(&records(&["a"])).await.expect("append");
+            log.shutdown().await.expect("shutdown");
+        }
+
+        let reopened = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), 99_999)
+            .expect("reopen");
+
+        assert_eq!(
+            reopened.base_offset(),
+            BASE,
+            "an existing shard was moved to a different base",
+        );
+        assert_eq!(reopened.tail_offset().await.expect("tail"), BASE + 1);
+    }
+
+    /// Below the base is `Trimmed`, exactly as on a leader whose retention has
+    /// removed the same records — the follower reports the same condition the
+    /// leader would.
+    #[tokio::test]
+    async fn a_read_below_the_base_is_trimmed() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+        log.append(&records(&["a"])).await.expect("append");
+
+        let err = log
+            .read_range(ReadRange {
+                start: BASE - 1,
+                max_bytes: 1024,
+            })
+            .await
+            .expect_err("a read below the base should be refused");
+
+        assert!(
+            matches!(err, crate::StorageError::Trimmed { .. }),
+            "expected Trimmed, got {err:?}",
+        );
+    }
+
+    /// A base of zero is an ordinary log, so the placing path costs nothing for
+    /// the shards that never needed it.
+    #[tokio::test]
+    async fn a_base_of_zero_is_an_ordinary_log() {
+        let dir = tempdir().expect("dir");
+        let log =
+            DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), 0).expect("place");
+
+        assert_eq!(log.base_offset(), 0);
+        let appended = log.append(&records(&["a"])).await.expect("append");
+        assert_eq!(appended.first_offset, 0);
+    }
+
+    /// Rollover keeps the offsets contiguous from a non-zero base, so a placed
+    /// log behaves like any other once it is being written to.
+    #[tokio::test]
+    async fn a_placed_log_rolls_over_without_breaking_the_offsets() {
+        let dir = tempdir().expect("dir");
+        let log = DiskLog::open_at(dir.path(), "shard", config(FsyncMode::OnCommit), BASE)
+            .expect("place");
+
+        for i in 0..200 {
+            log.append(&records(&[&format!("value-{i:04}")]))
+                .await
+                .expect("append");
+        }
+
+        assert!(
+            log.segments().len() > 1,
+            "the test did not force a rollover"
+        );
+        let read = log
+            .read_range(ReadRange {
+                start: BASE,
+                max_bytes: 64 * 1024,
+            })
+            .await
+            .expect("read");
+        for (index, record) in read.iter().enumerate() {
+            assert_eq!(
+                record.offset,
+                BASE + index as u64,
+                "offsets broke at {index}"
+            );
+        }
+    }
+}

--- a/crates/felix-wire/src/internal.rs
+++ b/crates/felix-wire/src/internal.rs
@@ -56,6 +56,7 @@ pub enum Kind {
     ReplicateRecords = 7,
     ReplicateOk = 8,
     ReplicateError = 9,
+    ReplicateBootstrap = 10,
 }
 
 impl Kind {
@@ -72,6 +73,7 @@ impl Kind {
             7 => Ok(Kind::ReplicateRecords),
             8 => Ok(Kind::ReplicateOk),
             9 => Ok(Kind::ReplicateError),
+            10 => Ok(Kind::ReplicateBootstrap),
             other => Err(Error::UnsupportedInternalKind(other)),
         }
     }
@@ -287,6 +289,28 @@ pub struct ReplicateOk {
     pub durable_offset: u64,
 }
 
+/// The leader has nothing older than `base_offset` left.
+///
+/// Sent when a follower's position is below everything the leader still holds,
+/// so shipping cannot reach it: the records in between are gone from the leader
+/// too. It says "the surviving log starts here" — which is the one fact a
+/// follower cannot work out for itself, and the fact it needs before it may
+/// place a log that begins anywhere other than zero.
+///
+/// A follower with records of its own refuses. Discarding them is an operator's
+/// decision, not a leader's.
+///
+/// A separate kind rather than a field on [`ReplicateRecords`]: this protocol
+/// freezes existing body layouts, and an older peer already rejects an unknown
+/// kind rather than misreading it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReplicateBootstrap {
+    pub correlation_id: u64,
+    pub shard: ShardRef,
+    /// Offset of the oldest record the leader still holds.
+    pub base_offset: u64,
+}
+
 /// The follower refused, and where it stands.
 ///
 /// `expected_offset` is what the follower wants next. For `LogGap` it is how
@@ -312,6 +336,7 @@ pub enum InternalMessage {
     ReplicateRecords(ReplicateRecords),
     ReplicateOk(ReplicateOk),
     ReplicateError(ReplicateError),
+    ReplicateBootstrap(ReplicateBootstrap),
 }
 
 impl InternalMessage {
@@ -326,6 +351,7 @@ impl InternalMessage {
             Self::ReplicateRecords(_) => Kind::ReplicateRecords,
             Self::ReplicateOk(_) => Kind::ReplicateOk,
             Self::ReplicateError(_) => Kind::ReplicateError,
+            Self::ReplicateBootstrap(_) => Kind::ReplicateBootstrap,
         }
     }
 
@@ -345,6 +371,7 @@ impl InternalMessage {
             Self::ReplicateRecords(m) => m.correlation_id,
             Self::ReplicateOk(m) => m.correlation_id,
             Self::ReplicateError(m) => m.correlation_id,
+            Self::ReplicateBootstrap(m) => m.correlation_id,
         }
     }
 
@@ -420,6 +447,15 @@ impl InternalMessage {
                 body.put_u16(m.code as u16);
                 body.put_u64(m.expected_offset);
                 put_str(&mut body, &m.detail)?;
+            }
+            Self::ReplicateBootstrap(m) => {
+                body.put_u64(m.correlation_id);
+                put_str(&mut body, &m.shard.tenant_id)?;
+                put_str(&mut body, &m.shard.namespace)?;
+                put_str(&mut body, &m.shard.stream)?;
+                body.put_u32(m.shard.shard);
+                body.put_u64(m.shard.generation);
+                body.put_u64(m.base_offset);
             }
         }
 
@@ -597,6 +633,21 @@ impl InternalMessage {
                 };
                 expect_empty(&body)?;
                 Ok(Self::ReplicateError(message))
+            }
+            Kind::ReplicateBootstrap => {
+                let message = ReplicateBootstrap {
+                    correlation_id: take_u64(&mut body)?,
+                    shard: ShardRef {
+                        tenant_id: take_str(&mut body)?,
+                        namespace: take_str(&mut body)?,
+                        stream: take_str(&mut body)?,
+                        shard: take_u32(&mut body)?,
+                        generation: take_u64(&mut body)?,
+                    },
+                    base_offset: take_u64(&mut body)?,
+                };
+                expect_empty(&body)?;
+                Ok(Self::ReplicateBootstrap(message))
             }
         }
     }

--- a/crates/felix-wire/src/internal_tests.rs
+++ b/crates/felix-wire/src/internal_tests.rs
@@ -61,6 +61,11 @@ fn every_message() -> Vec<InternalMessage> {
             expected_offset: 100,
             detail: "batch starts at 105, expected 100".to_string(),
         }),
+        InternalMessage::ReplicateBootstrap(ReplicateBootstrap {
+            correlation_id: 42,
+            shard: shard(),
+            base_offset: 5_000,
+        }),
     ]
 }
 
@@ -342,7 +347,7 @@ fn unknown_enum_values_are_rejected() {
     assert!(Kind::from_u16(0).is_err());
     // One past the highest kind: an unknown kind must be rejected rather than
     // skipped, because the kind is what selects how to read the body.
-    assert!(Kind::from_u16(10).is_err());
+    assert!(Kind::from_u16(11).is_err());
     assert!(ErrorCode::from_u16(0).is_err());
     assert!(ErrorCode::from_u16(999).is_err());
     assert!(AckMode::from_u8(9).is_err());
@@ -480,6 +485,7 @@ fn the_existing_kind_discriminants_are_unchanged() {
         (7, Kind::ReplicateRecords),
         (8, Kind::ReplicateOk),
         (9, Kind::ReplicateError),
+        (10, Kind::ReplicateBootstrap),
     ] {
         assert_eq!(Kind::from_u16(value).expect("known"), kind);
         assert_eq!(kind as u16, value);

--- a/docs/internal-protocol.md
+++ b/docs/internal-protocol.md
@@ -196,6 +196,33 @@ definition, so the two sides cannot compute it differently.
 disagree at an offset do not converge by retrying; progress stops and the
 condition is surfaced.
 
+### Bootstrapping a follower
+
+A follower can be positioned below everything the leader still holds — a new
+replica of a stream with retention, or one that fell far enough behind. Shipping
+cannot bridge that: the records in between are gone from the leader too.
+
+`ReplicateBootstrap` carries the offset of the oldest record the leader still
+has. It is the one fact a follower cannot work out for itself, and the fact it
+needs before it may place a log that begins anywhere other than zero.
+
+| The follower | Answer |
+| --- | --- |
+| holds no log for the shard | places it at `base_offset`, `ReplicateOk` |
+| already holds a log starting there | `ReplicateOk`; the offer is idempotent |
+| holds records starting elsewhere | `LogConflict` |
+
+The last row is the point. A log placed over existing records would have a hole
+between what the follower held and what it was given, and a log with a hole is
+one nothing downstream can detect — from the follower's own view its offsets are
+still contiguous. Discarding those records is an operator's decision, not a
+leader's, so the leader halts that follower instead.
+
+The same fence applies as to storing records: a superseded leader cannot place a
+log, and a broker outside the replica set cannot be given a shard. Placing a log
+and filling it are the same authority question, and a fence applied to one and
+not the other is a fence with a way round it.
+
 ## Errors
 
 Typed, because they need different responses:
@@ -214,6 +241,10 @@ Typed, because they need different responses:
 | `LogGap` | a replication batch starts past the follower's tail | resume from `expected_offset` |
 | `LogConflict` | a replication batch disagrees with stored bytes | do not retry; the logs have diverged |
 | `FencedEpoch` | the sender named an epoch older than the responder's | do not retry; it is no longer the leader |
+
+`ReplicateBootstrap` is kind 10. A peer that predates it rejects the kind rather
+than misreading the body, which is why it is a new kind rather than a field on
+`ReplicateRecords`: this protocol freezes existing body layouts.
 
 `NotLeader` is a distinct kind rather than an error code, because it carries a
 routing answer rather than only a reason.

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -202,10 +202,11 @@ the primitives the storage layer already exposes for this purpose.
 Once retention has trimmed past a follower's position, shipping cannot reach it:
 the records are not on the leader to send, and starting the follower at the
 surviving base offset would leave its log with a hole nothing downstream could
-detect. Such a follower is halted for bootstrap — it counts toward no quorum and
-is not shipped to again — and transferring its history is #114, which is not
-implemented. Until it is, a follower that falls that far behind needs its data
-directory rebuilt by hand.
+detect. Such a follower is offered a log that *begins* at the leader's oldest surviving
+offset (`ReplicateBootstrap`). A replica holding nothing takes it and replication
+resumes; one holding records of its own refuses, because a log placed over them
+would have a hole nothing downstream could detect, and it is halted for an
+operator to resolve.
 
 ### The `Leader` loss window, precisely
 

--- a/docs/storage-format.md
+++ b/docs/storage-format.md
@@ -65,6 +65,14 @@ File names are zero-padded to 20 digits so lexicographic and numeric order agree
 Recovery still parses the number and sorts on it rather than trusting directory
 iteration order, which is filesystem-defined.
 
+A file name is a **segment id**, not an offset. The two coincide for the common
+log — segment 0 begins at offset 0 — but they are independent, and a shard's
+first segment may begin anywhere. That is what lets a replica be given a shard
+whose early history is already gone everywhere: its log *begins* at the oldest
+surviving offset, and the offset is read back from the segment's own header
+rather than inferred from its name. A read below that offset is `Trimmed`,
+exactly as it is on a leader whose retention removed the same records.
+
 ## Segment file
 
 A 32-byte header, then records back to back, with a sparse index in a companion

--- a/services/broker/src/peer/dispatch.rs
+++ b/services/broker/src/peer/dispatch.rs
@@ -34,6 +34,7 @@ impl PeerRequestHandler for BrokerPeerHandler {
         match request {
             InternalMessage::ForwardPublish(publish) => self.forwarding.apply(publish).await,
             InternalMessage::ReplicateRecords(batch) => self.replica.apply(batch).await,
+            InternalMessage::ReplicateBootstrap(request) => self.replica.bootstrap(request).await,
             // Responses have no business arriving as requests, and a broker that
             // answered one would be inventing a request that was never made.
             other => InternalMessage::ForwardPublishError(ForwardPublishError {

--- a/services/broker/src/peer/metrics.rs
+++ b/services/broker/src/peer/metrics.rs
@@ -125,6 +125,9 @@ pub const OUTCOME_GAP: &str = "gap";
 pub const OUTCOME_CONFLICT: &str = "conflict";
 /// The batch did not survive the trip.
 pub const OUTCOME_CORRUPT: &str = "corrupt";
+/// This broker placed a shard log to begin where the leader's surviving log
+/// begins. Rare and deliberate: it happens once per replica per shard.
+pub const OUTCOME_BOOTSTRAPPED: &str = "bootstrapped";
 
 pub fn record_replicated(outcome: &'static str) {
     metrics::counter!(REPLICATED_TOTAL, "outcome" => outcome).increment(1);

--- a/services/broker/src/peer/pool.rs
+++ b/services/broker/src/peer/pool.rs
@@ -785,6 +785,12 @@ fn with_correlation(message: InternalMessage, correlation_id: u64) -> InternalMe
             correlation_id,
             ..m
         }),
+        InternalMessage::ReplicateBootstrap(m) => {
+            InternalMessage::ReplicateBootstrap(ReplicateBootstrap {
+                correlation_id,
+                ..m
+            })
+        }
     }
 }
 

--- a/services/broker/src/peer/pool_tests.rs
+++ b/services/broker/src/peer/pool_tests.rs
@@ -355,6 +355,7 @@ mod correlation {
             InternalMessage::ReplicateRecords(m) => m.correlation_id,
             InternalMessage::ReplicateOk(m) => m.correlation_id,
             InternalMessage::ReplicateError(m) => m.correlation_id,
+            InternalMessage::ReplicateBootstrap(m) => m.correlation_id,
         }
     }
 
@@ -417,6 +418,11 @@ mod correlation {
                 code: ErrorCode::LogGap,
                 expected_offset: 9,
                 detail: "behind".to_string(),
+            }),
+            InternalMessage::ReplicateBootstrap(ReplicateBootstrap {
+                correlation_id: 7,
+                shard: shard(),
+                base_offset: 5_000,
             }),
         ]
     }

--- a/services/broker/src/peer/replica.rs
+++ b/services/broker/src/peer/replica.rs
@@ -21,7 +21,7 @@ use felix_broker::Broker;
 use felix_broker::replication::{self, Divergence};
 use felix_router::{ReplicaRole, ShardRouter};
 use felix_wire::internal::{
-    ErrorCode, InternalMessage, ReplicateError, ReplicateOk, ReplicateRecords,
+    ErrorCode, InternalMessage, ReplicateBootstrap, ReplicateError, ReplicateOk, ReplicateRecords,
 };
 
 use super::metrics;
@@ -37,6 +37,148 @@ impl ReplicaHandler {
         Self { broker, router }
     }
 
+    /// May this broker store anything for `key` at `generation`?
+    ///
+    /// Shared by both entry points on purpose: storing records and placing the
+    /// log that holds them are the same authority question, and a fence applied
+    /// to one and not the other is a fence with a way round it.
+    fn check_role(
+        &self,
+        correlation_id: u64,
+        key: &felix_router::ShardKey,
+        generation: u64,
+    ) -> Option<InternalMessage> {
+        match self.router.replica_role(key, generation) {
+            ReplicaRole::Follower => None,
+            ReplicaRole::Fenced { have, named } => {
+                metrics::record_replicated(metrics::OUTCOME_FENCED);
+                Some(refused(
+                    correlation_id,
+                    ErrorCode::FencedEpoch,
+                    0,
+                    format!("this broker is at generation {have}, the sender at {named}"),
+                ))
+            }
+            ReplicaRole::Behind { have, named } => {
+                // Not a refusal of the leader, only of this moment: the watch
+                // has not caught up. Retryable, and the leader will find us
+                // ready once it has.
+                metrics::record_replicated(metrics::OUTCOME_BEHIND);
+                Some(refused(
+                    correlation_id,
+                    ErrorCode::StaleRoute,
+                    0,
+                    format!("this broker is at generation {have}, the sender at {named}"),
+                ))
+            }
+            ReplicaRole::NotAReplica => {
+                metrics::record_replicated(metrics::OUTCOME_REFUSED);
+                Some(refused(
+                    correlation_id,
+                    ErrorCode::Unauthorized,
+                    0,
+                    "this broker is not a replica of that shard".to_string(),
+                ))
+            }
+        }
+    }
+
+    /// Begin this shard's log where the leader's surviving log begins.
+    ///
+    /// The leader has nothing older left, so the records below `base_offset`
+    /// are gone from every copy: a log that starts there is complete rather
+    /// than truncated. The follower cannot work that out for itself, which is
+    /// why the leader has to say it.
+    ///
+    /// **A follower holding records of its own refuses.** Discarding them is an
+    /// operator's decision, not a leader's — and a log placed over them would
+    /// have a hole between what it held and what it was given, which nothing
+    /// downstream could detect.
+    pub async fn bootstrap(&self, request: ReplicateBootstrap) -> InternalMessage {
+        let correlation_id = request.correlation_id;
+        let key = felix_router::ShardKey {
+            tenant_id: request.shard.tenant_id.clone(),
+            namespace: request.shard.namespace.clone(),
+            stream: request.shard.stream.clone(),
+            shard: request.shard.shard,
+        };
+
+        if let Some(refusal) = self.check_role(correlation_id, &key, request.shard.generation) {
+            return refusal;
+        }
+        let Some(storage) = self.broker.durable_storage() else {
+            metrics::record_replicated(metrics::OUTCOME_REFUSED);
+            return refused(
+                correlation_id,
+                ErrorCode::Unauthorized,
+                0,
+                "this broker has no durable storage".to_string(),
+            );
+        };
+
+        // Creates the log at `base_offset` when this broker has never held the
+        // shard, and opens what is there otherwise. The base it comes back with
+        // is the authority either way.
+        let log = match storage.open_stream_at(
+            &key.tenant_id,
+            &key.namespace,
+            &key.stream,
+            key.shard,
+            request.base_offset,
+        ) {
+            Ok(log) => log,
+            Err(err) => {
+                metrics::record_replicated(metrics::OUTCOME_ERROR);
+                return refused(correlation_id, ErrorCode::StorageFailed, 0, err.to_string());
+            }
+        };
+
+        let base = log.base_offset();
+        if base != request.base_offset {
+            // A log is already here and it starts somewhere else. Placing the
+            // leader's base over it would leave a hole between the two.
+            metrics::record_replicated(metrics::OUTCOME_CONFLICT);
+            let tail = log.tail_offset().await.unwrap_or(base);
+            tracing::error!(
+                stream = %key.stream,
+                shard = key.shard,
+                held_from = base,
+                held_to = tail,
+                offered_from = request.base_offset,
+                "refusing to bootstrap: this broker already holds records for that shard",
+            );
+            return refused(
+                correlation_id,
+                ErrorCode::LogConflict,
+                tail,
+                format!(
+                    "this broker holds {base}..{tail} for that shard and cannot be \
+                     re-based at {}",
+                    request.base_offset
+                ),
+            );
+        }
+
+        let tail = match log.tail_offset().await {
+            Ok(tail) => tail,
+            Err(err) => {
+                metrics::record_replicated(metrics::OUTCOME_ERROR);
+                return refused(correlation_id, ErrorCode::StorageFailed, 0, err.to_string());
+            }
+        };
+        tracing::info!(
+            stream = %key.stream,
+            shard = key.shard,
+            base_offset = base,
+            "shard log placed for bootstrap",
+        );
+        metrics::record_replicated(metrics::OUTCOME_BOOTSTRAPPED);
+        InternalMessage::ReplicateOk(ReplicateOk {
+            correlation_id,
+            durable_offset: tail,
+        })
+    }
+
     pub async fn apply(&self, batch: ReplicateRecords) -> InternalMessage {
         let correlation_id = batch.correlation_id;
         let key = felix_router::ShardKey {
@@ -46,38 +188,8 @@ impl ReplicaHandler {
             shard: batch.shard.shard,
         };
 
-        match self.router.replica_role(&key, batch.shard.generation) {
-            ReplicaRole::Follower => {}
-            ReplicaRole::Fenced { have, named } => {
-                metrics::record_replicated(metrics::OUTCOME_FENCED);
-                return refused(
-                    correlation_id,
-                    ErrorCode::FencedEpoch,
-                    0,
-                    format!("this broker is at generation {have}, the sender at {named}"),
-                );
-            }
-            ReplicaRole::Behind { have, named } => {
-                // Not a refusal of the leader, only of this moment: the watch
-                // has not caught up. Retryable, and the leader will find us
-                // ready once it has.
-                metrics::record_replicated(metrics::OUTCOME_BEHIND);
-                return refused(
-                    correlation_id,
-                    ErrorCode::StaleRoute,
-                    0,
-                    format!("this broker is at generation {have}, the sender at {named}"),
-                );
-            }
-            ReplicaRole::NotAReplica => {
-                metrics::record_replicated(metrics::OUTCOME_REFUSED);
-                return refused(
-                    correlation_id,
-                    ErrorCode::Unauthorized,
-                    0,
-                    "this broker is not a replica of that shard".to_string(),
-                );
-            }
+        if let Some(refusal) = self.check_role(correlation_id, &key, batch.shard.generation) {
+            return refusal;
         }
 
         let Some(storage) = self.broker.durable_storage() else {

--- a/services/broker/src/peer/replica_tests.rs
+++ b/services/broker/src/peer/replica_tests.rs
@@ -250,3 +250,129 @@ async fn every_answer_carries_the_requests_correlation_id() {
         assert_eq!(handler.apply(request).await.correlation_id(), 99);
     }
 }
+
+/// Placing a shard log where the leader's surviving log begins.
+mod bootstrap {
+    use super::*;
+    use felix_wire::internal::ReplicateBootstrap;
+
+    const BASE: u64 = 5_000;
+
+    fn offer(generation: u64, base_offset: u64) -> ReplicateBootstrap {
+        ReplicateBootstrap {
+            correlation_id: 1,
+            shard: ShardRef {
+                tenant_id: TENANT.to_string(),
+                namespace: NAMESPACE.to_string(),
+                stream: STREAM.to_string(),
+                shard: 0,
+                generation,
+            },
+            base_offset,
+        }
+    }
+
+    /// **A replica with nothing takes the offer**, and reports that it now
+    /// stands at the offered base — which is where the leader resumes.
+    #[tokio::test]
+    async fn a_replica_holding_nothing_places_its_log_at_the_offered_base() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(Arc::clone(&broker), router_with(&[LOCAL], 4));
+
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        match answer {
+            InternalMessage::ReplicateOk(ok) => assert_eq!(ok.durable_offset, BASE),
+            other => panic!("expected an acknowledgement, got {:?}", other.kind()),
+        }
+        let log = broker
+            .durable_storage()
+            .expect("storage")
+            .open_stream(TENANT, NAMESPACE, STREAM, 0)
+            .expect("open");
+        assert_eq!(log.base_offset(), BASE);
+    }
+
+    /// Records shipped after a bootstrap land at the leader's offsets, which is
+    /// the whole point of placing the log rather than starting at zero.
+    #[tokio::test]
+    async fn records_after_a_bootstrap_land_at_the_leaders_offsets() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(Arc::clone(&broker), router_with(&[LOCAL], 4));
+        handler.bootstrap(offer(4, BASE)).await;
+
+        let answer = handler.apply(batch(4, BASE, &["a", "b"])).await;
+
+        match answer {
+            InternalMessage::ReplicateOk(ok) => assert_eq!(ok.durable_offset, BASE + 2),
+            other => panic!("expected an acknowledgement, got {:?}", other.kind()),
+        }
+    }
+
+    /// **A replica holding records refuses.** Discarding them is an operator's
+    /// decision, and a log placed over them would have a hole between what it
+    /// held and what it was given.
+    #[tokio::test]
+    async fn a_replica_holding_records_refuses_to_be_rebased() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(Arc::clone(&broker), router_with(&[LOCAL], 4));
+        handler.apply(batch(4, 0, &["a", "b"])).await;
+
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        let refused = refusal(&answer);
+        assert_eq!(refused.code, ErrorCode::LogConflict);
+        assert!(!refused.code.is_retryable());
+    }
+
+    /// Offering the same base twice is harmless: the second finds the log
+    /// already placed there and agrees.
+    #[tokio::test]
+    async fn repeating_the_same_offer_is_harmless() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(Arc::clone(&broker), router_with(&[LOCAL], 4));
+
+        handler.bootstrap(offer(4, BASE)).await;
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        match answer {
+            InternalMessage::ReplicateOk(ok) => assert_eq!(ok.durable_offset, BASE),
+            other => panic!("a repeated offer was refused: {:?}", other.kind()),
+        }
+    }
+
+    /// **The same fence applies to placing a log as to storing records.** A
+    /// superseded leader must not be able to re-base a follower's shard, which
+    /// would be a way round the check that guards the records themselves.
+    #[tokio::test]
+    async fn a_superseded_leader_cannot_place_a_log() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 5));
+
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        assert_eq!(refusal(&answer).code, ErrorCode::FencedEpoch);
+    }
+
+    /// And a broker outside the replica set cannot be given a shard at all.
+    #[tokio::test]
+    async fn a_broker_outside_the_replica_set_cannot_be_given_a_shard() {
+        let (broker, _dir) = broker_with_storage().await;
+        let handler = ReplicaHandler::new(broker, router_with(&["broker-c"], 4));
+
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        assert_eq!(refusal(&answer).code, ErrorCode::Unauthorized);
+    }
+
+    /// A replica with nowhere to put records says so rather than accepting.
+    #[tokio::test]
+    async fn a_replica_without_durable_storage_refuses() {
+        let broker = Arc::new(Broker::new(EphemeralCache::new().into()));
+        let handler = ReplicaHandler::new(broker, router_with(&[LOCAL], 4));
+
+        let answer = handler.bootstrap(offer(4, BASE)).await;
+
+        assert_eq!(refusal(&answer).code, ErrorCode::Unauthorized);
+    }
+}

--- a/services/broker/src/replication.rs
+++ b/services/broker/src/replication.rs
@@ -34,7 +34,7 @@ use std::net::SocketAddr;
 use bytes::Bytes;
 use felix_broker::StreamLog;
 use felix_wire::internal::{
-    ErrorCode, InternalMessage, ReplicateRecords, ShardRef, batch_checksum,
+    ErrorCode, InternalMessage, ReplicateBootstrap, ReplicateRecords, ShardRef, batch_checksum,
 };
 
 use crate::peer::{PeerError, PeerRequester};
@@ -153,17 +153,19 @@ pub async fn ship_once<R: PeerRequester>(
         // that the shard needs its history transferred -- which is #114's
         // subject and is not implemented.
         Err(felix_broker::BrokerError::CursorTooOld { oldest, requested }) => {
-            tracing::error!(
+            // The records between the follower's position and this leader's
+            // oldest are gone from both. Shipping cannot bridge that, so the
+            // follower is offered the one fact it cannot work out for itself:
+            // where the surviving log begins.
+            tracing::info!(
                 node_id = %cursor.node_id,
                 stream = %shard.stream,
                 shard = shard.shard,
                 requested,
                 oldest,
-                "replication stopped: the follower needs history retention has removed",
+                "the follower is below this leader's oldest record; offering a bootstrap",
             );
-            cursor.halted = Some(Halt::NeedsBootstrap);
-            metrics::record_shipped(metrics::OUTCOME_NEEDS_BOOTSTRAP);
-            return Progress::Halted(Halt::NeedsBootstrap);
+            return offer_bootstrap(requester, shard, cursor, oldest).await;
         }
         Err(err) => {
             // The leader could not read its own log. Nothing is wrong with the
@@ -238,6 +240,69 @@ pub async fn ship_once<R: PeerRequester>(
         Progress::UpToDate => {}
     }
     progress
+}
+
+/// Offer a follower a log that begins where this leader's surviving log does.
+///
+/// Only the follower can accept: one holding records of its own has a gap it
+/// cannot fill, and discarding them is an operator's decision rather than a
+/// leader's. A refusal halts this follower, which is where it stood before the
+/// offer was made.
+async fn offer_bootstrap<R: PeerRequester>(
+    requester: &R,
+    shard: &ShardRef,
+    cursor: &mut FollowerCursor,
+    base_offset: u64,
+) -> Progress {
+    let request = InternalMessage::ReplicateBootstrap(ReplicateBootstrap {
+        // The pool assigns the real id; it owns the connection this lands on.
+        correlation_id: 0,
+        shard: shard.clone(),
+        base_offset,
+    });
+    let answer = match requester
+        .request(&cursor.node_id, cursor.addr, request)
+        .await
+    {
+        Ok(answer) => answer,
+        Err(err) => {
+            // Unreachable, not unwilling. The offer stands and goes again.
+            metrics::record_shipped(unreachable_outcome(&err));
+            return Progress::Retry;
+        }
+    };
+
+    match read_answer(&answer) {
+        Progress::Stored { durable_offset } => {
+            cursor.next_offset = durable_offset;
+            tracing::info!(
+                node_id = %cursor.node_id,
+                stream = %shard.stream,
+                shard = shard.shard,
+                base_offset,
+                "the follower placed its log and replication resumed",
+            );
+            metrics::record_shipped(metrics::OUTCOME_BOOTSTRAPPED);
+            Progress::Resume {
+                offset: durable_offset,
+            }
+        }
+        // The follower will not take it, and nothing about that resolves by
+        // asking again: it holds records of its own, so a person has to decide
+        // what becomes of them.
+        _ => {
+            tracing::error!(
+                node_id = %cursor.node_id,
+                stream = %shard.stream,
+                shard = shard.shard,
+                base_offset,
+                "replication stopped: the follower refused a bootstrap and cannot be caught up",
+            );
+            cursor.halted = Some(Halt::NeedsBootstrap);
+            metrics::record_shipped(metrics::OUTCOME_NEEDS_BOOTSTRAP);
+            Progress::Halted(Halt::NeedsBootstrap)
+        }
+    }
 }
 
 fn unreachable_outcome(err: &PeerError) -> &'static str {

--- a/services/broker/src/replication/metrics.rs
+++ b/services/broker/src/replication/metrics.rs
@@ -38,6 +38,9 @@ pub const OUTCOME_FENCED: &str = "fenced";
 /// The follower needs records retention has removed from the leader. It cannot
 /// be caught up by shipping and needs its history transferred.
 pub const OUTCOME_NEEDS_BOOTSTRAP: &str = "needs_bootstrap";
+/// The follower took a log placed at this leader's oldest surviving offset and
+/// replication resumed. Once per replica per shard.
+pub const OUTCOME_BOOTSTRAPPED: &str = "bootstrapped";
 
 pub fn record_shipped(outcome: &'static str) {
     metrics::counter!(SHIPPED_TOTAL, "outcome" => outcome).increment(1);

--- a/services/broker/src/replication_tests.rs
+++ b/services/broker/src/replication_tests.rs
@@ -21,6 +21,8 @@ const GENERATION: u64 = 4;
 struct ScriptedFollower {
     answers: Mutex<std::collections::VecDeque<std::result::Result<InternalMessage, PeerError>>>,
     sent: Mutex<Vec<ReplicateRecords>>,
+    /// Base offsets this follower was offered, as distinct from records sent.
+    offered: Mutex<Vec<u64>>,
 }
 
 impl ScriptedFollower {
@@ -30,7 +32,13 @@ impl ScriptedFollower {
         Self {
             answers: Mutex::new(answers.into_iter().collect()),
             sent: Mutex::new(Vec::new()),
+            offered: Mutex::new(Vec::new()),
         }
+    }
+
+    /// Base offsets this follower was offered.
+    fn offered(&self) -> Vec<u64> {
+        self.offered.lock().expect("lock").clone()
     }
 
     /// The offsets and payloads of every batch this follower was sent.
@@ -62,6 +70,9 @@ impl PeerRequester for ScriptedFollower {
     ) -> std::result::Result<InternalMessage, PeerError> {
         match message {
             InternalMessage::ReplicateRecords(batch) => self.sent.lock().expect("lock").push(batch),
+            InternalMessage::ReplicateBootstrap(request) => {
+                self.offered.lock().expect("lock").push(request.base_offset)
+            }
             other => panic!("shipping sent a {:?}", other.kind()),
         }
         self.answers
@@ -523,10 +534,10 @@ mod quorum {
 
 /// A follower asking for records the leader has already trimmed.
 ///
-/// Shipping cannot bridge this: the records are not on the leader to send.
-/// Before this was recognised, the read failed, the exchange reported a
-/// transient refusal, and the leader retried the same impossible read on every
-/// pass — forever, silently, with the follower never advancing.
+/// Shipping cannot bridge this: the records are gone from the leader too. The
+/// leader offers the follower the one fact it cannot work out for itself —
+/// where the surviving log begins — and the follower decides whether it can
+/// take it.
 mod trimmed_history {
     use super::*;
 
@@ -564,55 +575,104 @@ mod trimmed_history {
         (log, base, dir)
     }
 
-    /// **The leader stops rather than retrying a read that cannot succeed.**
+    /// What the follower was asked, rather than sent.
+    fn offers(follower: &ScriptedFollower) -> Vec<u64> {
+        follower.offered()
+    }
+
+    /// **The leader offers a bootstrap rather than shipping a range it does not
+    /// have.** The offer names the oldest offset this leader still holds.
     #[tokio::test]
-    async fn a_follower_below_the_leaders_base_halts_for_bootstrap() {
+    async fn a_follower_below_the_leaders_base_is_offered_a_bootstrap() {
         let (log, base, _dir) = trimmed_leader().await;
-        let follower = ScriptedFollower::new([]);
+        let follower = ScriptedFollower::new([Ok(stored(base))]);
+        let mut cursor = cursor(0);
+
+        let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        assert_eq!(progress, Progress::Resume { offset: base });
+        assert_eq!(offers(&follower), vec![base]);
+        assert!(
+            follower.sent().is_empty(),
+            "records were shipped from a range the leader no longer holds",
+        );
+    }
+
+    /// Once the follower has taken the offer, the cursor sits at the surviving
+    /// base and ordinary shipping resumes from there.
+    #[tokio::test]
+    async fn an_accepted_bootstrap_resumes_ordinary_shipping() {
+        let (log, base, _dir) = trimmed_leader().await;
+        let tail = log.tail_offset().await.expect("tail");
+        let follower = ScriptedFollower::new([Ok(stored(base)), Ok(stored(tail))]);
+        let mut cursor = cursor(0);
+
+        ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+        assert_eq!(cursor.next_offset, base);
+
+        let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        assert!(matches!(progress, Progress::Stored { .. }), "{progress:?}");
+        let (first, _) = follower.sent().into_iter().next().expect("a batch");
+        assert_eq!(first, base, "shipping did not resume at the surviving base");
+    }
+
+    /// **A follower that refuses the offer is halted.** It holds records of its
+    /// own, so a person has to decide what becomes of them; asking again would
+    /// never change the answer.
+    #[tokio::test]
+    async fn a_refused_bootstrap_halts_the_follower() {
+        let (log, _base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([Ok(refused(ErrorCode::LogConflict, 0))]);
         let mut cursor = cursor(0);
 
         let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
 
         assert_eq!(progress, Progress::Halted(Halt::NeedsBootstrap));
         assert_eq!(cursor.halted, Some(Halt::NeedsBootstrap));
-        assert!(
-            follower.sent().is_empty(),
-            "records were shipped from a range the leader no longer holds",
-        );
-        assert!(base > 0);
     }
 
-    /// And it stays stopped, rather than trying again on the next pass.
+    /// And it stays halted: a refusal is not retried on the next pass.
     #[tokio::test]
-    async fn it_stays_halted_across_passes() {
+    async fn a_halted_follower_is_not_offered_again() {
         let (log, _base, _dir) = trimmed_leader().await;
-        let follower = ScriptedFollower::new([]);
+        let follower = ScriptedFollower::new([Ok(refused(ErrorCode::LogConflict, 0))]);
         let mut cursor = cursor(0);
 
         for _ in 0..3 {
             ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
         }
 
-        assert!(follower.sent().is_empty());
+        assert_eq!(offers(&follower).len(), 1, "a refused offer was repeated");
     }
 
-    /// **A follower that cannot be caught up counts toward no quorum.** This is
-    /// what stops a replica being counted before it is eligible: it is not
-    /// merely behind, it can never arrive without a transfer.
+    /// An unreachable follower keeps its offer open: nothing about the network
+    /// says the follower would refuse.
     #[tokio::test]
-    async fn a_follower_needing_bootstrap_counts_toward_no_quorum() {
+    async fn an_unreachable_follower_keeps_its_offer_open() {
         let (log, _base, _dir) = trimmed_leader().await;
-        let follower = ScriptedFollower::new([]);
+        let follower = ScriptedFollower::new([Err(PeerError::Timeout {
+            node_id: "broker-b".to_string(),
+            timeout: std::time::Duration::from_secs(5),
+        })]);
+        let mut cursor = cursor(0);
+
+        let progress = ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
+
+        assert_eq!(progress, Progress::Retry);
+        assert!(cursor.halted.is_none(), "a timeout halted replication");
+    }
+
+    /// **A follower still being offered a bootstrap counts toward no quorum.**
+    /// It is not merely behind; it cannot arrive until it accepts.
+    #[tokio::test]
+    async fn a_follower_that_refused_counts_toward_no_quorum() {
+        let (log, _base, _dir) = trimmed_leader().await;
+        let follower = ScriptedFollower::new([Ok(refused(ErrorCode::LogConflict, 0))]);
         let mut cursor = cursor(0);
         ship_once(&follower, &log, &shard(), &mut cursor, BATCH_BYTES).await;
 
         let tail = log.tail_offset().await.expect("tail");
-        // A set of three: the leader plus this follower plus one healthy peer.
-        assert_eq!(
-            quorum_offset(tail, &[cursor.clone(), super::cursor(tail)]),
-            tail,
-        );
-        // And alone, it cannot make a majority of three with the leader.
         assert_eq!(quorum_offset(tail, &[cursor.clone(), super::cursor(0)]), 0);
     }
 
@@ -628,8 +688,8 @@ mod trimmed_history {
 
         assert!(
             matches!(progress, Progress::Stored { .. }),
-            "a follower at the surviving base was refused: {progress:?}",
+            "a follower at the surviving base was offered a bootstrap: {progress:?}",
         );
-        assert!(cursor.halted.is_none());
+        assert!(offers(&follower).is_empty());
     }
 }


### PR DESCRIPTION
Closes the loop #260 opened, and finishes the correctness half of #114.

> **Note on overlap with #261.** This branch contains #261's commit (rebased onto current main, which #261's branch predates — it was cut before #260 landed, and this work modifies code #260 added). So this PR shows two commits. Merge #261 first and this diff reduces to the replication half on its own; or merge this and close #261 as contained. I did not force-push #261's branch to restack it, since rewriting a branch with an open PR is your call.

## The problem

A follower positioned below everything the leader still holds — a new replica of a stream with retention, or one that fell far enough behind — cannot be caught up by shipping: the records in between are gone from the leader too. #260 made that state explicit instead of an invisible infinite retry. This repairs it.

## The one fact a follower cannot work out for itself

Where the surviving log starts.

It cannot tell *"you are being given the whole of what still exists"* from *"you are being sent a batch from the middle"* — and placing a base on the second would create exactly the undetectable hole #260 refuses to create. So the leader states it, in `ReplicateBootstrap`.

**A new kind rather than a field on `ReplicateRecords`.** `docs/internal-protocol.md` freezes existing body layouts; additive change happens by adding a `Kind`, and a peer that predates this rejects an unknown kind rather than misreading a body. This is the wire decision I deferred out of #261 rather than bolting a field onto a frozen layout to finish faster.

## Who may accept

| The follower | Answer |
|---|---|
| holds no log for the shard | places it at `base_offset`, `ReplicateOk` |
| already holds a log starting there | `ReplicateOk` — the offer is idempotent |
| holds records starting elsewhere | `LogConflict`, and the leader halts it |

The last row is the point. A log placed over existing records would have a hole between what the follower held and what it was given, and **a log with a hole is one nothing downstream can detect** — from the follower's own view its offsets are still contiguous. Discarding those records is an operator's decision, not a leader's.

## The same fence on both paths

Placing a log and filling it are the same authority question, so the role check is shared rather than written twice. A fence applied to one and not the other is a fence with a way round it: a superseded leader that could not ship records but *could* re-base a follower's shard would be exactly that.

## Verification

Confirmed against reverted checks:

| Reverted | Fails |
|---|---|
| the base comparison, letting a held log be re-based | `a_replica_holding_records_refuses_to_be_rebased` |
| the role check on the placement path | `a_superseded_leader_cannot_place_a_log`, `a_broker_outside_the_replica_set_cannot_be_given_a_shard` |

Leader side: the offer names the leader's oldest offset, an accepted offer resumes ordinary shipping from that base, a refusal halts and is not repeated, an unreachable follower keeps its offer open, a follower still refusing counts toward no quorum, and a follower **at** the base is ordinary catch-up rather than a bootstrap.

`ReplicateBootstrap` joins `every_message()`, so it inherits the existing round-trip, truncation, single-byte-corruption and trailing-byte suites rather than needing a parallel one.

`task lint`, `task test`, `task conformance`, `task demo:check` all clean.

## What remains in #114

This handles the case the log itself can express: history that is **gone everywhere**. It does not do bulk segment transfer — a follower merely far behind still catches up record-by-record through the existing shipping path, which works but reads the whole range. Direct segment transfer with sealed-segment checksums is the optimisation the issue also asks for, and with the correctness gap closed it is now a performance change rather than a correctness one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)