### PR TITLE
feat(client): connect to a cluster rather than to one broker (M6.1)

### DIFF
--- a/crates/felix-client/src/client/client.rs
+++ b/crates/felix-client/src/client/client.rs
@@ -120,6 +120,69 @@ impl Client {
             .await
     }
 
+    /// Connect to whichever of `addrs` answers first, in order.
+    ///
+    /// A cluster has more than one broker and any of them will serve a publish —
+    /// one that does not own the shard forwards it. So a client given a single
+    /// address has a single point of failure that the cluster itself does not:
+    /// the broker it was pointed at can be the one that just died, and every
+    /// other broker is sitting there able to serve.
+    ///
+    /// Tried in the order given, so a caller can express preference. The errors
+    /// are collected rather than discarded: "nothing answered" is the only
+    /// outcome worth reporting, but *why* each endpoint refused is what an
+    /// operator needs, and a bare "connection refused" from the last one in the
+    /// list hides the credential error from the first.
+    ///
+    /// This is seed discovery, not topology: the client does not yet learn the
+    /// rest of the cluster from the broker it reaches, and does not move if that
+    /// broker later dies. Both are M6.
+    pub async fn connect_any(
+        addrs: &[SocketAddr],
+        server_name: &str,
+        client_config: ClientConfig,
+    ) -> Result<Self> {
+        Self::connect_any_with_transport(
+            addrs,
+            server_name,
+            client_config,
+            TransportConfig::default(),
+        )
+        .await
+    }
+
+    /// [`Client::connect_any`] with an explicit transport configuration.
+    pub async fn connect_any_with_transport(
+        addrs: &[SocketAddr],
+        server_name: &str,
+        client_config: ClientConfig,
+        transport: TransportConfig,
+    ) -> Result<Self> {
+        if addrs.is_empty() {
+            return Err(anyhow::anyhow!(
+                "no broker addresses were given to connect to"
+            ));
+        }
+        let mut refusals = Vec::with_capacity(addrs.len());
+        for addr in addrs {
+            match Self::connect_with_transport(
+                *addr,
+                server_name,
+                client_config.clone(),
+                transport.clone(),
+            )
+            .await
+            {
+                Ok(client) => return Ok(client),
+                Err(err) => refusals.push(format!("{addr}: {err:#}")),
+            }
+        }
+        Err(anyhow::anyhow!(
+            "no broker answered ({})",
+            refusals.join("; ")
+        ))
+    }
+
     pub async fn connect_with_transport(
         addr: SocketAddr,
         server_name: &str,

--- a/crates/felix-cluster/src/client.rs
+++ b/crates/felix-cluster/src/client.rs
@@ -15,7 +15,31 @@ use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, SignatureScheme};
 
 /// Connect to a broker's client-facing port as `tenant_id`.
