### PR TITLE
feat(storage): make the cache a projection over the log

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ flowchart LR
     subgraph B["Broker (services/broker + felix-broker)"]
         Ingress["QUIC accept + stream registry<br/>felix-wire framing + stream-type routing"]
         PS["Pub/Sub core<br/>enqueue + batching + fanout"]
-        Cache["Cache core<br/>lookup/insert + TTL"]
+        Cache["Cache core<br/>log-backed, key index + TTL"]
         Sync["Control-plane sync<br/>tenants/namespaces/streams/caches"]
 
         Ingress --> PS
@@ -186,7 +186,7 @@ The initial MVP targets:
 
 - Single-node broker
 - In-process pub/sub with fanout
-- Ephemeral cache with TTL
+- Log-backed cache with TTL, durable when the broker has a storage directory
 - Stable wire envelope (v1)
 - Basic observability (structured logs)
 - Tests validating core invariants

--- a/crates/felix-storage/src/lib.rs
+++ b/crates/felix-storage/src/lib.rs
@@ -8,11 +8,13 @@ use std::time::{Duration, Instant};
 pub mod disk_log;
 pub mod ephemeral_cache;
 pub mod log;
+pub mod log_cache;
 pub mod metrics_names;
 pub mod segment;
 pub mod tiered;
 pub use disk_log::{DiskLog, DiskLogProvider};
 pub use ephemeral_cache::EphemeralCache;
+pub use log_cache::LogCache;
 pub use segment::{Corruption, CorruptionKind, CorruptionSite};
 
 #[async_trait()]

