### PR TITLE
feat(replication): report replica positions so failover can fire (M5.2)

### DIFF
--- a/crates/felix-cluster/src/controlplane.rs
+++ b/crates/felix-cluster/src/controlplane.rs
@@ -42,6 +42,9 @@ const LIVENESS: NodeLivenessConfig = NodeLivenessConfig {
 pub struct ControlPlane {
     pub base_url: String,
     pub store: Arc<InMemoryStore>,
+    /// Shared with the running API, so a harness driving placement by hand sees
+    /// the same reports leaders have sent.
+    pub replica_positions: Arc<controlplane::replica_positions::ReplicaPositions>,
     keys: TenantSigningKeys,
     shutdown: CancellationToken,
     task: tokio::task::JoinHandle<()>,
@@ -61,6 +64,11 @@ impl ControlPlane {
             .await
             .context("seed tenant signing keys")?;
 
+        // Shared with `place_shards`, so a harness driving placement by hand
+        // sees the same reports the API recorded.
+        let replica_positions = Arc::new(controlplane::replica_positions::ReplicaPositions::new(
+            &Default::default(),
+        ));
         let state = AppState {
             region: Region {
                 region_id: "local".to_string(),
@@ -78,6 +86,7 @@ impl ControlPlane {
             bootstrap_enabled: false,
             bootstrap_token: None,
             node_liveness: LIVENESS,
+            replica_positions: Arc::clone(&replica_positions),
         };
 
         let addr = ports::free_tcp()?;
@@ -108,6 +117,7 @@ impl ControlPlane {
         Ok(Self {
             base_url: format!("http://{addr}"),
             store,
+            replica_positions,
             keys,
             shutdown,
             task,
@@ -228,7 +238,11 @@ impl ControlPlane {
     /// and a harness that slept for one would be timing-dependent in exactly the
     /// way the acceptance criteria rule out.
     pub async fn place_shards(&self) -> controlplane::placement::ReconcileOutcome {
-        controlplane::placement::reconcile_once(self.store.as_ref()).await
+        controlplane::placement::reconcile_once(
+            self.store.as_ref(),
+            self.replica_positions.as_ref(),
+        )
+        .await
     }
 
     pub async fn shutdown(self) {

--- a/demos/cross_tenant_isolation/src/main.rs
+++ b/demos/cross_tenant_isolation/src/main.rs
@@ -435,6 +435,9 @@ async fn spawn_controlplane(store: Arc<PostgresStore>) -> Result<(SocketAddr, Jo
         bootstrap_enabled: true,
         bootstrap_token: Some(BOOTSTRAP_TOKEN.to_string()),
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
 
     let app = build_router(state.clone()).merge(build_bootstrap_router(state));

--- a/demos/rbac-live/src/main.rs
+++ b/demos/rbac-live/src/main.rs
@@ -308,6 +308,9 @@ async fn spawn_controlplane() -> Result<(SocketAddr, JoinHandle<()>)> {
         bootstrap_enabled: true,
         bootstrap_token: Some(BOOTSTRAP_TOKEN.to_string()),
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
 
     let app = build_router(state.clone()).merge(build_bootstrap_router(state));

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -223,25 +223,45 @@ large it currently is.
 `Quorum` has no such window: a majority including the leader holds every
 acknowledged record, so any failure within the configured majority preserves it.
 
-### What a lost leader costs today
+### Who may be promoted
 
-Promotion is gated on a replica that holds the log, and **no replica's position
-reaches the control plane yet**, so promotion cannot fire. A replicated shard
-whose leader is lost is left *unplaced* until that leader returns.
+A leader reports, on every replication pass, which of its followers hold every
+record it does. The leader is the only party that can say: it knows both its own
+tail and how far each follower has acknowledged, where a follower knows only
+where it is.
 
-That is deliberate. The alternative is what the code used to do: fall back to
-ordinary scoring and hand the shard to whichever node scores highest, which may
-never have seen it. That broker then serves an empty log at a newer generation
-while the records sit on replicas that were not chosen — a failover that *is*
-the data loss, and one nothing downstream reports as one.
+The bound is **zero** — a follower is caught up when it is missing nothing. A
+bound above zero is a bound on how much a promotion may silently lose, and there
+is no honest value for it that is not a policy decision; zero needs no such
+decision, and a follower reaches it constantly on a healthy shard.
 
-Unavailable is the better answer: it is visible, and it resolves on its own when
-the old leader returns. It resolves properly when replica positions are reported
-and a caught-up follower can be promoted, which is the work that remains.
+Reports expire, after the node expiry timeout plus one heartbeat. A report says
+a follower *was* caught up; the leader kept writing afterwards, and promoting on
+a stale report loses whatever was written since. The window is derived from the
+liveness settings rather than configured separately, because it has to outlive
+exactly one thing: the time it takes to notice the leader is gone.
+
+A halted follower is never reported, however close its last position was. It has
+stopped rather than fallen behind.
+
+**If no replica qualifies, the shard is left unplaced.** The alternative is what
+the code used to do: fall back to ordinary scoring and hand the shard to
+whichever node scores highest, which may never have seen it. That broker then
+serves an empty log at a newer generation while the records sit on replicas that
+were not chosen — a failover that *is* the data loss, and one nothing downstream
+reports as one. Unavailable is visible and recoverable; silently empty is
+neither.
 
 A stream that never asked for replication is unaffected. It has no replicas, so
 there was never a copy to prefer, and a fresh placement stays the only thing
 available.
+
+Positions are held in the control plane's memory. They change constantly, are
+advisory, and expire in about a second, so persisting them would cost a write
+per report for data that is worthless by the time it could be read back. The
+consequence is that a second control-plane instance starts knowing nothing and
+cannot promote until leaders have reported to it — which matters for M7's
+multi-instance work and not before.
 
 ## Failure model
 

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -472,6 +472,19 @@ where
                     Arc::clone(&broker),
                     Arc::clone(router),
                     Arc::clone(&quorum_marks),
+                    // Only a broker that is a cluster member reports: the
+                    // report is about shards the control plane assigned, and a
+                    // broker it has never registered leads none of them.
+                    config
+                        .membership
+                        .as_ref()
+                        .map(|membership| replication::driver::ReportTo {
+                            client: membership_client.clone(),
+                            base_url: base_url.clone(),
+                            node_id: membership.node_id.clone(),
+                            token: Some(membership.token.clone()),
+                            incarnation: 0,
+                        }),
                     Duration::from_millis(config.controlplane_sync_interval_ms),
                     sync_shutdown.clone(),
                 );

--- a/services/broker/src/replication.rs
+++ b/services/broker/src/replication.rs
@@ -313,6 +313,37 @@ fn unreachable_outcome(err: &PeerError) -> &'static str {
     }
 }
 
+/// How far a follower may be behind and still be fit to lead.
+///
+/// Zero: a follower is caught up when it holds every record the leader does.
+///
+/// A bound above zero is a bound on how much a promotion may silently lose, and
+/// there is no honest value for it that is not a policy decision. Zero needs no
+/// such decision, and a follower reaches it constantly on a healthy shard — the
+/// leader only has to be momentarily idle. Loosening it is a change to make
+/// deliberately, with a measurement behind it, rather than a default nobody
+/// chose.
+pub const CATCH_UP_BOUND: u64 = 0;
+
+/// Which followers hold enough of the log to lead it.
+///
+/// Reported to the control plane, which gates promotion on it. A halted
+/// follower never qualifies however close its last position was: it has stopped
+/// rather than fallen behind, and its position is no longer moving toward the
+/// leader's.
+// The bound is zero today, so "within it" is an equality and clippy says so.
+// Written as a comparison because the bound is the thing meant to change: if it
+// is ever raised, this reads correctly without being rediscovered.
+#[allow(clippy::absurd_extreme_comparisons)]
+pub fn caught_up(tail: u64, followers: &[FollowerCursor]) -> Vec<String> {
+    followers
+        .iter()
+        .filter(|follower| follower.halted.is_none())
+        .filter(|follower| tail.saturating_sub(follower.next_offset) <= CATCH_UP_BOUND)
+        .map(|follower| follower.node_id.clone())
+        .collect()
+}
+
 /// How far behind the slowest follower is, in records.
 ///
 /// This is the `Leader` consistency level's loss window, and the design note is

--- a/services/broker/src/replication/driver.rs
+++ b/services/broker/src/replication/driver.rs
@@ -15,7 +15,7 @@ use felix_wire::internal::ShardRef;
 use tokio_util::sync::CancellationToken;
 
 use super::quorum::QuorumMarks;
-use super::{FollowerCursor, Progress, lag_records, metrics, quorum_offset, ship_once};
+use super::{FollowerCursor, Progress, caught_up, lag_records, metrics, quorum_offset, ship_once};
 use crate::peer::PeerRequester;
 
 /// Cursors for one shard, valid only at `generation`.
@@ -39,17 +39,18 @@ pub async fn replicate_once<R: PeerRequester>(
     router: &ShardRouter,
     marks: &QuorumMarks,
     cursors: &mut HashMap<ShardKey, ShardCursors>,
-) -> Option<u64> {
+) -> Pass {
     let Some(storage) = broker.durable_storage() else {
         // Nothing to replicate from. A broker without durable storage leads
         // only ephemeral streams, which have no log to ship.
-        return None;
+        return Pass::default();
     };
 
     let table = router.snapshot();
     let mut worst_lag: Option<u64> = None;
     let mut halted = 0usize;
     let mut live_shards = Vec::new();
+    let mut reports = Vec::new();
 
     for (key, route) in table.iter() {
         if route.leader.node_id != router.local_node_id() || route.replicas.is_empty() {
@@ -103,6 +104,15 @@ pub async fn replicate_once<R: PeerRequester>(
             {}
         }
 
+        // Who could take this shard over, as of this pass. Collected for the
+        // control plane, which gates promotion on it: without this a lost
+        // leader cannot be replaced at all.
+        reports.push(ShardReport {
+            key: key.clone(),
+            generation: route.generation,
+            caught_up: caught_up(tail, &entry.followers),
+        });
+
         // Published after shipping, so a publish waiting on this shard sees the
         // majority move as soon as this pass establishes it.
         marks.publish(
@@ -148,7 +158,24 @@ pub async fn replicate_once<R: PeerRequester>(
     if let Some(lag) = worst_lag {
         metrics::record_lag(lag);
     }
-    worst_lag
+    Pass { worst_lag, reports }
+}
+
+/// What one replication pass established.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Pass {
+    /// How far the slowest follower is behind, across every shard led here.
+    pub worst_lag: Option<u64>,
+    /// Per shard, who could take it over.
+    pub reports: Vec<ShardReport>,
+}
+
+/// One shard's replicas, as this leader currently sees them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShardReport {
+    pub key: ShardKey,
+    pub generation: u64,
+    pub caught_up: Vec<String>,
 }
 
 /// Add cursors for new replicas and drop those no longer in the set.
@@ -176,12 +203,68 @@ fn reconcile_followers(entry: &mut ShardCursors, route: &Route) {
     }
 }
 
+/// Where a leader sends its replica reports.
+///
+/// Optional: a broker with no control plane has nobody to tell, and the reports
+/// are only ever read by one.
+pub struct ReportTo {
+    pub client: reqwest::Client,
+    pub base_url: String,
+    pub node_id: String,
+    pub token: Option<String>,
+    pub incarnation: u64,
+}
+
+/// Tell the control plane which replicas could take each shard over.
+///
+/// A failure here is logged and dropped rather than retried. The next pass
+/// sends a fresher report anyway, and a queue of stale ones is worse than none:
+/// promotion is gated on *recent* positions, so a late report is at best
+/// ignored and at worst believed after it stopped being true.
+async fn send_reports(to: &ReportTo, reports: &[ShardReport]) {
+    if reports.is_empty() {
+        return;
+    }
+    let body = serde_json::json!({
+        "incarnation": to.incarnation,
+        "shards": reports
+            .iter()
+            .map(|report| serde_json::json!({
+                "tenant_id": report.key.tenant_id,
+                "namespace": report.key.namespace,
+                "stream": report.key.stream,
+                "shard": report.key.shard,
+                "generation": report.generation,
+                "caught_up": report.caught_up,
+            }))
+            .collect::<Vec<_>>(),
+    });
+    let url = format!("{}/v1/nodes/{}/replica-status", to.base_url, to.node_id);
+    let mut request = to.client.post(&url).json(&body);
+    if let Some(token) = &to.token {
+        request = request.bearer_auth(token);
+    }
+    match request.send().await {
+        Ok(response) if response.status().is_success() => {}
+        Ok(response) => {
+            tracing::warn!(
+                status = %response.status(),
+                "the control plane refused a replica report",
+            );
+        }
+        Err(err) => {
+            tracing::warn!(error = %err, "could not send a replica report");
+        }
+    }
+}
+
 /// Run replication until cancelled.
 pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
     requester: Arc<R>,
     broker: Arc<Broker>,
     router: Arc<ShardRouter>,
     marks: Arc<QuorumMarks>,
+    report_to: Option<ReportTo>,
     interval: Duration,
     shutdown: CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
@@ -194,7 +277,11 @@ pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
                 _ = shutdown.cancelled() => return,
                 _ = ticker.tick() => {}
             }
-            replicate_once(requester.as_ref(), &broker, &router, &marks, &mut cursors).await;
+            let pass =
+                replicate_once(requester.as_ref(), &broker, &router, &marks, &mut cursors).await;
+            if let Some(report_to) = &report_to {
+                send_reports(report_to, &pass.reports).await;
+            }
         }
     })
 }

--- a/services/broker/src/replication/driver_tests.rs
+++ b/services/broker/src/replication/driver_tests.rs
@@ -329,7 +329,9 @@ async fn a_broker_without_durable_storage_ships_nothing() {
     let mut cursors = HashMap::new();
 
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &marks, &mut cursors).await,
+        replicate_once(&follower, &broker, &router, &marks, &mut cursors)
+            .await
+            .worst_lag,
         None,
     );
     assert!(follower.batches().is_empty());
@@ -346,7 +348,99 @@ async fn the_reported_lag_is_the_distance_from_the_tail() {
 
     // Caught up after a full pass.
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &marks, &mut cursors).await,
+        replicate_once(&follower, &broker, &router, &marks, &mut cursors)
+            .await
+            .worst_lag,
         Some(0),
     );
+}
+
+/// What the leader tells the control plane about its replicas.
+mod reports {
+    use super::*;
+
+    /// A pass reports the shard, its generation, and who could take it over.
+    #[tokio::test]
+    async fn a_pass_reports_who_could_take_the_shard_over() {
+        let (broker, _dir) = leader_with(3).await;
+        let router = router(LOCAL, &["broker-b"], 4);
+        let follower = AcceptingFollower::default();
+        let marks = QuorumMarks::new();
+        let mut cursors = HashMap::new();
+
+        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+
+        assert_eq!(pass.reports.len(), 1);
+        let report = &pass.reports[0];
+        assert_eq!(report.key, key());
+        assert_eq!(report.generation, 4);
+        assert_eq!(report.caught_up, vec!["broker-b".to_string()]);
+    }
+
+    /// **A follower that did not keep up is not reported as able to lead.**
+    /// This is the whole point of the signal: the control plane promotes on it,
+    /// and a follower named here while behind would be promoted into a shard it
+    /// cannot serve.
+    #[tokio::test]
+    async fn a_follower_that_refused_is_not_reported_as_able_to_lead() {
+        let (broker, _dir) = leader_with(3).await;
+        let router = router(LOCAL, &["broker-b"], 4);
+        let follower = RefusingFollower;
+        let marks = QuorumMarks::new();
+        let mut cursors = HashMap::new();
+
+        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+
+        assert_eq!(pass.reports.len(), 1);
+        assert!(
+            pass.reports[0].caught_up.is_empty(),
+            "a follower holding nothing was reported as able to lead",
+        );
+    }
+
+    /// A shard this broker only follows is not reported on. Reporting about a
+    /// shard it does not lead would be an opinion it has no basis for.
+    #[tokio::test]
+    async fn a_shard_led_elsewhere_is_not_reported() {
+        let (broker, _dir) = leader_with(3).await;
+        let router = router("broker-b", &[LOCAL], 4);
+        let follower = AcceptingFollower::default();
+        let marks = QuorumMarks::new();
+        let mut cursors = HashMap::new();
+
+        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+
+        assert!(pass.reports.is_empty());
+    }
+
+    /// A shard with no replicas reports nobody rather than an empty promise.
+    #[tokio::test]
+    async fn a_shard_with_no_replicas_is_not_reported() {
+        let (broker, _dir) = leader_with(3).await;
+        let router = router(LOCAL, &[], 4);
+        let follower = AcceptingFollower::default();
+        let marks = QuorumMarks::new();
+        let mut cursors = HashMap::new();
+
+        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+
+        assert!(pass.reports.is_empty());
+    }
+}
+
+/// A follower that refuses everything, so it never advances.
+struct RefusingFollower;
+
+impl PeerRequester for RefusingFollower {
+    async fn request(
+        &self,
+        _node_id: &str,
+        _addr: SocketAddr,
+        _message: InternalMessage,
+    ) -> std::result::Result<InternalMessage, PeerError> {
+        Err(PeerError::Unavailable {
+            node_id: "broker-b".to_string(),
+            detail: "not now".to_string(),
+        })
+    }
 }

--- a/services/broker/src/replication_tests.rs
+++ b/services/broker/src/replication_tests.rs
@@ -693,3 +693,62 @@ mod trimmed_history {
         assert!(offers(&follower).is_empty());
     }
 }
+
+/// Which followers the leader reports as fit to lead.
+mod eligibility {
+    use super::*;
+
+    #[test]
+    fn a_follower_level_with_the_leader_is_caught_up() {
+        assert_eq!(caught_up(10, &[cursor(10)]), vec!["broker-b".to_string()]);
+    }
+
+    /// **Behind is not caught up.** The bound is zero, so a follower missing
+    /// even one record cannot lead: promoting it would lose that record, and a
+    /// bound above zero is a decision about how much loss is acceptable that
+    /// nobody has made.
+    #[test]
+    fn a_follower_missing_even_one_record_is_not_caught_up() {
+        assert!(caught_up(10, &[cursor(9)]).is_empty());
+    }
+
+    /// **A halted follower never qualifies**, however close it was. It has
+    /// stopped rather than fallen behind, so its position is not moving toward
+    /// the leader's and never will without intervention.
+    #[test]
+    fn a_halted_follower_is_never_reported_as_caught_up() {
+        for halt in [Halt::Diverged, Halt::Fenced, Halt::NeedsBootstrap] {
+            let mut stopped = cursor(10);
+            stopped.halted = Some(halt);
+
+            assert!(
+                caught_up(10, &[stopped]).is_empty(),
+                "{halt:?} was reported as fit to lead",
+            );
+        }
+    }
+
+    /// A follower reporting past the leader's tail is caught up rather than
+    /// rejected: it happens while an answer is in flight.
+    #[test]
+    fn a_follower_ahead_of_the_tail_is_caught_up() {
+        assert_eq!(caught_up(10, &[cursor(11)]), vec!["broker-b".to_string()]);
+    }
+
+    #[test]
+    fn only_the_caught_up_followers_are_named() {
+        let mut behind = cursor(3);
+        behind.node_id = "broker-c".to_string();
+
+        assert_eq!(
+            caught_up(10, &[cursor(10), behind]),
+            vec!["broker-b".to_string()]
+        );
+    }
+
+    /// An empty replica set reports nobody, rather than the leader itself.
+    #[test]
+    fn a_shard_with_no_followers_reports_nobody() {
+        assert!(caught_up(10, &[]).is_empty());
+    }
+}

--- a/services/broker/tests/membership_lifecycle.rs
+++ b/services/broker/tests/membership_lifecycle.rs
@@ -75,6 +75,9 @@ impl Cluster {
             bootstrap_enabled: false,
             bootstrap_token: None,
             node_liveness: LIVENESS,
+            replica_positions: std::sync::Arc::new(
+                controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+            ),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/services/broker/tests/shard_watch_integration.rs
+++ b/services/broker/tests/shard_watch_integration.rs
@@ -66,6 +66,9 @@ impl Cluster {
             bootstrap_enabled: false,
             bootstrap_token: None,
             node_liveness: LIVENESS,
+            replica_positions: std::sync::Arc::new(
+                controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+            ),
         };
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")

--- a/services/controlplane/src/api/mod.rs
+++ b/services/controlplane/src/api/mod.rs
@@ -117,6 +117,9 @@ mod tests {
             bootstrap_enabled: false,
             bootstrap_token: None,
             node_liveness: Default::default(),
+            replica_positions: std::sync::Arc::new(
+                crate::replica_positions::ReplicaPositions::new(&Default::default()),
+            ),
         }
     }
 

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -26,8 +26,8 @@ use crate::api::error::{
 };
 use crate::api::types::{
     NodeHeartbeatRequest, NodeHeartbeatResponse, NodeListResponse, NodePlacement,
-    NodeRegistrationRequest, NodeRegistrationResponse, NodeView, ShardAssignmentChangesResponse,
-    ShardAssignmentListResponse, ShardAssignmentSnapshotResponse,
+    NodeRegistrationRequest, NodeRegistrationResponse, NodeView, ReplicaStatusRequest,
+    ShardAssignmentChangesResponse, ShardAssignmentListResponse, ShardAssignmentSnapshotResponse,
 };
 use crate::app::AppState;
 use crate::auth::felix_token::verify_token;
@@ -89,6 +89,58 @@ pub(crate) async fn report_health(
         heartbeat_interval_ms: state.node_liveness.heartbeat_interval_ms,
         expiry_timeout_ms: state.node_liveness.expiry_timeout_ms,
     }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/v1/nodes/{node_id}/replica-status",
+    tag = "nodes",
+    params(("node_id" = String, Path, description = "Broker node identifier")),
+    request_body = ReplicaStatusRequest,
+    responses(
+        (status = 204, description = "Report recorded"),
+        (status = 404, description = "Node is not registered", body = crate::api::types::ErrorResponse)
+    )
+)]
+/// Record which replicas a leader believes hold each of its shards.
+///
+/// Promotion is gated on this. Without it a lost leader cannot be replaced at
+/// all, and with a stale answer it can be replaced by a broker holding less
+/// than it claims — so reports expire, and the expiry is derived from the
+/// liveness settings rather than trusted from the caller.
+///
+/// Authorised exactly as a heartbeat is: a broker may speak for itself and no
+/// one else. A broker that could report on another's behalf could nominate
+/// itself for promotion.
+///
+/// # Errors
+/// - 404 when the node is not registered.
+pub(crate) async fn report_replica_status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(node_id): Path<String>,
+    Json(request): Json<ReplicaStatusRequest>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    require_node_manage(&state, &headers, &node_id).await?;
+    // The control plane's clock, deliberately, exactly as for a heartbeat:
+    // letting a caller supply the time would let it keep a stale report alive.
+    let now = now_millis();
+    let _ = request.incarnation;
+
+    for shard in request.shards {
+        state.replica_positions.record(
+            crate::model::ShardKey {
+                tenant_id: shard.tenant_id,
+                namespace: shard.namespace,
+                stream: shard.stream,
+                shard: shard.shard,
+            },
+            shard.generation,
+            shard.caught_up.into_iter().collect(),
+            now,
+        );
+    }
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Wall-clock milliseconds since the Unix epoch.

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -158,6 +158,31 @@ pub struct NodeHeartbeatRequest {
     pub incarnation: u64,
 }
 
