### PR TITLE
fix(placement): never hand a replicated shard to a broker that lacks its log

### DIFF
--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -223,6 +223,26 @@ large it currently is.
 `Quorum` has no such window: a majority including the leader holds every
 acknowledged record, so any failure within the configured majority preserves it.
 
+### What a lost leader costs today
+
+Promotion is gated on a replica that holds the log, and **no replica's position
+reaches the control plane yet**, so promotion cannot fire. A replicated shard
+whose leader is lost is left *unplaced* until that leader returns.
+
+That is deliberate. The alternative is what the code used to do: fall back to
+ordinary scoring and hand the shard to whichever node scores highest, which may
+never have seen it. That broker then serves an empty log at a newer generation
+while the records sit on replicas that were not chosen — a failover that *is*
+the data loss, and one nothing downstream reports as one.
+
+Unavailable is the better answer: it is visible, and it resolves on its own when
+the old leader returns. It resolves properly when replica positions are reported
+and a caught-up follower can be promoted, which is the work that remains.
+
+A stream that never asked for replication is unaffected. It has no replicas, so
+there was never a copy to prefer, and a fresh placement stays the only thing
+available.
+
 ## Failure model
 
 | Situation | Behaviour |

--- a/services/controlplane/src/placement.rs
+++ b/services/controlplane/src/placement.rs
@@ -28,6 +28,16 @@ pub enum Unplaceable {
     NoEligibleNode,
     /// Every live node is at its `max_shards` cap.
     AllNodesAtCapacity,
+    /// The shard was replicated, its leader is gone, and no replica that holds
+    /// the log can take over.
+    ///
+    /// Deliberately unavailable rather than placed elsewhere. A node that has
+    /// never seen the shard would serve an empty log at a new generation while
+    /// the records sat on replicas that were not chosen — the failover would
+    /// *be* the data loss, and nothing downstream would report it as one. This
+    /// is visible, and it resolves on its own when a replica catches up or the
+    /// old leader returns.
+    NoCaughtUpReplica,
 }
 
 impl std::fmt::Display for Unplaceable {
@@ -37,6 +47,10 @@ impl std::fmt::Display for Unplaceable {
             Self::AllNodesAtCapacity => {
                 write!(f, "every live node is at its max_shards capacity")
             }
+            Self::NoCaughtUpReplica => write!(
+                f,
+                "the leader is gone and no replica holding this shard's log can take over"
+            ),
         }
     }
 }
@@ -211,6 +225,24 @@ pub fn plan(
             shards.push(ShardPlan {
                 key,
                 decision: Decision::Place(promoted.to_string(), replicas),
+            });
+            continue;
+        }
+
+        // The shard was replicated and nothing that holds it can lead. Placing
+        // it on a node that has never seen it is not a failover, it is a
+        // silently empty shard: the records stay on the replicas, unreachable,
+        // while a new leader serves nothing at a newer generation.
+        //
+        // A stream that never asked for replication is untouched by this — it
+        // has no replicas, so there was never a copy to prefer, and a fresh
+        // placement remains the only thing available.
+        if let Some(previous) = current.get(&key)
+            && !previous.replicas.is_empty()
+        {
+            shards.push(ShardPlan {
+                key,
+                decision: Decision::Unplaceable(Unplaceable::NoCaughtUpReplica),
             });
             continue;
         }
@@ -417,8 +449,11 @@ pub async fn reconcile_once(store: &dyn crate::store::ControlPlaneStore) -> Reco
         }
     };
 
