### PR TITLE
perf(broker): keep core::fmt off the publish path, and make shard 0 free

### DIFF
--- a/services/broker/src/transport/quic/handlers/publish.rs
+++ b/services/broker/src/transport/quic/handlers/publish.rs
@@ -97,6 +97,25 @@ use crate::transport::quic::STREAM_CACHE_TTL;
 
 pub(crate) type StreamHandleCache = HashMap<String, (Option<StreamHandle>, Instant)>;
 
+/// Append `value` as ASCII decimal, without `core::fmt`.
+///
+/// On the publish path, where the difference between this and `write!` is the
+/// whole formatting machinery for a number that is almost always one digit.
+fn push_decimal(buf: &mut String, mut value: u32) {
+    let mut digits = [0u8; 10];
+    let mut at = digits.len();
+    loop {
+        at -= 1;
+        digits[at] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    // Only ASCII digits were written, so the slice is valid UTF-8.
+    buf.push_str(std::str::from_utf8(&digits[at..]).expect("ascii digits"));
+}
+
 /// Work item consumed by publish workers.
 ///
 /// A publish job is the unit the broker’s ingress pipeline processes:
@@ -406,7 +425,7 @@ pub(crate) async fn resolve_route(
     // stream, they are separate logs, and a cache that ignored the shard would
     // hand a publish for one of them the handle of another.
     key_scratch.clear();
-    let needed = tenant_id.len() + namespace.len() + stream.len() + 14;
+    let needed = tenant_id.len() + namespace.len() + stream.len() + 13;
     if key_scratch.capacity() < needed {
         key_scratch.reserve(needed - key_scratch.capacity());
     }
@@ -415,10 +434,19 @@ pub(crate) async fn resolve_route(
     key_scratch.push_str(namespace);
     key_scratch.push('\0');
     key_scratch.push_str(stream);
-    key_scratch.push('\0');
-    {
-        use std::fmt::Write;
-        let _ = write!(key_scratch, "{shard}");
+    // Shard 0 adds nothing to the key.
+    //
+    // Every stream has a shard 0 and most have only that one, so the common
+    // publish builds exactly the bytes it did before shards existed. Keys stay
+    // distinct because a suffix is only ever present for a non-zero shard, and
+    // `\0` cannot appear in the parts above it.
+    //
+    // Written by hand rather than through `write!`: this key is rebuilt on
+    // every publish, and `core::fmt` is heavy next to the `push_str` calls the
+    // rest of it is deliberately made of.
+    if shard != 0 {
+        key_scratch.push('\0');
+        push_decimal(key_scratch, shard);
     }
     if let Some((handle, expires)) = cache.get(key_scratch.as_str())
         && *expires > Instant::now()

--- a/services/broker/src/transport/quic/handlers/publish/tests.rs
+++ b/services/broker/src/transport/quic/handlers/publish/tests.rs
@@ -2952,3 +2952,43 @@ mod ownership_gate {
         assert!(matches!(route, PublishRoute::Local(_)));
     }
 }
+
+/// The hot-path decimal encoder, which exists to keep `core::fmt` off the
+/// publish path. It has to agree with formatting for every value a shard can
+/// take, or two shards could share a cache entry.
+#[test]
+fn push_decimal_matches_formatting() {
+    for value in [0u32, 1, 7, 9, 10, 99, 100, 4095, 65_535, u32::MAX] {
+        let mut buf = String::new();
+        super::push_decimal(&mut buf, value);
+        assert_eq!(buf, value.to_string(), "encoding {value}");
+    }
+}
+
+/// **Shard 0 builds the key it always did.** Every stream has a shard 0 and
+/// most have only that one, so the common publish must pay nothing for shards
+/// existing — and a non-zero shard must still get a distinct key.
+#[test]
+fn shard_zero_adds_nothing_to_the_cache_key_and_others_stay_distinct() {
+    fn key(tenant: &str, namespace: &str, stream: &str, shard: u32) -> String {
+        let mut buf = String::new();
+        buf.push_str(tenant);
+        buf.push('\0');
+        buf.push_str(namespace);
+        buf.push('\0');
+        buf.push_str(stream);
+        if shard != 0 {
+            buf.push('\0');
+            super::push_decimal(&mut buf, shard);
+        }
+        buf
+    }
+
+    assert_eq!(key("t1", "ns", "orders", 0), "t1\0ns\0orders");
+    assert_ne!(key("t1", "ns", "orders", 0), key("t1", "ns", "orders", 1));
+    assert_ne!(key("t1", "ns", "orders", 1), key("t1", "ns", "orders", 2));
+    // Names containing a NUL can still collide -- `orders` shard 1 against a
+    // stream literally named "orders\0 1" on shard 0. That ambiguity predates
+    // shards (tenant "a\0b" against tenant "a" namespace "b") and is #295, not
+    // something this key shape introduced.
+}


### PR DESCRIPTION
Follow-up to #294, whose perf check flagged four potential regressions.

## The read

All four are on **`batch=1`** configs, where per-publish overhead dominates. The `batch=64` configs show nothing. That is the shape of a fixed cost added per publish rather than per byte.

#294 appended the shard to the stream-handle cache key with `write!(key_scratch, "{shard}")`, dragging `core::fmt` onto a path deliberately built out of hand-rolled `push_str` calls to avoid exactly that.

## The fix

**Shard 0 adds nothing to the key.** Every stream has a shard 0 and most have only that one, so the common publish builds precisely the bytes it built before shards existed. Keys stay distinct because a suffix is only ever present for a non-zero shard.

**A non-zero shard is encoded by hand** — ASCII digits, no `core::fmt` — with a test that it agrees with `to_string()` across the range including `u32::MAX`.

## On the numbers

I would not claim this recovers all four. Two of the flags are the same figure reported twice (`throughput` and `delivered_throughput` differ only by the fanout factor), and the p999 was a 934% swing at p=0.032 on a shared runner from a handful of samples — the least trustworthy metric in the table. The p99 +14.1% at p=0.018 is the one I would take seriously, and a per-publish `core::fmt` call is a plausible cause.

Removing it was worth doing on its own terms. The perf check on this PR is the measurement.

## Also filed: #295

The cache key joins its parts with `\0`, and nothing forbids a `\0` inside a tenant, namespace or stream name — so two distinct streams can share a cache entry and a publish can be handed the wrong handle.

That **predates shards** (tenant `"a\0b"` against tenant `"a"` namespace `"b"`), and the storage layer already length-prefixes its key material for this exact reason, with a comment saying so. Found by a test written here that asserted the stronger property and failed; I narrowed the assertion to what this key shape actually promises and pointed it at the issue rather than deleting it.

## Verification

- `task test` — green, 80 blocks, 0 failures
- `task lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)