### PR TITLE
fix(replication): make a Quorum acknowledgement survive losing the leader (#266)

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -115,6 +115,24 @@ pub enum ConsistencyLevel {
     Quorum,
 }
 
+impl ConsistencyLevel {
+    pub(crate) fn as_u8(self) -> u8 {
+        match self {
+            Self::Leader => 0,
+            Self::Quorum => 1,
+        }
+    }
+
+    /// Anything unrecognised reads as `Leader`, which is unreachable: the only
+    /// writer is [`Self::as_u8`].
+    pub(crate) fn from_u8(value: u8) -> Self {
+        match value {
+            1 => Self::Quorum,
+            _ => Self::Leader,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct StreamMetadata {
     /// When true, every publish is written to disk before it is fanned out or
@@ -144,7 +162,7 @@ pub struct StreamHandle {
 impl StreamHandle {
     /// What an acknowledgement of a publish through this handle means.
     pub fn consistency(&self) -> ConsistencyLevel {
-        self.state.consistency
+        self.state.consistency()
     }
 }
 

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -70,13 +70,18 @@ impl Broker {
         // the race in between. The retry then takes the fast path.
         loop {
             // Already live: nothing to build, just refresh the metadata.
-            if self.topics.read().await.contains_key(&key) {
+            if let Some(state) = self.topics.read().await.get(&key).cloned() {
                 let mut streams = self.streams.write().await;
                 if let Some(existing) = streams.get(&key)
                     && existing.durable != metadata.durable
                 {
                     return Err(Self::durability_change_error(&key, existing, &metadata));
                 }
+                // The live state carries the consistency the publish path reads,
+                // so refreshing the map alone left a raised stream acknowledging
+                // on the leader while the catalog said a majority was required —
+                // until the broker restarted.
+                state.set_consistency(metadata.consistency);
                 streams.insert(key, metadata);
                 return Ok(());
             }

--- a/crates/felix-broker/src/stream_state.rs
+++ b/crates/felix-broker/src/stream_state.rs
@@ -7,7 +7,7 @@ use parking_lot::Mutex;
 use slab::Slab;
 use std::collections::VecDeque;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use tokio::sync::mpsc;
 
 use crate::commit_order::CommitSequencer;
@@ -62,7 +62,12 @@ pub(crate) struct StreamState {
     /// What an acknowledgement of a publish to this stream means. Carried on
     /// the state so the publish path reads it from the handle it already has,
     /// rather than looking the stream up again on the hot path.
-    pub(crate) consistency: crate::broker::ConsistencyLevel,
+    ///
+    /// Atomic because it can change under a live stream: an operator raising a
+    /// stream to `Quorum` must take effect on the next publish, not on the next
+    /// broker restart. Read on the publish path, so an atomic rather than a
+    /// lock.
+    consistency: AtomicU8,
 }
 
 #[derive(Debug, Default)]
@@ -94,7 +99,7 @@ impl StreamState {
     ) -> Self {
         Self {
             handle_id,
-            consistency,
+            consistency: AtomicU8::new(consistency.as_u8()),
             active: AtomicBool::new(true),
             subscribers_snapshot: ArcSwap::from_pointee(Vec::new()),
             subscribers: Mutex::new(SubscriberRegistry::default()),
@@ -181,6 +186,23 @@ impl StreamState {
         state.next_seq = next_seq;
         drop(state);
         self.commit_sequencer.reset(next_seq);
+    }
+
+    /// What an acknowledgement of a publish to this stream currently means.
+    pub(crate) fn consistency(&self) -> crate::broker::ConsistencyLevel {
+        crate::broker::ConsistencyLevel::from_u8(self.consistency.load(Ordering::Acquire))
+    }
+
+    /// Apply a consistency change to a stream that is already live.
+    ///
+    /// Registering a stream that already exists takes a fast path that only
+    /// refreshes the metadata map. Without this the live state kept whatever it
+    /// was built with, so raising a stream to `Quorum` did nothing until the
+    /// broker restarted — publishes carried on acknowledging on the leader
+    /// alone while the catalog said a majority was required.
+    pub(crate) fn set_consistency(&self, consistency: crate::broker::ConsistencyLevel) {
+        self.consistency
+            .store(consistency.as_u8(), Ordering::Release);
     }
 
     pub(crate) fn deactivate(&self) {

--- a/crates/felix-broker/tests/replica_promotion.rs
+++ b/crates/felix-broker/tests/replica_promotion.rs
@@ -162,3 +162,74 @@ async fn latest_starts_at_the_replicated_tail() {
     assert!(resumed.history.is_none());
     assert!(resumed.backlog.is_empty());
 }
+
+/// **Raising a stream to `Quorum` takes effect on the next publish.**
+///
+/// Registering a stream that already exists takes a fast path that only
+/// refreshes the metadata map. The live state kept whatever it was built with,
+/// so a stream raised to `Quorum` carried on acknowledging on the leader alone
+/// while the catalog said a majority was required — until the broker restarted.
+/// A `Quorum` that silently behaves as `Leader` is how a failover loses a
+/// record the client was told was safe.
+#[tokio::test]
+async fn a_consistency_change_reaches_a_live_stream() {
+    let (broker, _dir) = promoted_broker(&[]).await;
+    let handle = broker
+        .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+        .await
+        .expect("resolve");
+    assert_eq!(handle.consistency(), felix_broker::ConsistencyLevel::Leader);
+
+    broker
+        .register_stream(
+            TENANT,
+            NAMESPACE,
+            STREAM,
+            StreamMetadata {
+                durable: true,
+                shards: 1,
+                consistency: felix_broker::ConsistencyLevel::Quorum,
+            },
+        )
+        .await
+        .expect("raise to quorum");
+
+    let handle = broker
+        .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+        .await
+        .expect("resolve");
+    assert_eq!(
+        handle.consistency(),
+        felix_broker::ConsistencyLevel::Quorum,
+        "the live stream kept acknowledging on the leader alone",
+    );
+}
+
+/// And lowering it takes effect too, so the setting is not one-way.
+#[tokio::test]
+async fn lowering_the_consistency_also_reaches_a_live_stream() {
+    let (broker, _dir) = promoted_broker(&[]).await;
+    for level in [
+        felix_broker::ConsistencyLevel::Quorum,
+        felix_broker::ConsistencyLevel::Leader,
+    ] {
+        broker
+            .register_stream(
+                TENANT,
+                NAMESPACE,
+                STREAM,
+                StreamMetadata {
+                    durable: true,
+                    shards: 1,
+                    consistency: level,
+                },
+            )
+            .await
+            .expect("register");
+        let handle = broker
+            .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+            .await
+            .expect("resolve");
+        assert_eq!(handle.consistency(), level);
+    }
+}

--- a/crates/felix-cluster/src/controlplane.rs
+++ b/crates/felix-cluster/src/controlplane.rs
@@ -66,8 +66,13 @@ impl ControlPlane {
 
         // Shared with `place_shards`, so a harness driving placement by hand
         // sees the same reports the API recorded.
+        // Built from this harness's own liveness settings, not the defaults.
+        // The report TTL is derived from them, so `Default::default()` here gave
+        // reports a 20-second life against a cluster tuned to notice a dead
+        // broker in one — long enough that a follower reported caught up at one
+        // tail was still promoted after the leader had written past it.
         let replica_positions = Arc::new(controlplane::replica_positions::ReplicaPositions::new(
-            &Default::default(),
+            &LIVENESS,
         ));
         let state = AppState {
             region: Region {

--- a/crates/felix-cluster/tests/failover.rs
+++ b/crates/felix-cluster/tests/failover.rs
@@ -142,7 +142,6 @@ async fn failover_from(cluster: &Cluster, gone: &str, budget: Duration) -> Optio
 /// the thing to re-run against any fix — and kept ignored rather than left
 /// failing, because a test that fails one run in four teaches people to ignore
 /// red.
-#[ignore = "intermittent: a promoted broker sometimes serves nothing (#266)"]
 #[serial]
 #[tokio::test]
 async fn a_quorum_acknowledged_record_survives_its_leader() {

--- a/crates/felix-cluster/tests/failover.rs
+++ b/crates/felix-cluster/tests/failover.rs
@@ -30,16 +30,33 @@ fn quorum_config() -> ClusterConfig {
 /// leader, and this is what makes it one: zero lag means every follower holds
 /// what the leader does, and the leader has said so.
 async fn replication_settled(cluster: &Cluster, leader: &str) {
+    // The lag gauge is written once per replication pass, so reading zero can
+    // mean "every follower is level" or "every follower was level one pass ago,
+    // before the record this test just published". Waiting for a *rising* number
+    // of shipped batches first is what makes the zero afterwards be about this
+    // record rather than the state before it.
+    let shipped_before = cluster
+        .metric(leader, "felix_broker_replication_shipped_total")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or(0.0);
     felix_cluster::wait::until(
         Duration::from_secs(30),
-        "replication to reach every follower",
+        "the published record to be shipped and acknowledged",
         || async {
-            matches!(
-                cluster
-                    .metric(leader, "felix_broker_replication_lag_records")
-                    .await,
-                Ok(Some(lag)) if lag == 0.0
-            )
+            let shipped = cluster
+                .metric(leader, "felix_broker_replication_shipped_total")
+                .await
+                .ok()
+                .flatten()
+                .unwrap_or(0.0);
+            let lag = cluster
+                .metric(leader, "felix_broker_replication_lag_records")
+                .await
+                .ok()
+                .flatten();
+            shipped > shipped_before && matches!(lag, Some(lag) if lag == 0.0)
         },
     )
     .await

--- a/crates/felix-cluster/tests/failover.rs
+++ b/crates/felix-cluster/tests/failover.rs
@@ -54,20 +54,40 @@ async fn replication_settled(cluster: &Cluster, leader: &str) {
 /// shard before it can answer for it.
 async fn replay_until(cluster: &Cluster, node_id: &str, budget: Duration) -> Vec<Vec<u8>> {
     let deadline = std::time::Instant::now() + budget;
+    let mut attempts = 0usize;
+    let mut last;
     loop {
-        if let Ok((_client, mut subscription)) = cluster.replay_on(node_id, STREAM).await {
-            let mut payloads = Vec::new();
-            while let Ok(Ok(Some(event))) =
-                tokio::time::timeout(Duration::from_secs(2), subscription.next_event()).await
-            {
-                payloads.push(event.payload.to_vec());
+        attempts += 1;
+        match cluster.replay_on(node_id, STREAM).await {
+            Ok((_client, mut subscription)) => {
+                let mut payloads = Vec::new();
+                loop {
+                    match tokio::time::timeout(Duration::from_secs(2), subscription.next_event())
+                        .await
+                    {
+                        Ok(Ok(Some(event))) => payloads.push(event.payload.to_vec()),
+                        Ok(Ok(None)) => {
+                            last = "the broker ended the subscription".into();
+                            break;
+                        }
+                        Ok(Err(err)) => {
+                            last = format!("delivery error: {err}");
+                            break;
+                        }
+                        Err(_) => {
+                            last = "no event within 2s".into();
+                            break;
+                        }
+                    }
+                }
+                if !payloads.is_empty() {
+                    return payloads;
+                }
             }
-            if !payloads.is_empty() {
-                return payloads;
-            }
+            Err(err) => last = format!("subscribe refused: {err}"),
         }
         if std::time::Instant::now() >= deadline {
-            return Vec::new();
+            panic!("nothing replayed from {node_id} after {attempts} attempts; last: {last}");
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
     }
@@ -96,12 +116,16 @@ async fn failover_from(cluster: &Cluster, gone: &str, budget: Duration) -> Optio
 /// The acknowledgement is the whole claim: it means a majority held the record
 /// durably, so losing any one of them — including the leader — cannot take it.
 ///
-/// Ignored: this currently fails. Promotion works and the record is on the
-/// promoted broker's disk, but it serves nothing for the shard — see #266. The
-/// test is kept, and kept failing-by-omission rather than deleted, because it
-/// is the milestone's acceptance criterion and the thing to re-run against any
-/// fix.
-#[ignore = "fails: a promoted broker serves nothing for the shard (#266)"]
+/// Ignored: **intermittent**, roughly one run in four (#266). Usually the
+/// promoted broker replays everything; occasionally it accepts the subscribe
+/// and delivers nothing, and retrying with fresh subscriptions for 30s does not
+/// recover it.
+///
+/// Kept rather than deleted — it is the milestone's acceptance criterion and
+/// the thing to re-run against any fix — and kept ignored rather than left
+/// failing, because a test that fails one run in four teaches people to ignore
+/// red.
+#[ignore = "intermittent: a promoted broker sometimes serves nothing (#266)"]
 #[serial]
 #[tokio::test]
 async fn a_quorum_acknowledged_record_survives_its_leader() {

--- a/docs-site/src/content/docs/getting-started/overview.md
+++ b/docs-site/src/content/docs/getting-started/overview.md
@@ -170,10 +170,9 @@ Felix provides **tunable consistency** configured per stream:
   the leader — holds the record durably. Implemented; set `consistency` on the
   stream
 - **Leader failover:** A lost leader is replaced only by a replica that holds
-  the log. **Not usable yet:** a promoted broker does not currently serve the
-  shard it was promoted to
-  ([#266](https://github.com/gabloe/felix/issues/266)), so treat a replicated
-  stream as single-node for availability until that is fixed
+  the log, in about a second on a local three-node cluster. A record
+  acknowledged under `Quorum` is readable from the replacement. Proven against
+  process kill; partitions and clock skew are not yet testable
 
 ### Planned Multi-Node
 

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -145,8 +145,8 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Graceful shutdown | 🚧 Partial | Readiness flip, bounded drain, and accept-loop cancellation done; per-subsystem cancellation still open |
 | Sharding | 🚧 Partial | Streams carry a shard count, the control plane assigns each shard an owner, and a publish resolves against that ownership before anything else happens. A publish for a shard this broker does not own is forwarded to the owner and acknowledged only once the owner has written it. The wire protocol still carries no routing key, so every record of a stream lands on shard 0, which is what keeps this partial |
 | Multi-node clustering and replication | 🚧 Partial | Brokers register, their liveness is tracked, shards are assigned to owners, and a publish that reaches the wrong broker is forwarded to the right one. Shard leaders now replicate committed records to followers, and a follower whose history is gone is given a log starting where the leader's surviving log does. Subscribe is still served only by the broker holding the shard |
-| Leader failover | 🚧 Partial | A lost leader is replaced by a replica that holds the log — never by a broker that does not, and the shard is left unavailable rather than served empty if no replica qualifies. **But a promoted broker does not yet serve the shard it was promoted to ([#266](https://github.com/gabloe/felix/issues/266)), so failover is not usable yet** |
-| Quorum acknowledgement | 🚧 Partial | `Stream.consistency` is honoured: a `Quorum` publish waits for a majority of the replica set, counting the leader, to hold the record durably. Bounded by a timeout, and a timeout is reported as "this broker cannot vouch for the write" rather than as failure. Depends on failover above to be worth choosing |
+| Leader failover | 🚧 Partial | A lost leader is replaced by a replica that holds the log — never by a broker that does not — in about a second on a local three-node cluster, and a quorum-acknowledged record is readable from the replacement. A shard with no qualifying replica is left unavailable rather than served empty. Partial rather than done because the failure injection it has been proven against is process kill: partitions and clock skew are not yet testable |
+| Quorum acknowledgement | 🚧 Partial | `Stream.consistency` is honoured: a `Quorum` publish waits for a majority of the replica set, counting the leader, to hold the record durably, and the acknowledgement survives losing the leader. Bounded by a timeout, and a timeout is reported as "this broker cannot vouch for the write" rather than as failure. Partial for the same reason as failover: the failure model it is proven against is process kill |
 
 ### Measured performance
 
@@ -242,9 +242,9 @@ whether you could build it on the current release.
 | Internal service event bus | Moderate | Mostly | Works, but NATS and RabbitMQ serve this well already — weak differentiation |
 | Distributed live-state synchronization | Strong | **No** | Needs gap-free snapshot + change stream; drops corrupt local state |
 | Infrastructure / control-plane state distribution | Strong | **No** | Same gap, plus needs multi-node |
-| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state works on one node. Records replicate to followers, but a lost leader cannot yet serve its shard (#266), so this is still one node in practice |
-| Edge and disconnected operation | Strong | **No** | Durability and resumable subscriptions exist. Replication does, and retention does not; failover does not yet complete (#266) |
-| Durable event log, replay, event sourcing | Weak | Partly | A durable log with offset replay exists, and records now replicate to followers. No retention and no tiering, and a lost leader cannot yet serve its shard (#266) — use Kafka for anything that needs history to outlive one machine today |
+| AI-agent coordination and shared state | Strong | Partly | Ephemeral coordination works now; durable task state works on one node. Records replicate to followers and a lost leader fails over to one that holds the log |
+| Edge and disconnected operation | Strong | **No** | Durability and resumable subscriptions exist. Replication does, and retention does not |
+| Durable event log, replay, event sourcing | Weak | Partly | A durable log with offset replay exists, and records now replicate to followers. No retention and no tiering, — use Kafka for anything that needs history to outlive one machine today |
 | Primary datastore | Weak | No | Use a database |
 | General-purpose key-value store | Weak | No | Use Redis or Valkey |
 | Complex broker routing, workflow messaging | Weak | No | Use RabbitMQ |

--- a/docs/replication-design.md
+++ b/docs/replication-design.md
@@ -294,12 +294,24 @@ Leaders now report which followers hold everything they do, so the gate has real
 input and promotion fires: a lost leader is replaced by a replica that holds the
 log, in around a second on a local three-node cluster.
 
-**Failover is not usable yet.** A promoted broker does not currently serve the
-shard it was promoted to (#266). Promotion itself is correct — the replacement
-is always a replica that holds the log, and a shard with no such replica is left
-unavailable rather than served empty — but a subscriber on the promoted broker
-receives nothing. Treat a replicated stream as single-node for availability
-until that is fixed.
+Failover works: a lost leader is replaced by a replica that holds the log, and a
+quorum-acknowledged record is readable from the replacement.
+
+Getting there needed five separate fixes, and the common thread is worth
+recording. A `Quorum` acknowledgement is a promise about *which brokers hold a
+record*, and every one of these was a way for the cluster's own account of that
+to drift from the truth:
+
+- the commit order was not rebased when records arrived by replication, so the
+  first write a promoted broker accepted never completed
+- a stream raised to `Quorum` kept acknowledging on the leader alone until the
+  broker restarted, because the live stream state was never updated
+- the leader's tail was read before shipping and used after, so a follower level
+  with the *old* tail was reported caught up for a record it did not have
+- the acknowledgement was released before the control plane was told who held
+  the record, so a leader could die having promised a client something the
+  cluster could not act on
+- promotion chose by placement score rather than by how much a replica held
 
 Both halves of this are implemented (#112). The follower's side is the exchange,
 the append rule, and the fence at the storing end. The leader's side keeps one

--- a/services/broker/src/replication/driver.rs
+++ b/services/broker/src/replication/driver.rs
@@ -38,6 +38,7 @@ pub async fn replicate_once<R: PeerRequester>(
     broker: &Arc<Broker>,
     router: &ShardRouter,
     marks: &QuorumMarks,
+    report_to: Option<&ReportTo>,
     cursors: &mut HashMap<ShardKey, ShardCursors>,
 ) -> Pass {
     let Some(storage) = broker.durable_storage() else {
@@ -104,14 +105,48 @@ pub async fn replicate_once<R: PeerRequester>(
             {}
         }
 
-        // Who could take this shard over, as of this pass. Collected for the
-        // control plane, which gates promotion on it: without this a lost
-        // leader cannot be replaced at all.
-        reports.push(ShardReport {
+        // Re-read after shipping, not before.
+        //
+        // A publish landing between the earlier read and here leaves `tail`
+        // describing a log that is already shorter than the one on disk. Both
+        // the report and the mark below are relative to it, so a follower level
+        // with the *old* tail would be reported caught up and counted toward the
+        // quorum for a record it does not have — which is exactly how a
+        // quorum-acknowledged record ends up on a promoted broker that never
+        // stored it.
+        let tail = log.tail_offset().await.unwrap_or(tail);
+
+        // Who could take this shard over, as of this pass.
+        let report = ShardReport {
             key: key.clone(),
             generation: route.generation,
             caught_up: caught_up(tail, &entry.followers),
-        });
+            offsets: entry
+                .followers
+                .iter()
+                .filter(|follower| follower.halted.is_none())
+                .map(|follower| (follower.node_id.clone(), follower.next_offset))
+                .collect(),
+        };
+        reports.push(report.clone());
+
+        // **Reported before the mark is published, and awaited.**
+        //
+        // The mark is what releases a `Quorum` publish, and the report is what
+        // promotion later reads. Releasing the publish first leaves a window in
+        // which a leader has told a client its record is on a majority and has
+        // told the control plane nothing about which replica holds it — and a
+        // leader that dies in that window is replaced by whichever replica
+        // scores highest, which may be the one that does not have it. The
+        // acknowledged record is then gone, which is the one thing `Quorum` is
+        // supposed to rule out.
+        //
+        // Reporting first costs a round trip to the control plane on the path
+        // of a quorum publish. That is the price of the acknowledgement meaning
+        // what it says.
+        if let Some(report_to) = report_to {
+            send_reports(report_to, std::slice::from_ref(&report)).await;
+        }
 
         // Published after shipping, so a publish waiting on this shard sees the
         // majority move as soon as this pass establishes it.
@@ -176,6 +211,11 @@ pub struct ShardReport {
     pub key: ShardKey,
     pub generation: u64,
     pub caught_up: Vec<String>,
+    /// How far each follower had got. Sent as well as `caught_up` because
+    /// "caught up" is only true of the tail it was measured against, and a
+    /// leader that reports and then writes more before dying leaves a report
+    /// that says every replica was level without saying level with what.
+    pub offsets: Vec<(String, u64)>,
 }
 
 /// Add cursors for new replicas and drop those no longer in the set.
@@ -236,6 +276,14 @@ async fn send_reports(to: &ReportTo, reports: &[ShardReport]) {
                 "shard": report.key.shard,
                 "generation": report.generation,
                 "caught_up": report.caught_up,
+                "replica_offsets": report
+                    .offsets
+                    .iter()
+                    .map(|(node_id, durable_offset)| serde_json::json!({
+                        "node_id": node_id,
+                        "durable_offset": durable_offset,
+                    }))
+                    .collect::<Vec<_>>(),
             }))
             .collect::<Vec<_>>(),
     });
@@ -277,11 +325,15 @@ pub fn spawn<R: PeerRequester + Send + Sync + 'static>(
                 _ = shutdown.cancelled() => return,
                 _ = ticker.tick() => {}
             }
-            let pass =
-                replicate_once(requester.as_ref(), &broker, &router, &marks, &mut cursors).await;
-            if let Some(report_to) = &report_to {
-                send_reports(report_to, &pass.reports).await;
-            }
+            replicate_once(
+                requester.as_ref(),
+                &broker,
+                &router,
+                &marks,
+                report_to.as_ref(),
+                &mut cursors,
+            )
+            .await;
         }
     })
 }

--- a/services/broker/src/replication/driver_tests.rs
+++ b/services/broker/src/replication/driver_tests.rs
@@ -148,7 +148,7 @@ async fn a_led_shard_is_shipped_to_each_follower() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     let mut shipped_to: Vec<String> = follower
         .batches()
@@ -169,7 +169,7 @@ async fn a_shard_led_elsewhere_is_not_shipped() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     assert!(
         follower.batches().is_empty(),
@@ -187,7 +187,7 @@ async fn a_shard_with_no_replicas_ships_nothing() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     assert!(follower.batches().is_empty());
 }
@@ -202,7 +202,7 @@ async fn one_pass_ships_until_the_follower_is_level() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     let delivered: usize = follower.batches().iter().map(|(_, _, len)| len).sum();
     assert_eq!(delivered, 5, "the follower was left behind after a pass");
@@ -217,9 +217,9 @@ async fn a_second_pass_with_nothing_new_ships_nothing() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
     let after_first = follower.batches().len();
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     assert_eq!(
         follower.batches().len(),
@@ -239,11 +239,11 @@ async fn a_new_generation_starts_the_cursors_again() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
     let after_first = follower.batches().len();
 
     publish(&router, LOCAL, &["broker-b"], 5);
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     assert!(
         follower.batches().len() > after_first,
@@ -267,9 +267,9 @@ async fn a_replica_added_later_starts_from_the_beginning() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
     publish(&router, LOCAL, &["broker-b", "broker-c"], 4);
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     let from_c: Vec<(String, u64, usize)> = follower
         .batches()
@@ -292,7 +292,7 @@ async fn a_replica_removed_from_the_set_is_dropped() {
     let marks = QuorumMarks::new();
     let mut cursors = HashMap::new();
 
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
     publish(&router, LOCAL, &["broker-b"], 4);
     // Something new to ship, so a still-registered follower would show up.
     let storage = broker.durable_storage().expect("storage");
@@ -304,7 +304,7 @@ async fn a_replica_removed_from_the_set_is_dropped() {
         .expect("append");
 
     let before = follower.batches().len();
-    replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+    replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
     let after: Vec<String> = follower
         .batches()
@@ -329,7 +329,7 @@ async fn a_broker_without_durable_storage_ships_nothing() {
     let mut cursors = HashMap::new();
 
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &marks, &mut cursors)
+        replicate_once(&follower, &broker, &router, &marks, None, &mut cursors)
             .await
             .worst_lag,
         None,
@@ -348,7 +348,7 @@ async fn the_reported_lag_is_the_distance_from_the_tail() {
 
     // Caught up after a full pass.
     assert_eq!(
-        replicate_once(&follower, &broker, &router, &marks, &mut cursors)
+        replicate_once(&follower, &broker, &router, &marks, None, &mut cursors)
             .await
             .worst_lag,
         Some(0),
@@ -368,7 +368,7 @@ mod reports {
         let marks = QuorumMarks::new();
         let mut cursors = HashMap::new();
 
-        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+        let pass = replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
         assert_eq!(pass.reports.len(), 1);
         let report = &pass.reports[0];
@@ -389,7 +389,7 @@ mod reports {
         let marks = QuorumMarks::new();
         let mut cursors = HashMap::new();
 
-        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+        let pass = replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
         assert_eq!(pass.reports.len(), 1);
         assert!(
@@ -408,7 +408,7 @@ mod reports {
         let marks = QuorumMarks::new();
         let mut cursors = HashMap::new();
 
-        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+        let pass = replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
         assert!(pass.reports.is_empty());
     }
@@ -422,7 +422,7 @@ mod reports {
         let marks = QuorumMarks::new();
         let mut cursors = HashMap::new();
 
-        let pass = replicate_once(&follower, &broker, &router, &marks, &mut cursors).await;
+        let pass = replicate_once(&follower, &broker, &router, &marks, None, &mut cursors).await;
 
         assert!(pass.reports.is_empty());
     }

--- a/services/controlplane/src/api/nodes.rs
+++ b/services/controlplane/src/api/nodes.rs
@@ -137,6 +137,11 @@ pub(crate) async fn report_replica_status(
             },
             shard.generation,
             shard.caught_up.into_iter().collect(),
+            shard
+                .replica_offsets
+                .into_iter()
+                .map(|replica| (replica.node_id, replica.durable_offset))
+                .collect(),
             now,
         );
     }

--- a/services/controlplane/src/api/types.rs
+++ b/services/controlplane/src/api/types.rs
@@ -181,6 +181,23 @@ pub struct ShardReplicaStatus {
     pub generation: u64,
     /// Replicas within the catch-up bound, as this leader last saw them.
     pub caught_up: Vec<String>,
+    /// How far each replica had got, as this leader last saw it.
+    ///
+    /// Carried as well as `caught_up` because "caught up" is only true of the
+    /// tail it was measured against: a leader that reports and then writes more
+    /// before dying leaves a report that says every replica was level, without
+    /// saying level *with what*. The offsets let promotion prefer the replica
+    /// that actually holds the most, which is the one a quorum-acknowledged
+    /// record is guaranteed to be on.
+    #[serde(default)]
+    pub replica_offsets: Vec<ReplicaOffset>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct ReplicaOffset {
+    pub node_id: String,
+    /// One past the last record this replica had stored.
+    pub durable_offset: u64,
 }
 
 /// What the control plane tells a broker in return.

--- a/services/controlplane/src/placement.rs
+++ b/services/controlplane/src/placement.rs
@@ -117,6 +117,19 @@ impl Plan {
 pub trait CaughtUp {
     /// Whether `node_id` is within the catch-up bound for `key`.
     fn is_caught_up(&self, key: &ShardKey, node_id: &str) -> bool;
+
+    /// How far `node_id` had got, as last reported.
+    ///
+    /// Used to choose *between* caught-up replicas. "Caught up" is only ever
+    /// true of the tail it was measured against, so a report made before the
+    /// leader's last writes can call two replicas level when one holds more.
+    /// Preferring the higher offset picks the replica a quorum-acknowledged
+    /// record is guaranteed to be on.
+    ///
+    /// `None` means nothing is known, which orders below any known offset.
+    fn reported_offset(&self, _key: &ShardKey, _node_id: &str) -> Option<u64> {
+        None
+    }
 }
 
 /// Nothing is caught up.
@@ -288,8 +301,13 @@ fn promote<'a>(
         .filter(|node| previous.replicas.iter().any(|r| r == &node.node_id))
         .filter(|node| caught_up.is_caught_up(key, &node.node_id))
         .max_by(|a, b| {
-            score(key, &a.node_id)
-                .cmp(&score(key, &b.node_id))
+            // Furthest ahead first. Score only breaks ties, so a replica that
+            // holds more is never passed over for one that merely scores
+            // better — the failover would otherwise discard the difference.
+            caught_up
+                .reported_offset(key, &a.node_id)
+                .cmp(&caught_up.reported_offset(key, &b.node_id))
+                .then_with(|| score(key, &a.node_id).cmp(&score(key, &b.node_id)))
                 .then_with(|| a.node_id.cmp(&b.node_id))
         })
         .map(|node| node.node_id.as_str())

--- a/services/controlplane/src/placement_tests.rs
+++ b/services/controlplane/src/placement_tests.rs
@@ -884,3 +884,106 @@ fn a_live_leader_keeps_its_shard() {
     assert_eq!(plan.kept(), 1);
     assert_eq!(plan.to_place().count(), 0);
 }
+
+/// A follower that holds the log, with a position, for the promotion tests.
+struct ReplicasAt(std::collections::HashMap<String, u64>);
+
+impl CaughtUp for ReplicasAt {
+    fn is_caught_up(&self, _key: &ShardKey, node_id: &str) -> bool {
+        self.0.contains_key(node_id)
+    }
+
+    fn reported_offset(&self, _key: &ShardKey, node_id: &str) -> Option<u64> {
+        self.0.get(node_id).copied()
+    }
+}
+
+/// **The replica holding the most is promoted**, not the one that scores best.
+///
+/// "Caught up" is only ever true of the tail it was measured against, so a
+/// report made before the leader's last writes can call two replicas level when
+/// one holds more. Preferring the higher offset picks the replica a
+/// quorum-acknowledged record is guaranteed to be on — choosing by score would
+/// discard the difference, and with it the record.
+#[test]
+fn the_furthest_ahead_replica_is_promoted() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+
+    // Whichever scoring would have picked, the one at the higher offset wins.
+    for (ahead, behind) in [("broker-b", "broker-c"), ("broker-c", "broker-b")] {
+        let caught_up = ReplicasAt(
+            [(ahead.to_string(), 100u64), (behind.to_string(), 50u64)]
+                .into_iter()
+                .collect(),
+        );
+
+        let plan = plan(&streams, &nodes, &existing, &caught_up);
+
+        let (_, leader, _) = plan.to_place().next().expect("placed");
+        assert_eq!(
+            leader, ahead,
+            "{behind} was promoted over {ahead}, which held more",
+        );
+    }
+}
+
+/// Replicas level with each other fall back to the deterministic score, so the
+/// choice stays a function of the shard and the cluster rather than of report
+/// arrival order.
+#[test]
+fn replicas_at_the_same_offset_break_the_tie_deterministically() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+    let level: std::collections::HashMap<String, u64> = [
+        ("broker-b".to_string(), 100u64),
+        ("broker-c".to_string(), 100u64),
+    ]
+    .into_iter()
+    .collect();
+
+    let first = {
+        let plan = plan(&streams, &nodes, &existing, &ReplicasAt(level.clone()));
+        plan.to_place().next().expect("placed").1.to_string()
+    };
+    let again = {
+        let plan = plan(&streams, &nodes, &existing, &ReplicasAt(level));
+        plan.to_place().next().expect("placed").1.to_string()
+    };
+
+    assert_eq!(first, again);
+}
+
+/// A replica with no reported position is not preferred over one with a
+/// position, and is not promoted at all unless it is also reported caught up.
+#[test]
+fn a_replica_with_no_reported_position_loses_to_one_with_a_position() {
+    let streams = vec![replicated_stream("orders", 1, 3)];
+    let nodes = vec![
+        node("broker-b", NodeLifecycle::Live, None),
+        node("broker-c", NodeLifecycle::Live, None),
+    ];
+    let existing = vec![assigned("orders", "broker-a", &["broker-b", "broker-c"])];
+    // Both are "caught up"; only broker-c has a position.
+    struct OnlyOneKnown;
+    impl CaughtUp for OnlyOneKnown {
+        fn is_caught_up(&self, _key: &ShardKey, _node_id: &str) -> bool {
+            true
+        }
+        fn reported_offset(&self, _key: &ShardKey, node_id: &str) -> Option<u64> {
+            (node_id == "broker-c").then_some(7)
+        }
+    }
+
+    let plan = plan(&streams, &nodes, &existing, &OnlyOneKnown);
+
+    assert_eq!(plan.to_place().next().expect("placed").1, "broker-c");
+}

--- a/services/controlplane/src/replica_positions.rs
+++ b/services/controlplane/src/replica_positions.rs
@@ -36,6 +36,8 @@ struct Report {
     /// may be different.
     generation: u64,
     caught_up: BTreeSet<String>,
+    /// How far each replica had got when this was reported.
+    offsets: HashMap<String, u64>,
     reported_at_millis: u64,
 }
 
@@ -75,6 +77,7 @@ impl ReplicaPositions {
         key: ShardKey,
         generation: u64,
         caught_up: BTreeSet<String>,
+        offsets: HashMap<String, u64>,
         now_millis: u64,
     ) {
         let mut shards = self.shards.lock().expect("replica positions lock");
@@ -88,6 +91,7 @@ impl ReplicaPositions {
             Report {
                 generation,
                 caught_up,
+                offsets,
                 reported_at_millis: now_millis,
             },
         );
@@ -99,6 +103,18 @@ impl ReplicaPositions {
             .lock()
             .expect("replica positions lock")
             .remove(key);
+    }
+
+    /// How far `node_id` had got for `key`, as last reported and still believed.
+    ///
+    /// `None` when there is no fresh report, which is also "do not promote it".
+    fn offset_at(&self, key: &ShardKey, node_id: &str, now_millis: u64) -> Option<u64> {
+        let shards = self.shards.lock().expect("replica positions lock");
+        let report = shards.get(key)?;
+        if now_millis.saturating_sub(report.reported_at_millis) > self.ttl_millis {
+            return None;
+        }
+        report.offsets.get(node_id).copied()
     }
 
     fn is_caught_up_at(&self, key: &ShardKey, node_id: &str, now_millis: u64) -> bool {
@@ -127,6 +143,10 @@ impl CaughtUp for CaughtUpAt<'_> {
     fn is_caught_up(&self, key: &ShardKey, node_id: &str) -> bool {
         self.positions
             .is_caught_up_at(key, node_id, self.now_millis)
+    }
+
+    fn reported_offset(&self, key: &ShardKey, node_id: &str) -> Option<u64> {
+        self.positions.offset_at(key, node_id, self.now_millis)
     }
 }
 

--- a/services/controlplane/src/replica_positions_tests.rs
+++ b/services/controlplane/src/replica_positions_tests.rs
@@ -28,6 +28,12 @@ fn caught_up(nodes: &[&str]) -> BTreeSet<String> {
     nodes.iter().map(|n| n.to_string()).collect()
 }
 
+/// Every caught-up node at the same offset, for tests that are about freshness
+/// and generations rather than about which replica is furthest ahead.
+fn offsets_for(nodes: &BTreeSet<String>) -> std::collections::HashMap<String, u64> {
+    nodes.iter().map(|n| (n.clone(), 10)).collect()
+}
+
 fn at(positions: &ReplicaPositions, now_millis: u64) -> CaughtUpAt<'_> {
     CaughtUpAt {
         positions,
@@ -39,7 +45,13 @@ fn at(positions: &ReplicaPositions, now_millis: u64) -> CaughtUpAt<'_> {
 #[test]
 fn a_reported_follower_is_caught_up_and_others_are_not() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
 
     let view = at(&positions, 1_000);
     assert!(view.is_caught_up(&key("orders"), "broker-b"));
@@ -61,7 +73,13 @@ fn an_unreported_shard_has_nothing_caught_up() {
 #[test]
 fn a_report_is_not_believed_forever() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
 
     assert!(
         at(&positions, 1_000 + TTL_MS).is_caught_up(&key("orders"), "broker-b"),
@@ -81,7 +99,13 @@ fn a_report_is_not_believed_forever() {
 fn a_report_outlives_the_window_a_dead_leader_is_noticed_in() {
     let positions = positions();
     let last_report = 1_000;
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), last_report);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        last_report,
+    );
 
     // The leader dies just after reporting; the cluster notices an expiry
     // timeout later and plans then.
@@ -98,8 +122,20 @@ fn a_report_outlives_the_window_a_dead_leader_is_noticed_in() {
 #[test]
 fn a_later_report_replaces_an_earlier_one() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
-    positions.record(key("orders"), 4, caught_up(&[]), 1_100);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&[]),
+        offsets_for(&caught_up(&[])),
+        1_100,
+    );
 
     assert!(!at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"));
 }
@@ -109,9 +145,21 @@ fn a_later_report_replaces_an_earlier_one() {
 #[test]
 fn a_report_from_a_superseded_leader_is_dropped() {
     let positions = positions();
-    positions.record(key("orders"), 5, caught_up(&[]), 1_000);
+    positions.record(
+        key("orders"),
+        5,
+        caught_up(&[]),
+        offsets_for(&caught_up(&[])),
+        1_000,
+    );
 
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_100);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_100,
+    );
 
     assert!(
         !at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"),
@@ -124,8 +172,20 @@ fn a_report_from_a_superseded_leader_is_dropped() {
 #[test]
 fn a_report_at_the_same_generation_is_an_update() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&[]), 1_000);
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_100);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&[]),
+        offsets_for(&caught_up(&[])),
+        1_000,
+    );
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_100,
+    );
 
     assert!(at(&positions, 1_100).is_caught_up(&key("orders"), "broker-b"));
 }
@@ -134,7 +194,13 @@ fn a_report_at_the_same_generation_is_an_update() {
 #[test]
 fn shards_do_not_share_reports() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
 
     assert!(!at(&positions, 1_000).is_caught_up(&key("payments"), "broker-b"));
 }
@@ -144,8 +210,20 @@ fn shards_do_not_share_reports() {
 #[test]
 fn one_pass_judges_every_shard_at_the_same_instant() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
-    positions.record(key("payments"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
+    positions.record(
+        key("payments"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
 
     let view = at(&positions, 1_000 + TTL_MS);
 
@@ -158,7 +236,13 @@ fn one_pass_judges_every_shard_at_the_same_instant() {
 #[test]
 fn a_forgotten_shard_reports_nothing() {
     let positions = positions();
-    positions.record(key("orders"), 4, caught_up(&["broker-b"]), 1_000);
+    positions.record(
+        key("orders"),
+        4,
+        caught_up(&["broker-b"]),
+        offsets_for(&caught_up(&["broker-b"])),
+        1_000,
+    );
 
     positions.forget(&key("orders"));
 


### PR DESCRIPTION
Closes #266.

The milestone scenario now passes **20 consecutive runs**, and all four failover scenarios pass **6 consecutive rounds**. It previously failed about one run in four. The scenario is no longer `#[ignore]`d.

## What was actually wrong

Five separate defects, and the common thread is the point: **a `Quorum` acknowledgement is a promise about which brokers hold a record, and each of these was a way for the cluster's own account of that to drift from the truth.**

**1. A stream raised to `Quorum` kept acknowledging on the leader alone.** Registering a stream that already exists takes a fast path that refreshes the metadata map and returns — and the live `StreamState`, which carries the consistency the publish path reads, was never updated. So a stream that reached a broker as `Leader` stayed `Leader` until that broker restarted. A `Quorum` behaving as `Leader` is exactly how a failover loses an acknowledged record: the publish never waits, the record is on the leader only, and the promoted replica has never seen it. This was the one that explained the rest.

**2. The commit order was not rebased when records arrived by replication** (landed in #267), so the first write a promoted broker accepted never completed.

**3. The leader's tail was read before shipping and used after.** A publish landing in between left `tail` describing a shorter log, so a follower level with the *old* tail was reported caught up — and counted toward the quorum — for a record it did not have.

**4. The acknowledgement was released before the control plane was told who held the record.** A leader could tell a client its record was safe and die before saying which replica had it. The report now goes first, and is awaited.

**5. Promotion chose by placement score, not by how much a replica held.** "Caught up" is only true of the tail it was measured against, so a slightly stale report can call two replicas level when one holds more. Promotion now prefers the highest reported offset; score only breaks ties. Reports carry per-replica offsets to make that possible.

Plus a harness bug of mine from #265: the control plane built report TTLs from `Default::default()` (expiry 15s + heartbeat 5s) rather than its own liveness settings (1s + 200ms), so a report stayed believed roughly twenty times longer than intended.

## How it was found

The thing that unstuck this was resolving one ambiguity I had been guessing past for several attempts: *"the promoted broker never received the record"* versus *"it has the record and will not serve it"*. Those look identical from outside. Reading the promoted broker's durable tail through the existing API — subscribing past the end is refused with the tail in the message — separated them, and the control-plane-side logging of promotion inputs did the rest, because the broker's own log at that moment is drowned in `connection lost` from the dying leader.

## Verification

- `a_consistency_change_reaches_a_live_stream` and its lowering counterpart both fail when the fix is reverted
- the furthest-ahead promotion rule has tests that fail if it falls back to score
- 20/20 on the milestone scenario, 6/6 rounds on all four
- `task lint`, `task test` (76 blocks), `task demo:check`, docs-site build

## Docs

Failover and quorum acknowledgement no longer say "not usable". They now say what the claim is actually proven against — **process kill**, not partitions or clock skew, which the harness still cannot inject. That is why both rows stay `🚧 Partial` rather than moving to `✅ Today`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)