-    // Nothing is caught up until records are replicated (#112), so promotion
-    // does not yet fire and placement behaves as it did.
+    // Nothing reports being caught up yet: replication ships records (#112) but
+    // no replica's position reaches the control plane, so promotion cannot
+    // fire. A replicated shard whose leader is lost therefore stays unplaced
+    // until the leader returns -- unavailable, and recoverable, rather than
+    // handed to a broker holding none of it.
     let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
     let mut outcome = ReconcileOutcome {
         kept: plan.kept(),

--- a/services/controlplane/src/placement_tests.rs
+++ b/services/controlplane/src/placement_tests.rs
@@ -685,14 +685,13 @@ fn a_caught_up_follower_is_promoted() {
 }
 
 /// **The gate.** A follower that holds nothing is not promoted, however
-/// eligible it looks: promoting it would serve an empty shard, which is the data
-/// loss a failover is supposed to prevent.
+/// eligible it looks: promoting it would serve an empty shard, which is the
+/// data loss a failover is supposed to prevent.
 ///
-/// Asserted against a baseline with no replica set recorded, because "did not
-/// promote" and "promoted the node it would have chosen anyway" are otherwise
-/// the same outcome. Both single-node replica sets are tried, so at least one
-/// names a follower that scoring would *not* have picked — without that, the
-/// two paths coincide and the assertion proves nothing.
+/// And nothing else is promoted in its place. A node that has never seen the
+/// shard is just as empty as an uncaught-up replica, so falling back to
+/// ordinary scoring would defeat the gate rather than respect it — the shard
+/// stays unplaced until something that holds the log can take it.
 #[test]
 fn a_follower_that_holds_nothing_is_not_promoted() {
     let streams = vec![replicated_stream("orders", 1, 2)];
@@ -701,27 +700,15 @@ fn a_follower_that_holds_nothing_is_not_promoted() {
         node("broker-c", NodeLifecycle::Live, None),
     ];
 
-    let baseline = plan(
-        &streams,
-        &nodes,
-        &[assigned("orders", "broker-a", &[])],
-        &NothingCaughtUp,
-    );
-    let expected: Vec<_> = baseline
-        .to_place()
-        .map(|(k, l, _)| (k.clone(), l.to_string()))
-        .collect();
-
     for replica in ["broker-b", "broker-c"] {
         let existing = vec![assigned("orders", "broker-a", &[replica])];
-        let chosen: Vec<_> = plan(&streams, &nodes, &existing, &NothingCaughtUp)
-            .to_place()
-            .map(|(k, l, _)| (k.clone(), l.to_string()))
-            .collect();
+
+        let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
+
         assert_eq!(
-            chosen, expected,
-            "a replica ({replica}) holding nothing was promoted; with no caught-up \
-             follower, placement must ignore the replica set entirely",
+            plan.to_place().count(),
+            0,
+            "with {replica} holding nothing, the shard was placed anyway",
         );
     }
 }
@@ -768,4 +755,108 @@ fn promotion_rebuilds_the_replica_set_without_the_new_leader() {
         !replicas.contains(&leader.to_string()),
         "{leader} was promoted and is still listed as a follower of itself",
     );
+}
+
+/// **A replicated shard is never handed to a node that does not hold it.**
+///
+/// The leader is gone and no replica is caught up. Placing the shard on a node
+/// that has never seen it would serve an empty log at a new generation while
+/// the records sat on the replicas — the failover would *be* the data loss, and
+/// nothing downstream would report it as one.
+#[test]
+fn a_replicated_shard_with_no_caught_up_replica_is_left_unplaceable() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    // broker-a led it; b and c hold copies. broker-a is gone, and broker-z has
+    // never seen this shard.
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+        node("broker-z", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+
+    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
+
+    assert_eq!(
+        plan.to_place().count(),
+        0,
+        "a shard was placed on a node that does not hold its log",
+    );
+    assert!(
+        plan.unplaceable()
+            .any(|(_, why)| matches!(why, Unplaceable::NoCaughtUpReplica)),
+        "the shard was dropped without saying why",
+    );
+}
+
+/// And it is placed the moment a replica can take over, so the state above is
+/// a pause rather than a dead end.
+#[test]
+fn the_shard_is_placed_as_soon_as_a_replica_is_caught_up() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+        node("broker-z", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+    let caught_up = CaughtUpNodes(["broker-b".to_string()].into_iter().collect());
+
+    let plan = plan(&streams, &nodes, &existing, &caught_up);
+
+    let (_, leader, _) = plan.to_place().next().expect("placed");
+    assert_eq!(leader, "broker-b");
+}
+
+/// **A stream that never asked for replication is untouched.** It has no
+/// replicas, so there was never a copy to prefer, and a fresh placement stays
+/// the only thing available — refusing there would turn a recoverable single-copy
+/// outage into a permanent one.
+#[test]
+fn an_unreplicated_shard_is_still_placed_after_its_node_is_lost() {
+    let streams = vec![replicated_stream("orders", 1, 1)];
+    let nodes = vec![node("broker-b", NodeLifecycle::Live, None)];
+    let existing = vec![assigned("orders", "broker-a", &[])];
+
+    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
+
+    let (_, leader, _) = plan
+        .to_place()
+        .next()
+        .expect("an unreplicated shard should still be placed");
+    assert_eq!(leader, "broker-b");
+}
+
+/// A shard that has never been assigned is a first placement, not a failover,
+/// so it is placed normally.
+#[test]
+fn a_shard_with_no_previous_assignment_is_placed_normally() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+        node("broker-z", NodeLifecycle::Live, None),
+    ];
+
+    let plan = plan(&streams, &nodes, &[], &NothingCaughtUp);
+
+    assert_eq!(plan.to_place().count(), 1);
+}
+
+/// A leader that is still live keeps the shard, caught-up replicas or not.
+/// Nothing about this changes the ordinary path.
+#[test]
+fn a_live_leader_keeps_its_shard() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-a", NodeLifecycle::Live, None),
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+
+    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
+
+    assert_eq!(plan.kept(), 1);
+    assert_eq!(plan.to_place().count(), 0);
 }