--- a/crates/felix-storage/src/log_cache/mod.rs
+++ b/crates/felix-storage/src/log_cache/mod.rs
@@ -1,0 +1,546 @@
+//! A cache that is a log.
+//!
+//! `put` and `delete` append a record; an in-memory index maps each key to the
+//! offset of the record that currently defines it; `get` reads the log at that
+//! offset. See `docs/cache-on-log.md` for the design and the reasoning behind
+//! each part of it.
+//!
+//! This is what makes "one core log, many semantics" true of the cache rather
+//! than aspirational: crash safety, group commit, the fsync policy, and
+//! eventually replication are all inherited from the log rather than
+//! reimplemented beside it.
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use parking_lot::Mutex as SyncMutex;
+use tokio::sync::Mutex;
+
+use crate::disk_log::{DiskLog, layout};
+use crate::log::{AppendOnlyLog, AppendRecord, LogConfig, Offset, ReadRange, ShardKey};
+use crate::{Result, StorageApi, StorageError};
+
+mod record;
+pub use record::CacheOp;
+
+/// How much larger than its live bytes a log may grow before it is compacted.
+///
+/// A multiple rather than a fixed size, so the cost is proportional to the
+/// garbage: a cache that is mostly live is never compacted however big it is,
+/// and one that is mostly overwrites is compacted however small.
+const COMPACT_WHEN_TIMES_LIVE: u64 = 4;
+
+/// Below this there is nothing worth reclaiming, whatever the ratio says. Stops
+/// a cache holding a handful of keys from compacting on every other write.
+const COMPACT_FLOOR_BYTES: u64 = 1024 * 1024;
+
+/// Where one key's current value lives.
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    offset: Offset,
+    /// Absolute Unix milliseconds; zero means it never expires.
+    expires_at_millis: u64,
+    /// What this record costs on disk, for deciding when to compact.
+    bytes: u64,
+}
+
+impl Entry {
+    fn is_expired(&self, now_millis: u64) -> bool {
+        self.expires_at_millis != 0 && self.expires_at_millis <= now_millis
+    }
+}
+
+/// The index over one cache's log, and the accounting compaction needs.
+#[derive(Debug, Default)]
+struct Index {
+    entries: HashMap<String, Entry>,
+    /// Bytes held by records the index still points at.
+    live_bytes: u64,
+    /// Bytes appended since the log was last compacted, live or not.
+    log_bytes: u64,
+}
+
+/// One cache: its log, and the index derived from it.
+struct CacheShard {
+    dir: PathBuf,
+    label: String,
+    config: LogConfig,
+    /// Held across a write and across compaction. A cache write is serialised
+    /// here anyway, so compaction adds no new contention -- only a longer hold.
+    state: Mutex<ShardState>,
+}
+
+struct ShardState {
+    log: DiskLog,
+    index: Index,
+}
+
+/// A cache backed by the same log streams are.
+#[derive(Debug)]
+pub struct LogCache {
+    root: PathBuf,
+    config: LogConfig,
+    shards: SyncMutex<HashMap<CacheId, Arc<CacheShard>>>,
+}
+
+impl std::fmt::Debug for CacheShard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CacheShard")
+            .field("label", &self.label)
+            .finish()
+    }
+}
+
+type CacheId = (String, String, String);
+
+impl LogCache {
+    /// Open the cache store rooted at `root`.
+    ///
+    /// Callers pass the *cache* root, which is deliberately not the stream root:
+    /// a shard directory is named from a hash of its tenant, namespace and
+    /// stream, so a cache and a stream sharing a name would otherwise interleave
+    /// their records in one directory.
+    pub fn open(root: impl Into<PathBuf>, config: LogConfig) -> Result<Self> {
+        let root = root.into();
+        std::fs::create_dir_all(&root).map_err(StorageError::Io)?;
+        Ok(Self {
+            root,
+            config,
+            shards: SyncMutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Flush every open cache. Call once during graceful shutdown.
+    pub async fn shutdown(&self) -> Result<()> {
+        let shards: Vec<Arc<CacheShard>> = self.shards.lock().values().cloned().collect();
+        for shard in shards {
+            shard.state.lock().await.log.shutdown().await?;
+        }
+        Ok(())
+    }
+
+    fn shard(&self, tenant: &str, namespace: &str, cache: &str) -> Result<Arc<CacheShard>> {
+        let id = (tenant.to_string(), namespace.to_string(), cache.to_string());
+        // Opening runs under the lock: two callers racing to open the same new
+        // cache must not both replay the log and both create segment zero.
+        let mut shards = self.shards.lock();
+        if let Some(shard) = shards.get(&id) {
+            return Ok(Arc::clone(shard));
+        }
+        let key = ShardKey {
+            tenant: tenant.to_string(),
+            namespace: namespace.to_string(),
+            stream: cache.to_string(),
+            shard: 0,
+        };
+        let dir = layout::shard_dir(&self.root, &key);
+        let label = layout::shard_label(&key);
+        let log = DiskLog::open(dir.clone(), label.clone(), self.config.clone())?;
+        let shard = Arc::new(CacheShard {
+            dir,
+            label,
+            config: self.config.clone(),
+            state: Mutex::new(ShardState {
+                log,
+                index: Index::default(),
+            }),
+        });
+        shards.insert(id, Arc::clone(&shard));
+        Ok(shard)
+    }
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// How much of the log one replay or compaction pass reads at a time.
+///
+/// Bounds peak memory during a rebuild: a cache far larger than this costs many
+/// reads, not one enormous allocation.
+const SCAN_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+impl CacheShard {
+    /// Rebuild the index by replaying the log.
+    ///
+    /// Run once, lazily, the first time a cache is touched after opening. The
+    /// index is derived and never trusted from disk -- the same rule the segment
+    /// indexes follow, and for the same reason: anything recomputable from the
+    /// log must be, because then it cannot be stale in a way that matters.
+    async fn ensure_index(&self, state: &mut ShardState) -> Result<()> {
+        if state.index.log_bytes != 0 || !state.index.entries.is_empty() {
+            return Ok(());
+        }
+        let tail = state.log.tail_offset().await?;
+        let mut offset = state.log.base_offset();
+        let mut index = Index::default();
+        while offset < tail {
+            let records = state
+                .log
+                .read_range(ReadRange {
+                    start: offset,
+                    max_bytes: SCAN_CHUNK_BYTES,
+                })
+                .await?;
+            if records.is_empty() {
+                break;
+            }
+            for record in &records {
+                let bytes = record.payload.len() as u64;
+                index.log_bytes += bytes;
+                let op = record::CacheOp::decode(&record.payload)
+                    .map_err(|err| StorageError::Corruption(err.in_shard(&self.label)))?;
+                match op {
+                    CacheOp::Put {
+                        key,
+                        expires_at_millis,
+                        ..
+                    } => {
+                        if let Some(previous) = index.entries.insert(
+                            key,
+                            Entry {
+                                offset: record.offset,
+                                expires_at_millis,
+                                bytes,
+                            },
+                        ) {
+                            index.live_bytes -= previous.bytes;
+                        }
+                        index.live_bytes += bytes;
+                    }
+                    CacheOp::Delete { key } => {
+                        if let Some(previous) = index.entries.remove(&key) {
+                            index.live_bytes -= previous.bytes;
+                        }
+                    }
+                }
+                offset = record.offset + 1;
+            }
+        }
+        state.index = index;
+        Ok(())
+    }
+
+    /// Append one record and fold it into the index.
+    async fn write(&self, state: &mut ShardState, op: CacheOp) -> Result<()> {
+        let payload = op.encode();
+        let bytes = payload.len() as u64;
+        let appended = state
+            .log
+            .append(&[AppendRecord {
+                payload,
+                timestamp_micros: now_millis() * 1000,
+            }])
+            .await?;
+
+        state.index.log_bytes += bytes;
+        match op {
+            CacheOp::Put {
+                key,
+                expires_at_millis,
+                ..
+            } => {
+                let entry = Entry {
+                    offset: appended.first_offset,
+                    expires_at_millis,
+                    bytes,
+                };
+                if let Some(previous) = state.index.entries.insert(key, entry) {
+                    state.index.live_bytes -= previous.bytes;
+                }
+                state.index.live_bytes += bytes;
+            }
+            CacheOp::Delete { key } => {
+                if let Some(previous) = state.index.entries.remove(&key) {
+                    state.index.live_bytes -= previous.bytes;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Read the record the index points at, and hand back its value.
+    async fn read_value(&self, state: &ShardState, entry: Entry) -> Result<Option<Bytes>> {
+        let records = state
+            .log
+            .read_range(ReadRange {
+                start: entry.offset,
+                // One record. The cap has to exceed it, and a record larger
+                // than this could not have been appended in the first place.
+                max_bytes: SCAN_CHUNK_BYTES,
+            })
+            .await?;
+        let Some(found) = records.first() else {
+            // The index points past the end of the log. Nothing can make that
+            // right, and returning a miss would hide it.
+            return Err(StorageError::NotFound);
+        };
+        match record::CacheOp::decode(&found.payload)
+            .map_err(|err| StorageError::Corruption(err.in_shard(&self.label)))?
+        {
+            CacheOp::Put { value, .. } => Ok(Some(value)),
+            // The index only ever points at a put; a tombstone here means the
+            // index and the log disagree, which is a bug rather than a miss.
+            CacheOp::Delete { .. } => Err(StorageError::NotFound),
+        }
+    }
+
+    /// True when the log holds enough garbage to be worth rewriting.
+    fn should_compact(index: &Index) -> bool {
+        index.log_bytes > COMPACT_FLOOR_BYTES
+            && index.log_bytes > index.live_bytes.saturating_mul(COMPACT_WHEN_TIMES_LIVE)
+    }
+
+    /// Rewrite the live set into a fresh log and swap it in.
+    ///
+    /// **Records are never rewritten**, which is the invariant the whole storage
+    /// layer rests on. Compaction honours it: it writes new segments in a new
+    /// directory and swaps directories, and never edits a byte in place. A crash
+    /// at any point leaves either the old log or the new one whole, because the
+    /// swap is two renames and the old log is not removed until the new one is
+    /// in position.
+    async fn compact(&self, state: &mut ShardState) -> Result<()> {
+        let now = now_millis();
+        let mut live: Vec<(String, Bytes, u64)> = Vec::with_capacity(state.index.entries.len());
+        for (key, entry) in &state.index.entries {
+            if entry.is_expired(now) {
+                // Expired entries are exactly what compaction is for: reclaimed
+                // here rather than carried into the new log.
+                continue;
+            }
+            if let Some(value) = self.read_value(state, *entry).await? {
+                live.push((key.clone(), value, entry.expires_at_millis));
+            }
+        }
+
+        let staging = self.dir.with_extension("compacting");
+        if staging.exists() {
+            // Left by a crash mid-compaction. It was never swapped in, so it
+            // holds nothing the current log does not.
+            std::fs::remove_dir_all(&staging).map_err(StorageError::Io)?;
+        }
+        let fresh = DiskLog::open(staging.clone(), self.label.clone(), self.config.clone())?;
+
+        let mut index = Index::default();
+        for (key, value, expires_at_millis) in live {
+            let payload = CacheOp::Put {
+                key: key.clone(),
+                value,
+                expires_at_millis,
+            }
+            .encode();
+            let bytes = payload.len() as u64;
+            let appended = fresh
+                .append(&[AppendRecord {
+                    payload,
+                    timestamp_micros: now * 1000,
+                }])
+                .await?;
+            index.entries.insert(
+                key,
+                Entry {
+                    offset: appended.first_offset,
+                    expires_at_millis,
+                    bytes,
+                },
+            );
+            index.live_bytes += bytes;
+            index.log_bytes += bytes;
+        }
+        fresh.shutdown().await?;
+        state.log.shutdown().await?;
+
+        let retired = self.dir.with_extension("retired");
+        if retired.exists() {
+            std::fs::remove_dir_all(&retired).map_err(StorageError::Io)?;
+        }
+        std::fs::rename(&self.dir, &retired).map_err(StorageError::Io)?;
+        std::fs::rename(&staging, &self.dir).map_err(StorageError::Io)?;
+        std::fs::remove_dir_all(&retired).map_err(StorageError::Io)?;
+
+        state.log = DiskLog::open(self.dir.clone(), self.label.clone(), self.config.clone())?;
+        state.index = index;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl StorageApi for LogCache {
+    async fn put(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        cache: &str,
+        key: &str,
+        value: Bytes,
+        ttl: Option<std::time::Duration>,
+    ) {
+        if let Err(err) = self
+            .put_checked(tenant_id, namespace, cache, key, value, ttl)
+            .await
+        {
+            // The trait returns nothing, so a failed write can only be reported
+            // here. Worth a loud line: the caller has been told the write
+            // succeeded and it did not.
+            tracing::error!(
+                tenant_id, namespace, cache, key, error = %err,
+                "cache write failed after the client was acknowledged",
+            );
+        }
+    }
+
+    async fn get(&self, tenant_id: &str, namespace: &str, cache: &str, key: &str) -> Option<Bytes> {
+        match self.get_checked(tenant_id, namespace, cache, key).await {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::error!(
+                    tenant_id, namespace, cache, key, error = %err,
+                    "cache read failed; reporting a miss",
+                );
+                None
+            }
+        }
+    }
+
+    async fn delete(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        cache: &str,
+        key: &str,
+    ) -> Option<Bytes> {
+        match self.delete_checked(tenant_id, namespace, cache, key).await {
+            Ok(value) => value,
+            Err(err) => {
+                tracing::error!(
+                    tenant_id, namespace, cache, key, error = %err,
+                    "cache delete failed",
+                );
+                None
+            }
+        }
+    }
+
+    async fn len(&self) -> usize {
+        let shards: Vec<Arc<CacheShard>> = self.shards.lock().values().cloned().collect();
+        let now = now_millis();
+        let mut total = 0;
+        for shard in shards {
+            let mut state = shard.state.lock().await;
+            if shard.ensure_index(&mut state).await.is_err() {
+                continue;
+            }
+            // Expired entries are gone as far as any reader is concerned, so
+            // counting them would report a size nothing can observe.
+            total += state
+                .index
+                .entries
+                .values()
+                .filter(|entry| !entry.is_expired(now))
+                .count();
+        }
+        total
+    }
+
+    async fn is_empty(&self) -> bool {
+        self.len().await == 0
+    }
+}
+
+impl LogCache {
+    /// `put`, with the failure the trait cannot express.
+    pub async fn put_checked(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        cache: &str,
+        key: &str,
+        value: Bytes,
+        ttl: Option<std::time::Duration>,
+    ) -> Result<()> {
+        let shard = self.shard(tenant_id, namespace, cache)?;
+        let mut state = shard.state.lock().await;
+        shard.ensure_index(&mut state).await?;
+        let expires_at_millis = ttl.map_or(0, |ttl| now_millis() + ttl.as_millis() as u64);
+        shard
+            .write(
+                &mut state,
+                CacheOp::Put {
+                    key: key.to_string(),
+                    value,
+                    expires_at_millis,
+                },
+            )
+            .await?;
+        if CacheShard::should_compact(&state.index) {
+            shard.compact(&mut state).await?;
+        }
+        Ok(())
+    }
+
+    /// `get`, with the failure the trait cannot express.
+    pub async fn get_checked(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        cache: &str,
+        key: &str,
+    ) -> Result<Option<Bytes>> {
+        let shard = self.shard(tenant_id, namespace, cache)?;
+        let mut state = shard.state.lock().await;
+        shard.ensure_index(&mut state).await?;
+        let Some(entry) = state.index.entries.get(key).copied() else {
+            return Ok(None);
+        };
+        if entry.is_expired(now_millis()) {
+            // Lazy expiry, as the in-memory cache always did: reported absent
+            // now, and the space reclaimed when the log is next compacted.
+            return Ok(None);
+        }
+        shard.read_value(&state, entry).await
+    }
+
+    /// `delete`, with the failure the trait cannot express.
+    pub async fn delete_checked(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        cache: &str,
+        key: &str,
+    ) -> Result<Option<Bytes>> {
+        let shard = self.shard(tenant_id, namespace, cache)?;
+        let mut state = shard.state.lock().await;
+        shard.ensure_index(&mut state).await?;
+        let Some(entry) = state.index.entries.get(key).copied() else {
+            return Ok(None);
+        };
+        let previous = if entry.is_expired(now_millis()) {
+            None
+        } else {
+            shard.read_value(&state, entry).await?
+        };
+        shard
+            .write(
+                &mut state,
+                CacheOp::Delete {
+                    key: key.to_string(),
+                },
+            )
+            .await?;
+        Ok(previous)
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/felix-storage/src/log_cache/record.rs
+++ b/crates/felix-storage/src/log_cache/record.rs
@@ -1,0 +1,131 @@
+//! The on-disk shape of one cache write.
+//!
+//! Durable, so it is explicit and versioned rather than whatever a serialiser
+//! happened to emit. See `docs/cache-on-log.md` for the layout and the
+//! reasoning; the short version is that a reader years from now has only these
+//! bytes, and a misread record is worse than an unreadable one.
+use bytes::{BufMut, Bytes, BytesMut};
+
+use crate::segment::{Corruption, CorruptionKind};
+
+/// The only version this build writes, and the only one it reads.
+pub const VERSION: u8 = 1;
+
+const OP_PUT: u8 = 0;
+const OP_DELETE: u8 = 1;
+
+const OP_AT: usize = 1;
+const EXPIRES_AT: usize = 2;
+const KEY_LEN_AT: usize = 10;
+/// Version, op, expiry, key length. Every record carries all four.
+pub const HEADER_LEN: usize = 14;
+
+/// What one record says happened to one key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CacheOp {
+    /// This key now has this value, until `expires_at_millis` unless it is zero.
+    Put {
+        key: String,
+        value: Bytes,
+        /// Absolute Unix milliseconds; zero means it never expires.
+        ///
+        /// Absolute rather than a duration, because a record read back after a
+        /// restart has to mean what it meant when it was written. A duration
+        /// would silently restart its life on every recovery, so an entry with
+        /// a one-hour TTL would outlive any number of restarts an hour apart.
+        expires_at_millis: u64,
+    },
+    /// This key is gone.
+    ///
+    /// A tombstone has to be written rather than the record simply dropped: the
+    /// log is the history, and an absence cannot be appended.
+    Delete { key: String },
+}
+
+impl CacheOp {
+    pub fn key(&self) -> &str {
+        match self {
+            CacheOp::Put { key, .. } | CacheOp::Delete { key } => key,
+        }
+    }
+
+    pub fn encode(&self) -> Bytes {
+        let (op, key, value, expires_at_millis) = match self {
+            CacheOp::Put {
+                key,
+                value,
+                expires_at_millis,
+            } => (OP_PUT, key, Some(value), *expires_at_millis),
+            CacheOp::Delete { key } => (OP_DELETE, key, None, 0),
+        };
+        let value_len = value.map_or(0, |value| value.len());
+        let mut buf = BytesMut::with_capacity(HEADER_LEN + key.len() + value_len);
+        buf.put_u8(VERSION);
+        buf.put_u8(op);
+        buf.put_u64_le(expires_at_millis);
+        buf.put_u32_le(key.len() as u32);
+        buf.put_slice(key.as_bytes());
+        if let Some(value) = value {
+            buf.put_slice(value);
+        }
+        buf.freeze()
+    }
+
+    /// Decode one record read back from the log.
+    ///
+    /// Every failure here means the bytes are not what this build can read, and
+    /// none of them are recoverable by guessing — so all of them are errors
+    /// rather than a best effort at the remainder.
+    pub fn decode(payload: &Bytes) -> Result<Self, Corruption> {
+        if payload.len() < HEADER_LEN {
+            return Err(Corruption::new(CorruptionKind::CacheRecordTooShort {
+                len: payload.len(),
+                header_len: HEADER_LEN,
+            }));
+        }
+        let version = payload[0];
+        if version != VERSION {
+            return Err(Corruption::new(CorruptionKind::CacheRecordVersion {
+                found: version,
+                expected: VERSION,
+            }));
+        }
+        let expires_at_millis = u64::from_le_bytes(
+            payload[EXPIRES_AT..EXPIRES_AT + 8]
+                .try_into()
+                .expect("eight bytes, length checked above"),
+        );
+        let key_len = u32::from_le_bytes(
+            payload[KEY_LEN_AT..KEY_LEN_AT + 4]
+                .try_into()
+                .expect("four bytes, length checked above"),
+        ) as usize;
+        let available = payload.len() - HEADER_LEN;
+        if key_len > available {
+            return Err(Corruption::new(CorruptionKind::CacheRecordKeyLength {
+                claimed: key_len,
+                available,
+            }));
+        }
+        let key_end = HEADER_LEN + key_len;
+        let key = std::str::from_utf8(&payload[HEADER_LEN..key_end])
+            .map_err(|_| Corruption::new(CorruptionKind::CacheRecordKeyNotUtf8))?
+            .to_string();
+
+        match payload[OP_AT] {
+            OP_PUT => Ok(CacheOp::Put {
+                key,
+                // The rest of the record. The segment framing already delimits
+                // it, so the value needs no length of its own.
+                value: payload.slice(key_end..),
+                expires_at_millis,
+            }),
+            OP_DELETE => Ok(CacheOp::Delete { key }),
+            found => Err(Corruption::new(CorruptionKind::CacheRecordOp { found })),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "record_tests.rs"]
+mod tests;

--- a/crates/felix-storage/src/log_cache/record_tests.rs
+++ b/crates/felix-storage/src/log_cache/record_tests.rs
@@ -1,0 +1,144 @@
+//! The durable record format.
+//!
+//! Worth testing byte-for-byte: these bytes outlive the process that wrote
+//! them, and a format that only round-trips within one build has proven
+//! nothing about the build that reads it back.
+use super::*;
+
+#[test]
+fn a_put_round_trips() {
+    let op = CacheOp::Put {
+        key: "session:42".to_string(),
+        value: Bytes::from_static(b"hello"),
+        expires_at_millis: 1_700_000_000_000,
+    };
+    assert_eq!(CacheOp::decode(&op.encode()).expect("decode"), op);
+}
+
+#[test]
+fn a_delete_round_trips() {
+    let op = CacheOp::Delete {
+        key: "session:42".to_string(),
+    };
+    assert_eq!(CacheOp::decode(&op.encode()).expect("decode"), op);
+}
+
+/// An empty value is a value, not an absence. Only a tombstone means absent,
+/// and the two must not collapse into each other.
+#[test]
+fn an_empty_value_is_not_a_delete() {
+    let op = CacheOp::Put {
+        key: "k".to_string(),
+        value: Bytes::new(),
+        expires_at_millis: 0,
+    };
+    let decoded = CacheOp::decode(&op.encode()).expect("decode");
+    assert_eq!(decoded, op);
+    assert!(matches!(decoded, CacheOp::Put { .. }));
+}
+
+#[test]
+fn a_key_may_hold_any_utf8() {
+    let op = CacheOp::Put {
+        key: "ключ/例え:🔑".to_string(),
+        value: Bytes::from_static(b"v"),
+        expires_at_millis: 0,
+    };
+    assert_eq!(CacheOp::decode(&op.encode()).expect("decode"), op);
+}
+
+/// **The layout is pinned, not just self-consistent.** A round-trip test alone
+/// would let both sides move together and still call it a pass; a build reading
+/// bytes written by another build would then find a plausible wrong answer.
+#[test]
+fn the_encoding_is_the_documented_layout() {
+    let encoded = CacheOp::Put {
+        key: "ab".to_string(),
+        value: Bytes::from_static(b"xyz"),
+        expires_at_millis: 1,
+    }
+    .encode();
+
+    assert_eq!(encoded[0], VERSION, "version leads the record");
+    assert_eq!(encoded[1], 0, "0 is a put");
+    assert_eq!(
+        &encoded[2..10],
+        &1u64.to_le_bytes(),
+        "expiry is little-endian absolute milliseconds"
+    );
+    assert_eq!(
+        &encoded[10..14],
+        &2u32.to_le_bytes(),
+        "key length is little-endian"
+    );
+    assert_eq!(&encoded[14..16], b"ab");
+    assert_eq!(
+        &encoded[16..],
+        b"xyz",
+        "the value is the rest of the record"
+    );
+}
+
+/// A record from a later build is refused, not read with this build's layout.
+/// Guessing would produce a plausible wrong value where an error is honest.
+#[test]
+fn a_future_version_is_refused() {
+    let mut encoded = CacheOp::Put {
+        key: "k".to_string(),
+        value: Bytes::from_static(b"v"),
+        expires_at_millis: 0,
+    }
+    .encode()
+    .to_vec();
+    encoded[0] = VERSION + 1;
+
+    let err = CacheOp::decode(&Bytes::from(encoded)).expect_err("a later version is unreadable");
+    assert!(
+        err.to_string().contains("not readable by this build"),
+        "unhelpful message: {err}"
+    );
+}
+
+#[test]
+fn an_unknown_op_is_refused() {
+    let mut encoded = CacheOp::Put {
+        key: "k".to_string(),
+        value: Bytes::from_static(b"v"),
+        expires_at_millis: 0,
+    }
+    .encode()
+    .to_vec();
+    encoded[1] = 9;
+    assert!(CacheOp::decode(&Bytes::from(encoded)).is_err());
+}
+
+#[test]
+fn a_record_shorter_than_its_header_is_refused() {
+    assert!(CacheOp::decode(&Bytes::from_static(b"short")).is_err());
+}
+
+/// A key length larger than the record is refused rather than clamped: it means
+/// the bytes are not what they claim, and truncating to fit would invent a key.
+#[test]
+fn a_key_longer_than_the_record_is_refused() {
+    let mut encoded = CacheOp::Put {
+        key: "ab".to_string(),
+        value: Bytes::new(),
+        expires_at_millis: 0,
+    }
+    .encode()
+    .to_vec();
+    encoded[10..14].copy_from_slice(&9999u32.to_le_bytes());
+    assert!(CacheOp::decode(&Bytes::from(encoded)).is_err());
+}
+
+#[test]
+fn a_key_that_is_not_utf8_is_refused() {
+    let mut encoded = Vec::new();
+    encoded.push(VERSION);
+    encoded.push(0);
+    encoded.extend_from_slice(&0u64.to_le_bytes());
+    encoded.extend_from_slice(&2u32.to_le_bytes());
+    encoded.extend_from_slice(&[0xff, 0xfe]);
+    assert!(CacheOp::decode(&Bytes::from(encoded)).is_err());
+}

--- a/crates/felix-storage/src/log_cache/tests.rs
+++ b/crates/felix-storage/src/log_cache/tests.rs
@@ -1,0 +1,332 @@
+//! The cache behaving as a cache, and as a log.
+//!
+//! The headline is `a_cache_survives_a_restart`: it is what "the cache is a
+//! log" buys, and what the in-memory cache could never do.
+use super::*;
+use std::time::Duration;
+
+fn config() -> LogConfig {
+    LogConfig {
+        segment_size_bytes: 64 * 1024,
+        index_spacing_bytes: 256,
+        fsync_mode: crate::log::FsyncMode::None,
+        preallocate_segments: false,
+        ..LogConfig::default()
+    }
+}
+
+async fn cache(dir: &std::path::Path) -> LogCache {
+    LogCache::open(dir, config()).expect("open")
+}
+
+const T: &str = "t1";
+const NS: &str = "ns";
+const C: &str = "sessions";
+
+#[tokio::test]
+async fn a_value_reads_back() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(T, NS, C, "k", Bytes::from_static(b"v"), None)
+        .await;
+
+    assert_eq!(cache.get(T, NS, C, "k").await.as_deref(), Some(&b"v"[..]));
+}
+
+#[tokio::test]
+async fn a_missing_key_reads_as_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+    assert!(cache.get(T, NS, C, "nothing").await.is_none());
+}
+
+#[tokio::test]
+async fn a_later_write_wins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(T, NS, C, "k", Bytes::from_static(b"first"), None)
+        .await;
+    cache
+        .put(T, NS, C, "k", Bytes::from_static(b"second"), None)
+        .await;
+
+    assert_eq!(
+        cache.get(T, NS, C, "k").await.as_deref(),
+        Some(&b"second"[..]),
+        "the log is append-only, so the *newest* record has to win",
+    );
+}
+
+#[tokio::test]
+async fn a_delete_hides_the_value_and_returns_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(T, NS, C, "k", Bytes::from_static(b"v"), None)
+        .await;
+    assert_eq!(
+        cache.delete(T, NS, C, "k").await.as_deref(),
+        Some(&b"v"[..])
+    );
+    assert!(cache.get(T, NS, C, "k").await.is_none());
+}
+
+/// Caches are scoped, so the same key in two of them is two entries.
+#[tokio::test]
+async fn caches_do_not_share_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(T, NS, "a", "k", Bytes::from_static(b"a"), None)
+        .await;
+    cache
+        .put(T, NS, "b", "k", Bytes::from_static(b"b"), None)
+        .await;
+
+    assert_eq!(cache.get(T, NS, "a", "k").await.as_deref(), Some(&b"a"[..]));
+    assert_eq!(cache.get(T, NS, "b", "k").await.as_deref(), Some(&b"b"[..]));
+}
+
+/// Tenants are the outermost boundary, and the disk layout has to honour it.
+#[tokio::test]
+async fn tenants_do_not_share_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put("t1", NS, C, "k", Bytes::from_static(b"one"), None)
+        .await;
+    cache
+        .put("t2", NS, C, "k", Bytes::from_static(b"two"), None)
+        .await;
+
+    assert_eq!(
+        cache.get("t1", NS, C, "k").await.as_deref(),
+        Some(&b"one"[..])
+    );
+    assert_eq!(
+        cache.get("t2", NS, C, "k").await.as_deref(),
+        Some(&b"two"[..])
+    );
+}
+
+#[tokio::test]
+async fn an_expired_entry_reads_as_absent() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(
+            T,
+            NS,
+            C,
+            "k",
+            Bytes::from_static(b"v"),
+            Some(Duration::from_millis(1)),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert!(cache.get(T, NS, C, "k").await.is_none());
+}
+
+#[tokio::test]
+async fn an_unexpired_entry_still_reads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(
+            T,
+            NS,
+            C,
+            "k",
+            Bytes::from_static(b"v"),
+            Some(Duration::from_secs(300)),
+        )
+        .await;
+
+    assert_eq!(cache.get(T, NS, C, "k").await.as_deref(), Some(&b"v"[..]));
+}
+
+/// **A cache survives a restart.** The point of the whole design: the entries
+/// are on disk, and the index is rebuilt from them rather than being the only
+/// place they ever lived.
+#[tokio::test]
+async fn a_cache_survives_a_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let cache = cache(dir.path()).await;
+        cache
+            .put(T, NS, C, "a", Bytes::from_static(b"1"), None)
+            .await;
+        cache
+            .put(T, NS, C, "b", Bytes::from_static(b"2"), None)
+            .await;
+        cache
+            .put(T, NS, C, "a", Bytes::from_static(b"3"), None)
+            .await;
+        cache.delete(T, NS, C, "b").await;
+        cache.shutdown().await.expect("shutdown");
+    }
+
+    let reopened = cache(dir.path()).await;
+    assert_eq!(
+        reopened.get(T, NS, C, "a").await.as_deref(),
+        Some(&b"3"[..]),
+        "the newest value for a key has to survive, not the first",
+    );
+    assert!(
+        reopened.get(T, NS, C, "b").await.is_none(),
+        "a delete has to survive too, or a restart resurrects deleted keys",
+    );
+}
+
+/// An expiry that passes while the process is down is still an expiry. This is
+/// why the record stores an absolute time rather than a duration: a duration
+/// would start its life again on every recovery.
+#[tokio::test]
+async fn an_expiry_survives_a_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    {
+        let cache = cache(dir.path()).await;
+        cache
+            .put(
+                T,
+                NS,
+                C,
+                "k",
+                Bytes::from_static(b"v"),
+                Some(Duration::from_millis(1)),
+            )
+            .await;
+        cache.shutdown().await.expect("shutdown");
+    }
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert!(cache(dir.path()).await.get(T, NS, C, "k").await.is_none());
+}
+
+#[tokio::test]
+async fn len_counts_live_entries_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(T, NS, C, "a", Bytes::from_static(b"1"), None)
+        .await;
+    cache
+        .put(T, NS, C, "b", Bytes::from_static(b"2"), None)
+        .await;
+    cache.delete(T, NS, C, "a").await;
+    cache
+        .put(
+            T,
+            NS,
+            C,
+            "c",
+            Bytes::from_static(b"3"),
+            Some(Duration::from_millis(1)),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    assert_eq!(cache.len().await, 1, "only b is live");
+    assert!(!cache.is_empty().await);
+}
+
+/// **Compaction reclaims overwrites and keeps the data.** Without it the log
+/// grows forever and "the cache is a log" is a slow leak rather than a design.
+#[tokio::test]
+async fn compaction_reclaims_overwritten_records() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    // One key, rewritten until the log is mostly garbage. The value is large
+    // enough that the floor is crossed without writing for a minute.
+    let value = Bytes::from(vec![b'x'; 64 * 1024]);
+    for _ in 0..40 {
+        cache.put(T, NS, C, "hot", value.clone(), None).await;
+    }
+
+    let shard = cache.shard(T, NS, C).expect("shard");
+    let state = shard.state.lock().await;
+    assert!(
+        state.index.log_bytes < 40 * value.len() as u64,
+        "the log was never compacted: {} bytes for 40 writes of {}",
+        state.index.log_bytes,
+        value.len(),
+    );
+    drop(state);
+
+    assert_eq!(
+        cache.get(T, NS, C, "hot").await.map(|v| v.len()),
+        Some(value.len()),
+        "compaction must not lose the value it is compacting around",
+    );
+}
+
+/// Compaction drops expired entries rather than copying them forward.
+#[tokio::test]
+async fn compaction_drops_expired_entries() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let cache = cache(dir.path()).await;
+
+    cache
+        .put(
+            T,
+            NS,
+            C,
+            "doomed",
+            Bytes::from(vec![b'y'; 32 * 1024]),
+            Some(Duration::from_millis(1)),
+        )
+        .await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let value = Bytes::from(vec![b'x'; 64 * 1024]);
+    for _ in 0..40 {
+        cache.put(T, NS, C, "hot", value.clone(), None).await;
+    }
+
+    let shard = cache.shard(T, NS, C).expect("shard");
+    let state = shard.state.lock().await;
+    assert!(
+        !state.index.entries.contains_key("doomed"),
+        "an expired entry was carried through compaction",
+    );
+}
+
+/// A compacted cache still reopens. Compaction swaps directories, so a bug
+/// there would be invisible until the next restart.
+#[tokio::test]
+async fn a_compacted_cache_survives_a_restart() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let value = Bytes::from(vec![b'x'; 64 * 1024]);
+    {
+        let cache = cache(dir.path()).await;
+        for _ in 0..40 {
+            cache.put(T, NS, C, "hot", value.clone(), None).await;
+        }
+        cache
+            .put(T, NS, C, "cold", Bytes::from_static(b"kept"), None)
+            .await;
+        cache.shutdown().await.expect("shutdown");
+    }
+
+    let reopened = cache(dir.path()).await;
+    assert_eq!(
+        reopened.get(T, NS, C, "hot").await.map(|v| v.len()),
+        Some(value.len())
+    );
+    assert_eq!(
+        reopened.get(T, NS, C, "cold").await.as_deref(),
+        Some(&b"kept"[..])
+    );
+}