+/// A leader's account of which replicas hold a shard's log.
+///
+/// Sent by the shard's leader, because it is the only party that knows both
+/// ends of the comparison: its own tail, and how far each follower has
+/// acknowledged. A follower knows where it is, not whether that is caught up.
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct ReplicaStatusRequest {
+    /// The reporting process's own incarnation, from its last registration.
+    pub incarnation: u64,
+    pub shards: Vec<ShardReplicaStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct ShardReplicaStatus {
+    pub tenant_id: String,
+    pub namespace: String,
+    pub stream: String,
+    pub shard: u32,
+    /// The assignment generation the reporting broker held. A report from an
+    /// older generation is dropped: the replica set may have changed with it.
+    pub generation: u64,
+    /// Replicas within the catch-up bound, as this leader last saw them.
+    pub caught_up: Vec<String>,
+}
+
 /// What the control plane tells a broker in return.
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct NodeHeartbeatResponse {

--- a/services/controlplane/src/app.rs
+++ b/services/controlplane/src/app.rs
@@ -28,6 +28,14 @@ pub struct AppState {
     pub bootstrap_enabled: bool,
     pub bootstrap_token: Option<String>,
     pub node_liveness: NodeLivenessConfig,
+    /// Which replicas their leaders last reported as holding each shard's log.
+    ///
+    /// In memory: these change constantly, are advisory, and expire in about a
+    /// second. Persisting them would cost a write per report for data that is
+    /// worthless by the time it could be read back. The consequence is that a
+    /// second control-plane instance starts knowing nothing and cannot promote
+    /// until leaders have reported to *it* — see `docs/replication-design.md`.
+    pub replica_positions: Arc<crate::replica_positions::ReplicaPositions>,
 }
 
 pub fn build_router(state: AppState) -> Router {
@@ -124,6 +132,10 @@ pub fn build_router(state: AppState) -> Router {
         .route(
             "/v1/nodes/{node_id}/heartbeat",
             axum::routing::post(api::nodes::report_health),
+        )
+        .route(
+            "/v1/nodes/{node_id}/replica-status",
+            axum::routing::post(api::nodes::report_replica_status),
         )
         .route(
             "/v1/nodes/{node_id}/drain",

--- a/services/controlplane/src/auth/exchange.rs
+++ b/services/controlplane/src/auth/exchange.rs
@@ -402,6 +402,9 @@ mod tests {
             bootstrap_enabled: false,
             bootstrap_token: None,
             node_liveness: Default::default(),
+            replica_positions: std::sync::Arc::new(
+                crate::replica_positions::ReplicaPositions::new(&Default::default()),
+            ),
         }
     }
 

--- a/services/controlplane/src/lib.rs
+++ b/services/controlplane/src/lib.rs
@@ -13,4 +13,5 @@ pub mod membership_metrics;
 pub mod model;
 pub mod observability;
 pub mod placement;
+pub mod replica_positions;
 pub mod store;

--- a/services/controlplane/src/main.rs
+++ b/services/controlplane/src/main.rs
@@ -61,6 +61,7 @@ where
     // at the same point the listener does.
     let reconcile_task = placement::spawn_reconciler(
         Arc::clone(&state.store) as Arc<dyn store::ControlPlaneStore + Send + Sync>,
+        Arc::clone(&state.replica_positions),
         Duration::from_millis(state.node_liveness.shard_reconcile_interval_ms),
         api_shutdown.clone(),
     );
@@ -228,6 +229,9 @@ async fn build_state(config: config::ControlPlaneConfig) -> anyhow::Result<AppSt
         ),
         bootstrap_enabled: config.bootstrap.enabled,
         bootstrap_token: config.bootstrap.token,
+        replica_positions: Arc::new(controlplane::replica_positions::ReplicaPositions::new(
+            &config.node_liveness,
+        )),
         node_liveness: config.node_liveness,
     })
 }

