### PR TITLE
fix(broker): stop acknowledging a Quorum publish that no majority holds (#282)

### DIFF
--- a/crates/felix-cluster/tests/failover.rs
+++ b/crates/felix-cluster/tests/failover.rs
@@ -140,15 +140,18 @@ async fn failover_from(cluster: &Cluster, gone: &str, budget: Duration) -> Optio
 /// The acknowledgement is the whole claim: it means a majority held the record
 /// durably, so losing any one of them — including the leader — cannot take it.
 ///
-/// Ignored: **intermittent**, roughly one run in four (#266). Usually the
-/// promoted broker replays everything; occasionally it accepts the subscribe
-/// and delivers nothing, and retrying with fresh subscriptions for 30s does not
-/// recover it.
+/// Was intermittent, roughly one run in four, and the cause is now known: the
+/// acknowledgement did not require a majority at all. `Quorum` degraded to the
+/// `Leader` behaviour whenever `ack_on_commit` was off — the default — because
+/// the enqueue-ack path answered "accepted into the ingress queue" to a
+/// question about majorities, and the quorum wait ran in a worker nobody was
+/// listening to. A record acknowledged that way existed only on the leader, so
+/// promoting any replica legitimately lost it, and the test failed whenever the
+/// promoted broker was one that had not received it (#282).
 ///
-/// Kept rather than deleted — it is the milestone's acceptance criterion and
-/// the thing to re-run against any fix — and kept ignored rather than left
-/// failing, because a test that fails one run in four teaches people to ignore
-/// red.
+/// The comment that used to sit here said this test was ignored. It was not —
+/// there was no `#[ignore]`, so it ran and failed one run in four, which is
+/// worse than either honest option.
 #[serial]
 #[tokio::test]
 async fn a_quorum_acknowledged_record_survives_its_leader() {

--- a/crates/felix-cluster/tests/fencing.rs
+++ b/crates/felix-cluster/tests/fencing.rs
@@ -1,0 +1,310 @@
+//! What happens to a leader that was never told it stopped being one.
+//!
+//! #115's central safety criterion: *no record is acknowledged by two
+//! conflicting leaders for the same logical epoch*. A killed leader cannot
+//! violate it — it is gone. A **paused** one can: it is alive, it still
+//! believes it holds the shard, and it comes back after the cluster has moved
+//! on. That is the case worth injecting, and it is what `pause_node` exists
+//! for.
+//!
+//! Run with `cargo test -p felix-cluster --test fencing`.
+use std::time::Duration;
+
+use felix_cluster::{Cluster, ClusterConfig, StreamSpec};
+use serial_test::serial;
+
+const STREAM: &str = "orders";
+
+fn quorum_cluster(nodes: usize, replication_factor: u32) -> ClusterConfig {
+    ClusterConfig {
+        nodes,
+        streams: vec![StreamSpec::quorum(STREAM, 1, replication_factor)],
+        inherit_output: std::env::var("FELIX_TEST_BROKER_OUTPUT").is_ok(),
+        ..Default::default()
+    }
+}
+
+/// Everything `node_id` will replay, retried until it yields something: being
+/// named leader and being ready to serve are different moments.
+async fn replay(cluster: &Cluster, node_id: &str) -> Vec<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    loop {
+        if let Ok((_client, mut subscription)) = cluster.replay_on(node_id, STREAM).await {
+            let mut payloads = Vec::new();
+            while let Ok(Ok(Some(event))) =
+                tokio::time::timeout(Duration::from_secs(2), subscription.next_event()).await
+            {
+                payloads.push(String::from_utf8_lossy(&event.payload).to_string());
+            }
+            if !payloads.is_empty() {
+                return payloads;
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            return Vec::new();
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
+/// Publish through a broker that has just been promoted, retrying while it gets
+/// ready.
+///
+/// Being named leader and being able to serve are different moments: the
+/// promoted broker learns of its own promotion through the same watch as
+/// everything else, and has to open the shard before it can accept a write.
+/// Retrying is what the cluster asks of an application here, and #119 is where
+/// the client learns to do it for itself.
+async fn publish_when_ready(cluster: &Cluster, node_id: &str, payload: &[u8]) {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut last = String::new();
+    while std::time::Instant::now() < deadline {
+        match cluster.publish_via(node_id, STREAM, payload.to_vec()).await {
+            Ok(()) => return,
+            Err(err) => last = format!("{err:#}"),
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    panic!(
+        "{} never accepted a publish within 30s of being promoted; last: {last}",
+        node_id
+    );
+}
+
+/// Wait for a broker other than `gone` to own the shard.
+async fn failover_from(cluster: &Cluster, gone: &str) -> Option<String> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < deadline {
+        // The harness's control plane does not reconcile on a timer, so a
+        // failure test has to step placement itself. Without this nothing
+        // re-plans after the fault and the wait measures nothing.
+        cluster.place_shards().await;
+        if let Ok(owner) = cluster.owner(STREAM).await
+            && owner != gone
+        {
+            return Some(owner);
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    None
+}
+
+/// What every broker in the cluster holds, and who the cluster thinks owns the
+/// shard.
+///
+/// #115 asks for a timeline when a scenario fails, because "a record is
+/// missing" is not something anyone can act on: the question is always whether
+/// it is missing from the log or missing from the answer, and which brokers
+/// have it.
+async fn timeline(cluster: &Cluster, note: &str) -> String {
+    let mut out = format!("\n--- {note} ---\n");
+    match cluster.owner(STREAM).await {
+        Ok(owner) => out.push_str(&format!("owner: {owner}\n")),
+        Err(err) => out.push_str(&format!("owner: unresolved ({err})\n")),
+    }
+    for node in &cluster.nodes {
+        let running = node.is_running();
+        let held = if running {
+            match tokio::time::timeout(Duration::from_secs(5), replay_once(cluster, &node.node_id))
+                .await
+            {
+                Ok(payloads) => format!("{payloads:?}"),
+                Err(_) => "replay timed out".to_string(),
+            }
+        } else {
+            "not running".to_string()
+        };
+        out.push_str(&format!(
+            "  {:<10} running={running:<5} {held}\n",
+            node.node_id
+        ));
+    }
+    out
+}
+
+/// One replay attempt, without the retry the assertions use.
+async fn replay_once(cluster: &Cluster, node_id: &str) -> Vec<String> {
+    let Ok((_client, mut subscription)) = cluster.replay_on(node_id, STREAM).await else {
+        return Vec::new();
+    };
+    let mut payloads = Vec::new();
+    while let Ok(Ok(Some(event))) =
+        tokio::time::timeout(Duration::from_secs(2), subscription.next_event()).await
+    {
+        payloads.push(String::from_utf8_lossy(&event.payload).to_string());
+    }
+    payloads
+}
+
+/// **A leader that was paused past its lease does not acknowledge writes the
+/// cluster never sees.** The one thing fencing exists to prevent.
+///
+/// A pause is the interesting fault precisely because the process survives it.
+/// The broker wakes believing it still leads the shard at its old generation;
+/// if nothing stopped it, it would accept a write, acknowledge it, and write it
+/// to a log no promoted replica is reading. The client would be told the record
+/// is durable and it would not exist.
+///
+/// The test does not require the write to *fail* — forwarding it to the broker
+/// that now owns the shard is a perfectly good answer, and the ordinary one.
+/// What it requires is that a write this broker acknowledged is really there.
+#[serial]
+#[tokio::test]
+async fn a_resumed_leader_does_not_acknowledge_writes_the_cluster_loses() {
+    let cluster = Cluster::start(quorum_cluster(3, 3))
+        .await
+        .expect("start cluster");
+    let deposed = cluster.owner(STREAM).await.expect("owner");
+
+    for index in 1..=3u32 {
+        cluster
+            .publish_via(&deposed, STREAM, format!("before-{index}").into_bytes())
+            .await
+            .expect("publish before the pause");
+    }
+
+    cluster.pause_node(&deposed).expect("pause the leader");
+    let promoted = failover_from(&cluster, &deposed)
+        .await
+        .expect("a replica should have been promoted while the leader was frozen");
+
+    // Awake, and still holding the beliefs it had when it was frozen.
+    cluster
+        .resume_node(&deposed)
+        .expect("resume the old leader");
+
+    let acknowledged = cluster
+        .publish_via(&deposed, STREAM, b"after-resume".to_vec())
+        .await
+        .is_ok();
+
+    let payloads = replay(&cluster, &promoted).await;
+
+    for index in 1..=3u32 {
+        let expected = format!("before-{index}");
+        if !payloads.contains(&expected) {
+            let timeline = timeline(&cluster, "after the resume").await;
+            panic!(
+                "{expected} was acknowledged before the pause and is not on the promoted \
+                 leader {promoted} (deposed {deposed}); it replayed {payloads:?}{timeline}",
+            );
+        }
+    }
+    if acknowledged {
+        assert!(
+            payloads.contains(&"after-resume".to_string()),
+            "the resumed leader acknowledged a record the cluster does not have: {payloads:?}",
+        );
+    }
+
+    cluster.shutdown().await;
+}
+
+/// **A paused follower does not stop a quorum the rest of the set can reach.**
+/// Losing a minority is the case `Quorum` exists to tolerate; a pause is the
+/// sharpest version of it, because the follower is neither answering nor
+/// refusing.
+#[serial]
+#[tokio::test]
+async fn a_frozen_follower_does_not_block_a_quorum() {
+    let cluster = Cluster::start(quorum_cluster(3, 3))
+        .await
+        .expect("start cluster");
+    let (leader, follower) = cluster
+        .owner_and_non_owner(STREAM)
+        .await
+        .expect("resolve a follower");
+
+    cluster.pause_node(&follower).expect("pause a follower");
+
+    // The leader and the one remaining follower are two of three: a majority.
+    cluster
+        .publish_via(&leader, STREAM, b"despite-a-frozen-follower".to_vec())
+        .await
+        .expect("a majority was available and the publish should have been acknowledged");
+
+    cluster.resume_node(&follower).expect("resume");
+    cluster.shutdown().await;
+}
+
+/// **Records survive two failovers in a row.** One failover proves promotion
+/// works; two prove the cluster is still correct afterwards rather than merely
+/// still running.
+///
+/// Five replicas so a majority survives both losses: three of five is a quorum,
+/// and three brokers are left.
+#[serial]
+#[tokio::test]
+async fn records_survive_repeated_failovers() {
+    let mut cluster = Cluster::start(quorum_cluster(5, 5))
+        .await
+        .expect("start cluster");
+
+    let first = cluster.owner(STREAM).await.expect("owner");
+    cluster
+        .publish_via(&first, STREAM, b"epoch-1".to_vec())
+        .await
+        .expect("publish under the first leader");
+
+    cluster.kill_node(&first).expect("kill the first leader");
+    let second = failover_from(&cluster, &first)
+        .await
+        .expect("a replica should have been promoted");
+    publish_when_ready(&cluster, &second, b"epoch-2").await;
+
+    cluster.kill_node(&second).expect("kill the second leader");
+    let third = failover_from(&cluster, &second)
+        .await
+        .expect("a replica should have been promoted a second time");
+
+    let payloads = replay(&cluster, &third).await;
+
+    for expected in ["epoch-1", "epoch-2"] {
+        assert!(
+            payloads.contains(&expected.to_string()),
+            "{expected} was acknowledged under a quorum and did not survive two failovers: {payloads:?}",
+        );
+    }
+
+    cluster.shutdown().await;
+}
+
+/// **A `Quorum` publish with no available majority is refused.** The guarantee
+/// stated at its simplest: freeze every follower, and a majority of three
+/// cannot exist, so the broker must not claim one.
+///
+/// This failed before #282. `Quorum` degraded to the `Leader` behaviour
+/// whenever `ack_on_commit` was off -- the default -- because the enqueue-ack
+/// path answered "accepted into the ingress queue" to a question about
+/// majorities, and the quorum wait ran in a worker nobody was listening to.
+#[serial]
+#[tokio::test]
+async fn a_quorum_publish_without_a_majority_is_refused() {
+    let cluster = Cluster::start(quorum_cluster(3, 3))
+        .await
+        .expect("start cluster");
+    let leader = cluster.owner(STREAM).await.expect("owner");
+    let followers: Vec<String> = cluster
+        .nodes
+        .iter()
+        .map(|node| node.node_id.clone())
+        .filter(|id| id != &leader)
+        .collect();
+
+    for follower in &followers {
+        cluster.pause_node(follower).expect("pause");
+    }
+
+    let outcome = cluster
+        .publish_via(&leader, STREAM, b"no-majority".to_vec())
+        .await;
+
+    for follower in &followers {
+        let _ = cluster.resume_node(follower);
+    }
+    assert!(
+        outcome.is_err(),
+        "a Quorum publish was acknowledged with no majority available",
+    );
+    cluster.shutdown().await;
+}

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -217,6 +217,18 @@ impl PublishContext {
 /// resolve, or the shard belongs to a peer this broker has no transport to.
 /// Callers answer that the same way they always answered an unresolvable
 /// stream.
+/// True when this publish must not be acknowledged until a majority holds it.
+///
+/// `Quorum` is the stream that said "accepted by this broker is not good
+/// enough", so the local ack-on-commit policy cannot answer for it.
+pub(crate) fn needs_quorum(target: &Option<PublishTarget>) -> bool {
+    matches!(
+        target,
+        Some(PublishTarget::Resolved { handle, .. })
+            if handle.consistency() == felix_broker::ConsistencyLevel::Quorum
+    )
+}
+
 pub(crate) fn publish_target(
     route: PublishRoute,
     publish_ctx: &PublishContext,

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -422,8 +422,20 @@ pub(crate) async fn handle_publish_message(
     // accepted nothing: the data is not on its disk, and the owner may still
     // refuse it.
     let forwarding = matches!(target, Some(PublishTarget::Forward { .. }));
+    // A `Quorum` publish is acknowledged only once a majority holds it,
+    // whatever `ack_on_commit` says -- the same reasoning as forwarding, one
+    // step further. `ack_on_commit` is a local policy meaning "accepted by this
+    // broker is good enough", and `Quorum` is precisely the stream that said it
+    // is not.
+    //
+    // Without this the quorum wait still runs, in a worker holding a response
+    // channel nobody created, and its answer -- including its refusals -- goes
+    // nowhere. The client is told the record is on a majority the moment it is
+    // queued. `ack_on_commit` is off by default, so that was every direct
+    // `Quorum` publish.
+    let quorum = super::needs_quorum(&target);
     let (response_tx, response_rx) =
-        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding) {
+        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding || quorum) {
             let (response_tx, response_rx) = oneshot::channel();
             (Some(response_tx), Some(response_rx))
         } else {
@@ -465,7 +477,7 @@ pub(crate) async fn handle_publish_message(
         },
         if ack_mode == felix_wire::AckMode::None {
             publish_ctx.overflow_policy()
-        } else if ack_on_commit || forwarding {
+        } else if ack_on_commit || forwarding || quorum {
             EnqueuePolicy::Wait
         } else {
             EnqueuePolicy::Fail
@@ -546,7 +558,12 @@ pub(crate) async fn handle_publish_message(
     // A forward has no enqueue-ack mode: this broker enqueued the batch to send
     // it somewhere else, which is not a fact worth acknowledging. The commit-ack
     // path below waits for the owner's answer instead.
-    if !ack_on_commit && !forwarding {
+    //
+    // Nor does a `Quorum` publish. "Accepted into the ingress queue" is not an
+    // answer to "is this on a majority", and answering it anyway is how a
+    // `Quorum` stream came to behave exactly like a `Leader` one whenever
+    // `ack_on_commit` was off -- which is the default.
+    if !ack_on_commit && !forwarding && !quorum {
         // Enqueue-ack mode:
         // Ack means "accepted into the ingress queue", not "committed". This keeps
         // latency low but can report success even if a later broker error occurs.
@@ -795,8 +812,10 @@ pub(crate) async fn handle_publish_batch_message(
         internal_ack(ack),
     );
     // See the single-publish path: a forward is acknowledged only once the owner
-    // has answered, whatever `ack_on_commit` says.
+    // has answered, whatever `ack_on_commit` says, and a `Quorum` publish only
+    // once a majority holds it.
     let forwarding = matches!(target, Some(PublishTarget::Forward { .. }));
+    let quorum = super::needs_quorum(&target);
     let Some(target) = target else {
         t_counter!("felix_publish_requests_total", "result" => "error").increment(1);
         if ack_mode != felix_wire::AckMode::None {
@@ -825,8 +844,11 @@ pub(crate) async fn handle_publish_batch_message(
         .map(|payload| payload.len())
         .collect::<Vec<_>>();
     let payloads = payloads.into_iter().map(Bytes::from).collect::<Vec<_>>();
+    // Same reasoning as the JSON path above: `Quorum` outranks the local
+    // ack-on-commit policy, because it is the stream saying this broker alone
+    // cannot answer for the record.
     let (response_tx, response_rx) =
-        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding) {
+        if ack_mode != felix_wire::AckMode::None && (ack_on_commit || forwarding || quorum) {
             let (response_tx, response_rx) = oneshot::channel();
             (Some(response_tx), Some(response_rx))
         } else {
@@ -843,7 +865,7 @@ pub(crate) async fn handle_publish_batch_message(
         },
         if ack_mode == felix_wire::AckMode::None {
             publish_ctx.overflow_policy()
-        } else if ack_on_commit || forwarding {
+        } else if ack_on_commit || forwarding || quorum {
             EnqueuePolicy::Wait
         } else {
             EnqueuePolicy::Fail
@@ -911,7 +933,12 @@ pub(crate) async fn handle_publish_batch_message(
     // A forward has no enqueue-ack mode: this broker enqueued the batch to send
     // it somewhere else, which is not a fact worth acknowledging. The commit-ack
     // path below waits for the owner's answer instead.
-    if !ack_on_commit && !forwarding {
+    //
+    // Nor does a `Quorum` publish. "Accepted into the ingress queue" is not an
+    // answer to "is this on a majority", and answering it anyway is how a
+    // `Quorum` stream came to behave exactly like a `Leader` one whenever
+    // `ack_on_commit` was off -- which is the default.
+    if !ack_on_commit && !forwarding && !quorum {
         // Enqueue-ack mode:
         // Ack means "accepted into the ingress queue", not "committed". This keeps
         // latency low but can report success even if a later broker error occurs.


### PR DESCRIPTION
Closes #282. Contributes to #115.

## The bug

**`Quorum` behaved exactly like `Leader` whenever `ack_on_commit` was off — which is the default.** A publish to a `Quorum` stream was acknowledged the moment it was queued.

Reproducer, now a test: freeze both followers of a three-replica shard and publish through the leader. A majority of three is two, only the leader is running, and the publish returned `Ok` in about a second.

## Where it was

The enqueue-ack short circuit is gated on `!ack_on_commit && !forwarding`. Forwarding was excluded for a reason already written there — *"this broker enqueued the batch to send it somewhere else, which is not a fact worth acknowledging"*. `Quorum` is the same argument one step further: **"accepted into the ingress queue" is not an answer to "is this on a majority"**. It simply wasn't excluded.

The quorum wait still ran — in a worker holding a response channel nobody had created, with its answer discarded.

## The evidence

Probing to a file rather than stdout (interleaving with the test's own output had misled me repeatedly), four publishes entered `await_quorum` and only three returned:

- two returned **`NotLeading`** — an error — and their publishes returned `Ok` to the client
- the fourth **never returned at all**, still blocked on the frozen followers, while its publish had already returned `Ok`

An acknowledgement cannot depend on a wait that has not returned.

## The fix

`Quorum` now forces the commit-ack path at **every** point the decision is made — the response channel, the enqueue policy, and the enqueue-ack short circuit — in both the JSON and binary batch handlers. I found these one at a time; fixing the first two changed nothing, because the third was still acking first.

## This explains the 1-in-4 flake

`a_quorum_acknowledged_record_survives_its_leader` is M5's acceptance criterion. A record acknowledged without a majority existed only on the leader, so promoting any replica legitimately lost it, and the test failed whenever the promoted broker was one that never received it.

**Three consecutive runs of the failover suite are now clean.**

Its doc comment also claimed the test was ignored. It was not — there is no `#[ignore]` — so it ran and failed one run in four, which is worse than either honest option. The comment now says what actually happened.

## New tests (#115)

`crates/felix-cluster/tests/fencing.rs`:

- **a paused leader, resumed after failover, must not acknowledge writes the cluster loses** — a pause is the fault worth injecting because the process survives it and wakes still believing it leads
- **a frozen follower must not block a majority the rest of the set can reach**
- **records survive two failovers in a row** (five replicas, so a majority survives both)
- **a `Quorum` publish with every follower frozen is refused** — the one that found this

They carry the failure timeline #115 asks for: on failure they dump every broker's held records and the current owner, because "a record is missing" is not actionable without knowing whether it is missing from the log or from the answer.

Verified load-bearing: reverting the `!quorum` gate fails the reproducer with *"a Quorum publish was acknowledged with no majority available"*.

## Verification

- `task test` — green, 79 blocks, 0 failures
- `task lint` — clean
- failover suite run 3× consecutively — clean each time

## Still open on #115

Partitions and clock skew remain uninjectable; the faults available are kill, stop and pause. Also noted on #282 and not fixed here: `send_reports` logs a refused replica report and the pass publishes the quorum mark anyway, which is the same class of hole in a different place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)