--- a/crates/felix-storage/src/segment/format.rs
+++ b/crates/felix-storage/src/segment/format.rs
@@ -116,6 +116,29 @@ pub enum CorruptionKind {
         expected: Offset,
         found: Offset,
     },
+    /// A cache record was shorter than its own fixed header.
+    CacheRecordTooShort {
+        len: usize,
+        header_len: usize,
+    },
+    /// Written by a build whose cache record layout this one does not know.
+    ///
+    /// Refused rather than read with the layout this build happens to have: a
+    /// later version may have moved a field, and guessing produces a plausible
+    /// wrong value where an error would have been honest.
+    CacheRecordVersion {
+        found: u8,
+        expected: u8,
+    },
+    CacheRecordOp {
+        found: u8,
+    },
+    /// The record claims a key longer than the bytes it carries.
+    CacheRecordKeyLength {
+        claimed: usize,
+        available: usize,
+    },
+    CacheRecordKeyNotUtf8,
 }
 
 impl fmt::Display for CorruptionKind {
@@ -158,6 +181,24 @@ impl fmt::Display for CorruptionKind {
                     "offset out of order (expected {expected}, found {found})"
                 )
             }
+            CorruptionKind::CacheRecordTooShort { len, header_len } => write!(
+                f,
+                "cache record is {len} bytes, shorter than its {header_len}-byte header"
+            ),
+            CorruptionKind::CacheRecordVersion { found, expected } => write!(
+                f,
+                "cache record version {found} is not readable by this build (expects {expected})"
+            ),
+            CorruptionKind::CacheRecordOp { found } => {
+                write!(f, "unknown cache record op {found}")
+            }
+            CorruptionKind::CacheRecordKeyLength { claimed, available } => write!(
+                f,
+                "cache record claims a {claimed}-byte key but carries {available} bytes after it"
+            ),
+            CorruptionKind::CacheRecordKeyNotUtf8 => {
+                write!(f, "cache record key is not valid UTF-8")
+            }
         }
     }
 }