--- a/services/controlplane/src/placement.rs
+++ b/services/controlplane/src/placement.rs
@@ -439,7 +439,10 @@ pub fn assignment_for(key: &ShardKey, leader: &str, replicas: Vec<String>) -> Sh
 ///
 /// Idempotent. A pass over an already-placed cluster writes nothing, so running
 /// it on a timer does not churn the persisted rows or the changefeed.
-pub async fn reconcile_once(store: &dyn crate::store::ControlPlaneStore) -> ReconcileOutcome {
+pub async fn reconcile_once(
+    store: &dyn crate::store::ControlPlaneStore,
+    positions: &crate::replica_positions::ReplicaPositions,
+) -> ReconcileOutcome {
     let (streams, nodes, existing) = match load(store).await {
         Ok(loaded) => loaded,
         Err(err) => {
@@ -449,12 +452,13 @@ pub async fn reconcile_once(store: &dyn crate::store::ControlPlaneStore) -> Reco
         }
     };
 
-    // Nothing reports being caught up yet: replication ships records (#112) but
-    // no replica's position reaches the control plane, so promotion cannot
-    // fire. A replicated shard whose leader is lost therefore stays unplaced
-    // until the leader returns -- unavailable, and recoverable, rather than
-    // handed to a broker holding none of it.
-    let plan = plan(&streams, &nodes, &existing, &NothingCaughtUp);
+    // One instant for the whole pass, so a report cannot be fresh for one shard
+    // and stale for the next within the same plan.
+    let caught_up = crate::replica_positions::CaughtUpAt {
+        positions,
+        now_millis: crate::api::nodes::now_millis(),
+    };
+    let plan = plan(&streams, &nodes, &existing, &caught_up);
     let mut outcome = ReconcileOutcome {
         kept: plan.kept(),
         ..ReconcileOutcome::default()
@@ -537,6 +541,7 @@ pub const RECONCILE_FAILURES_TOTAL: &str = "felix_shard_reconcile_failures_total
 /// Place shards on an interval until `shutdown` fires.
 pub fn spawn_reconciler(
     store: std::sync::Arc<dyn crate::store::ControlPlaneStore + Send + Sync>,
+    positions: std::sync::Arc<crate::replica_positions::ReplicaPositions>,
     interval: std::time::Duration,
     shutdown: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
@@ -548,7 +553,7 @@ pub fn spawn_reconciler(
             tokio::select! {
                 _ = shutdown.cancelled() => return,
                 _ = ticker.tick() => {
-                    reconcile_once(store.as_ref()).await;
+                    reconcile_once(store.as_ref(), positions.as_ref()).await;
                 }
             }
         }

--- a/services/controlplane/src/placement_tests.rs
+++ b/services/controlplane/src/placement_tests.rs
@@ -444,7 +444,11 @@ mod reconcile {
     async fn three_nodes_and_three_shards_each_get_one_owner() {
         let store = cluster(&["broker-a", "broker-b", "broker-c"]).await;
 
-        let outcome = reconcile_once(&store).await;
+        let outcome = reconcile_once(
+            &store,
+            &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+        )
+        .await;
         assert_eq!(outcome.placed, 3);
         assert_eq!(outcome.unplaceable, 0);
         assert_eq!(outcome.failed, 0);
@@ -460,7 +464,11 @@ mod reconcile {
     #[tokio::test]
     async fn a_second_pass_writes_nothing() {
         let store = cluster(&["broker-a", "broker-b", "broker-c"]).await;
-        reconcile_once(&store).await;
+        reconcile_once(
+            &store,
+            &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+        )
+        .await;
         let after_first = store
             .shard_assignment_snapshot()
             .await
@@ -468,7 +476,11 @@ mod reconcile {
             .next_seq;
 
         for _ in 0..5 {
-            let outcome = reconcile_once(&store).await;
+            let outcome = reconcile_once(
+                &store,
+                &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+            )
+            .await;
             assert_eq!(outcome.placed, 0);
             assert_eq!(outcome.kept, 3);
         }
@@ -489,7 +501,11 @@ mod reconcile {
     #[tokio::test]
     async fn a_lost_node_has_its_shards_replaced() {
         let store = cluster(&["broker-a", "broker-b", "broker-c"]).await;
-        reconcile_once(&store).await;
+        reconcile_once(
+            &store,
+            &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+        )
+        .await;
 
         let before = store.list_shard_assignments().await.expect("list");
         let victim = before[0].leader.clone();
@@ -499,7 +515,11 @@ mod reconcile {
             .await
             .expect("down");
 
-        let outcome = reconcile_once(&store).await;
+        let outcome = reconcile_once(
+            &store,
+            &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+        )
+        .await;
         assert_eq!(outcome.placed, lost);
         assert_eq!(outcome.kept, 3 - lost);
 
@@ -519,7 +539,11 @@ mod reconcile {
     #[tokio::test]
     async fn an_empty_cluster_places_nothing_and_says_so() {
         let store = cluster(&[]).await;
-        let outcome = reconcile_once(&store).await;
+        let outcome = reconcile_once(
+            &store,
+            &crate::replica_positions::ReplicaPositions::new(&Default::default()),
+        )
+        .await;
         assert_eq!(outcome.placed, 0);
         assert_eq!(outcome.unplaceable, 3);
         assert!(

--- a/services/controlplane/src/replica_positions.rs
+++ b/services/controlplane/src/replica_positions.rs
@@ -1,0 +1,135 @@
+//! Which replicas hold a shard's log, as their leaders last reported.
+//!
+//! Promotion is gated on this. Without it a lost leader cannot be replaced at
+//! all — see `docs/replication-design.md` — and with a *wrong* answer it can be
+//! replaced by a broker holding less than it claims, which is worse.
+//!
+//! # Why the leader reports it
+//!
+//! The leader is the only party that knows both ends of the comparison: its own
+//! tail, and how far each follower has acknowledged. A follower knows only where
+//! it is, not whether that is caught up.
+//!
+//! # Why reports expire
+//!
+//! A report says a follower *was* caught up at the moment it was made. The
+//! leader then keeps writing, and the follower may fall behind. Promoting on a
+//! stale report is how a failover silently loses the records written after it.
+//!
+//! So a report is only believed for a bounded time — long enough to outlive the
+//! window in which a leader's death is noticed, and no longer. The bound is
+//! derived from the liveness settings rather than configured separately: those
+//! already say how quickly a dead leader is detected, and a report has to
+//! survive exactly that long to be usable.
+use std::collections::{BTreeSet, HashMap};
+
+use std::sync::Mutex;
+
+use crate::model::ShardKey;
+use crate::placement::CaughtUp;
+
+/// One leader's account of its followers for one shard.
+#[derive(Debug, Clone)]
+struct Report {
+    /// The assignment generation the leader held when it reported. A report
+    /// from an older generation says nothing about this one: the replica set
+    /// may be different.
+    generation: u64,
+    caught_up: BTreeSet<String>,
+    reported_at_millis: u64,
+}
+
+/// The control plane's view of which replicas can take over.
+#[derive(Debug)]
+pub struct ReplicaPositions {
+    shards: Mutex<HashMap<ShardKey, Report>>,
+    /// How long a report is believed.
+    ttl_millis: u64,
+}
+
+impl ReplicaPositions {
+    /// Believe a report for `expiry_timeout_ms` plus one heartbeat interval.
+    ///
+    /// It has to outlive the detection window: the last report a leader makes
+    /// is from just before it dies, and promotion happens only after the
+    /// cluster has noticed, which takes the expiry timeout. A margin of one
+    /// heartbeat covers the gap between a leader's final report and its final
+    /// heartbeat.
+    ///
+    /// Not longer, deliberately. Every extra second is a second of writes a
+    /// promoted follower might be missing.
+    pub fn new(liveness: &crate::config::NodeLivenessConfig) -> Self {
+        Self {
+            shards: Mutex::new(HashMap::new()),
+            ttl_millis: liveness.expiry_timeout_ms + liveness.heartbeat_interval_ms,
+        }
+    }
+
+    /// Record what a leader reports about one shard.
+    ///
+    /// A report at an older generation than the one already held is dropped:
+    /// leadership has moved on, and the old leader's view of its followers is
+    /// no longer about the current replica set.
+    pub fn record(
+        &self,
+        key: ShardKey,
+        generation: u64,
+        caught_up: BTreeSet<String>,
+        now_millis: u64,
+    ) {
+        let mut shards = self.shards.lock().expect("replica positions lock");
+        if let Some(held) = shards.get(&key)
+            && held.generation > generation
+        {
+            return;
+        }
+        shards.insert(
+            key,
+            Report {
+                generation,
+                caught_up,
+                reported_at_millis: now_millis,
+            },
+        );
+    }
+
+    /// Forget everything about a shard.
+    pub fn forget(&self, key: &ShardKey) {
+        self.shards
+            .lock()
+            .expect("replica positions lock")
+            .remove(key);
+    }
+
+    fn is_caught_up_at(&self, key: &ShardKey, node_id: &str, now_millis: u64) -> bool {
+        let shards = self.shards.lock().expect("replica positions lock");
+        let Some(report) = shards.get(key) else {
+            return false;
+        };
+        if now_millis.saturating_sub(report.reported_at_millis) > self.ttl_millis {
+            return false;
+        }
+        report.caught_up.contains(node_id)
+    }
+}
+
+/// The reports as of `now_millis`.
+///
+/// A snapshot rather than a live view, so every shard in one planning pass is
+/// judged against the same instant. Planning that read the clock per shard
+/// could promote on one side of a report's expiry and refuse on the other.
+pub struct CaughtUpAt<'a> {
+    pub positions: &'a ReplicaPositions,
+    pub now_millis: u64,
+}
+
+impl CaughtUp for CaughtUpAt<'_> {
+    fn is_caught_up(&self, key: &ShardKey, node_id: &str) -> bool {
+        self.positions
+            .is_caught_up_at(key, node_id, self.now_millis)
+    }
+}
+
+#[cfg(test)]
+#[path = "replica_positions_tests.rs"]
+mod tests;

--- a/services/controlplane/src/replica_positions_tests.rs
+++ b/services/controlplane/src/replica_positions_tests.rs
@@ -1,0 +1,166 @@
+//! What the control plane believes about replicas, and for how long.
+use super::*;
+use crate::config::NodeLivenessConfig;
+
+const HEARTBEAT_MS: u64 = 500;
+const EXPIRY_MS: u64 = 1_500;
+/// Reports are believed for expiry plus one heartbeat.
+const TTL_MS: u64 = EXPIRY_MS + HEARTBEAT_MS;
+
+fn positions() -> ReplicaPositions {
+    ReplicaPositions::new(&NodeLivenessConfig {
+        heartbeat_interval_ms: HEARTBEAT_MS,
+        expiry_timeout_ms: EXPIRY_MS,
+        ..Default::default()
+    })
+}
+
+fn key(stream: &str) -> ShardKey {
+    ShardKey {
+        tenant_id: "t1".to_string(),
+        namespace: "ns".to_string(),
+        stream: stream.to_string(),
+        shard: 0,
+    }
+}
+
+fn caught_up(nodes: &[&str]) -> BTreeSet<String> {
+    nodes.iter().map(|n| n.to_string()).collect()
+}
+
+fn at(positions: &ReplicaPositions, now_millis: u64) -> CaughtUpAt<'_> {
+    CaughtUpAt {
+        positions,
+        now_millis,
+    }
+}
+
+/// A reported follower can take over; one that was not reported cannot.
+#[test]
+fn a_reported_follower_is_caught_up_and_others_are_not() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+
+    let view = at(&positions, 1_000);
+    assert!(view.is_caught_up(&key("orders"), "broker-b"));
+    assert!(!view.is_caught_up(&key("orders"), "broker-c"));
+}
+
+/// **Nothing is caught up until a leader says so.** The absence of a report is
+/// not permission to promote.
+#[test]
+fn an_unreported_shard_has_nothing_caught_up() {
+    let positions = positions();
+
+    assert!(!at(&positions, 1_000).is_caught_up(&key("orders"), "broker-b"));
+}
+
+/// **A report expires.** It says a follower *was* caught up; the leader kept
+/// writing afterwards, and promoting on a stale report silently loses whatever
+/// was written since.
+#[test]
+fn a_report_is_not_believed_forever() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+
+    assert!(
+        at(&positions, 1_000 + TTL_MS).is_caught_up(&key("orders"), "broker-b"),
+        "a report expired before the window it has to survive",
+    );
+    assert!(
+        !at(&positions, 1_000 + TTL_MS + 1).is_caught_up(&key("orders"), "broker-b"),
+        "a stale report was still believed",
+    );
+}
+
+/// **The window outlives the detection of a dead leader.** The last report a
+/// leader makes is from just before it dies, and promotion happens only after
+/// the cluster has noticed — which takes the expiry timeout. A report that
+/// expired sooner could never be used for the failover it exists for.
+#[test]
+fn a_report_outlives_the_window_a_dead_leader_is_noticed_in() {
+    let positions = positions();
+    let last_report = 1_000;
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), last_report);
+
+    // The leader dies just after reporting; the cluster notices an expiry
+    // timeout later and plans then.
+    let planning_at = last_report + EXPIRY_MS;
+
+    assert!(
+        at(&positions, planning_at).is_caught_up(&key("orders"), "broker-b"),
+        "the report expired before failover could use it",
+    );
+}
+
+/// A later report replaces an earlier one, so a follower that falls behind
+/// stops being promotable.
+#[test]
+fn a_later_report_replaces_an_earlier_one() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(key("orders"), 4, caught_up(&[]), 1_100);
+
+    assert!(!at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"));
+}
+
+/// **An older generation's report is dropped.** Leadership has moved on, and
+/// the old leader's view is about a replica set that may no longer exist.
+#[test]
+fn a_report_from_a_superseded_leader_is_dropped() {
+    let positions = positions();
+    positions.record(key("orders"), 5, caught_up(&[]), 1_000);
+
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_100);
+
+    assert!(
+        !at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"),
+        "a superseded leader's report overwrote the current one",
+    );
+}
+
+/// A report at the same generation is an update, not a stale duplicate: the
+/// same leader reporting again is exactly the normal case.
+#[test]
+fn a_report_at_the_same_generation_is_an_update() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&[]), 1_000);
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_100);
+
+    assert!(at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"));
+}
+
+/// Shards are independent: one shard's replicas say nothing about another's.
+#[test]
+fn shards_do_not_share_reports() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+
+    assert!(!at(&positions, 1_000).is_caught_up(&key("payments"), "broker-b"));
+}
+
+/// A planning pass judges every shard against one instant, so a report cannot
+/// be fresh for one shard and stale for the next within the same pass.
+#[test]
+fn one_pass_judges_every_shard_at_the_same_instant() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(key("payments"), 4, caught_up(&["broker-b"]), 1_000);
+
+    let view = at(&positions, 1_000 + TTL_MS);
+
+    assert!(view.is_caught_up(&key("orders"), "broker-b"));
+    assert!(view.is_caught_up(&key("payments"), "broker-b"));
+}
+
+/// A forgotten shard reports nothing, so a shard that is deleted and recreated
+/// does not inherit the old one's promotability.
+#[test]
+fn a_forgotten_shard_reports_nothing() {
+    let positions = positions();
+    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+
+    positions.forget(&key("orders"));
+
+    assert!(!at(&positions, 1_000).is_caught_up(&key("orders"), "broker-b"));
+}

--- a/services/controlplane/tests/api_coverage.rs
+++ b/services/controlplane/tests/api_coverage.rs
@@ -33,6 +33,9 @@ fn app_with_state() -> axum::routing::RouterIntoService<Body, ()> {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     build_router(state).into_service()
 }

--- a/services/controlplane/tests/auth_admin.rs
+++ b/services/controlplane/tests/auth_admin.rs
@@ -35,6 +35,9 @@ fn build_state(store: Arc<InMemoryStore>) -> AppState {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     }
 }
 

--- a/services/controlplane/tests/auth_bootstrap.rs
+++ b/services/controlplane/tests/auth_bootstrap.rs
@@ -36,6 +36,9 @@ fn bootstrap_state(enabled: bool, token: Option<String>) -> (Arc<InMemoryStore>,
         bootstrap_enabled: enabled,
         bootstrap_token: token,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     (store, state)
 }

--- a/services/controlplane/tests/auth_exchange.rs
+++ b/services/controlplane/tests/auth_exchange.rs
@@ -222,6 +222,9 @@ async fn exchange_returns_tenant_scoped_token() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -331,6 +334,9 @@ async fn exchange_forbidden_without_policies() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -450,6 +456,9 @@ async fn exchange_supports_group_claim_based_rbac() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -586,6 +595,9 @@ async fn exchange_group_claim_rbac_requires_groups_claim_mapping() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -702,6 +714,9 @@ async fn exchange_supports_group_claim_values_with_group_prefix() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();

--- a/services/controlplane/tests/auth_jwks.rs
+++ b/services/controlplane/tests/auth_jwks.rs
@@ -62,6 +62,9 @@ async fn jwks_endpoint_returns_keys_for_tenant() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app = build_router(state).into_service();
 
@@ -110,6 +113,9 @@ async fn jwks_endpoint_missing_tenant_returns_404() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app = build_router(state).into_service();
 

--- a/services/controlplane/tests/http_smoke.rs
+++ b/services/controlplane/tests/http_smoke.rs
@@ -43,6 +43,9 @@ fn app_with_region_id(region_id: &str) -> axum::routing::RouterIntoService<axum:
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     build_router(state).into_service()
 }
