### PR TITLE
fix(broker): unblock writes on a promoted broker, and correct the docs

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -597,6 +597,26 @@ impl Broker {
         ))
     }
 
+    /// Tell a stream that records reached its log without passing through it.
+    ///
+    /// Replication writes the shard's log directly, so a follower's in-memory
+    /// view of the stream stays at zero while its disk fills. Left that way, the
+    /// first publish this broker accepts after being promoted waits on commit
+    /// turns that were never taken, and never returns.
+    pub async fn adopt_replicated(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        durable_offset: u64,
+    ) -> Result<()> {
+        let handle = self
+            .resolve_stream_handle(tenant_id, namespace, stream)
+            .await?;
+        handle.state.advance_to(durable_offset);
+        Ok(())
+    }
+
     /// Read persisted records for a durable stream, starting at `from_offset`.
     ///
     /// This is the historical replay path, and it is deliberately separate from

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -157,6 +157,32 @@ impl StreamState {
         self.commit_sequencer.reset(next_seq);
     }
 
+    /// Move the stream's idea of its tail up to `next_seq`.
+    ///
+    /// For records that reached the log without passing through this state —
+    /// replication writes the shard's log directly, so a follower's `next_seq`
+    /// and commit order stay at zero while its disk fills.
+    ///
+    /// **The commit order has to move with it.** It is keyed on disk offsets, so
+    /// a publish after those writes reserves a turn past them and then waits for
+    /// turns that were never taken: the first write a promoted broker accepts
+    /// would hang forever. Same reasoning as recovery after a restart, which is
+    /// why `hydrate` does this too.
+    ///
+    /// The ring is deliberately left alone. Refilling it from disk on every
+    /// replicated batch would read the whole window each time, and a reader is
+    /// served from the log when the ring has nothing — see
+    /// `Broker::subscribe_from`.
+    pub(crate) fn advance_to(&self, next_seq: u64) {
+        let mut state = self.log_state.lock();
+        if next_seq <= state.next_seq {
+            return;
+        }
+        state.next_seq = next_seq;
+        drop(state);
+        self.commit_sequencer.reset(next_seq);
+    }
+
     pub(crate) fn deactivate(&self) {
         self.active.store(false, Ordering::Release);
     }

--- a/crates/felix-broker/tests/replica_promotion.rs
+++ b/crates/felix-broker/tests/replica_promotion.rs
@@ -1,0 +1,164 @@
+//! What a broker serves for a shard whose records arrived by replication.
+//!
+//! A follower's records do not come through `publish`. They are written to the
+//! shard's log by the replication path, which never touches the in-memory
+//! replay ring. When that broker is promoted, everything it holds is on disk
+//! and nothing is in the ring — and a subscriber has to be served from disk
+//! regardless.
+use std::sync::Arc;
+
+use bytes::Bytes;
+use felix_broker::{Broker, DurableStorage, StartPosition, StreamMetadata};
+use felix_storage::EphemeralCache;
+use felix_storage::log::{FsyncMode, LogConfig};
+use tempfile::{TempDir, tempdir};
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+
+fn payload(value: &str) -> Bytes {
+    Bytes::copy_from_slice(value.as_bytes())
+}
+
+/// A broker holding a durable stream whose records were written the way
+/// replication writes them: straight to the shard log, never through publish.
+async fn promoted_broker(records: &[&str]) -> (Arc<Broker>, TempDir) {
+    let dir = tempdir().expect("dir");
+    let storage = DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage.clone());
+    broker.register_tenant(TENANT).await.expect("tenant");
+    broker
+        .register_namespace(TENANT, NAMESPACE)
+        .await
+        .expect("namespace");
+    broker
+        .register_stream(
+            TENANT,
+            NAMESPACE,
+            STREAM,
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("stream");
+
+    // The replication path: the shard's log, directly — then telling the stream
+    // its tail moved, exactly as the replica handler does.
+    let log = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open the shard log");
+    for record in records {
+        log.append(&[payload(record)]).await.expect("append");
+    }
+    let tail = log.tail_offset().await.expect("tail");
+    broker
+        .adopt_replicated(TENANT, NAMESPACE, STREAM, tail)
+        .await
+        .expect("adopt the replicated records");
+
+    (Arc::new(broker), dir)
+}
+
+async fn drain(subscription: &mut felix_broker::Subscription, expected: usize) -> Vec<String> {
+    let mut seen = Vec::new();
+    while seen.len() < expected {
+        match tokio::time::timeout(std::time::Duration::from_millis(500), subscription.recv()).await
+        {
+            Ok(Some(payload)) => seen.push(String::from_utf8(payload.to_vec()).expect("utf8")),
+            _ => break,
+        }
+    }
+    seen
+}
+
+/// **A promoted broker serves the records it replicated.**
+///
+/// They are on its disk and nowhere else in its memory. A subscriber asking for
+/// the whole stream must get them; returning nothing makes a completed failover
+/// look like an empty shard.
+#[tokio::test]
+async fn a_replicated_stream_replays_from_the_start() {
+    let (broker, _dir) = promoted_broker(&["a", "b", "c"]).await;
+
+    let resumed = broker
+        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Earliest)
+        .await
+        .expect("subscribe from the start");
+
+    let mut from_disk = Vec::new();
+    if let Some(range) = resumed.history {
+        let records = broker
+            .read_durable(TENANT, NAMESPACE, STREAM, range.from_offset, 1024 * 1024)
+            .await
+            .expect("read history");
+        for record in records {
+            if record.offset >= range.until_offset {
+                break;
+            }
+            from_disk.push(String::from_utf8(record.payload.to_vec()).expect("utf8"));
+        }
+    }
+    let backlog: Vec<String> = resumed
+        .backlog
+        .iter()
+        .map(|(_, p)| String::from_utf8(p.to_vec()).expect("utf8"))
+        .collect();
+
+    let mut everything = from_disk;
+    everything.extend(backlog);
+    assert_eq!(
+        everything,
+        vec!["a", "b", "c"],
+        "a promoted broker served nothing for records it holds on disk",
+    );
+}
+
+/// The live edge still works: a record published after promotion is delivered
+/// on top of the replicated history rather than instead of it.
+#[tokio::test]
+async fn a_publish_after_promotion_follows_the_replicated_history() {
+    let (broker, _dir) = promoted_broker(&["a", "b"]).await;
+
+    let resumed = broker
+        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Earliest)
+        .await
+        .expect("subscribe from the start");
+    let mut subscription = resumed.subscription;
+
+    broker
+        .publish(TENANT, NAMESPACE, STREAM, payload("c"))
+        .await
+        .expect("publish after promotion");
+
+    assert_eq!(drain(&mut subscription, 1).await, vec!["c"]);
+}
+
+/// `Latest` on a replicated stream starts at the disk tail, so a subscriber
+/// joining after promotion does not replay what it did not ask for.
+#[tokio::test]
+async fn latest_starts_at_the_replicated_tail() {
+    let (broker, _dir) = promoted_broker(&["a", "b"]).await;
+
+    let resumed = broker
+        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Latest)
+        .await
+        .expect("subscribe at the tail");
+
+    assert!(resumed.history.is_none());
+    assert!(resumed.backlog.is_empty());
+}

