### PR TITLE
fix(broker): give every shard its own log (#286)

### DIFF
--- a/crates/felix-broker/src/broker.rs
+++ b/crates/felix-broker/src/broker.rs
@@ -16,7 +16,7 @@ use crate::config::{
 use crate::delivery::{DeliveryEnvelope, QueuedDelivery};
 use crate::durable::DurableStorage;
 use crate::error::{BrokerError, Result};
-use crate::keys::{CacheKey, NamespaceKey, StreamKey};
+use crate::keys::{CacheKey, NamespaceKey, StreamKey, TopicKey};
 use crate::stream_state::{Cursor, StreamState};
 use crate::subscription::{Subscription, SubscriptionGuard};
 use crate::telemetry::{t_now_if, t_should_sample};
@@ -45,8 +45,10 @@ pub use felix_wire::StartPosition;
 ///         .register_stream("t1", "default", "topic", Default::default())
 ///         .await
 ///         .expect("register");
+///     // Shard 0: a stream with one shard has only that one, and `publish`
+///     // below resolves to the same.
 ///     let mut sub = broker
-///         .subscribe("t1", "default", "topic")
+///         .subscribe("t1", "default", "topic", 0)
 ///         .await
 ///         .expect("subscribe");
 ///     broker
@@ -60,7 +62,7 @@ pub use felix_wire::StartPosition;
 #[derive(Debug)]
 pub struct Broker {
     // Map of stream key -> stream state (subscriber registry + log).
-    pub(crate) topics: RwLock<HashMap<StreamKey, Arc<StreamState>, RandomState>>,
+    pub(crate) topics: RwLock<HashMap<TopicKey, Arc<StreamState>, RandomState>>,
     // Map of stream key -> metadata for existence checks.
     pub(crate) streams: RwLock<HashMap<StreamKey, StreamMetadata, RandomState>>,
     // Map of cache key -> metadata for existence checks.
@@ -277,6 +279,10 @@ impl Broker {
         self
     }
 
+    /// Publish one payload to a single-shard stream.
+    ///
+    /// Shard 0 by construction: a caller with a routing key resolves the shard
+    /// first and uses [`Broker::publish_batch`].
     pub async fn publish(
         &self,
         tenant_id: &str,
@@ -285,7 +291,7 @@ impl Broker {
         payload: Bytes,
     ) -> Result<usize> {
         let payloads = [payload];
-        self.publish_batch(tenant_id, namespace, stream, &payloads)
+        self.publish_batch(tenant_id, namespace, stream, 0, &payloads)
             .await
     }
 
@@ -294,12 +300,13 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         payloads: &[Bytes],
     ) -> Result<usize> {
         let sample = t_should_sample();
         let lookup_start = t_now_if(sample);
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         if let Some(start) = lookup_start {
             let lookup_ns = start.elapsed().as_nanos() as u64;
@@ -533,9 +540,10 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
     ) -> Result<Subscription> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         let stream_state = handle.state;
         let (subscriber_id, receiver) = stream_state.register_subscriber();
@@ -563,9 +571,10 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
     ) -> Result<Cursor> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
 
         let next_seq = match &handle.state.durable {
@@ -582,10 +591,11 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         cursor: Cursor,
     ) -> Result<(Vec<Bytes>, Subscription)> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         let stream_state = handle.state;
 
@@ -626,10 +636,11 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         durable_offset: u64,
     ) -> Result<()> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         handle.state.advance_to(durable_offset);
         Ok(())
@@ -659,11 +670,12 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         from_offset: u64,
         max_bytes: usize,
     ) -> Result<Vec<felix_storage::log::LogRecord>> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         let Some(log) = &handle.state.durable else {
             return Err(BrokerError::StreamNotDurable {
@@ -698,10 +710,11 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         start: StartPosition,
     ) -> Result<ResumedSubscription> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         let stream_state = handle.state;
         let durable = stream_state.durable.clone();
@@ -798,9 +811,10 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
     ) -> Result<usize> {
         let handle = self
-            .resolve_stream_handle(tenant_id, namespace, stream)
+            .resolve_stream_handle(tenant_id, namespace, stream, shard)
             .await?;
         Ok(handle.state.subscriber_count())
     }

--- a/crates/felix-broker/src/keys.rs
+++ b/crates/felix-broker/src/keys.rs
@@ -83,6 +83,68 @@ impl<'a> hashbrown::Equivalent<StreamKey> for StreamKeyRef<'a> {
     }
 }
 
+/// One shard of one stream: what a broker actually holds.
+///
+/// Distinct from [`StreamKey`], which identifies the stream a *catalog* entry
+/// describes. Metadata is per stream — its shard count, its consistency — while
+/// a log, a replay ring and a subscriber set are per shard, because a broker can
+/// own several shards of one stream and each is a separate log.
+///
+/// Conflating the two is what made every shard share shard 0's log while
+/// replication shipped the real one.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct TopicKey {
+    pub(crate) tenant_id: String,
+    pub(crate) namespace: String,
+    pub(crate) stream: String,
+    pub(crate) shard: u32,
+}
+
+impl TopicKey {
+    pub fn new(
+        tenant_id: impl Into<String>,
+        namespace: impl Into<String>,
+        stream: impl Into<String>,
+        shard: u32,
+    ) -> Self {
+        Self {
+            tenant_id: tenant_id.into(),
+            namespace: namespace.into(),
+            stream: stream.into(),
+            shard,
+        }
+    }
+}
+
+/// Borrowed lookup key, so the publish path does not allocate to find a shard.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct TopicKeyRef<'a> {
+    pub(crate) tenant_id: &'a str,
+    pub(crate) namespace: &'a str,
+    pub(crate) stream: &'a str,
+    pub(crate) shard: u32,
+}
+
+impl<'a> TopicKeyRef<'a> {
+    pub(crate) fn new(tenant_id: &'a str, namespace: &'a str, stream: &'a str, shard: u32) -> Self {
+        Self {
+            tenant_id,
+            namespace,
+            stream,
+            shard,
+        }
+    }
+}
+
+impl<'a> hashbrown::Equivalent<TopicKey> for TopicKeyRef<'a> {
+    fn equivalent(&self, key: &TopicKey) -> bool {
+        self.shard == key.shard
+            && self.tenant_id == key.tenant_id
+            && self.namespace == key.namespace
+            && self.stream == key.stream
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct CacheKey {
     pub(crate) tenant_id: String,

--- a/crates/felix-broker/src/lib.rs
+++ b/crates/felix-broker/src/lib.rs
@@ -42,7 +42,7 @@ pub use config::SubQueuePolicy;
 pub use delivery::DeliveryEnvelope;
 pub use durable::{DurableStorage, StreamLog};
 pub use error::{BrokerError, Result};
-pub use keys::{CacheKey, NamespaceKey, StreamKey};
+pub use keys::{CacheKey, NamespaceKey, StreamKey, TopicKey};
 pub use stream_state::Cursor;
 pub use subscription::{Subscription, SubscriptionGuard, SubscriptionReceiver};
 

--- a/crates/felix-broker/src/registry.rs
+++ b/crates/felix-broker/src/registry.rs
@@ -9,7 +9,10 @@ use std::sync::atomic::Ordering;
 
 use crate::broker::{Broker, CacheMetadata, StreamHandle, StreamMetadata};
 use crate::error::{BrokerError, Result};
-use crate::keys::{CacheKey, CacheKeyRef, NamespaceKey, NamespaceKeyRef, StreamKey, StreamKeyRef};
+use crate::keys::{
+    CacheKey, CacheKeyRef, NamespaceKey, NamespaceKeyRef, StreamKey, StreamKeyRef, TopicKey,
+    TopicKeyRef,
+};
 use crate::stream_state::StreamState;
 
 /// Byte ceiling on the replay ring refill at startup.
@@ -70,7 +73,13 @@ impl Broker {
         // the race in between. The retry then takes the fast path.
         loop {
             // Already live: nothing to build, just refresh the metadata.
-            if let Some(state) = self.topics.read().await.get(&key).cloned() {
+            //
+            // Registration opens shard 0 only. A broker opens the other shards
+            // of a stream when it is asked to serve one, because it may own any
+            // subset of them and opening all of them would create a log per
+            // shard on every broker in the cluster.
+            let topic = TopicKey::new(&key.tenant_id, &key.namespace, &key.stream, 0);
+            if let Some(state) = self.topics.read().await.get(&topic).cloned() {
                 let mut streams = self.streams.write().await;
                 if let Some(existing) = streams.get(&key)
                     && existing.durable != metadata.durable
@@ -87,7 +96,7 @@ impl Broker {
             }
 
             let durable = self
-                .open_durable_log(&key.tenant_id, &key.namespace, &key.stream, &metadata)
+                .open_durable_log(&key.tenant_id, &key.namespace, &key.stream, 0, &metadata)
                 .await?;
             let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
             let state = Arc::new(StreamState::new(
@@ -107,14 +116,14 @@ impl Broker {
                 return Err(Self::durability_change_error(&key, existing, &metadata));
             }
             let mut topics = self.topics.write().await;
-            if topics.contains_key(&key) {
+            if topics.contains_key(&topic) {
                 // Lost the race while hydrating; the winner's state is the live
                 // one, so discard this one and take the fast path.
                 drop(topics);
                 drop(streams);
                 continue;
             }
-            topics.insert(key.clone(), state);
+            topics.insert(topic, state);
             streams.insert(key.clone(), metadata);
             return Ok(());
         }
@@ -189,6 +198,7 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
         metadata: &StreamMetadata,
     ) -> Result<Option<crate::durable::StreamLog>> {
         if !metadata.durable {
@@ -201,10 +211,12 @@ impl Broker {
                 stream: stream.to_string(),
             });
         };
-        // The broker keeps one log per stream today. `metadata.shards` is
-        // carried through to the shard key so that when the data path is
-        // sharded, existing single-shard directories keep their identity.
-        Ok(Some(storage.open_stream(tenant_id, namespace, stream, 0)?))
+        // One log per shard. Shard 0 keeps the directory a single-shard stream
+        // has always had, so nothing needs migrating; every other shard gets its
+        // own, which is what the replication driver has always opened.
+        Ok(Some(
+            storage.open_stream(tenant_id, namespace, stream, shard)?,
+        ))
     }
 
     pub async fn register_cache(
@@ -278,10 +290,17 @@ impl Broker {
         let removed = self.streams.write().await.remove(&key).is_some();
         if removed {
             let mut topics = self.topics.write().await;
-            if let Some(state) = topics.get(&key) {
-                state.deactivate();
-            }
-            topics.remove(&key);
+            // Every shard of the stream, not just the one registration opened:
+            // a broker may have been asked to serve several.
+            topics.retain(|topic, state| {
+                let same_stream = topic.tenant_id == key.tenant_id
+                    && topic.namespace == key.namespace
+                    && topic.stream == key.stream;
+                if same_stream {
+                    state.deactivate();
+                }
+                !same_stream
+            });
         }
         Ok(removed)
     }
@@ -389,23 +408,86 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
     ) -> std::result::Result<Arc<StreamState>, BrokerError> {
         #[cfg(feature = "perf_debug")]
         let lock_wait_start = std::time::Instant::now();
-        let guard = self.topics.read().await;
-        #[cfg(feature = "perf_debug")]
-        {
-            let wait_ns = lock_wait_start.elapsed().as_nanos() as u64;
-            metrics::histogram!("felix_perf_topics_read_lock_wait_ns").record(wait_ns as f64);
+        let found = {
+            let guard = self.topics.read().await;
+            #[cfg(feature = "perf_debug")]
+            {
+                let wait_ns = lock_wait_start.elapsed().as_nanos() as u64;
+                metrics::histogram!("felix_perf_topics_read_lock_wait_ns").record(wait_ns as f64);
+            }
+            guard
+                .get(&TopicKeyRef::new(tenant_id, namespace, stream, shard))
+                .cloned()
+        };
+        if let Some(state) = found {
+            return Ok(state);
         }
-        guard
-            .get(&StreamKeyRef::new(tenant_id, namespace, stream))
-            .cloned()
-            .ok_or_else(|| BrokerError::StreamNotFound {
+        // A shard this broker has not opened yet. Registration opens shard 0;
+        // any other arrives here the first time the broker is asked to serve
+        // it, because ownership is decided by the control plane long after the
+        // stream was registered and a broker may hold any subset.
+        self.open_stream_shard(tenant_id, namespace, stream, shard)
+            .await
+    }
+
+    /// Build, hydrate and install the state for one shard.
+    ///
+    /// Hydration happens **before** the state is visible, for the same reason
+    /// registration does it in that order: a durable shard that is publishable
+    /// with an empty replay ring answers `CursorTooOld` for every pre-existing
+    /// cursor, and nothing upstream would know it was never initialised.
+    async fn open_stream_shard(
+        &self,
+        tenant_id: &str,
+        namespace: &str,
+        stream: &str,
+        shard: u32,
+    ) -> std::result::Result<Arc<StreamState>, BrokerError> {
+        let stream_key = StreamKeyRef::new(tenant_id, namespace, stream);
+        let metadata = self.streams.read().await.get(&stream_key).cloned().ok_or(
+            BrokerError::StreamNotFound {
                 tenant_id: tenant_id.to_string(),
                 namespace: namespace.to_string(),
                 stream: stream.to_string(),
-            })
+            },
+        )?;
+        if shard >= metadata.shards.max(1) {
+            // Asking for a shard the stream does not have is a routing bug, and
+            // opening a log for it would create a directory nothing will ever
+            // read.
+            return Err(BrokerError::StreamNotFound {
+                tenant_id: tenant_id.to_string(),
+                namespace: namespace.to_string(),
+                stream: format!("{stream} (shard {shard} of {})", metadata.shards),
+            });
+        }
+
+        let topic = TopicKey::new(tenant_id, namespace, stream, shard);
+        let durable = self
+            .open_durable_log(tenant_id, namespace, stream, shard, &metadata)
+            .await?;
+        let handle_id = self.next_stream_handle.fetch_add(1, Ordering::Relaxed);
+        let state = Arc::new(StreamState::new(
+            handle_id,
+            self.topic_capacity,
+            self.subscriber_queue_policy,
+            durable,
+            metadata.consistency,
+        ));
+        self.hydrate_durable_stream(&state).await?;
+
+        let mut topics = self.topics.write().await;
+        // No retry loop: a caller that lost the race takes the winner's state
+        // rather than building another, so there is nothing to go round for.
+        if let Some(existing) = topics.get(&topic) {
+            return Ok(Arc::clone(existing));
+        }
+        topics.insert(topic, Arc::clone(&state));
+        Ok(state)
     }
 
     pub async fn resolve_stream_handle(
@@ -413,8 +495,11 @@ impl Broker {
         tenant_id: &str,
         namespace: &str,
         stream: &str,
+        shard: u32,
     ) -> Result<StreamHandle> {
-        let state = self.get_stream_state(tenant_id, namespace, stream).await?;
+        let state = self
+            .get_stream_state(tenant_id, namespace, stream, shard)
+            .await?;
         if !state.active.load(Ordering::Acquire) {
             return Err(BrokerError::StreamHandleInactive(state.handle_id));
         }

--- a/crates/felix-broker/src/tests.rs
+++ b/crates/felix-broker/src/tests.rs
@@ -25,7 +25,7 @@ async fn publish_delivers_to_subscriber() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     broker
@@ -68,7 +68,7 @@ async fn stream_delivers_in_order_to_single_subscriber() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "ordered")
+        .subscribe("t1", "default", "ordered", 0)
         .await
         .expect("subscribe");
     broker
@@ -132,7 +132,7 @@ async fn slow_subscriber_drops_messages_without_blocking_publish() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "laggy")
+        .subscribe("t1", "default", "laggy", 0)
         .await
         .expect("subscribe");
     broker
@@ -164,7 +164,7 @@ async fn block_policy_backpressures_publish_when_queue_is_full() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "blocky")
+        .subscribe("t1", "default", "blocky", 0)
         .await
         .expect("subscribe");
 
@@ -204,7 +204,7 @@ async fn drop_old_policy_is_emulated_as_drop_new() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "drop_old")
+        .subscribe("t1", "default", "drop_old", 0)
         .await
         .expect("subscribe");
 
@@ -237,7 +237,7 @@ async fn small_queue_does_not_grow_unbounded_under_burst() {
         .await
         .expect("register");
     let mut sub = broker
-        .subscribe("t1", "default", "bounded")
+        .subscribe("t1", "default", "bounded", 0)
         .await
         .expect("subscribe");
 
@@ -268,11 +268,11 @@ async fn multiple_subscribers_receive_payload() {
         .await
         .expect("register");
     let mut sub_a = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     let mut sub_b = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     broker
@@ -302,18 +302,18 @@ async fn publish_batch_shares_one_encoded_frame_across_subscribers() {
         .await
         .expect("register");
     let (mut rx_a, _guard_a) = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe a")
         .into_parts();
     let (mut rx_b, _guard_b) = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe b")
         .into_parts();
     let payloads = [Bytes::from_static(b"one"), Bytes::from_static(b"two")];
     broker
-        .publish_batch("t1", "default", "orders", &payloads)
+        .publish_batch("t1", "default", "orders", 0, &payloads)
         .await
         .expect("publish");
 
@@ -339,18 +339,18 @@ async fn queue_depth_returns_to_zero_after_receive_and_receiver_drop() {
         .await
         .expect("register");
     let stream_state = broker
-        .get_stream_state("t1", "default", "orders")
+        .get_stream_state("t1", "default", "orders", 0)
         .await
         .expect("stream state");
     let (mut receiver, _guard) = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe")
         .into_parts();
     let payloads = [Bytes::from_static(b"one"), Bytes::from_static(b"two")];
 
     broker
-        .publish_batch("t1", "default", "orders", &payloads)
+        .publish_batch("t1", "default", "orders", 0, &payloads)
         .await
         .expect("publish");
     assert_eq!(stream_state.queued_items.load(Ordering::Relaxed), 2);
@@ -358,7 +358,7 @@ async fn queue_depth_returns_to_zero_after_receive_and_receiver_drop() {
     assert_eq!(stream_state.queued_items.load(Ordering::Relaxed), 0);
 
     broker
-        .publish_batch("t1", "default", "orders", &payloads)
+        .publish_batch("t1", "default", "orders", 0, &payloads)
         .await
         .expect("publish");
     assert_eq!(stream_state.queued_items.load(Ordering::Relaxed), 2);
@@ -380,13 +380,13 @@ async fn subscribe_drop_unregisters_subscriber() {
         .expect("register");
 
     let stream_state = broker
-        .get_stream_state("t1", "default", "orders")
+        .get_stream_state("t1", "default", "orders", 0)
         .await
         .expect("stream state");
     assert_eq!(stream_state.subscriber_count(), 0);
 
     let sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     assert_eq!(stream_state.subscriber_count(), 1);
@@ -411,7 +411,7 @@ async fn perf_hot_path_payload_4096_fanout_1_batch_64_binary() {
         .expect("stream");
 
     let mut sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     let iterations = 200usize;
@@ -425,7 +425,7 @@ async fn perf_hot_path_payload_4096_fanout_1_batch_64_binary() {
     });
 
     let stream_state = broker
-        .get_stream_state("t1", "default", "orders")
+        .get_stream_state("t1", "default", "orders", 0)
         .await
         .expect("stream_state");
 
@@ -441,7 +441,7 @@ async fn perf_hot_path_payload_4096_fanout_1_batch_64_binary() {
 
         let start = Instant::now();
         broker
-            .publish_batch("t1", "default", "orders", &payloads)
+            .publish_batch("t1", "default", "orders", 0, &payloads)
             .await
             .expect("publish");
         publish_ns += start.elapsed().as_nanos();
@@ -484,7 +484,7 @@ async fn cursor_replays_log_then_streams_new_events() {
         .await
         .expect("register");
     let cursor = broker
-        .cursor_tail("t1", "default", "orders")
+        .cursor_tail("t1", "default", "orders", 0)
         .await
         .expect("cursor");
     broker
@@ -496,7 +496,7 @@ async fn cursor_replays_log_then_streams_new_events() {
         .await
         .expect("publish");
     let (backlog, mut sub) = broker
-        .subscribe_with_cursor("t1", "default", "orders", cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, cursor)
         .await
         .expect("subscribe");
     assert_eq!(
@@ -595,11 +595,11 @@ async fn resolved_stream_handle_publishes_without_name_lookup() {
         .await
         .expect("stream");
     let mut sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     let handle = broker
-        .resolve_stream_handle("t1", "default", "orders")
+        .resolve_stream_handle("t1", "default", "orders", 0)
         .await
         .expect("handle");
 
@@ -626,7 +626,7 @@ async fn removed_stream_invalidates_resolved_handle() {
         .await
         .expect("stream");
     let handle = broker
-        .resolve_stream_handle("t1", "default", "orders")
+        .resolve_stream_handle("t1", "default", "orders", 0)
         .await
         .expect("handle");
     broker
@@ -650,7 +650,7 @@ async fn subscribe_to_nonexistent_stream_errors() {
         .await
         .expect("namespace");
     let err = broker
-        .subscribe("t1", "default", "missing")
+        .subscribe("t1", "default", "missing", 0)
         .await
         .expect_err("stream");
     assert!(matches!(err, BrokerError::StreamNotFound { .. }));

--- a/crates/felix-broker/tests/durable_streams.rs
+++ b/crates/felix-broker/tests/durable_streams.rs
@@ -145,7 +145,7 @@ async fn a_cursor_taken_after_restart_reflects_the_recovered_tail() {
     // at zero, so a cursor a client saved before the restart still means the
     // same position.
     let cursor = broker
-        .cursor_tail("t1", "default", "orders")
+        .cursor_tail("t1", "default", "orders", 0)
         .await
         .expect("cursor");
     assert_eq!(cursor.next_seq(), 5);
@@ -158,7 +158,7 @@ async fn durable_publishes_are_delivered_to_subscribers_too() {
     register(&broker, "orders", true).await;
 
     let mut sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
     broker
@@ -180,7 +180,7 @@ async fn a_non_durable_stream_writes_nothing_to_disk() {
     register(&broker, "ephemeral", false).await;
 
     let mut sub = broker
-        .subscribe("t1", "default", "ephemeral")
+        .subscribe("t1", "default", "ephemeral", 0)
         .await
         .expect("subscribe");
     for i in 0..10 {
@@ -217,11 +217,11 @@ async fn durable_and_non_durable_streams_coexist() {
     // Cursors taken before publishing, so the backlog replay below has
     // something to return for each stream.
     let durable_cursor = broker
-        .cursor_tail("t1", "default", "orders")
+        .cursor_tail("t1", "default", "orders", 0)
         .await
         .expect("cursor");
     let ephemeral_cursor = broker
-        .cursor_tail("t1", "default", "ephemeral")
+        .cursor_tail("t1", "default", "ephemeral", 0)
         .await
         .expect("cursor");
 
@@ -243,13 +243,13 @@ async fn durable_and_non_durable_streams_coexist() {
     // ...but in-memory replay behaves identically for both, which is what keeps
     // the non-durable path unchanged.
     let (durable_backlog, _) = broker
-        .subscribe_with_cursor("t1", "default", "orders", durable_cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, durable_cursor)
         .await
         .expect("subscribe");
     assert_eq!(durable_backlog, vec![payload("kept")]);
 
     let (ephemeral_backlog, _) = broker
-        .subscribe_with_cursor("t1", "default", "ephemeral", ephemeral_cursor)
+        .subscribe_with_cursor("t1", "default", "ephemeral", 0, ephemeral_cursor)
         .await
         .expect("subscribe");
     assert_eq!(ephemeral_backlog, vec![payload("lost")]);
@@ -475,7 +475,7 @@ async fn a_batch_publish_lands_as_one_contiguous_run() {
 
     let batch: Vec<Bytes> = (0..8).map(|i| payload(&format!("b{i}"))).collect();
     broker
-        .publish_batch("t1", "default", "orders", &batch)
+        .publish_batch("t1", "default", "orders", 0, &batch)
         .await
         .expect("publish");
 
@@ -507,11 +507,11 @@ async fn disk_order_cursor_order_and_delivery_order_agree_under_concurrency() {
     register(&broker, "orders", true).await;
 
     let cursor = broker
-        .cursor_tail("t1", "default", "orders")
+        .cursor_tail("t1", "default", "orders", 0)
         .await
         .expect("cursor");
     let mut sub = broker
-        .subscribe("t1", "default", "orders")
+        .subscribe("t1", "default", "orders", 0)
         .await
         .expect("subscribe");
 
@@ -555,7 +555,7 @@ async fn disk_order_cursor_order_and_delivery_order_agree_under_concurrency() {
 
     // 3. The order cursor replay returns them in.
     let (replayed, _) = broker
-        .subscribe_with_cursor("t1", "default", "orders", cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, cursor)
         .await
         .expect("replay");
     let replayed: Vec<String> = replayed
@@ -584,7 +584,7 @@ async fn a_pre_restart_cursor_still_replays_after_a_restart() {
         // A client subscribes, reads a few records, and remembers where it got
         // to — the ordinary resume pattern.
         saved_cursor = broker
-            .cursor_tail("t1", "default", "orders")
+            .cursor_tail("t1", "default", "orders", 0)
             .await
             .expect("cursor");
         for i in 0..20 {
@@ -603,7 +603,7 @@ async fn a_pre_restart_cursor_still_replays_after_a_restart() {
     register(&broker, "orders", true).await;
 
     let (backlog, mut sub) = broker
-        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, saved_cursor)
         .await
         .expect("replay after restart");
     let replayed: Vec<String> = backlog
@@ -660,9 +660,9 @@ async fn hydration_is_bounded_by_the_replay_ring_capacity() {
 
     // Cursors inside the ring window resolve from memory...
     let (backlog, _sub) = broker
-        .subscribe_with_cursor("t1", "default", "orders", {
+        .subscribe_with_cursor("t1", "default", "orders", 0, {
             let tail = broker
-                .cursor_tail("t1", "default", "orders")
+                .cursor_tail("t1", "default", "orders", 0)
                 .await
                 .expect("cursor");
             assert_eq!(tail.next_seq(), 300, "cursor did not resume at the tail");
@@ -678,7 +678,7 @@ async fn hydration_is_bounded_by_the_replay_ring_capacity() {
     let mut offset = 0u64;
     loop {
         let page = broker
-            .read_durable("t1", "default", "orders", offset, 4096)
+            .read_durable("t1", "default", "orders", 0, offset, 4096)
             .await
             .expect("read_durable");
         if page.is_empty() {
@@ -702,7 +702,7 @@ async fn historical_replay_is_rejected_for_a_non_durable_stream() {
     register(&broker, "ephemeral", false).await;
 
     let err = broker
-        .read_durable("t1", "default", "ephemeral", 0, 4096)
+        .read_durable("t1", "default", "ephemeral", 0, 0, 4096)
         .await
         .expect_err("no persisted history");
     assert!(matches!(err, BrokerError::StreamNotDurable { .. }), "{err}");
@@ -836,7 +836,7 @@ async fn hydration_never_leaves_a_gap_between_the_ring_and_the_tail() {
                 .expect("publish");
         }
         saved_cursor = broker
-            .cursor_tail("t1", "default", "orders")
+            .cursor_tail("t1", "default", "orders", 0)
             .await
             .expect("cursor");
         assert_eq!(saved_cursor.next_seq(), 550);
@@ -855,7 +855,7 @@ async fn hydration_never_leaves_a_gap_between_the_ring_and_the_tail() {
     // 550 is accepted (550 >= 100) and answered with silence.
     let (broker, _storage) = boot(&dir, config).await;
     let (backlog, _sub) = broker
-        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, saved_cursor)
         .await
         .expect("replay from a saved cursor");
 
@@ -891,7 +891,7 @@ async fn a_cancelled_publish_does_not_shift_cursor_identity() {
 
         // A client takes its cursor after that, then reads five records.
         saved_cursor = broker
-            .cursor_tail("t1", "default", "orders")
+            .cursor_tail("t1", "default", "orders", 0)
             .await
             .expect("cursor");
         for i in 0..5 {
@@ -902,7 +902,7 @@ async fn a_cancelled_publish_does_not_shift_cursor_identity() {
         }
 
         let (backlog, _) = broker
-            .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+            .subscribe_with_cursor("t1", "default", "orders", 0, saved_cursor)
             .await
             .expect("replay");
         before_restart = backlog
@@ -921,7 +921,7 @@ async fn a_cancelled_publish_does_not_shift_cursor_identity() {
     let (broker, _storage) = broker_with_storage(&dir, FsyncMode::OnCommit).await;
     register(&broker, "orders", true).await;
     let (backlog, _) = broker
-        .subscribe_with_cursor("t1", "default", "orders", saved_cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, saved_cursor)
         .await
         .expect("replay after restart");
     let after_restart: Vec<String> = backlog
@@ -960,11 +960,11 @@ async fn the_backlog_to_live_handoff_loses_nothing_under_concurrent_publishes() 
     // Join mid-flight.
     tokio::time::sleep(Duration::from_millis(5)).await;
     let cursor = broker
-        .cursor_tail("t1", "default", "orders")
+        .cursor_tail("t1", "default", "orders", 0)
         .await
         .expect("cursor");
     let (backlog, mut sub) = broker
-        .subscribe_with_cursor("t1", "default", "orders", cursor)
+        .subscribe_with_cursor("t1", "default", "orders", 0, cursor)
         .await
         .expect("subscribe");
     publisher.await.expect("join");
@@ -1039,7 +1039,7 @@ async fn drain_resume(
         let mut at = range.from_offset;
         while at < range.until_offset {
             let records = broker
-                .read_durable("t1", "default", stream, at, 64 * 1024)
+                .read_durable("t1", "default", stream, 0, at, 64 * 1024)
                 .await
                 .expect("history");
             if records.is_empty() {
@@ -1074,7 +1074,7 @@ async fn resuming_at_an_offset_older_than_the_ring_replays_from_disk() {
     }
 
     let mut resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(3))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(3))
         .await
         .expect("resume");
 
@@ -1102,7 +1102,7 @@ async fn a_publish_during_the_resume_arrives_live_exactly_once() {
     }
 
     let mut resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(3))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(3))
         .await
         .expect("resume");
 
@@ -1139,7 +1139,7 @@ async fn resuming_within_the_ring_needs_no_disk_history() {
     }
 
     let mut resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(5))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(5))
         .await
         .expect("resume");
     assert!(resumed.history.is_none(), "the ring covered the request");
@@ -1163,7 +1163,7 @@ async fn latest_delivers_nothing_already_published() {
     }
 
     let mut resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Latest)
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Latest)
         .await
         .expect("resume");
     assert!(resumed.history.is_none());
@@ -1187,7 +1187,7 @@ async fn earliest_replays_the_whole_retained_stream() {
     }
 
     let mut resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Earliest)
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Earliest)
         .await
         .expect("resume");
     let seen = drain_resume(&broker, "orders", &mut resumed).await;
@@ -1210,7 +1210,7 @@ async fn an_in_memory_stream_reports_a_cursor_older_than_its_ring() {
     }
 
     let err = broker
-        .subscribe_from("t1", "default", "ephemeral", StartPosition::Offset(2))
+        .subscribe_from("t1", "default", "ephemeral", 0, StartPosition::Offset(2))
         .await
         .expect_err("cursor is below the ring and there is no disk");
     assert!(
@@ -1235,7 +1235,7 @@ async fn a_resume_past_the_tail_is_rejected_not_reinterpreted() {
     // handed over records at offsets 5, 6, 7... -- below the requested position,
     // which is the opposite of what was asked for.
     let err = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(99))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(99))
         .await
         .expect_err("99 is past the tail");
     assert!(
@@ -1268,7 +1268,7 @@ async fn a_rejected_resume_leaves_no_subscriber_behind() {
     // the slab without ever touching the per-connection subscription cap.
     for _ in 0..50 {
         let err = broker
-            .subscribe_from("t1", "default", "ephemeral", StartPosition::Offset(1))
+            .subscribe_from("t1", "default", "ephemeral", 0, StartPosition::Offset(1))
             .await
             .expect_err("below the ring, and no disk to fall back to");
         assert!(matches!(err, BrokerError::CursorTooOld { .. }));
@@ -1276,7 +1276,7 @@ async fn a_rejected_resume_leaves_no_subscriber_behind() {
 
     assert_eq!(
         broker
-            .registered_subscribers("t1", "default", "ephemeral")
+            .registered_subscribers("t1", "default", "ephemeral", 0)
             .await
             .expect("count"),
         0,
@@ -1297,7 +1297,7 @@ async fn backlog_entries_carry_their_own_offsets() {
     }
 
     let resumed = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(2))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(2))
         .await
         .expect("resume");
 
@@ -1369,7 +1369,7 @@ async fn resuming_below_the_retained_range_reports_cursor_too_old() {
     // Offset 0 existed and is gone. That is a different answer from "nothing
     // there yet", and it is the one a resuming client needs.
     let err = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Offset(0))
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Offset(0))
         .await
         .expect_err("offset 0 has been trimmed");
     match err {
@@ -1399,7 +1399,7 @@ async fn earliest_resumes_from_the_oldest_retained_record() {
     // `earliest` must mean "oldest still retained", not "offset 0" -- otherwise
     // it is an error for every trimmed stream.
     let resumed: ResumedSubscription = broker
-        .subscribe_from("t1", "default", "orders", StartPosition::Earliest)
+        .subscribe_from("t1", "default", "orders", 0, StartPosition::Earliest)
         .await
         .expect("earliest still resumes after a trim");
     if let Some(history) = &resumed.history {
@@ -1429,7 +1429,7 @@ async fn a_trimmed_read_reports_cursor_too_old_rather_than_a_storage_error() {
     // This is the mid-replay case: a paging replay whose next read lands below
     // a base offset that moved underneath it. Reported, not silently short.
     let err = broker
-        .read_durable("t1", "default", "orders", 0, 64 * 1024)
+        .read_durable("t1", "default", "orders", 0, 0, 64 * 1024)
         .await
         .expect_err("reading trimmed offsets must fail");
     match err {
@@ -1477,12 +1477,12 @@ async fn a_cursor_never_points_past_the_live_edge() {
     // is the cursor's own position, never something older.
     for _ in 0..250 {
         let cursor = broker
-            .cursor_tail("t1", "default", "orders")
+            .cursor_tail("t1", "default", "orders", 0)
             .await
             .expect("cursor");
         let from = cursor.next_seq();
         let (backlog, mut sub) = broker
-            .subscribe_with_cursor("t1", "default", "orders", cursor)
+            .subscribe_with_cursor("t1", "default", "orders", 0, cursor)
             .await
             .expect("subscribe");
 

--- a/crates/felix-broker/tests/replica_promotion.rs
+++ b/crates/felix-broker/tests/replica_promotion.rs
@@ -67,7 +67,7 @@ async fn promoted_broker(records: &[&str]) -> (Arc<Broker>, TempDir) {
     }
     let tail = log.tail_offset().await.expect("tail");
     broker
-        .adopt_replicated(TENANT, NAMESPACE, STREAM, tail)
+        .adopt_replicated(TENANT, NAMESPACE, STREAM, 0, tail)
         .await
         .expect("adopt the replicated records");
 
@@ -96,14 +96,14 @@ async fn a_replicated_stream_replays_from_the_start() {
     let (broker, _dir) = promoted_broker(&["a", "b", "c"]).await;
 
     let resumed = broker
-        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Earliest)
+        .subscribe_from(TENANT, NAMESPACE, STREAM, 0, StartPosition::Earliest)
         .await
         .expect("subscribe from the start");
 
     let mut from_disk = Vec::new();
     if let Some(range) = resumed.history {
         let records = broker
-            .read_durable(TENANT, NAMESPACE, STREAM, range.from_offset, 1024 * 1024)
+            .read_durable(TENANT, NAMESPACE, STREAM, 0, range.from_offset, 1024 * 1024)
             .await
             .expect("read history");
         for record in records {
@@ -135,7 +135,7 @@ async fn a_publish_after_promotion_follows_the_replicated_history() {
     let (broker, _dir) = promoted_broker(&["a", "b"]).await;
 
     let resumed = broker
-        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Earliest)
+        .subscribe_from(TENANT, NAMESPACE, STREAM, 0, StartPosition::Earliest)
         .await
         .expect("subscribe from the start");
     let mut subscription = resumed.subscription;
@@ -155,7 +155,7 @@ async fn latest_starts_at_the_replicated_tail() {
     let (broker, _dir) = promoted_broker(&["a", "b"]).await;
 
     let resumed = broker
-        .subscribe_from(TENANT, NAMESPACE, STREAM, StartPosition::Latest)
+        .subscribe_from(TENANT, NAMESPACE, STREAM, 0, StartPosition::Latest)
         .await
         .expect("subscribe at the tail");
 
@@ -175,7 +175,7 @@ async fn latest_starts_at_the_replicated_tail() {
 async fn a_consistency_change_reaches_a_live_stream() {
     let (broker, _dir) = promoted_broker(&[]).await;
     let handle = broker
-        .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+        .resolve_stream_handle(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("resolve");
     assert_eq!(handle.consistency(), felix_broker::ConsistencyLevel::Leader);
@@ -195,7 +195,7 @@ async fn a_consistency_change_reaches_a_live_stream() {
         .expect("raise to quorum");
 
     let handle = broker
-        .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+        .resolve_stream_handle(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("resolve");
     assert_eq!(
@@ -227,7 +227,7 @@ async fn lowering_the_consistency_also_reaches_a_live_stream() {
             .await
             .expect("register");
         let handle = broker
-            .resolve_stream_handle(TENANT, NAMESPACE, STREAM)
+            .resolve_stream_handle(TENANT, NAMESPACE, STREAM, 0)
             .await
             .expect("resolve");
         assert_eq!(handle.consistency(), level);

--- a/crates/felix-broker/tests/sharded_streams.rs
+++ b/crates/felix-broker/tests/sharded_streams.rs
@@ -1,0 +1,187 @@
+//! A stream whose shards are separate logs.
+//!
+//! #286. The registry used to open shard 0's log whatever shard it was asked
+//! for, while the replication driver and shard lifecycle opened the real index.
+//! They agreed only for shard 0, which is the only shard anything could reach —
+//! so a routing key (#240) would have written a record to one log and shipped
+//! another.
+//!
+//! Run with `cargo test -p felix-broker --test sharded_streams`.
+use std::sync::Arc;
+
+use bytes::Bytes;
+use felix_broker::{Broker, DurableStorage, StreamMetadata};
+use felix_storage::EphemeralCache;
+use felix_storage::log::{FsyncMode, LogConfig};
+use tempfile::{TempDir, tempdir};
+
+const TENANT: &str = "t1";
+const NAMESPACE: &str = "ns";
+const STREAM: &str = "orders";
+const SHARDS: u32 = 4;
+
+async fn sharded_broker() -> (Arc<Broker>, DurableStorage, TempDir) {
+    let dir = tempdir().expect("dir");
+    let storage = DurableStorage::open(
+        dir.path(),
+        LogConfig {
+            segment_size_bytes: 4 * 1024,
+            index_spacing_bytes: 256,
+            fsync_mode: FsyncMode::None,
+            preallocate_segments: false,
+            ..LogConfig::default()
+        },
+    )
+    .expect("storage");
+
+    let broker = Broker::new(EphemeralCache::new().into()).with_durable_storage(storage.clone());
+    broker.register_tenant(TENANT).await.expect("tenant");
+    broker
+        .register_namespace(TENANT, NAMESPACE)
+        .await
+        .expect("namespace");
+    broker
+        .register_stream(
+            TENANT,
+            NAMESPACE,
+            STREAM,
+            StreamMetadata {
+                durable: true,
+                shards: SHARDS,
+                ..StreamMetadata::default()
+            },
+        )
+        .await
+        .expect("stream");
+    (Arc::new(broker), storage, dir)
+}
+
+/// Everything on `shard`, read straight from its log.
+///
+/// The log is the question here — whether two shards share one — so this reads
+/// it directly rather than through a subscription, whose replay ring would
+/// answer a different question.
+async fn replay(broker: &Broker, shard: u32) -> Vec<String> {
+    broker
+        .read_durable(TENANT, NAMESPACE, STREAM, shard, 0, 1024 * 1024)
+        .await
+        .expect("read the shard log")
+        .into_iter()
+        .map(|record| String::from_utf8_lossy(&record.payload).to_string())
+        .collect()
+}
+
+/// **Each shard is its own log.** A record published to shard 2 must not be
+/// visible on shard 0, or the shard dimension is decoration.
+#[tokio::test]
+async fn shards_of_one_stream_do_not_share_a_log() {
+    let (broker, _storage, _dir) = sharded_broker().await;
+
+    broker
+        .publish_batch(TENANT, NAMESPACE, STREAM, 0, &[Bytes::from_static(b"zero")])
+        .await
+        .expect("publish to shard 0");
+    broker
+        .publish_batch(TENANT, NAMESPACE, STREAM, 2, &[Bytes::from_static(b"two")])
+        .await
+        .expect("publish to shard 2");
+
+    assert_eq!(replay(&broker, 0).await, vec!["zero".to_string()]);
+    assert_eq!(replay(&broker, 2).await, vec!["two".to_string()]);
+    assert!(
+        replay(&broker, 1).await.is_empty(),
+        "a shard nothing was published to must be empty",
+    );
+}
+
+/// **Offsets are per shard.** Both shards start at zero, because each is a log.
+/// A shared log would have given the second record offset 1.
+#[tokio::test]
+async fn each_shard_numbers_its_own_records() {
+    let (broker, _storage, _dir) = sharded_broker().await;
+
+    for shard in [0u32, 3] {
+        broker
+            .publish_batch(
+                TENANT,
+                NAMESPACE,
+                STREAM,
+                shard,
+                &[Bytes::from_static(b"first")],
+            )
+            .await
+            .expect("publish");
+    }
+
+    for shard in [0u32, 3] {
+        let tail = broker
+            .cursor_tail(TENANT, NAMESPACE, STREAM, shard)
+            .await
+            .expect("tail");
+        assert_eq!(
+            tail.next_seq(),
+            1,
+            "shard {shard} should hold exactly one record"
+        );
+    }
+}
+
+/// **The publish path and the replication path open the same log.** This is the
+/// disagreement #286 was filed for: the registry opened shard 0 whatever it was
+/// asked for, while replication opened `key.shard`, so a record published to
+/// shard 2 was invisible to the driver shipping shard 2.
+#[tokio::test]
+async fn a_publish_lands_in_the_log_replication_ships() {
+    let (broker, storage, _dir) = sharded_broker().await;
+
+    broker
+        .publish_batch(
+            TENANT,
+            NAMESPACE,
+            STREAM,
+            2,
+            &[Bytes::from_static(b"routed-here")],
+        )
+        .await
+        .expect("publish to shard 2");
+
+    // Opened exactly as `replication::driver` opens it, from the shard key.
+    let shipped = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 2)
+        .expect("open shard 2 the way replication does");
+    assert_eq!(
+        shipped.tail_offset().await.expect("tail"),
+        1,
+        "replication would ship an empty log for a shard that was published to",
+    );
+
+    let untouched = storage
+        .open_stream(TENANT, NAMESPACE, STREAM, 0)
+        .expect("open shard 0");
+    assert_eq!(
+        untouched.tail_offset().await.expect("tail"),
+        0,
+        "the record was written to shard 0's log instead of the one it routed to",
+    );
+}
+
+/// A shard the stream does not have is refused rather than silently created:
+/// opening a log for it would leave a directory nothing ever reads.
+#[tokio::test]
+async fn a_shard_beyond_the_stream_is_refused() {
+    let (broker, _storage, _dir) = sharded_broker().await;
+
+    assert!(
+        broker
+            .publish_batch(
+                TENANT,
+                NAMESPACE,
+                STREAM,
+                SHARDS,
+                &[Bytes::from_static(b"nowhere")]
+            )
+            .await
+            .is_err(),
+        "shard {SHARDS} is out of range for a stream with {SHARDS} shards",
+    );
+}

--- a/crates/felix-client/src/client/inprocess.rs
+++ b/crates/felix-client/src/client/inprocess.rs
@@ -72,7 +72,7 @@ impl InProcessClient {
         stream: &str,
     ) -> Result<Subscription> {
         self.broker
-            .subscribe(tenant_id, namespace, stream)
+            .subscribe(tenant_id, namespace, stream, 0)
             .await
             .map_err(Into::into)
     }

--- a/demos/broker/durable_restart_demo.rs
+++ b/demos/broker/durable_restart_demo.rs
@@ -142,7 +142,7 @@ async fn run_demo() -> Result<()> {
     // The non-durable stream has no disk state at all; a fresh broker starts it
     // empty, which is what "in-memory" means when the process goes away.
     let ephemeral_cursor = broker
-        .cursor_tail(TENANT, NAMESPACE, EPHEMERAL_STREAM)
+        .cursor_tail(TENANT, NAMESPACE, EPHEMERAL_STREAM, 0)
         .await?;
     println!(
         "  ephemeral `{EPHEMERAL_STREAM}`: 0 of {RECORDS} records recovered (cursor restarts at {})",

--- a/demos/cross_tenant_isolation/Cargo.lock
+++ b/demos/cross_tenant_isolation/Cargo.lock
@@ -451,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,7 +501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -710,7 +716,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -765,6 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]

--- a/demos/rbac-live/Cargo.lock
+++ b/demos/rbac-live/Cargo.lock
@@ -451,6 +451,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,7 +501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -710,7 +716,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -765,6 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]

--- a/services/broker/src/peer/handler.rs
+++ b/services/broker/src/peer/handler.rs
@@ -147,7 +147,7 @@ impl ForwardingHandler {
 
         let handle = match self
             .broker
-            .resolve_stream_handle(&key.tenant_id, &key.namespace, &key.stream)
+            .resolve_stream_handle(&key.tenant_id, &key.namespace, &key.stream, key.shard)
             .await
         {
             Ok(handle) => handle,

--- a/services/broker/src/peer/replica.rs
+++ b/services/broker/src/peer/replica.rs
@@ -226,6 +226,7 @@ impl ReplicaHandler {
                         &key.tenant_id,
                         &key.namespace,
                         &key.stream,
+                        key.shard,
                         applied.durable_offset,
                     )
                     .await

--- a/services/broker/src/transport/quic/conn.rs
+++ b/services/broker/src/transport/quic/conn.rs
@@ -266,7 +266,7 @@ fn build_publish_context(
                         namespace,
                         stream,
                     } => broker_for_worker
-                        .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                        .publish_batch(tenant_id, namespace, stream, 0, &job.payloads)
                         .await
                         .map(|_| ())
                         .map_err(Into::into),

--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -331,6 +331,10 @@ pub(crate) enum PublishRoute {
 /// changes the instant the control plane says so, and caching it would keep a
 /// broker serving a reassigned shard for up to a TTL. The check is two atomic
 /// loads, so paying it per publish costs less than reasoning about staleness.
+// Six of these are the shard's identity plus the two things needed to resolve
+// it. Bundling them into a struct would move the argument list rather than
+// shorten it, and the same allow is already on the publish handlers.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn resolve_route(
     broker: &Broker,
     authority: Authority<'_>,
@@ -339,6 +343,7 @@ pub(crate) async fn resolve_route(
     tenant_id: &str,
     namespace: &str,
     stream: &str,
+    shard: u32,
 ) -> PublishRoute {
     // Single-node brokers short-circuit on a null check; a cluster member pays
     // two loads. Either way there is no lock and no await.
@@ -365,9 +370,10 @@ pub(crate) async fn resolve_route(
             tenant_id: tenant_id.to_string(),
             namespace: namespace.to_string(),
             stream: stream.to_string(),
-            // No routing key on the wire yet, so every record of a stream lands
-            // on shard 0. See `shard_routing::shard_for`.
-            shard: shard_for(1, None),
+            // The shard the caller resolved. Dispatch and the log this publish
+            // lands in must agree on it, or a record is written to one shard's
+            // log and replicated from another's.
+            shard,
         };
         match dispatch(ingress, &key) {
             Dispatch::Local => {}
@@ -395,8 +401,12 @@ pub(crate) async fn resolve_route(
     }
 
     // Short-lived cache to avoid repeated stream lookups on hot paths.
+    //
+    // Keyed by shard as well as stream: a broker can own several shards of one
+    // stream, they are separate logs, and a cache that ignored the shard would
+    // hand a publish for one of them the handle of another.
     key_scratch.clear();
-    let needed = tenant_id.len() + namespace.len() + stream.len() + 2;
+    let needed = tenant_id.len() + namespace.len() + stream.len() + 14;
     if key_scratch.capacity() < needed {
         key_scratch.reserve(needed - key_scratch.capacity());
     }
@@ -405,6 +415,11 @@ pub(crate) async fn resolve_route(
     key_scratch.push_str(namespace);
     key_scratch.push('\0');
     key_scratch.push_str(stream);
+    key_scratch.push('\0');
+    {
+        use std::fmt::Write;
+        let _ = write!(key_scratch, "{shard}");
+    }
     if let Some((handle, expires)) = cache.get(key_scratch.as_str())
         && *expires > Instant::now()
         && handle.as_ref().is_none_or(StreamHandle::is_active)
@@ -412,7 +427,7 @@ pub(crate) async fn resolve_route(
         return PublishRoute::from(handle.clone());
     }
     let handle = broker
-        .resolve_stream_handle(tenant_id, namespace, stream)
+        .resolve_stream_handle(tenant_id, namespace, stream, shard)
         .await
         .ok();
     cache.insert(

--- a/services/broker/src/transport/quic/handlers/publish/control.rs
+++ b/services/broker/src/transport/quic/handlers/publish/control.rs
@@ -90,6 +90,8 @@ pub(crate) async fn handle_binary_publish_batch_control(
             &batch.tenant_id,
             &batch.namespace,
             &batch.stream,
+            // No routing key on the wire yet (#240).
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,
@@ -407,6 +409,9 @@ pub(crate) async fn handle_publish_message(
             &tenant_id,
             &namespace,
             &stream,
+            // No routing key on the wire yet, so every record lands on shard 0
+            // (#240). The plumbing below is shard-correct either way.
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,
@@ -803,6 +808,9 @@ pub(crate) async fn handle_publish_batch_message(
             &tenant_id,
             &namespace,
             &stream,
+            // No routing key on the wire yet, so every record lands on shard 0
+            // (#240). The plumbing below is shard-correct either way.
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -1778,6 +1778,7 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         "t1",
         "ns",
         "stream",
+        0,
     )
     .await;
     assert!(
@@ -1811,6 +1812,7 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         "t1",
         "ns",
         "stream",
+        0,
     )
     .await;
     assert!(
@@ -1830,6 +1832,7 @@ async fn resolve_stream_cached_uses_cached_entry_until_cleared() {
         "t1",
         "ns",
         "stream",
+        0,
     )
     .await;
     assert!(
@@ -2802,6 +2805,7 @@ mod ownership_gate {
             "t1",
             "ns",
             "stream",
+            0,
         )
         .await;
         assert!(
@@ -2831,6 +2835,7 @@ mod ownership_gate {
             "t1",
             "ns",
             "stream",
+            0,
         )
         .await;
         match route {
@@ -2859,6 +2864,7 @@ mod ownership_gate {
             "t1",
             "ns",
             "stream",
+            0,
         )
         .await;
         assert!(
@@ -2888,7 +2894,8 @@ mod ownership_gate {
                     &mut key,
                     "t1",
                     "ns",
-                    "stream"
+                    "stream",
+                    0
                 )
                 .await,
                 PublishRoute::Local(_)
@@ -2911,7 +2918,8 @@ mod ownership_gate {
                     &mut key,
                     "t1",
                     "ns",
-                    "stream"
+                    "stream",
+                    0
                 )
                 .await,
                 PublishRoute::Forward(_)
@@ -2938,6 +2946,7 @@ mod ownership_gate {
             "t1",
             "ns",
             "stream",
+            0,
         )
         .await;
         assert!(matches!(route, PublishRoute::Local(_)));

--- a/services/broker/src/transport/quic/handlers/publish/uni.rs
+++ b/services/broker/src/transport/quic/handlers/publish/uni.rs
@@ -72,6 +72,7 @@ pub(crate) async fn handle_binary_publish_batch_uni(
             &batch.tenant_id,
             &batch.namespace,
             &batch.stream,
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,
@@ -144,6 +145,7 @@ pub(crate) async fn handle_publish_message_uni(
             &tenant_id,
             &namespace,
             &stream,
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,
@@ -215,6 +217,7 @@ pub(crate) async fn handle_publish_batch_message_uni(
             &tenant_id,
             &namespace,
             &stream,
+            crate::shard_routing::shard_for(1, None),
         )
         .await,
         publish_ctx,

--- a/services/broker/src/transport/quic/handlers/subscribe.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe.rs
@@ -165,6 +165,7 @@ async fn write_replay<S: EventSink>(
     tenant_id: &str,
     namespace: &str,
     stream: &str,
+    shard: u32,
     subscription_id: u64,
     history: Option<felix_broker::HistoryRange>,
     backlog: Vec<(u64, bytes::Bytes)>,
@@ -182,7 +183,7 @@ async fn write_replay<S: EventSink>(
         let mut at = range.from_offset;
         while at < range.until_offset {
             let records = broker
-                .read_durable(tenant_id, namespace, stream, at, HISTORY_PAGE_BYTES)
+                .read_durable(tenant_id, namespace, stream, shard, at, HISTORY_PAGE_BYTES)
                 .await?;
             if records.is_empty() {
                 break;
@@ -242,6 +243,7 @@ async fn write_replay<S: EventSink>(
                         tenant_id,
                         namespace,
                         stream,
+                        shard,
                         subscription_id,
                         delivered_upto,
                         base,
@@ -293,6 +295,7 @@ async fn write_history_range<S: EventSink>(
     tenant_id: &str,
     namespace: &str,
     stream: &str,
+    shard: u32,
     subscription_id: u64,
     from: u64,
     until: u64,
@@ -304,7 +307,7 @@ async fn write_history_range<S: EventSink>(
     let mut at = from;
     while at < until {
         let records = broker
-            .read_durable(tenant_id, namespace, stream, at, HISTORY_PAGE_BYTES)
+            .read_durable(tenant_id, namespace, stream, shard, at, HISTORY_PAGE_BYTES)
             .await?;
         if records.is_empty() {
             break;
@@ -464,6 +467,11 @@ pub(crate) async fn handle_subscribe_message(
     start: Option<StartPosition>,
     peer_flags: u16,
 ) -> Result<bool> {
+    // Which shard of the stream this subscription reads. No routing key on the
+    // wire yet, so a stream has one reachable shard (#240); the plumbing is
+    // shard-correct either way, and the redirect above already resolved
+    // ownership against the same number.
+    let shard = crate::shard_routing::shard_for(1, None);
     // Offsets ride the event batch only for a client that negotiated the bit.
     // One that did not gets exactly the frames it got before this existed.
     let offsets_enabled = felix_wire::supports(peer_flags, felix_wire::FLAG_EVENT_BATCH_OFFSETS);
@@ -515,7 +523,10 @@ pub(crate) async fn handle_subscribe_message(
     // On failure, respond on the control stream (through the ack queue) and keep the stream alive.
     let mut replay = None;
     let mut subscription = match start {
-        None => match broker.subscribe(&tenant_id, &namespace, &stream).await {
+        None => match broker
+            .subscribe(&tenant_id, &namespace, &stream, shard)
+            .await
+        {
             Ok(subscription) => subscription,
             Err(err) => {
                 return subscribe_failed(
@@ -531,7 +542,7 @@ pub(crate) async fn handle_subscribe_message(
             }
         },
         Some(start) => match broker
-            .subscribe_from(&tenant_id, &namespace, &stream, start)
+            .subscribe_from(&tenant_id, &namespace, &stream, shard, start)
             .await
         {
             Ok(resumed) => {
@@ -642,6 +653,7 @@ pub(crate) async fn handle_subscribe_message(
             &tenant_id,
             &namespace,
             &stream,
+            shard,
             subscription_id,
             history,
             backlog,
@@ -744,7 +756,7 @@ pub(crate) async fn handle_subscribe_message(
     // `publish_worker_index` (handle id % shard count).
     let shard_runtime = match crate::core_shards::global_shards(&config) {
         Some(shards) => match broker
-            .resolve_stream_handle(&tenant_id, &namespace, &stream)
+            .resolve_stream_handle(&tenant_id, &namespace, &stream, shard)
             .await
         {
             Ok(handle) => Some(shards.handle_for(handle.id()).clone()),

--- a/services/broker/src/transport/quic/handlers/subscribe/replay_tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/replay_tests.rs
@@ -127,6 +127,7 @@ async fn replay(
         TENANT,
         NAMESPACE,
         STREAM,
+        0,
         SUBSCRIPTION,
         history,
         backlog,
@@ -146,7 +147,7 @@ async fn history_is_replayed_from_disk_in_order() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b", "c", "d"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -180,7 +181,7 @@ async fn the_history_range_stops_before_its_end() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b", "c", "d"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -209,7 +210,7 @@ async fn history_is_followed_by_the_backlog() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -241,7 +242,7 @@ async fn a_publish_that_arrives_during_replay_is_carried_across() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
 
@@ -280,7 +281,7 @@ async fn a_gap_left_by_the_queue_is_filled_from_disk() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b", "c", "d", "e"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
 
@@ -318,7 +319,7 @@ async fn a_gap_left_by_the_queue_is_filled_from_disk() {
 async fn a_queued_record_already_covered_by_history_is_not_repeated() {
     let (broker, _dir) = durable_broker().await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     publish(&broker, &["a", "b", "c"]).await;
@@ -349,7 +350,7 @@ async fn a_queued_record_already_covered_by_history_is_not_repeated() {
 async fn an_empty_replay_writes_nothing() {
     let (broker, _dir) = durable_broker().await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -376,7 +377,7 @@ async fn replay_is_split_into_batches_without_losing_the_run() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a", "b", "c", "d", "e", "f"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -405,7 +406,7 @@ async fn replay_is_split_into_batches_without_losing_the_run() {
 async fn a_backlog_without_history_is_delivered() {
     let (broker, _dir) = durable_broker().await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();
@@ -432,7 +433,7 @@ async fn a_history_range_past_the_end_of_the_log_stops() {
     let (broker, _dir) = durable_broker().await;
     publish(&broker, &["a"]).await;
     let mut subscription = broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let mut sink = Recorder::default();

--- a/services/broker/src/transport/quic/handlers/subscribe/tests.rs
+++ b/services/broker/src/transport/quic/handlers/subscribe/tests.rs
@@ -1371,7 +1371,7 @@ async fn run_connection_writer_coalesces_multiple_deliveries() -> Result<()> {
             felix_broker::StreamMetadata::default(),
         )
         .await?;
-    let subscription = broker.subscribe("t1", "default", "orders").await?;
+    let subscription = broker.subscribe("t1", "default", "orders", 0).await?;
     let (_rx, guard) = subscription.into_parts();
 
     let (server_config, cert) = make_server_config()?;
@@ -1466,7 +1466,7 @@ async fn run_connection_writer_handles_write_error() -> Result<()> {
             felix_broker::StreamMetadata::default(),
         )
         .await?;
-    let subscription = broker.subscribe("t1", "default", "orders").await?;
+    let subscription = broker.subscribe("t1", "default", "orders", 0).await?;
     let (_rx, guard) = subscription.into_parts();
 
     let (server_config, cert) = make_server_config()?;
@@ -1528,7 +1528,7 @@ async fn run_connection_writer_unregister_drops_late_deliveries() -> Result<()> 
             felix_broker::StreamMetadata::default(),
         )
         .await?;
-    let subscription = broker.subscribe("t1", "default", "orders").await?;
+    let subscription = broker.subscribe("t1", "default", "orders", 0).await?;
     let (_rx, guard) = subscription.into_parts();
 
     let (server_config, cert) = make_server_config()?;

--- a/services/broker/src/transport/quic/streams/tests.rs
+++ b/services/broker/src/transport/quic/streams/tests.rs
@@ -566,7 +566,7 @@ async fn build_publish_context(broker: Arc<Broker>) -> PublishContext {
                     stream,
                 } => {
                     broker
-                        .publish_batch(tenant_id, namespace, stream, &job.payloads)
+                        .publish_batch(tenant_id, namespace, stream, 0, &job.payloads)
                         .await
                 }
             }

--- a/services/broker/tests/cross_broker_forwarding.rs
+++ b/services/broker/tests/cross_broker_forwarding.rs
@@ -201,7 +201,7 @@ async fn a_forwarded_publish_is_written_by_the_owner() {
     // rather than merely answering.
     let mut subscription = owner
         .broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
@@ -237,7 +237,7 @@ async fn an_owner_behind_the_requester_refuses_rather_than_writing() {
     let owner = Owner::new(OWNER, 1, true).await;
     let mut subscription = owner
         .broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let listener = Listener::start(OWNER, owner.handler("10.0.0.5:7000"));
@@ -480,7 +480,7 @@ async fn a_lost_answer_is_reported_as_indeterminate_and_never_retried() {
         async fn handle(&self, request: InternalMessage) -> InternalMessage {
             if let InternalMessage::ForwardPublish(publish) = &request {
                 self.broker
-                    .publish_batch(TENANT, NAMESPACE, STREAM, &publish.payloads)
+                    .publish_batch(TENANT, NAMESPACE, STREAM, 0, &publish.payloads)
                     .await
                     .expect("publish");
                 self.applied.fetch_add(1, Ordering::SeqCst);
@@ -495,7 +495,7 @@ async fn a_lost_answer_is_reported_as_indeterminate_and_never_retried() {
     let owner = Owner::new(OWNER, 1, true).await;
     let mut subscription = owner
         .broker
-        .subscribe(TENANT, NAMESPACE, STREAM)
+        .subscribe(TENANT, NAMESPACE, STREAM, 0)
         .await
         .expect("subscribe");
     let applied = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Closes #286. Unblocks #240.

## The bug

The stream registry opened shard `0`'s log whatever shard it was asked for:

```rust
Ok(Some(storage.open_stream(tenant_id, namespace, stream, 0)?))
```

while the replication driver and shard lifecycle opened `key.shard`. They agreed only for shard 0 — the only shard anything could reach, because `shard_for` is always called with no routing key.

**That agreement is exactly what #240 would have broken.** The moment a routing key sends a publish to shard 3, it lands in shard 0's log while replication ships the empty shard-3 log: acknowledged, never replicated, lost on failover — and under `Quorum`, never reaching a majority at all.

## The fix

`topics` is keyed by `(tenant, namespace, stream, shard)`. Metadata stays per stream — its shard count and consistency describe the stream — while a log, a replay ring and a subscriber set are per shard, because **a broker can own several shards of one stream and each is a separate log**. Conflating the two produced the bug.

Registration opens shard 0 alone. Any other shard opens the first time the broker is asked to serve it: ownership is decided by the control plane long after registration and a broker holds an arbitrary subset, so opening all of them eagerly would create a log per shard on every broker. The lazy open **hydrates before the state is visible**, for the reason registration already did — a durable shard publishable with an empty replay ring answers `CursorTooOld` for every pre-existing cursor with nothing upstream aware it was never initialised.

Shard 0 keeps the directory a single-shard stream has always had, so **there is nothing to migrate**.

## Two easy-to-miss consequences

- **The publish path's stream-handle cache** was keyed by stream alone. Left that way it would hand a publish for one shard the handle of another — the same bug through a different door.
- **Deregistering a stream** now drops every shard of it, not just the one registration opened.

## Tests

`crates/felix-broker/tests/sharded_streams.rs`:

- shards of one stream do not share a log
- each shard numbers its own records from zero
- **a publish lands in the log replication ships** — opens the log exactly as `replication::driver` does and checks the record is in it, and that shard 0's log is untouched
- a shard beyond the stream's count is refused rather than silently created

Verified load-bearing: restoring the shard-0 hardcode fails three of the four.

## Verification

- `task test` — green, 82 blocks, 0 failures
- `task lint` — clean
- `task demo:check` — clean

## Next

#240 can now land: the wire routing key, `shard_for` with the real shard count, and the multi-shard cluster tests that have never been runnable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)