@@ -1141,6 +1144,9 @@ async fn system_health_reports_internal_error_on_store_failure() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1171,6 +1177,9 @@ async fn tenant_endpoints_report_internal_error_on_store_failure() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1234,6 +1243,9 @@ async fn stream_and_cache_endpoints_report_internal_error_after_scope_checks() {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1350,6 +1362,9 @@ async fn stream_and_cache_create_report_not_found_when_store_reports_missing_nam
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_router(state).into_service();
@@ -1412,6 +1427,9 @@ async fn bootstrap_initialize_reports_internal_error_when_signing_key_ensure_fai
         bootstrap_enabled: true,
         bootstrap_token: Some("secret".to_string()),
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let app: axum::routing::RouterIntoService<axum::body::Body, ()> =
         build_bootstrap_router(state).into_service();

--- a/services/controlplane/tests/node_admin_api.rs
+++ b/services/controlplane/tests/node_admin_api.rs
@@ -56,6 +56,9 @@ async fn setup() -> (App, Arc<InMemoryStore>, TenantSigningKeys) {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: LIVENESS,
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&LIVENESS),
+        ),
     };
     (build_router(state).into_service(), store, keys)
 }

--- a/services/controlplane/tests/node_heartbeat.rs
+++ b/services/controlplane/tests/node_heartbeat.rs
@@ -86,6 +86,9 @@ async fn app_with(store: Arc<InMemoryStore>) -> axum::routing::RouterIntoService
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: LIVENESS,
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&LIVENESS),
+        ),
     };
     build_router(state).into_service()
 }