--- a/crates/felix-cluster/src/bin/felix-cluster.rs
+++ b/crates/felix-cluster/src/bin/felix-cluster.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 use felix_cluster::session::{self, Session};
-use felix_cluster::{Cluster, ClusterConfig};
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
 
 const STREAM: &str = "orders";
 
@@ -454,7 +454,7 @@ async fn stop_signal() -> Result<()> {
 fn cluster_config(nodes: usize, inherit_output: bool) -> ClusterConfig {
     ClusterConfig {
         nodes,
-        streams: vec![(STREAM.to_string(), 1)],
+        streams: vec![StreamSpec::new(STREAM, 1)],
         inherit_output: inherit_output && std::env::var("FELIX_CLUSTER_VERBOSE").is_ok(),
         ..Default::default()
     }

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -129,14 +129,65 @@ pub struct Cluster {
     _root: tempfile::TempDir,
 }
 
+/// A stream to create when the cluster starts.
+///
+/// Replication and consistency are separate from the shard count because a
+/// failure test needs them apart: a shard with no replicas has nothing to fail
+/// over to, and a `Leader` stream acknowledges before a follower has the record,
+/// so neither proves anything about the other.
+#[derive(Clone, Debug)]
+pub struct StreamSpec {
+    pub name: String,
+    pub shards: u32,
+    /// Copies of each shard, leader included. `1` is leader-only.
+    pub replication_factor: u32,
+    /// `"Leader"` or `"Quorum"`, as the control plane spells them.
+    pub consistency: String,
+}
+
+impl StreamSpec {
+    /// An unreplicated, leader-acknowledged stream — the default a cluster gets
+    /// when a test says nothing about replication.
+    pub fn new(name: impl Into<String>, shards: u32) -> Self {
+        Self {
+            name: name.into(),
+            shards,
+            replication_factor: 1,
+            consistency: "Leader".to_string(),
+        }
+    }
+
+    /// Replicated across `replication_factor` brokers, acknowledged by a
+    /// majority. What a failover test needs: records that are on more than one
+    /// broker by the time the publish returns.
+    pub fn quorum(name: impl Into<String>, shards: u32, replication_factor: u32) -> Self {
+        Self {
+            name: name.into(),
+            shards,
+            replication_factor,
+            consistency: "Quorum".to_string(),
+        }
+    }
+
+    /// Replicated, but acknowledged by the leader alone.
+    pub fn replicated(name: impl Into<String>, shards: u32, replication_factor: u32) -> Self {
+        Self {
+            name: name.into(),
+            shards,
+            replication_factor,
+            consistency: "Leader".to_string(),
+        }
+    }
+}
+
 /// How to build a cluster.
 #[derive(Clone)]
 pub struct ClusterConfig {
     pub nodes: usize,
     pub tenant_id: String,
     pub namespace: String,
-    /// Streams to create, and how many shards each has.
-    pub streams: Vec<(String, u32)>,
+    /// Streams to create.
+    pub streams: Vec<StreamSpec>,
     /// Inherit the parent's stdout/stderr rather than discarding it. Useful when
     /// running the harness by hand; noisy inside a test.
     pub inherit_output: bool,
@@ -148,7 +199,7 @@ impl Default for ClusterConfig {
             nodes: 3,
             tenant_id: "t1".to_string(),
             namespace: "ns".to_string(),
-            streams: vec![("orders".to_string(), 1)],
+            streams: vec![StreamSpec::new("orders", 1)],
             inherit_output: false,
         }
     }
@@ -212,6 +263,16 @@ impl Cluster {
         cluster.await_brokers_ready().await?;
         cluster.await_cluster_ready(&config).await?;
         Ok(cluster)
+    }
+
+    /// Step placement once.
+    ///
+    /// Exposed because the harness's control plane does not run the reconciler
+    /// on a timer: a test that slept for one would be timing-dependent in
+    /// exactly the way the acceptance criteria rule out. A failure test has to
+    /// drive placement while it waits, or nothing re-plans after the fault.
+    pub async fn place_shards(&self) -> ::controlplane::placement::ReconcileOutcome {
+        self.control_plane().place_shards().await
     }
 
     fn control_plane(&self) -> &ControlPlane {
@@ -296,7 +357,7 @@ impl Cluster {
 
         // Placement is stepped rather than waited on, then the result is
         // verified: a leader for every shard of every stream.
-        let total_shards: usize = config.streams.iter().map(|(_, s)| *s as usize).sum();
+        let total_shards: usize = config.streams.iter().map(|spec| spec.shards as usize).sum();
         wait::until(
             READY_TIMEOUT,
             "every shard assigned a leader",
@@ -314,7 +375,8 @@ impl Cluster {
         // That gap is exactly where a publish is refused as `NotReady`, and no
         // control-plane state distinguishes the two — so the only honest check
         // is a publish that succeeds.
-        for (stream, _) in &config.streams {
+        for spec in &config.streams {
+            let stream = &spec.name;
             let stream = stream.clone();
             wait::until(
                 READY_TIMEOUT,
@@ -406,6 +468,33 @@ impl Cluster {
             .subscribe(&self.tenant_id, &self.namespace, stream)
             .await
             .with_context(|| format!("subscribe to {stream} on {node_id}"))?;
+        Ok((client, subscription))
+    }
+
+    /// Subscribe on a named broker, replaying from the start of the stream.
+    ///
+    /// A failure test needs this: the records it cares about were published
+    /// before the fault, and a live subscription would not replay them. Asking
+    /// for history is also the stronger check — it reads what the broker has on
+    /// disk rather than what it happens to fan out next.
+    pub async fn replay_on(
+        &self,
+        node_id: &str,
+        stream: &str,
+    ) -> Result<(felix_client::Client, felix_client::Subscription)> {
+        let node = self
+            .node(node_id)
+            .ok_or_else(|| anyhow!("unknown node {node_id}"))?;
+        let client = client::connect(node.client_addr, &self.tenant_id, &self.client_token).await?;
+        let subscription = client
+            .subscribe_from(
+                &self.tenant_id,
+                &self.namespace,
+                stream,
+                Some(felix_client::StartPosition::Earliest),
+            )
+            .await
+            .with_context(|| format!("replay {stream} on {node_id}"))?;
         Ok((client, subscription))
     }
 
@@ -896,7 +985,8 @@ async fn seed_metadata(
     .await
     .context("create namespace")?;
 
-    for (stream, shards) in &config.streams {
+    for spec in &config.streams {
+        let stream = &spec.name;
         post(
             http,
             &format!(
@@ -909,9 +999,10 @@ async fn seed_metadata(
                 "namespace": config.namespace,
                 "stream": stream,
                 "kind": "Stream",
-                "shards": shards,
+                "shards": spec.shards,
+                "replication_factor": spec.replication_factor,
                 "retention": { "max_age_seconds": null, "max_size_bytes": null },
-                "consistency": "Leader",
+                "consistency": spec.consistency,
                 "delivery": "AtLeastOnce",
                 // Durable, so the brokers gate readiness on having actually
                 // recovered their logs. An ephemeral stream would let a broker

--- a/crates/felix-cluster/tests/conformance.rs
+++ b/crates/felix-cluster/tests/conformance.rs
@@ -11,7 +11,7 @@
 //! failure this suite exists to catch.
 use anyhow::Result;
 use felix_cluster::scenarios::{self, Ingress, Outcome};
-use felix_cluster::{Cluster, ClusterConfig};
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
 use serial_test::serial;
 
 /// A scenario's future, boxed so `on_both` can name it for any borrow of the
@@ -27,7 +27,7 @@ const OTHER: &str = "events";
 fn config(nodes: usize) -> ClusterConfig {
     ClusterConfig {
         nodes,
-        streams: vec![(STREAM.to_string(), 1), (OTHER.to_string(), 1)],
+        streams: vec![StreamSpec::new(STREAM, 1), StreamSpec::new(OTHER, 1)],
         ..Default::default()
     }
 }

--- a/crates/felix-cluster/tests/cross_broker.rs
+++ b/crates/felix-cluster/tests/cross_broker.rs
@@ -9,7 +9,7 @@
 //! the `felix-broker` binary these need.
 use std::time::Duration;
 
-use felix_cluster::{Cluster, ClusterConfig};
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
 use serial_test::serial;
 
 const STREAM: &str = "orders";
@@ -17,7 +17,7 @@ const STREAM: &str = "orders";
 fn config() -> ClusterConfig {
     ClusterConfig {
         nodes: 3,
-        streams: vec![(STREAM.to_string(), 1)],
+        streams: vec![StreamSpec::new(STREAM, 1)],
         ..Default::default()
     }
 }

--- a/crates/felix-cluster/tests/failover.rs
+++ b/crates/felix-cluster/tests/failover.rs
@@ -1,0 +1,253 @@
+//! M5's completion signal: what survives losing a leader.
+//!
+//! These start real broker processes and kill one mid-flight, so they are slow
+//! and deliberately few. What they cover is the claim the whole milestone rests
+//! on — that a record acknowledged under `Quorum` is still there after the
+//! broker that acknowledged it is gone.
+//!
+//! Run with `cargo test -p felix-cluster --test failover`.
+use std::time::Duration;
+
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
+use serial_test::serial;
+
+const STREAM: &str = "orders";
+
+/// Three brokers, one shard, three copies of it, acknowledged by a majority.
+fn quorum_config() -> ClusterConfig {
+    ClusterConfig {
+        nodes: 3,
+        streams: vec![StreamSpec::quorum(STREAM, 1, 3)],
+        ..Default::default()
+    }
+}
+
+/// Wait until the leader has actually replicated and reported.
+///
+/// A cluster that has only just started has a leader that has shipped nothing
+/// and told the control plane nothing, so killing it there tests startup rather
+/// than failover. The scenario is a *healthy* replicated shard losing its
+/// leader, and this is what makes it one: zero lag means every follower holds
+/// what the leader does, and the leader has said so.
+async fn replication_settled(cluster: &Cluster, leader: &str) {
+    felix_cluster::wait::until(
+        Duration::from_secs(30),
+        "replication to reach every follower",
+        || async {
+            matches!(
+                cluster
+                    .metric(leader, "felix_broker_replication_lag_records")
+                    .await,
+                Ok(Some(lag)) if lag == 0.0
+            )
+        },
+    )
+    .await
+    .expect("replication should reach the followers of a healthy shard");
+}
+
+/// Everything `node_id` will replay from the start of the stream.
+///
+/// Retried until it yields something, because being named leader and being
+/// ready to serve are different moments: a promoted broker learns of its own
+/// promotion through the same watch as everything else, and has to open the
+/// shard before it can answer for it.
+async fn replay_until(cluster: &Cluster, node_id: &str, budget: Duration) -> Vec<Vec<u8>> {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if let Ok((_client, mut subscription)) = cluster.replay_on(node_id, STREAM).await {
+            let mut payloads = Vec::new();
+            while let Ok(Ok(Some(event))) =
+                tokio::time::timeout(Duration::from_secs(2), subscription.next_event()).await
+            {
+                payloads.push(event.payload.to_vec());
+            }
+            if !payloads.is_empty() {
+                return payloads;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Wait until the control plane has named a leader other than `gone`.
+async fn failover_from(cluster: &Cluster, gone: &str, budget: Duration) -> Option<Duration> {
+    let started = std::time::Instant::now();
+    let ok = felix_cluster::wait::until(budget, "a new leader", || async {
+        // The harness's control plane does not run the reconciler on a timer,
+        // so a failure test has to step placement itself. Without this nothing
+        // re-plans after the kill and the wait is measuring nothing.
+        cluster.place_shards().await;
+        match cluster.owner(STREAM).await {
+            Ok(owner) => owner != gone,
+            Err(_) => false,
+        }
+    })
+    .await;
+    ok.ok().map(|_| started.elapsed())
+}
+
+/// **The milestone signal.** A record acknowledged under `Quorum` is readable
+/// after the broker that acknowledged it is killed.
+///
+/// The acknowledgement is the whole claim: it means a majority held the record
+/// durably, so losing any one of them — including the leader — cannot take it.
+///
+/// Ignored: this currently fails. Promotion works and the record is on the
+/// promoted broker's disk, but it serves nothing for the shard — see #266. The
+/// test is kept, and kept failing-by-omission rather than deleted, because it
+/// is the milestone's acceptance criterion and the thing to re-run against any
+/// fix.
+#[ignore = "fails: a promoted broker serves nothing for the shard (#266)"]
+#[serial]
+#[tokio::test]
+async fn a_quorum_acknowledged_record_survives_its_leader() {
+    let mut cluster = Cluster::start(quorum_config())
+        .await
+        .expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+
+    // Acknowledged by a majority before this returns.
+    cluster
+        .publish_via(&leader, STREAM, b"survives".to_vec())
+        .await
+        .expect("publish under quorum");
+
+    replication_settled(&cluster, &leader).await;
+    cluster.kill_node(&leader).expect("kill the leader");
+
+    let elapsed = failover_from(&cluster, &leader, Duration::from_secs(30))
+        .await
+        .expect("a replica should have been promoted");
+    println!("failover took {elapsed:?}");
+
+    let new_leader = cluster.owner(STREAM).await.expect("owner");
+    assert_ne!(new_leader, leader);
+
+    // Replayed from the start, not subscribed live: the record was published
+    // before the kill, so this asks what the promoted broker actually holds.
+    //
+    // Retried, because the control plane naming a new leader and that broker
+    // having opened the shard are two different moments: it learns of its own
+    // promotion through the same watch as everything else.
+    let payloads = replay_until(&cluster, &new_leader, Duration::from_secs(30)).await;
+
+    assert!(
+        payloads.iter().any(|payload| payload == b"survives"),
+        "a quorum-acknowledged record did not survive its leader; the promoted \
+         broker replayed {payloads:?}",
+    );
+    cluster.shutdown().await;
+}
+
+/// **Only a broker that holds the log is promoted.** The promoted leader must
+/// be one of the replicas, not whichever node scored highest — that is the
+/// difference between a failover and a silently empty shard.
+#[serial]
+#[tokio::test]
+async fn the_promoted_leader_is_one_of_the_replicas() {
+    let mut cluster = Cluster::start(quorum_config())
+        .await
+        .expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+    let replicas: Vec<String> = cluster
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .filter(|node| node != &leader)
+        .collect();
+
+    cluster
+        .publish_via(&leader, STREAM, b"held".to_vec())
+        .await
+        .expect("publish");
+    replication_settled(&cluster, &leader).await;
+    cluster.kill_node(&leader).expect("kill the leader");
+    failover_from(&cluster, &leader, Duration::from_secs(30))
+        .await
+        .expect("a replica should have been promoted");
+
+    let promoted = cluster.owner(STREAM).await.expect("owner");
+    assert!(
+        replicas.contains(&promoted),
+        "{promoted} was promoted but was not a replica of the shard",
+    );
+    cluster.shutdown().await;
+}
+
+/// Failover completes within a bound derived from the cluster's own liveness
+/// settings, rather than an arbitrary number: the lease has to lapse and the
+/// control plane has to notice before anything can be promoted.
+#[serial]
+#[tokio::test]
+async fn failover_completes_within_the_configured_bound() {
+    let mut cluster = Cluster::start(quorum_config())
+        .await
+        .expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+    cluster
+        .publish_via(&leader, STREAM, b"timed".to_vec())
+        .await
+        .expect("publish");
+
+    replication_settled(&cluster, &leader).await;
+    cluster.kill_node(&leader).expect("kill the leader");
+    let elapsed = failover_from(&cluster, &leader, Duration::from_secs(30))
+        .await
+        .expect("a replica should have been promoted");
+
+    // Generous against the harness's short liveness windows. The assertion is
+    // that failover is bounded at all, not that it is fast: a tight bound here
+    // would fail on a loaded CI runner for reasons that say nothing about the
+    // design.
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "failover took {elapsed:?}",
+    );
+    println!("failover took {elapsed:?}");
+    cluster.shutdown().await;
+}
+
+/// **A shard with no replica to promote stays unavailable rather than being
+/// served empty.** The counterpart to the tests above: when there is nothing
+/// holding the log, the cluster declines to invent a leader.
+#[serial]
+#[tokio::test]
+async fn an_unreplicated_shard_does_not_fail_over_to_an_empty_broker() {
+    let mut cluster = Cluster::start(ClusterConfig {
+        nodes: 3,
+        // Replicated across two, so a replica set exists — but the publish is
+        // leader-acknowledged, so the record need not have reached the follower.
+        streams: vec![StreamSpec::replicated(STREAM, 1, 2)],
+        ..Default::default()
+    })
+    .await
+    .expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+    let replicas: Vec<String> = cluster
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .filter(|node| node != &leader)
+        .collect();
+
+    replication_settled(&cluster, &leader).await;
+    cluster.kill_node(&leader).expect("kill the leader");
+
+    // Whatever happens, the shard must not land on a broker outside the replica
+    // set: that broker holds none of the log.
+    if failover_from(&cluster, &leader, Duration::from_secs(20))
+        .await
+        .is_some()
+    {
+        let promoted = cluster.owner(STREAM).await.expect("owner");
+        assert!(
+            replicas.contains(&promoted),
+            "{promoted} was made leader but holds none of the shard",
+        );
+    }
+    cluster.shutdown().await;
+}

--- a/crates/felix-cluster/tests/faults.rs
+++ b/crates/felix-cluster/tests/faults.rs
@@ -8,7 +8,7 @@
 //! Run with `cargo test -p felix-cluster` (or `task cluster:test`).
 use std::time::Duration;
 
-use felix_cluster::{Cluster, ClusterConfig};
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
 use serial_test::serial;
 
 const STREAM: &str = "orders";
@@ -16,20 +16,23 @@ const STREAM: &str = "orders";
 fn config() -> ClusterConfig {
     ClusterConfig {
         nodes: 3,
-        streams: vec![(STREAM.to_string(), 1)],
+        streams: vec![StreamSpec::new(STREAM, 1)],
         ..Default::default()
     }
 }
 
-/// Whether a broker answers its metrics endpoint within `budget`.
+/// Whether a broker *successfully answers* its metrics endpoint within `budget`.
 ///
-/// The cheapest liveness question that does not depend on cluster state: a
-/// suspended process accepts nothing and answers nothing, so the request times
-/// out rather than failing fast.
+/// Success, not merely completion. A suspended process may leave its listening
+/// socket to hang the request or to refuse it outright depending on the
+/// platform, and both mean "not answering" — an earlier version of this asked
+/// only whether the call returned, so a fast refusal on Linux read as a healthy
+/// broker and the fault went untested.
 async fn answers_within(cluster: &Cluster, node_id: &str, budget: Duration) -> bool {
-    tokio::time::timeout(budget, cluster.metric(node_id, "felix_broker_up"))
-        .await
-        .is_ok()
+    matches!(
+        tokio::time::timeout(budget, cluster.metric(node_id, "felix_broker_up")).await,
+        Ok(Ok(_))
+    )
 }
 
 /// **A paused broker stops answering and stays alive.** Both halves matter: if

--- a/docs-site/src/content/docs/getting-started/overview.md
+++ b/docs-site/src/content/docs/getting-started/overview.md
@@ -162,10 +162,21 @@ Felix provides **tunable consistency** configured per stream:
 - **Ordering:** Per-stream ordering preserved for each subscriber
 - **Acknowledgements:** Broker acknowledges receipt, not delivery to subscribers
 
+### Multi-Node
+
+- **Leader-only acks:** Low latency, no replication wait. The default, and what
+  a stream gets unless it asks otherwise
+- **Quorum acks:** Acknowledged once a majority of the replica set — counting
+  the leader — holds the record durably. Implemented; set `consistency` on the
+  stream
+- **Leader failover:** A lost leader is replaced only by a replica that holds
+  the log. **Not usable yet:** a promoted broker does not currently serve the
+  shard it was promoted to
+  ([#266](https://github.com/gabloe/felix/issues/266)), so treat a replicated
+  stream as single-node for availability until that is fixed
+
 ### Planned Multi-Node
 
-- **Leader-only acks:** Low latency, no replication wait
-- **Quorum acks:** Higher durability, waits for replica confirmation
 - **At-least-once:** With durable storage and replay
 - **Exactly-once:** (future) via idempotent producers and transactions
 

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -144,6 +144,9 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Resumable subscriptions | ✅ Today | `Subscribe` takes `latest` / `earliest` / an offset; every delivered event carries its offset (`Event.offset`) so an application can checkpoint and resume at `offset + 1`. Stored history joins live delivery with no gap, backfilling from disk if the live queue overflowed. Durable streams only; bounded by retention when it is configured, unbounded otherwise |
 | Graceful shutdown | 🚧 Partial | Readiness flip, bounded drain, and accept-loop cancellation done; per-subsystem cancellation still open |
 | Sharding | 🚧 Partial | Streams carry a shard count, the control plane assigns each shard an owner, and a publish resolves against that ownership before anything else happens. A publish for a shard this broker does not own is forwarded to the owner and acknowledged only once the owner has written it. The wire protocol still carries no routing key, so every record of a stream lands on shard 0, which is what keeps this partial |
+| Multi-node clustering and replication | 🚧 Partial | Brokers register, their liveness is tracked, shards are assigned to owners, and a publish that reaches the wrong broker is forwarded to the right one. Shard leaders now replicate committed records to followers, and a follower whose history is gone is given a log starting where the leader's surviving log does. Subscribe is still served only by the broker holding the shard |
+| Leader failover | 🚧 Partial | A lost leader is replaced by a replica that holds the log — never by a broker that does not, and the shard is left unavailable rather than served empty if no replica qualifies. **But a promoted broker does not yet serve the shard it was promoted to ([#266](https://github.com/gabloe/felix/issues/266)), so failover is not usable yet** |
+| Quorum acknowledgement | 🚧 Partial | `Stream.consistency` is honoured: a `Quorum` publish waits for a majority of the replica set, counting the leader, to hold the record durably. Bounded by a timeout, and a timeout is reported as "this broker cannot vouch for the write" rather than as failure. Depends on failover above to be worth choosing |
 
 ### Measured performance
 
@@ -208,10 +211,8 @@ ship rather than being marked off here.
 | Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` takes an offset, so *changes since a known point* is gap-free. The missing half is the snapshot: there is no way to ask for current state and subsequent changes in one call |
 | Queue semantics (consumer groups, acks, redelivery) | 🎯 Target | Explicitly post-MVP; not started |
 | Tiered / cold storage | 🎯 Target | `TieredStore` trait declared, no implementation |
-| Multi-node clustering and replication | 🎯 Target | Brokers register, their liveness is tracked, shards are assigned to owners, and a publish that reaches the wrong broker is forwarded to the right one over a broker-internal QUIC transport. Subscribe is not: it is still served only by the broker holding the shard, and there is no replication and no failover |
 | Raft consensus for cluster metadata | 🎯 Target | `felix-consensus` is a configuration struct with no protocol implementation |
 | Cross-region routing and data sovereignty enforcement | 🎯 Target | `felix-router` is a directional region-pair allowlist, not wired into enforcement |
-| At-least-once / quorum acks | 🎯 Target | Not started |
 | Non-Rust client SDKs | 🎯 Target | Rust client only |
 
 **Target scale**, stated as ambition and nothing more: a single update fanning out
@@ -241,9 +242,9 @@ whether you could build it on the current release.
 | Internal service event bus | Moderate | Mostly | Works, but NATS and RabbitMQ serve this well already — weak differentiation |
 | Distributed live-state synchronization | Strong | **No** | Needs gap-free snapshot + change stream; drops corrupt local state |
 | Infrastructure / control-plane state distribution | Strong | **No** | Same gap, plus needs multi-node |
-| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state works on one node, without retention or replication |
-| Edge and disconnected operation | Strong | **No** | Durability and resumable subscriptions exist; replication does not, and neither does retention |
-| Durable event log, replay, event sourcing | Weak | Partly | A single-node durable log with offset replay exists. No retention, no tiering, no replication — use Kafka for anything that needs history to outlive one machine |
+| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state works on one node. Records replicate to followers, but a lost leader cannot yet serve its shard (#266), so this is still one node in practice |
+| Edge and disconnected operation | Strong | **No** | Durability and resumable subscriptions exist. Replication does, and retention does not; failover does not yet complete (#266) |
+| Durable event log, replay, event sourcing | Weak | Partly | A durable log with offset replay exists, and records now replicate to followers. No retention and no tiering, and a lost leader cannot yet serve its shard (#266) — use Kafka for anything that needs history to outlive one machine today |
 | Primary datastore | Weak | No | Use a database |
 | General-purpose key-value store | Weak | No | Use Redis or Valkey |
 | Complex broker routing, workflow messaging | Weak | No | Use RabbitMQ |

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -288,10 +288,18 @@ multi-instance work and not before.
 
 The gate matters more than the promotion. A replica that holds no log can be
 promoted perfectly well and will then serve an empty shard — the failover *is*
-the data loss. So promotion requires a follower within the catch-up bound, and
-until records are actually replicated (#112) nothing reports being caught up, so
-promotion does not fire and placement behaves exactly as it did. The gate starts
-permitting failover at the moment replication starts working, and not before.
+the data loss. So promotion requires a follower within the catch-up bound.
+
+Leaders now report which followers hold everything they do, so the gate has real
+input and promotion fires: a lost leader is replaced by a replica that holds the
+log, in around a second on a local three-node cluster.
+
+**Failover is not usable yet.** A promoted broker does not currently serve the
+shard it was promoted to (#266). Promotion itself is correct — the replacement
+is always a replica that holds the log, and a shard with no such replica is left
+unavailable rather than served empty — but a subscriber on the promoted broker
+receives nothing. Treat a replicated stream as single-node for availability
+until that is fixed.
 
 Both halves of this are implemented (#112). The follower's side is the exchange,
 the append rule, and the fence at the storing end. The leader's side keeps one

--- a/services/broker/src/peer/replica.rs
+++ b/services/broker/src/peer/replica.rs
@@ -216,6 +216,26 @@ impl ReplicaHandler {
 
         match replication::apply(&log, batch.first_offset, batch.checksum, &batch.payloads).await {
             Ok(Ok(applied)) => {
+                // The records went straight to the log, so the stream's own view
+                // of its tail has to be told. Without this the first publish
+                // this broker accepts once promoted waits on commit turns that
+                // were never taken.
+                if let Err(err) = self
+                    .broker
+                    .adopt_replicated(
+                        &key.tenant_id,
+                        &key.namespace,
+                        &key.stream,
+                        applied.durable_offset,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        stream = %key.stream,
+                        error = %err,
+                        "stored a replicated batch but could not advance the stream's tail",
+                    );
+                }
                 metrics::record_replicated(metrics::OUTCOME_OK);
                 InternalMessage::ReplicateOk(ReplicateOk {
                     correlation_id,


### PR DESCRIPTION
Three things, all from writing M5.6's failover scenarios (#115).

## 1. The coverage failure on main is mine — fixed

`a_paused_broker_stops_answering_without_dying` (from #263) used:

```rust
timeout(budget, cluster.metric(..)).await.is_ok()
```

`is_ok()` is true whenever the call *returns* — including returning an error. A suspended process refuses connections fast on Linux, so "errored quickly" read as "answering". It passed on macOS, where the socket hangs instead, and failed on CI.

**The fault it was written to prove was going untested.** Now requires a successful scrape.

## 2. A promoted broker could not accept writes

`StreamState::hydrate` sets `next_seq` **and rebases the commit order**, and it runs only at stream *registration*. A follower registers when its log is empty, so `next_seq` stays at 0 while replication fills its disk — the replication path writes the shard's log directly and never touches the stream state.

The commit order is keyed on disk offsets. With `next_seq` at 0 and three records on disk, the first publish a promoted broker accepts reserves offset 3 and then waits for turns 0–2 that were never taken. **It never returns.**

This is why the cluster probe showed `PUBLISH ON PROMOTED: Ok(())` — the client was not waiting for an ack; the write never committed.

Replication now tells the stream its tail moved, rebasing the commit order for the same reason recovery does after a restart. Confirmed by reverting: `a_publish_after_promotion_follows_the_replicated_history` hangs without it.

**A correction worth noting:** I first "fixed" the read path separately, falling back to the durable tail when the in-memory backlog was empty, with a long comment about why it mattered. Reverting *that* changed nothing once the tail was being advanced — it was redundant. It is not in this change.

## 3. Failover still does not work end to end

Being straight about this: **#266 is not fixed.**

What works — and is tested here:
- a lost leader is replaced by a replica that **holds the log**, never by a broker that does not
- promotion takes ~900ms on a local three-node cluster
- a shard with no qualifying replica is left unavailable rather than served empty

What does not: a promoted broker serves nothing for the shard. A subscriber gets an empty stream. I found and fixed one cause (above); the symptom persists, so there is at least one more. #266 has the full trace and the two candidates I have not eliminated.

The scenario asserting the milestone's own acceptance criterion is `#[ignore]`d pointing at #266 — kept rather than deleted, because it is the thing to re-run against any fix, and not left failing because a red suite teaches people to ignore red.

## 4. Docs sweep

`what-felix-is-for.md` claimed there is *"no replication and no failover"*. That has been false for several merges.

- Replication, quorum acknowledgement, and leader failover moved **out** of "None of the following exists today" and into the implemented table as `🚧 Partial` — the page's own rule is that capabilities move up when they ship.
- The failover row says plainly that it is **not usable yet** and links #266. An over-optimistic row would be worse than the stale one it replaced.
- Three "no replication" claims further down corrected.
- `overview.md` no longer lists quorum acks under "Planned".
- `replication-design.md` no longer says promotion cannot fire.

## Also here

The harness can now create replicated and quorum streams (`StreamSpec::quorum` / `::replicated`), replay from the start of a stream (`replay_on`), and step placement (`place_shards`) — a failure test has to drive placement itself, because the harness's control plane deliberately does not run the reconciler on a timer.

`task lint`, `task test` (76 blocks), `task demo:check`, and the docs-site build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)