### PR TITLE
test(cluster): give the harness the faults M5.6 needs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "controlplane",
  "felix-client",
  "felix-wire",
+ "libc",
  "quinn",
  "reqwest 0.12.28",
  "rustls",

--- a/crates/felix-cluster/Cargo.toml
+++ b/crates/felix-cluster/Cargo.toml
@@ -32,6 +32,11 @@ tokio-util = { version = "0.7", features = ["rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+# Suspending a broker needs a signal, not a kill: the point of the fault is a
+# process that is still alive and holding its lease while answering nothing.
+libc = "0.2"
+
 [dev-dependencies]
 # These spawn several broker processes each. Run one cluster at a time: a CI
 # runner with two cores starting nine brokers at once starves them all, and the

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -767,6 +767,71 @@ impl Cluster {
         response.json().await.context("decode response")
     }
 
+    /// Suspend a broker without stopping it.
+    ///
+    /// The process stays alive and keeps every lease and connection it holds,
+    /// and answers nothing. That is the fault a kill cannot produce, and it is
+    /// the one the commit-boundary lease check exists for: a broker suspended
+    /// past its lease expiry must refuse the write it was in the middle of when
+    /// it wakes, rather than committing to a shard someone else now leads.
+    ///
+    /// Unix only. Elsewhere there is no equivalent that leaves the process
+    /// holding its state, and a test that quietly did something weaker would be
+    /// worse than one that does not run.
+    #[cfg(unix)]
+    pub fn pause_node(&self, node_id: &str) -> Result<()> {
+        self.signal(node_id, libc::SIGSTOP, "pause")
+    }
+
+    /// Let a suspended broker run again.
+    #[cfg(unix)]
+    pub fn resume_node(&self, node_id: &str) -> Result<()> {
+        self.signal(node_id, libc::SIGCONT, "resume")
+    }
+
+    #[cfg(unix)]
+    fn signal(&self, node_id: &str, signal: libc::c_int, what: &str) -> Result<()> {
+        let node = self
+            .node(node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let process = node
+            .process
+            .as_ref()
+            .ok_or_else(|| anyhow!("cannot {what} {node_id}: it is not running"))?;
+        let pid = process.id() as libc::pid_t;
+        // Safety: `pid` came from a child this harness spawned and has not
+        // reaped, so it names that child or nothing. `kill` reports an error
+        // rather than misbehaving if the process is already gone.
+        let sent = unsafe { libc::kill(pid, signal) };
+        if sent != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("{what} {node_id} (pid {pid})"));
+        }
+        Ok(())
+    }
+
+    /// Kill a broker and return immediately.
+    ///
+    /// Unlike [`Cluster::stop_node`], this does not wait for the control plane
+    /// to notice. A test measuring how long failover takes has to start its
+    /// clock at the kill, not after the cluster has already reacted to it.
+    pub fn kill_node(&mut self, node_id: &str) -> Result<()> {
+        let node = self
+            .nodes
+            .iter_mut()
+            .find(|node| node.node_id == node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let Some(mut process) = node.process.take() else {
+            return Ok(());
+        };
+        let _ = process.kill();
+        // Reaped so the process does not linger as a zombie for the rest of the
+        // test; the kill itself has already happened, so this does not wait on
+        // anything the caller is timing.
+        let _ = process.wait();
+        Ok(())
+    }
+
     /// Stop everything. Called by `Drop` too, so an aborted test leaves nothing
     /// behind — this exists for the case where a caller wants to wait for it.
     pub async fn shutdown(mut self) {

--- a/crates/felix-cluster/tests/faults.rs
+++ b/crates/felix-cluster/tests/faults.rs
@@ -1,0 +1,152 @@
+//! The faults the harness can inject, and proof that each is the fault it claims.
+//!
+//! A failure-injection test is only as good as the failure it injects. A
+//! "paused" broker that is really just slow, or a "killed" one that is still
+//! answering, would make every scenario built on it pass for the wrong reason —
+//! so these assert the fault itself rather than anything about replication.
+//!
+//! Run with `cargo test -p felix-cluster` (or `task cluster:test`).
+use std::time::Duration;
+
+use felix_cluster::{Cluster, ClusterConfig};
+use serial_test::serial;
+
+const STREAM: &str = "orders";
+
+fn config() -> ClusterConfig {
+    ClusterConfig {
+        nodes: 3,
+        streams: vec![(STREAM.to_string(), 1)],
+        ..Default::default()
+    }
+}
+
+/// Whether a broker answers its metrics endpoint within `budget`.
+///
+/// The cheapest liveness question that does not depend on cluster state: a
+/// suspended process accepts nothing and answers nothing, so the request times
+/// out rather than failing fast.
+async fn answers_within(cluster: &Cluster, node_id: &str, budget: Duration) -> bool {
+    tokio::time::timeout(budget, cluster.metric(node_id, "felix_broker_up"))
+        .await
+        .is_ok()
+}
+
+/// **A paused broker stops answering and stays alive.** Both halves matter: if
+/// it died the test would be a kill by another name, and if it kept answering
+/// there would be no fault at all.
+#[serial]
+#[tokio::test]
+async fn a_paused_broker_stops_answering_without_dying() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+    let node_id = cluster.nodes[0].node_id.clone();
+    assert!(
+        answers_within(&cluster, &node_id, Duration::from_secs(5)).await,
+        "the broker was not answering before it was paused",
+    );
+
+    cluster.pause_node(&node_id).expect("pause");
+
+    assert!(
+        !answers_within(&cluster, &node_id, Duration::from_millis(750)).await,
+        "a paused broker was still answering",
+    );
+    assert!(
+        cluster
+            .node(&node_id)
+            .expect("the node should still be known")
+            .is_running(),
+        "pausing killed the broker instead of suspending it",
+    );
+
+    cluster.resume_node(&node_id).expect("resume");
+    cluster.shutdown().await;
+}
+
+/// And it answers again once resumed, which is what makes the fault a pause
+/// rather than a slower kill.
+#[serial]
+#[tokio::test]
+async fn a_resumed_broker_answers_again() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+    let node_id = cluster.nodes[0].node_id.clone();
+
+    cluster.pause_node(&node_id).expect("pause");
+    assert!(!answers_within(&cluster, &node_id, Duration::from_millis(750)).await);
+
+    cluster.resume_node(&node_id).expect("resume");
+
+    assert!(
+        answers_within(&cluster, &node_id, Duration::from_secs(10)).await,
+        "a resumed broker never came back",
+    );
+    cluster.shutdown().await;
+}
+
+/// An immediate kill returns without waiting for the cluster to react, so a
+/// test can start its own clock at the moment of the kill.
+#[serial]
+#[tokio::test]
+async fn an_immediate_kill_does_not_wait_for_the_cluster_to_notice() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let node_id = cluster.nodes[0].node_id.clone();
+
+    let started = std::time::Instant::now();
+    cluster.kill_node(&node_id).expect("kill");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "kill_node waited for something: {elapsed:?}",
+    );
+    assert!(
+        !cluster
+            .node(&node_id)
+            .expect("the node should still be known")
+            .is_running(),
+    );
+    cluster.shutdown().await;
+}
+
+/// Both faults refuse a node that is not there, rather than reporting success
+/// for something they did not do.
+#[serial]
+#[tokio::test]
+async fn a_fault_aimed_at_an_unknown_node_is_an_error() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+
+    assert!(cluster.pause_node("broker-does-not-exist").is_err());
+    assert!(cluster.resume_node("broker-does-not-exist").is_err());
+    cluster.shutdown().await;
+}
+
+/// Pausing a broker that has already been killed is an error too: there is no
+/// process to suspend, and silently succeeding would let a scenario believe it
+/// had injected a fault it had not.
+#[serial]
+#[tokio::test]
+async fn pausing_a_stopped_broker_is_an_error() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let node_id = cluster.nodes[0].node_id.clone();
+    cluster.kill_node(&node_id).expect("kill");
+
+    assert!(cluster.pause_node(&node_id).is_err());
+    cluster.shutdown().await;
+}
+
+/// **Teardown reclaims a suspended broker.** A test that panics mid-fault
+/// leaves exactly this, and a teardown that hung there would wedge the whole
+/// suite rather than failing one test — so the property is worth pinning even
+/// though a signal-stopped process does die to `SIGKILL`.
+#[serial]
+#[tokio::test]
+async fn teardown_reclaims_a_suspended_broker() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+    let node_id = cluster.nodes[0].node_id.clone();
+    cluster.pause_node(&node_id).expect("pause");
+
+    // Deliberately not resumed.
+    tokio::time::timeout(Duration::from_secs(20), cluster.shutdown())
+        .await
+        .expect("shutdown hung on a suspended broker");
+}