--- a/services/controlplane/tests/node_write_auth.rs
+++ b/services/controlplane/tests/node_write_auth.rs
@@ -54,6 +54,9 @@ async fn setup() -> (App, Arc<InMemoryStore>, TenantSigningKeys) {
         bootstrap_enabled: false,
         bootstrap_token: None,
         node_liveness: LIVENESS,
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&LIVENESS),
+        ),
     };
     (build_router(state).into_service(), store, keys)
 }

--- a/services/controlplane/tests/pg_store_e2e.rs
+++ b/services/controlplane/tests/pg_store_e2e.rs
@@ -1776,6 +1776,9 @@ async fn pg_bootstrap_initialize_and_jwks_includes_previous_keys() -> Result<()>
         bootstrap_enabled: true,
         bootstrap_token: Some("token".to_string()),
         node_liveness: Default::default(),
+        replica_positions: std::sync::Arc::new(
+            controlplane::replica_positions::ReplicaPositions::new(&Default::default()),
+        ),
     };
     let bootstrap_app = app::build_bootstrap_router(state.clone());
     let body = json!({


### PR DESCRIPTION
The other half of #264. That one stopped a lost leader being replaced by a broker holding none of its log — at the cost of leaving the shard unavailable, because nothing reported which replicas *could* take over. This supplies that signal, so failover works instead of merely being safe.

It completes the promotion gate #111 opened and deferred: *"until records are actually replicated (#112) nothing reports being caught up"*. Records are replicated now.

## The leader reports, because only it can

It knows both ends of the comparison — its own tail, and how far each follower has acknowledged. A follower knows where it is, not whether that is caught up. Sent on every replication pass.

## The bound is zero

A follower is caught up when it is missing **nothing**.

A bound above zero is a bound on how much a promotion may silently lose, and there is no honest value for it that is not a policy decision. Zero needs no such decision, and a follower reaches it constantly on a healthy shard — the leader only has to be momentarily idle. Written as a comparison rather than an equality so that raising it later reads correctly without being rediscovered (with the clippy allow that requires, and the reason).

**A halted follower is never reported**, however close its last position was. It has stopped rather than fallen behind, so its position is not moving toward the leader's and will not without intervention.

## Reports expire, and the window is not arbitrary

A report says a follower *was* caught up. The leader kept writing afterwards, and promoting on a stale report silently loses whatever was written since.

The window is **expiry timeout + one heartbeat**, derived from the liveness settings rather than configured separately, because it has to outlive exactly one thing: the time it takes to notice the leader is gone.

- The last report a leader makes is from just before it dies, and promotion happens only after the cluster has noticed. A report expiring sooner could never be used for the failover it exists for — there is a test for exactly that boundary.
- Not longer either. Every extra second is a second of writes a promoted follower might be missing.

A report from an **older generation is dropped**: leadership has moved on, and the old leader's view is about a replica set that may no longer exist.

## Held in memory, deliberately

Positions change constantly, are advisory, and expire in about a second. Persisting them would cost a write per report for data that is worthless by the time it could be read back.

The consequence: **a second control-plane instance starts knowing nothing and cannot promote until leaders have reported to it.** That is documented in `docs/replication-design.md` and belongs to M7's multi-instance work, not here.

## Authorisation

Exactly as a heartbeat: a broker may speak for itself and no one else. A broker that could report on another's behalf could nominate itself for promotion.

## Tests

Store: a reported follower is promotable and others are not; an unreported shard has nothing caught up; a report expires; **a report outlives the window a dead leader is noticed in**; a later report replaces an earlier one; a superseded leader's report is dropped; a same-generation report is an update; shards are independent; one pass judges every shard at one instant.

Broker: a pass reports the shard, generation and caught-up set; **a follower that refused is not reported as able to lead**; a shard led elsewhere is not reported on; a shard with no replicas reports nobody.

`task lint`, `task test` clean.

## What this unblocks

#115's headline scenario — "a three-node cluster recovers within the configured failover bound" — is now actually testable, because promotion can fire. With #263's harness faults, the scenarios have everything they need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)