+/// Connect to whichever of `addrs` answers, the way an application with a seed
+/// list would.
+///
+/// The server name is `"localhost"` for every broker, which is only sound
+/// because this harness installs [`AcceptAnyBroker`] and never validates a
+/// certificate — the name reaches the wire as SNI and is not checked against
+/// anything. A deployment that verified certificates would need a name per
+/// broker, or a certificate naming them all. `Client::connect_any` takes the
+/// name as a parameter for exactly that reason; the hardcoding is the harness's,
+/// not the client's.
+pub async fn connect_any(addrs: &[SocketAddr], tenant_id: &str, token: &str) -> Result<Client> {
+    let config = client_config(tenant_id, token)?;
+    Client::connect_any(addrs, "localhost", config)
+        .await
+        .with_context(|| format!("connect to any of {addrs:?}"))
+}
+
 pub async fn connect(addr: SocketAddr, tenant_id: &str, token: &str) -> Result<Client> {
+    let config = client_config(tenant_id, token)?;
+    Client::connect(addr, "localhost", config)
+        .await
+        .with_context(|| format!("connect to broker at {addr}"))
+}
+
+fn client_config(tenant_id: &str, token: &str) -> Result<ClientConfig> {
     let mut tls = rustls::ClientConfig::builder_with_provider(provider())
         .with_protocol_versions(rustls::ALL_VERSIONS)
         .context("client protocol versions")?
@@ -33,9 +57,7 @@ pub async fn connect(addr: SocketAddr, tenant_id: &str, token: &str) -> Result<C
     config.auth_tenant_id = Some(tenant_id.to_string());
     config.auth_token = Some(token.to_string());
 
-    Client::connect(addr, "localhost", config)
-        .await
-        .with_context(|| format!("connect to broker at {addr}"))
+    Ok(config)
 }
 
 fn provider() -> Arc<rustls::crypto::CryptoProvider> {

--- a/crates/felix-cluster/src/lib.rs
+++ b/crates/felix-cluster/src/lib.rs
@@ -498,6 +498,29 @@ impl Cluster {
         Ok((client, subscription))
     }
 
+    /// Every broker's client address, for a seed list.
+    pub fn broker_addrs(&self) -> Vec<SocketAddr> {
+        self.nodes.iter().map(|node| node.client_addr).collect()
+    }
+
+    /// Publish through whichever broker in the cluster answers, the way an
+    /// application with a seed list would.
+    pub async fn publish_via_any(&self, stream: &str, payload: Vec<u8>) -> Result<()> {
+        let client =
+            client::connect_any(&self.broker_addrs(), &self.tenant_id, &self.client_token).await?;
+        let publisher = client.publisher().await.context("open publisher")?;
+        publisher
+            .publish(
+                &self.tenant_id,
+                &self.namespace,
+                stream,
+                payload,
+                felix_wire::AckMode::PerMessage,
+            )
+            .await
+            .with_context(|| format!("publish to {stream} through a seed endpoint"))
+    }
+
     /// Node ids the control plane currently considers placeable.
     pub async fn placeable_nodes(&self) -> Result<Vec<String>> {
         #[derive(serde::Deserialize)]

--- a/crates/felix-cluster/tests/seed_endpoints.rs
+++ b/crates/felix-cluster/tests/seed_endpoints.rs
@@ -1,0 +1,162 @@
+//! A client given several brokers rather than one.
+//!
+//! M5 made the cluster survive losing a leader. A client pointed at a single
+//! address does not: the broker it was given can be the one that just died,
+//! while every other broker sits there able to serve. These cover the seam
+//! between "the cluster is fine" and "the application can tell".
+//!
+//! Run with `cargo test -p felix-cluster --test seed_endpoints`.
+use std::time::Duration;
+
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
+use serial_test::serial;
+
+const STREAM: &str = "orders";
+
+fn config() -> ClusterConfig {
+    ClusterConfig {
+        nodes: 3,
+        streams: vec![StreamSpec::quorum(STREAM, 1, 3)],
+        ..Default::default()
+    }
+}
+
+/// The ordinary case: any broker in the seed list will do, because one that
+/// does not own the shard forwards the publish to the one that does.
+#[serial]
+#[tokio::test]
+async fn a_seed_list_publishes_through_whichever_broker_answers() {
+    let cluster = Cluster::start(config()).await.expect("start cluster");
+
+    cluster
+        .publish_via_any(STREAM, b"seeded".to_vec())
+        .await
+        .expect("publish through a seed endpoint");
+
+    cluster.shutdown().await;
+}
+
+/// **A dead broker in the list is skipped.** This is the whole point: the
+/// address an application was configured with is exactly the one that may have
+/// just failed over, and the cluster can still serve the write.
+#[serial]
+#[tokio::test]
+async fn a_dead_broker_in_the_list_is_skipped() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let dead = cluster.nodes[0].node_id.clone();
+    cluster.kill_node(&dead).expect("kill a broker");
+
+    cluster
+        .publish_via_any(STREAM, b"past-a-dead-broker".to_vec())
+        .await
+        .expect("a dead first endpoint should not stop the publish");
+
+    cluster.shutdown().await;
+}
+
+/// **Publishing through a seed list survives losing the shard's leader.** The
+/// cluster promotes a replica; the client reaches it because it was given more
+/// than one way in.
+#[serial]
+#[tokio::test]
+async fn a_seed_list_survives_losing_the_leader() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+    cluster
+        .publish_via(&leader, STREAM, b"before".to_vec())
+        .await
+        .expect("publish");
+    felix_cluster::wait::until(Duration::from_secs(20), "the leader to report", || async {
+        matches!(
+            cluster
+                .metric(&leader, "felix_broker_replication_shipped_total")
+                .await,
+            Ok(Some(n)) if n > 0.0
+        )
+    })
+    .await
+    .expect("the leader should ship and report");
+
+    cluster.kill_node(&leader).expect("kill the leader");
+    felix_cluster::wait::until(Duration::from_secs(30), "a new leader", || async {
+        cluster.place_shards().await;
+        matches!(cluster.owner(STREAM).await, Ok(owner) if owner != leader)
+    })
+    .await
+    .expect("a replica should be promoted");
+
+    // Retried, and that is the finding rather than a convenience.
+    //
+    // A seed list gets the client to a live broker, but a broker that is not the
+    // shard's owner forwards — and for a short window after a failover its
+    // routing view still names the broker that just died, so the forward goes to
+    // a corpse and times out. The cluster recovers within a feed interval; the
+    // client does not know that and has no retry of its own.
+    //
+    // So this is what an application has to write today, and it is exactly what
+    // #119 moves into the client: classify the failure as retryable, back off,
+    // and try again.
+    let mut published = false;
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let mut last = String::new();
+    while !published && std::time::Instant::now() < deadline {
+        match cluster.publish_via_any(STREAM, b"after".to_vec()).await {
+            Ok(()) => published = true,
+            Err(err) => {
+                last = format!("{err:#}");
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+        }
+    }
+    assert!(
+        published,
+        "a seed list never reached the promoted leader; last failure: {last}",
+    );
+
+    cluster.shutdown().await;
+}
+
+/// **Nothing answering is one error naming every endpoint**, not the last
+/// one's. A credential that the first broker refused is invisible if only the
+/// final "connection refused" survives.
+#[serial]
+#[tokio::test]
+async fn nothing_answering_reports_every_endpoint() {
+    let mut cluster = Cluster::start(config()).await.expect("start cluster");
+    let addrs = cluster.broker_addrs();
+    for node in cluster
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .collect::<Vec<_>>()
+    {
+        cluster.kill_node(&node).expect("kill");
+    }
+
+    let message =
+        match felix_cluster::client::connect_any(&addrs, &cluster.tenant_id, &cluster.client_token)
+            .await
+        {
+            Ok(_) => panic!("a broker answered after every one was killed"),
+            Err(err) => format!("{err:#}"),
+        };
+    for addr in &addrs {
+        assert!(
+            message.contains(&addr.to_string()),
+            "{addr} is missing from: {message}",
+        );
+    }
+    cluster.shutdown().await;
+}
+
+/// An empty seed list is a configuration error, said plainly rather than as a
+/// connection failure to nowhere.
+#[tokio::test]
+async fn an_empty_seed_list_is_refused() {
+    let message = match felix_cluster::client::connect_any(&[], "t1", "token").await {
+        Ok(_) => panic!("an empty list should be refused"),
+        Err(err) => format!("{err:#}"),
+    };
+
+    assert!(message.contains("no broker addresses"), "{message}");
+}


### PR DESCRIPTION
## The problem

M5 made a cluster survive losing a leader. A client could not: `Client::connect` takes **one** address, so the broker an application was configured with can be exactly the one that just died, while every other broker sits there able to serve.

## What this adds

`Client::connect_any(&[addr], server_name, config)` — tries the addresses in order and uses the first that answers. Any broker will serve a publish, because one that does not own the shard forwards it, so a seed list is enough to reach a healthy cluster without knowing which broker leads what.

Errors are **collected, not discarded**. "Nothing answered" is the only outcome worth reporting, but *why* each endpoint refused is what an operator needs — a bare "connection refused" from the last address hides the credential error from the first. There is a test asserting every address appears in the message.

## On the hardcoded server name

You spotted `"localhost"` in the harness. To be precise about where it lives:

- **The library takes it as a parameter.** `connect_any(addrs, server_name, config)`.
- **The harness hardcodes it**, and already did in the existing `connect`. It is sound there only because the harness installs `AcceptAnyBroker`, so the name reaches the wire as SNI and is never validated.

That is now commented at the harness helper, because one name covering *several* brokers reads like a limitation otherwise. A deployment that verified certificates would need a name per broker, or a certificate naming them all.

## A gap this surfaced — filed as #269

Before a failover every broker serves a publish. After one, a **non-owner times out**:

```
AFTER PROMOTION (was broker-2, now broker-1):
  via broker-0: publish failed: publish commit timeout
  via broker-1: ok
```

broker-0's routing view still names the dead leader, so the forward goes to a corpse and the publish waits out its commit timeout rather than failing fast. Two separable halves in the issue: the forward should fail fast (`PeerError::Unavailable` already means "nothing was sent" and is retryable), and the client should retry a retryable failure (#119).

**`a_seed_list_survives_losing_the_leader` retries, and the comment says why** — that retry is what an application has to write today. The test pins the behaviour and leaves the gap visible rather than hiding it behind a passing assertion.

## Scope

Deliberately not here, and stated in the doc comment so it is not mistaken for working: the client does not learn the rest of the cluster from the broker it reaches (#117), does not follow a redirect (#118), and does not move if its broker later dies (#119).

## Tests

Against a real three-node cluster: a seed list publishes through whichever broker answers; a dead broker in the list is skipped; a seed list survives losing the leader; nothing answering names every endpoint; an empty list is refused as a configuration error rather than a connection failure to nowhere.

`task lint`, `task test` (77 blocks), `task demo:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)