--- a/docs/cluster-harness.md
+++ b/docs/cluster-harness.md
@@ -156,9 +156,33 @@ such test races the expiry sweep. Liveness windows are tuned short (a 1s expiry
 timeout) because every process is local, so a stopped broker is observable in
 about a second.
 
+`kill_node` kills without waiting for the control plane to react. A test
+measuring how long failover takes has to start its clock at the kill, not after
+the cluster has already responded to it.
+
+`pause_node` and `resume_node` suspend and resume a broker with `SIGSTOP` and
+`SIGCONT`. This is the fault a kill cannot produce: the process stays alive,
+keeps every lease and connection it holds, and answers nothing. It is what the
+commit-boundary lease check exists for — a broker suspended past its lease
+expiry has to refuse the write it was in the middle of when it wakes, rather
+than committing to a shard someone else now leads. Unix only; there is no
+equivalent elsewhere that leaves the process holding its state, and a test that
+quietly did something weaker would be worse than one that does not run.
+
+`crates/felix-cluster/tests/faults.rs` asserts each fault is the fault it
+claims — a paused broker stops answering *and* stays alive, a resumed one comes
+back, a kill returns immediately — because a scenario built on a fault that is
+really something else passes for the wrong reason. It also pins that teardown
+reclaims a suspended broker, so a test panicking mid-fault fails on its own
+rather than wedging the suite.
+
+Skewing a broker's clock is not supported. Lease expiry is read from the system
+clock, so testing expiry against a skewed one needs either an injectable clock
+in the broker or `libfaketime` around the process, and neither is in place.
+
 Blocking a peer link without stopping the process is not supported yet; it needs
 either a proxy in front of the internal listener or platform firewall rules, and