@@ -186,6 +227,13 @@ impl Corruption {
 
     /// Attach the byte position, unless a nested call already recorded a more
     /// specific one.
+    /// Attach the shard, for a decoder that knows which log it was reading but
+    /// not which segment within it.
+    pub fn in_shard(mut self, shard: impl fmt::Display) -> Self {
+        self.site.shard = Some(shard.to_string());
+        self
+    }
+
     pub fn at_position(mut self, position: u64) -> Self {
         self.site.position.get_or_insert(position);
         self

--- a/docs-site/src/content/docs/architecture/system-design.md
+++ b/docs-site/src/content/docs/architecture/system-design.md
@@ -12,7 +12,7 @@ Internally, Felix is built around a single append-only log abstraction. Differen
 
 - **Streams (Pub/Sub):** Fanout cursors per subscription
 - **Queues:** Shared consumer-group cursors with acknowledgements
-- **Cache:** Key → latest value with TTL, backed by the same log for invalidation and replay
+- **Cache:** key → latest value with TTL, written to the same log as records and read back through an index rebuilt from it. Compaction reclaims superseded and expired entries. Cache operations are not yet routed across brokers — see `docs/cache-on-log.md`
 
 This drastically reduces operational complexity and consistency bugs compared to running Kafka, Redis, and a queueing system side-by-side.
 

--- a/docs-site/src/content/docs/getting-started/what-felix-is-for.md
+++ b/docs-site/src/content/docs/getting-started/what-felix-is-for.md
@@ -135,7 +135,7 @@ These are shipped and measured. If you need one of these, Felix is usable now.
 | Batched publish and batched delivery | ✅ Today | Count- and time-bounded, JSON or binary framing |
 | Bounded per-subscriber queues | ✅ Today | Explicit depth limits at every stage |
 | Slow-consumer isolation | ✅ Today | `Block`, `DropNew` (default), `DropOld` — see [`SubQueuePolicy`](/felix/reference/configuration/) |
-| Key/value cache with TTL | ✅ Today | Scoped `(tenant, namespace, cache, key)`, lazy expiry, best-effort eviction |
+| Key/value cache with TTL | ✅ Today | Scoped `(tenant, namespace, cache, key)`, lazy expiry against an absolute expiry time that survives a restart |
 | Multi-tenant scoping | ✅ Today | Tenant and namespace required on all data-plane operations |
 | Token-based authorization | ✅ Today | OIDC token exchange, tenant-scoped JWTs, broker-side permission checks on publish/subscribe/cache |
 | Control plane metadata service | ✅ Today | REST + OpenAPI, tenant/namespace/stream/cache CRUD, snapshot and changes feeds, in-memory or Postgres backing |
@@ -208,7 +208,7 @@ ship rather than being marked off here.
 
 | Capability | Status | Current state of the code |
 |---|---|---|
-| Log-backed cache (one core log, many semantics) | 🎯 Target | Cache is a separate storage handle, not a projection over the stream log |
+| Log-backed cache (one core log, many semantics) | 🚧 Partial | A cache is a log: writes append records, reads go through an index of key → offset rebuilt from the log at startup, and compaction reclaims superseded and expired records without ever rewriting one. Entries survive a restart when the broker has `FELIX_DURABLE_STORAGE_DIR`; without one the cache is in memory, because there is nowhere to write a log. Partial because cache operations are not routed across brokers — every broker serves its own cache — and the wire protocol has no cache delete |
 | Gap-free "current state + subsequent changes" subscribe | 🎯 Target | `Subscribe` takes an offset, so *changes since a known point* is gap-free. The missing half is the snapshot: there is no way to ask for current state and subsequent changes in one call |
 | Queue semantics (consumer groups, acks, redelivery) | 🎯 Target | Explicitly post-MVP; not started |
 | Tiered / cold storage | 🎯 Target | `TieredStore` trait declared, no implementation |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,7 @@ Internally, Felix is built around a single append-only log abstraction. Differen
 are projections over this core:
 - **Streams (Pub/Sub):** fanout cursors per subscription
 - **Queues:** shared consumer-group cursors with acknowledgements
-- **Cache:** key → latest value with TTL, backed by the same log for invalidation and replay
+- **Cache:** key → latest value with TTL, written to the same log as records and read back through an index rebuilt from it. Compaction reclaims superseded and expired entries. Cache operations are not yet routed across brokers — see `docs/cache-on-log.md`
 
 This drastically reduces operational complexity and consistency bugs compared to running Kafka,
 Redis, and a queueing system side-by-side.

--- a/docs/assets/storage/cache-record.svg
+++ b/docs/assets/storage/cache-record.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 430" width="760" height="430" role="img" aria-label="Cache record byte layout: version, op, expires_at_millis, key_len, then the key and the value">
+  <style>
+    .cell    { stroke: var(--edge); stroke-width: 1.25; }
+    .id      { fill: var(--c-id); }
+    .len     { fill: var(--c-len); }
+    .data    { fill: var(--c-data); }
+    .pay     { fill: var(--c-pay); }
+    .label   { fill: var(--ink); font: 500 13px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif; text-anchor: middle; }
+    .sub     { fill: var(--ink-dim); font: 400 11px ui-monospace, SFMono-Regular, "JetBrains Mono", Menlo, monospace; text-anchor: middle; }
+    .offset  { fill: var(--ink-dim); font: 400 11px ui-monospace, SFMono-Regular, Menlo, monospace; text-anchor: end; }
+    .gutter  { fill: var(--ink-dim); font: 400 10px ui-sans-serif, system-ui, sans-serif; text-anchor: end; }
+    .title   { fill: var(--ink); font: 600 14px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .note    { fill: var(--ink-dim); font: 400 12px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .brace   { stroke: var(--accent); stroke-width: 1.5; fill: none; }
+    .braceTx { fill: var(--accent); font: 500 12px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .dash    { stroke-dasharray: 5 4; }
+
+    :root {
+      --ink: #1a2b40; --ink-dim: #5b6b7f;
+      --edge: #4a6fa5; --edge-dim: #aab6c6; --accent: #b0653a;
+      --c-id: #dbe6f7; --c-len: #d6ecf5; --c-data: #e3f0e7; --c-pay: #f2ecf8;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root:not([data-theme="light"]) {
+        --ink: #dfe8f3; --ink-dim: #9aabbf;
+        --edge: #6d94cc; --edge-dim: #46536a; --accent: #d99a6c;
+        --c-id: #24344b; --c-len: #1f3a45; --c-data: #223a2c; --c-pay: #322940;
+      }
+    }
+    :root[data-theme="dark"] {
+      --ink: #dfe8f3; --ink-dim: #9aabbf;
+      --edge: #6d94cc; --edge-dim: #46536a; --accent: #d99a6c;
+      --c-id: #24344b; --c-len: #1f3a45; --c-data: #223a2c; --c-pay: #322940;
+    }
+    :root[data-theme="light"] {
+      --ink: #1a2b40; --ink-dim: #5b6b7f;
+      --edge: #4a6fa5; --edge-dim: #aab6c6; --accent: #b0653a;
+      --c-id: #dbe6f7; --c-len: #d6ecf5; --c-data: #e3f0e7; --c-pay: #f2ecf8;
+    }
+  </style>
+
+  <text class="title" x="24" y="26">Cache record — 14-byte header, then the key, then the value</text>
+
+  <rect class="cell id" x="64" y="52" width="304" height="46" rx="3"/>
+  <text class="label" x="216" y="73">version</text>
+  <text class="sub" x="216" y="89">u8 — 1</text>
+
+  <rect class="cell id" x="368" y="52" width="304" height="46" rx="3"/>
+  <text class="label" x="520" y="73">op</text>
+  <text class="sub" x="520" y="89">u8 — 0 put, 1 delete</text>
+
+  <rect class="cell data" x="64" y="98" width="608" height="92" rx="3"/>
+  <text class="label" x="368" y="142">expires_at_millis</text>
+  <text class="sub" x="368" y="158">u64 little-endian — absolute, 0 means never</text>
+
+  <rect class="cell len" x="64" y="190" width="608" height="46" rx="3"/>
+  <text class="label" x="368" y="211">key_len</text>
+  <text class="sub" x="368" y="227">u32 little-endian</text>
+
+  <rect class="cell pay" x="64" y="236" width="608" height="46" rx="3"/>
+  <text class="label" x="368" y="257">key</text>
+  <text class="sub" x="368" y="273">key_len bytes, UTF-8</text>
+
+  <rect class="cell pay dash" x="64" y="282" width="608" height="46" rx="3"/>
+  <text class="label" x="368" y="303">value</text>
+  <text class="sub" x="368" y="319">the rest of the record — put only</text>
+
+  <text class="gutter" x="54" y="44">offset</text>
+  <text class="offset" x="54" y="79">0</text>
+  <text class="offset" x="54" y="125">2</text>
+  <text class="offset" x="54" y="217">10</text>
+  <text class="offset" x="54" y="263">14</text>
+  <text class="offset" x="54" y="309">14+key_len</text>
+
+  <path class="brace" d="M 679 240 q 7 0 7 9 L 686 296 q 0 9 7 9 q -7 0 -7 9 L 686 314 q 0 9 -7 9"/>
+  <text class="braceTx" x="700" y="268">a delete stops</text>
+  <text class="braceTx" x="700" y="284">after the key</text>
+
+  <text class="note" x="24" y="366">The value needs no length of its own: the segment framing already delimits the record, so the value is simply what is left.</text>
+  <text class="note" x="24" y="386">The expiry is absolute rather than a duration, so a record read back after a restart means what it meant when it was written.</text>
+  <text class="note" x="24" y="406">An unknown version is refused rather than read with this layout — a misread record is worse than an unreadable one.</text>
+</svg>

--- a/docs/cache-on-log.md
+++ b/docs/cache-on-log.md
@@ -1,0 +1,109 @@
+# The cache is a projection over the log
+
+**Decision: a cache is a log. `put` and `delete` append records, an in-memory
+index maps key to offset, and `get` reads the log. The separate in-memory
+key/value store is kept only for brokers configured without durable storage.**
+
+This is what `docs/architecture.md` has claimed from the start — "one core log,
+many semantics", with the cache as "key → latest value with TTL, backed by the
+same log". Until now that was aspiration stated as description: the cache was a
+`RwLock<HashMap>` alongside the stream registry, sharing no code, no durability,
+and no replication with it.
+
+## What the log already gives, free
+
+Everything a durable cache needs is already built and already tested, because
+streams needed it first:
+
+- **Crash safety.** CRC-verified records, torn-tail repair, interior corruption
+  refused rather than silently accepted.
+- **Group commit and fsync policy.** A cache write is an append, so it inherits
+  the same throughput lever.
+- **Replication.** The driver ships log records and does not care what semantic
+  reads them. A cache on the log is replicated by the code that already
+  replicates streams, once its shards are placed (#240 and the cache-routing
+  work that follows this).
+
+That last point is the argument for doing it this way rather than bolting
+durability onto a hash map: the alternative is a second durability path and a
+second replication path, which is exactly what the storage design set out not to
+have.
+
+## Where a cache lives on disk
+
+Under `<root>/caches/`, with a provider of its own; streams stay at `<root>/`.
+
+A shard directory is named from a hash of `(tenant, namespace, stream)`, so a
+cache and a stream with the same name in the same namespace would otherwise
+land in the same directory and interleave their records. Separating the roots
+makes that impossible rather than unlikely, costs nothing, and leaves the
+existing stream layout untouched — no migration, because no stream path
+changes.
+
+Nothing enumerates the storage root (recovery scans a *shard* directory for
+segment files), so an extra subdirectory under it is inert.
+
+## The record format
+
+One record per write. Little-endian, and versioned in its first byte, because
+this is a durable format and a reader years from now has only these bytes.
+
+<p align="center">
+  <img src="assets/storage/cache-record.svg" alt="Cache record byte layout: a one-byte version, a one-byte op, an eight-byte absolute expiry, a four-byte key length, then the key and — for a put — the value" width="760">
+</p>
+
+- `op` is `0` for a put and `1` for a delete. A delete carries no value.
+- `expires_at_millis` is absolute Unix milliseconds, `0` meaning "never".
+  Absolute rather than a duration: a record read back after a restart has to
+  mean the same thing it meant when written, and a duration would silently
+  restart its life on every recovery.
+- `key_len` bounds the key so the value needs no length of its own — it is
+  simply the rest of the record, which the segment framing already delimits.
+
+An unknown version is refused rather than guessed at, for the same reason an
+unknown frame flag is: a misread record is worse than an unreadable one.
+
+## The index is derived, never trusted
+
+`key -> (offset, expires_at)`, held in memory and rebuilt by replaying the log
+when the cache is opened. This is the same rule the segment indexes follow, and
+for the same reason: anything that can be recomputed from the log must be,
+because then it can never be stale in a way that matters.
+
+**The index holds offsets, not values.** The log is the store; memory holds only
+where to look. This costs a read per `get` that a hash map would not pay, and it
+is what makes the durability real rather than a write-behind of an in-memory
+map that is still the actual source of truth. Caching hot values in memory in
+front of this index is a straightforward later optimisation, and deliberately
+not part of making the claim true.
+
+## TTL
+
+Checked at read against the record's own `expires_at_millis`, which is lazy
+expiry — the same behaviour the in-memory cache always had. An expired entry is
+reported as absent immediately; the space it occupies is reclaimed by
+compaction.
+
+## Compaction
+
+Without it the log grows forever, and "the cache is a log" would be a slow leak
+rather than a design.
+
+Compaction writes the live set — the newest surviving record for each key that
+is neither deleted nor expired — into a fresh log, then swaps it in. **Records
+are never rewritten**, which is the invariant everything in the storage layer
+rests on: compaction produces new segments and drops old ones, and never edits a
+byte in place.
+
+It runs when the log has grown past a multiple of its live bytes, so the cost is
+proportional to the garbage and a cache that is mostly live is never compacted.
+Writes are excluded for the duration; a cache write is already serialised behind
+the index lock, so this adds no new contention, only a longer hold.
+
+## What this does not do yet
+
+Cache operations are not routed. Every broker serves its own cache, so a `put`
+on one broker is invisible to a `get` on another, and the control plane does not
+place cache shards. That is the next piece, and it is the same machinery
+publishes and subscribes already use — which is the point of putting the cache
+on the log first.

--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -33,14 +33,25 @@ The goal is predictable p99/p999 behavior, even when the system is under pressur
 - **Authorization:** ACL evaluation is not implemented in the MVP.
 - **Quotas:** per-tenant/namespace quotas are not enforced in the MVP.
 
-## Cache Semantics (MVP)
+## Cache Semantics
 
 - **Scoping:** cache entries are scoped to `(tenant_id, namespace, cache, key)`.
-- **TTL:** entries expire after TTL; expiration is lazy on access.
-- **Eviction:** if a cache capacity is configured, eviction is best-effort and not LRU.
+- **Storage:** a cache is a log. A write appends a record; a read consults an
+  in-memory index of key → offset and reads the log. See `docs/cache-on-log.md`.
+- **Durability:** entries survive a restart when the broker runs with
+  `FELIX_DURABLE_STORAGE_DIR`. Without it the cache is in memory and is lost,
+  because there is nowhere to write a log.
+- **TTL:** entries expire after TTL; expiration is lazy on access. The expiry is
+  stored as an absolute time, so it survives a restart rather than beginning
+  again.
+- **Reclamation:** compaction rewrites the live set and drops superseded and
+  expired records once a log has grown past a multiple of its live bytes.
+- **Routing:** cache operations are **not** routed. Every broker serves its own
+  cache, so a write on one is not visible on another.
 
 ## Non-Goals (MVP)
 
 - Exactly-once or at-least-once delivery.
 - Cross-region replication or routing guarantees.
-- Durability beyond in-memory storage.
+- Durability beyond in-memory storage *for ephemeral streams*. Durable streams and the
+  cache are both log-backed and survive a restart.

--- a/services/broker/src/main.rs
+++ b/services/broker/src/main.rs
@@ -174,17 +174,11 @@ where
     // Configuration is resolved from environment variables (and optionally a YAML file).
     // Keep this early so the remainder of startup is entirely driven by `config`.
 
-    // Start an in-process broker. The cache backend is in-memory; stream
-    // durability is separate and opt-in via `FELIX_DURABLE_STORAGE_DIR`.
-    let broker = Broker::new(EphemeralCache::new().into())
-        .with_topic_capacity(config.subscriber_queue_capacity.max(1))
-        .context("configure subscriber queue depth")?
-        .with_subscriber_queue_policy(config.subscriber_queue_policy);
-
     // Durable storage is opened before the listener binds: recovering segments
     // can take time and can fail, and both are better surfaced as a startup
     // error than as a failed publish once traffic is arriving.
-    let durable_storage = match DurableStorageConfig::from_env()? {
+    let durable_config = DurableStorageConfig::from_env()?;
+    let durable_storage = match &durable_config {
         Some(durable) => {
             tracing::info!(config = %durable.summary(), "opening durable stream storage");
             let storage = DurableStorage::open(&durable.root, durable.log.clone())
@@ -198,6 +192,35 @@ where
             None
         }
     };
+
+    // The cache is a log when there is a disk to put one on.
+    //
+    // Under `caches/`, not the stream root: a shard directory is named from a
+    // hash of its tenant, namespace and stream, so a cache and a stream sharing
+    // a name would otherwise interleave their records. See
+    // `docs/cache-on-log.md`.
+    //
+    // Without durable storage the cache stays in memory, which is the only
+    // thing it can be: there is nowhere to write a log.
+    let cache: Box<dyn felix_storage::StorageApi + Send> = match &durable_config {
+        Some(durable) => {
+            let root = durable.root.join("caches");
+            tracing::info!(root = %root.display(), "opening the cache on durable storage");
+            Box::new(
+                felix_storage::LogCache::open(&root, durable.log.clone())
+                    .with_context(|| format!("open the cache log at {}", root.display()))?,
+            )
+        }
+        None => {
+            tracing::info!("cache is in memory and is lost on restart");
+            Box::new(EphemeralCache::new())
+        }
+    };
+
+    let broker = Broker::new(cache)
+        .with_topic_capacity(config.subscriber_queue_capacity.max(1))
+        .context("configure subscriber queue depth")?
+        .with_subscriber_queue_policy(config.subscriber_queue_policy);
     let broker = match durable_storage.clone() {
         Some(storage) => broker.with_durable_storage(storage),
         None => broker,

--- a/services/broker/tests/cache_durability.rs
+++ b/services/broker/tests/cache_durability.rs
@@ -1,0 +1,255 @@
+//! The cache outliving the process that wrote it.
+//!
+//! The storage-level tests prove the log-backed cache keeps its entries; this
+//! proves the broker is actually wired to it. Both matter: a correct
+//! implementation nothing is connected to would pass the first and fail here.
+//!
+//! "Restart" is the broker and its storage torn down and rebuilt over the same
+//! directory, which is what a process restart is from the cache's point of
+//! view: nothing in memory survives, and only the log does.
+use anyhow::{Context, Result};
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use broker::{auth::BrokerAuth, quic};
+use ed25519_dalek::SigningKey as Ed25519SigningKey;
+use felix_authz::{FelixTokenIssuer, Jwks, TenantId, TenantKeyCache, TenantKeyMaterial};
+use felix_broker::{Broker, CacheMetadata};
+use felix_client::{Client, ClientConfig};
+use felix_storage::LogCache;
+use felix_storage::log::{FsyncMode, LogConfig};
+use felix_transport::{QuicServer, TransportConfig};
+use quinn::ClientConfig as QuinnClientConfig;
+use rcgen::generate_simple_self_signed;
+use rustls::RootCertStore;
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+const DEMO_PRIVATE_KEY: [u8; 32] = [42u8; 32];
+const CACHE: &str = "sessions";
+
+struct DemoAuthBundle {
+    auth: Arc<BrokerAuth>,
+    tokens: HashMap<String, String>,
+}
+
+/// A broker serving over QUIC with its cache on `root`.
+struct Running {
+    addr: std::net::SocketAddr,
+    cert: CertificateDer<'static>,
+    tokens: HashMap<String, String>,
+    server: Arc<QuicServer>,
+    task: tokio::task::JoinHandle<Result<()>>,
+}
+
+async fn start(root: &std::path::Path) -> Result<Running> {
+    let cache = LogCache::open(
+        root,
+        LogConfig {
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .context("open the cache log")?;
+
+    let broker = Arc::new(Broker::new(Box::new(cache)));
+    broker.register_tenant("t1").await?;
+    broker.register_namespace("t1", "default").await?;
+    broker
+        .register_cache("t1", "default", CACHE, CacheMetadata)
+        .await?;
+
+    let config = broker::config::BrokerConfig::from_env()?;
+    let demo_auth = demo_auth_for_tenants(&["t1"], Duration::from_secs(900))?;
+    let (server_config, cert) = build_server_config()?;
+    let server = Arc::new(QuicServer::bind(
+        "127.0.0.1:0".parse()?,
+        server_config,
+        TransportConfig::default(),
+    )?);
+    let addr = server.local_addr()?;
+    let task = tokio::spawn(quic::serve(
+        Arc::clone(&server),
+        broker,
+        config,
+        demo_auth.auth,
+    ));
+
+    Ok(Running {
+        addr,
+        cert,
+        tokens: demo_auth.tokens,
+        server,
+        task,
+    })
+}
+
+impl Running {
+    async fn client(&self) -> Result<Client> {
+        let mut config = build_client_config(self.cert.clone())?;
+        config.auth_tenant_id = Some("t1".to_string());
+        config.auth_token = self.tokens.get("t1").cloned();
+        Client::connect(self.addr, "localhost", config).await
+    }
+
+    /// Stop serving, the way a process going away does.
+    async fn stop(self) {
+        self.task.abort();
+        let _ = self.task.await;
+        drop(self.server);
+    }
+}
+
+/// **A cached value outlives the broker that stored it.** The claim the whole
+/// design exists to make true: the cache is a log, so it is on disk, so a
+/// restart does not lose it.
+#[tokio::test]
+async fn a_cached_value_survives_a_restart() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let running = start(dir.path()).await?;
+    running
+        .client()
+        .await?
+        .cache_put(
+            "t1",
+            "default",
+            CACHE,
+            "user:1",
+            b"alice".to_vec().into(),
+            None,
+        )
+        .await?;
+    running.stop().await;
+
+    let restarted = start(dir.path()).await?;
+    let value = restarted
+        .client()
+        .await?
+        .cache_get("t1", "default", CACHE, "user:1")
+        .await?;
+    assert_eq!(
+        value.as_deref(),
+        Some(&b"alice"[..]),
+        "the cache lost its entry across a restart",
+    );
+    restarted.stop().await;
+    Ok(())
+}
+
+/// The newest write is the one that survives, not the first.
+#[tokio::test]
+async fn the_latest_value_is_the_one_that_survives() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let running = start(dir.path()).await?;
+    let client = running.client().await?;
+    for value in ["one", "two", "three"] {
+        client
+            .cache_put(
+                "t1",
+                "default",
+                CACHE,
+                "user:1",
+                value.as_bytes().to_vec().into(),
+                None,
+            )
+            .await?;
+    }
+    drop(client);
+    running.stop().await;
+
+    let restarted = start(dir.path()).await?;
+    let value = restarted
+        .client()
+        .await?
+        .cache_get("t1", "default", CACHE, "user:1")
+        .await?;
+    assert_eq!(value.as_deref(), Some(&b"three"[..]));
+    restarted.stop().await;
+    Ok(())
+}
+
+fn demo_auth_for_tenants(tenants: &[&str], ttl: Duration) -> Result<DemoAuthBundle> {
+    let mut key_store: HashMap<String, TenantKeyMaterial> = HashMap::new();
+    let mut tokens = HashMap::new();
+    let mut jwks_per_tenant = HashMap::new();
+
+    for tenant in tenants {
+        let signing_key = Ed25519SigningKey::from_bytes(&DEMO_PRIVATE_KEY);
+        let public_key = signing_key.verifying_key().to_bytes();
+        let jwks = build_demo_jwks("demo-k1", &public_key)?;
+        key_store.insert(
+            (*tenant).to_string(),
+            TenantKeyMaterial {
+                kid: "demo-k1".to_string(),
+                alg: jsonwebtoken::Algorithm::EdDSA,
+                private_key: DEMO_PRIVATE_KEY,
+                public_key,
+                jwks: jwks.clone(),
+            },
+        );
+        jwks_per_tenant.insert((*tenant).to_string(), jwks);
+    }
+
+    let issuer = FelixTokenIssuer::new("felix-auth", "felix-broker", ttl, Arc::new(key_store));
+    for tenant in tenants {
+        let perms = vec![
+            format!("tenant.manage:tenant:{tenant}"),
+            format!("ns.manage:namespace:{tenant}/*"),
+            format!("cache.read:cache:{tenant}/*/*"),
+            format!("cache.write:cache:{tenant}/*/*"),
+        ];
+        tokens.insert(
+            (*tenant).to_string(),
+            issuer.mint(&TenantId::new(*tenant), "p:demo", perms)?,
+        );
+    }
+
+    let key_store = Arc::new(broker::auth::ControlPlaneKeyStore::new(
+        "http://127.0.0.1".to_string(),
+        Arc::new(TenantKeyCache::default()),
+    ));
+    for (tenant, jwks) in jwks_per_tenant {
+        key_store.insert_jwks(&TenantId::new(&tenant), jwks);
+    }
+
+    Ok(DemoAuthBundle {
+        auth: Arc::new(BrokerAuth::with_key_store(key_store)),
+        tokens,
+    })
+}
+
+fn build_demo_jwks(kid: &str, public_key: &[u8; 32]) -> Result<Jwks> {
+    Ok(Jwks {
+        keys: vec![felix_authz::Jwk {
+            kty: "OKP".to_string(),
+            kid: kid.to_string(),
+            alg: "EdDSA".to_string(),
+            use_field: felix_authz::KeyUse::Sig,
+            crv: Some("Ed25519".to_string()),
+            x: Some(URL_SAFE_NO_PAD.encode(public_key)),
+        }],
+    })
+}
+
+fn build_server_config() -> Result<(quinn::ServerConfig, CertificateDer<'static>)> {
+    let cert = generate_simple_self_signed(vec!["localhost".into()])?;
+    let cert_der = cert.cert.der().clone();
+    let key_der = PrivatePkcs8KeyDer::from(cert.signing_key.serialize_der());
+    Ok((
+        quinn::ServerConfig::with_single_cert(vec![cert_der.clone()], key_der.into())?,
+        cert_der,
+    ))
+}
+
+fn build_client_config(cert: CertificateDer<'static>) -> Result<ClientConfig> {
+    let mut roots = RootCertStore::empty();
+    roots.add(cert)?;
+    ClientConfig::from_env_or_yaml(
+        QuinnClientConfig::with_root_certificates(Arc::new(roots))?,
+        None,
+    )
+}


### PR DESCRIPTION
Closes #277.

`docs/architecture.md` has claimed **"one core log, many semantics"** from the start, with the cache as *"key → latest value with TTL, backed by the same log"*. That was aspiration written in the present tense. The cache was a `RwLock<HashMap>` beside the stream registry — no shared code, no durability, no replication, and everything lost on restart.

It is now actually a log.

## The design

`put` and `delete` append a record. An index maps each key to the offset of the record that defines it. `get` reads the log there. Full reasoning in the new [`docs/cache-on-log.md`](docs/cache-on-log.md).

**The index is derived, never trusted** — rebuilt by replaying the log when a cache is opened, the same rule the segment indexes already follow.

**The index holds offsets, not values.** The log is the store; memory holds only where to look. That costs a read per `get` that a hash map would not pay, and it is exactly what makes the durability real rather than a write-behind of an in-memory map that is still the true source of truth. Caching hot values in front of the index is a later optimisation, and deliberately not part of making the claim true.

**Compaction**, because without it the log grows forever and "the cache is a log" is a slow leak rather than a design. It rewrites the live set — newest surviving record per key, expired entries dropped — into a fresh directory and swaps. **Records are never rewritten**, the invariant the whole storage layer rests on: new segments, dropped old ones, never a byte edited in place. It triggers on a multiple of live bytes, so the cost is proportional to the garbage and a mostly-live cache is never compacted.

**The record format** is explicit and versioned rather than whatever a serialiser emits — these bytes outlive the process that wrote them. The expiry is stored **absolute**, not as a duration, so a restart does not hand every entry a fresh life. An unknown version is refused rather than read with this build's layout.

**Caches live under `<root>/caches/`.** A shard directory is named from a hash of `(tenant, namespace, stream)`, so a cache and a stream sharing a name would otherwise interleave records in one directory. No stream path changes, so there is nothing to migrate.

Without `FELIX_DURABLE_STORAGE_DIR` the cache stays in memory — the only thing it can be when there is nowhere to write a log.

## Tests

- **24 storage tests**: read-back, overwrite-wins, delete, tenant and cache isolation, TTL, `len` counting only live entries; **`a_cache_survives_a_restart`** and **`an_expiry_survives_a_restart`**; compaction reclaiming overwrites, dropping expired entries, and surviving a reopen
- **10 record-format tests**, including one that pins the byte layout rather than only round-tripping it — a round-trip alone lets both sides drift together and still pass
- **2 end-to-end broker tests** over QUIC: a value written through the client survives the broker being torn down and rebuilt over the same directory. Verified load-bearing — swapping `LogCache` for `EphemeralCache` fails them with *"the cache lost its entry across a restart"*

## Docs swept, not appended to

You asked for the docs to be correct and robust, so I went through every cache claim rather than just adding a page:

- `architecture.md` and its docs-site copy stated the premise as fact — now they say what is and is not true
- `semantics.md` described the in-memory cache's TTL and eviction; it now describes the log's, including that expiry survives a restart and that cache ops are **not** routed
- the non-goal *"durability beyond in-memory storage"* was already false for durable streams
- the README's MVP list said "ephemeral cache with TTL"
- the status table row moves **🎯 Target → 🚧 Partial**

The record layout is drawn as a theme-aware SVG in the same idiom as the other storage diagrams, replacing an ASCII block.

## Not in this PR

**Cache operations are not routed.** Every broker serves its own cache, so a write on one is invisible on another, and the control plane does not place cache shards. That is the next slice, and it is the same machinery publishes and subscribes already use — which is the point of putting the cache on the log first. Replication then comes free: the driver ships log records and does not care what semantic reads them.

Also surfaced: **the wire protocol has no cache delete.** `StorageApi::delete` exists and the client cannot reach it.

## Verification

- `task test` — green, 78 blocks, 0 failures
- `task lint` — clean
- `node scripts/check-mermaid.mjs` — 92 diagrams valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)