### PR DESCRIPTION
Found while scoping #115's failover scenarios — which, written against today's code, would have proved the opposite of what they set out to prove.

**This changes behaviour in a way that trades availability for correctness. That is the main thing to review.**

## The contradiction

Promotion is gated on a replica that holds the log. The comment above the gate says why: *"only one that actually holds the log, or the failover is the data loss"*.

Directly below it, when no replica qualifies, placement fell through to ordinary scoring and chose whichever node scored highest — which may never have seen the shard.

So the gate refused to promote an uncaught-up replica, and then immediately handed the shard to a node that was just as empty. **A node that has never seen the shard is exactly as empty as an uncaught-up replica**, so the fallback defeated the gate rather than respecting it.

## Reproduced before fixing

`broker-a` leads a shard replicated to `broker-b` and `broker-c`. `broker-a` dies:

```
placed: [("broker-z", ["broker-b", "broker-c"])]
```

`broker-z` — which has never held the shard — becomes leader, with b and c demoted to *its* followers. The records stay on b and c, unreachable, while z serves an empty log at a newer generation. Nothing downstream reports it as loss.

## The fix

A replicated shard with no replica able to take over is left **unplaced**, with its own `Unplaceable` reason. Unavailable is visible and recoverable: the shard returns when the old leader does, and it will fail over properly once replica positions reach the control plane.

## The trade — please push back if you disagree

Nothing reports being caught up today (production passes `NothingCaughtUp`), so in practice **a replicated shard is now unavailable while its leader is down, where it was previously served empty.**

I think that is clearly right — the availability was not real, because the shard it served held nothing, and a silently empty shard is the worse failure. But it is a live behaviour change for anyone running `replication_factor > 1`, so it deserves a second opinion rather than my say-so.

**Unreplicated streams are untouched.** They have no replicas, so there was never a copy to prefer, and a fresh placement stays the only option. `replication_factor` defaults to 1, so the default path is unchanged.

## An existing test asserted the old behaviour

`a_follower_that_holds_nothing_is_not_promoted` asserted that placement "must ignore the replica set entirely" when nothing is caught up — i.e. it checked the shard still got placed by ordinary scoring.

Its *stated intent* was the gate. Its *method* accepted the behaviour that defeats the gate. I rewrote it to assert the intent — the shard is not placed at all — rather than deleting it or working around it. Worth a look, since I am overriding a deliberate-looking assertion.

## Tests

- a replicated shard with no caught-up replica is left unplaceable, with a reason rather than silently dropped
- it is placed the moment a replica *is* caught up, so the state is a pause rather than a dead end
- an unreplicated shard is still placed after its node is lost
- a shard with no previous assignment is a first placement, not a failover
- a live leader keeps its shard, caught-up replicas or not

`task lint`, `task test` clean.

## What this unblocks

#115's headline scenario needs promotion to actually fire, which needs replica positions reported to the control plane — the leader tracks follower offsets (#258) but nothing sends them. That is the next slice, and with this in place it is a change that *restores* availability rather than one that quietly papers over its absence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)