-nothing in M4 required it.
+nothing so far has required it.
 
 ## Watching it
 


### PR DESCRIPTION
Groundwork for #115. Does not close it — this is the capability its scenarios need, not the scenarios.

## Why the harness was the blocker

#115 asks for failures injected at controlled points in the write and replication pipeline. The harness could kill a broker and nothing else, which leaves the faults that matter most to a lease-fenced design unreachable.

## `pause_node` / `resume_node`

Suspend and resume a broker with `SIGSTOP` / `SIGCONT`.

**This is the fault a kill cannot produce.** The process stays alive, keeps every lease and connection it holds, and answers nothing. It is precisely what the commit-boundary lease check exists for: a broker suspended past its lease expiry must refuse the write it was in the middle of when it wakes, rather than committing to a shard someone else now leads.

A kill cannot test that, because a dead broker never wakes up to be refused.

Unix only. There is no equivalent elsewhere that leaves the process holding its state, and a test that quietly did something weaker would be worse than one that does not run.

## `kill_node`

Kills without waiting for the control plane to react. `stop_node` waits until the node is no longer placeable — right for a test that needs the cluster settled, wrong for one timing failover, where the clock has to start at the kill rather than after the cluster has already responded.

## Each fault is tested as a fault

A "paused" broker that was really just slow, or a "killed" one still answering, would make every scenario built on it pass for the wrong reason. So `tests/faults.rs` asserts the fault itself, not replication:

- a paused broker stops answering **and** stays alive — both halves, since one without the other is a different fault
- a resumed broker comes back
- a kill returns immediately
- a fault aimed at an unknown or already-stopped node is an error, not a silent success that lets a scenario believe it injected something
- **teardown reclaims a suspended broker** — a test panicking mid-fault must fail on its own rather than wedge the suite

That last one corrected me. I had written a comment claiming teardown *couldn't* reap a suspended child; I checked instead of shipping it, found `SIGKILL` terminates a stopped process, and turned the check into a test.

## Still not injectable

**Clock skew.** Lease expiry reads the system clock, so testing expiry against a skewed one needs either an injectable clock in the broker or `libfaketime` around the process. `docs/cluster-harness.md` says so rather than leaving it to be discovered.

**Peer-link partition without killing the process** — unchanged, still needs a proxy or firewall rules.

Both matter for #115's full scope: "test stale leader rejoin, repeated failovers, slow followers, partitions, and control-plane delay". Partitions and clock-driven expiry are the two that remain out of reach.

`task lint`, `task test` clean; the new suite runs against real broker processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)