### PR TITLE
Replace the architecture diagrams with one that is true

### DIFF
--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "astro dev",
     "check:mermaid": "node ../scripts/check-mermaid.mjs",
-    "build": "npm run check:mermaid && astro build",
+    "check:diagrams": "node ../scripts/check-diagram-copies.mjs",
+    "build": "npm run check:mermaid && npm run check:diagrams && astro build",
     "preview": "astro preview"
   },
   "dependencies": {

--- a/docs-site/public/diagrams/architecture.svg
+++ b/docs-site/public/diagrams/architecture.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 660" width="900" height="660" role="img" aria-label="Clients connect to any broker over QUIC. Brokers are peers that forward requests for shards they do not own and replicate the ones they lead. A control plane backed by Postgres places shards by rendezvous hashing, and brokers watch its assignment feed. Inside a shard, one append-only log is read as a stream by offset and as a cache through a key index.">
+
+  <style>
+    .band   { fill: var(--ink-dim); font: 600 11px ui-sans-serif, system-ui, sans-serif; letter-spacing: .09em; }
+    .title  { fill: var(--ink); font: 600 15px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .lbl    { fill: var(--ink); font: 500 13px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .sub    { fill: var(--ink-dim); font: 400 11.5px ui-sans-serif, system-ui, sans-serif; }
+    .mono   { fill: var(--ink); font: 500 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .edgelb { fill: var(--ink-dim); font: 500 11.5px ui-sans-serif, system-ui, sans-serif; }
+
+    .box    { stroke: var(--edge); stroke-width: 1.25; fill: var(--c-step); }
+    .cp     { stroke: var(--accent); stroke-width: 1.5;  fill: var(--c-dev); }
+    .chip   { stroke: var(--edge-dim); stroke-width: 1; fill: var(--c-wait); }
+    .rec    { stroke: var(--edge); stroke-width: 1; fill: var(--c-step); }
+    .flow   { stroke: var(--edge); stroke-width: 1.75; fill: none; }
+    .peer   { stroke: var(--edge); stroke-width: 1.75; fill: none; stroke-dasharray: 6 4; }
+    .rule   { stroke: var(--edge-dim); stroke-width: 1; }
+
+    :root {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5;
+    }
+    @media (prefers-color-scheme: dark) { :root {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; } }
+    :root[data-theme="dark"] {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; }
+    :root[data-theme="light"] {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5; }
+  </style>
+
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--edge)"/>
+    </marker>
+    <marker id="ah-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"/>
+    </marker>
+  </defs>
+
+  <!-- ============ clients ============ -->
+  <text class="band" x="40" y="30">CLIENTS</text>
+  <g>
+    <rect class="box" x="220" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="290" y="66" text-anchor="middle">Producer</text>
+
+    <rect class="box" x="380" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="450" y="66" text-anchor="middle">Consumer</text>
+
+    <rect class="box" x="540" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="610" y="66" text-anchor="middle">Cache client</text>
+  </g>
+  <text class="sub" x="450" y="99" text-anchor="middle">one library · connects to any broker · asks it for the topology</text>
+
+  <path class="flow" d="M 450 108 L 450 146" marker-end="url(#ah)"/>
+  <text class="edgelb" x="462" y="132">QUIC</text>
+
+  <!-- ============ brokers ============ -->
+  <line class="rule" x1="40" y1="160" x2="860" y2="160"/>
+  <text class="band" x="40" y="180">BROKERS · peers, with no coordinator among them</text>
+
+  <g>
+    <rect class="box" x="60" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="80" y="222">Broker A</text>
+    <text class="sub" x="80" y="242">leads</text>
+    <rect class="chip" x="80" y="250" width="96" height="22" rx="4"/>
+    <text class="mono" x="128" y="265" text-anchor="middle">orders · 0</text>
+    <rect class="chip" x="184" y="250" width="100" height="22" rx="4"/>
+    <text class="mono" x="234" y="265" text-anchor="middle">sessions · 1</text>
+    <text class="sub" x="80" y="296">forwards everything else</text>
+
+    <rect class="box" x="330" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="350" y="222">Broker B</text>
+    <text class="sub" x="350" y="242">leads</text>
+    <rect class="chip" x="350" y="250" width="96" height="22" rx="4"/>
+    <text class="mono" x="398" y="265" text-anchor="middle">orders · 1</text>
+    <text class="sub" x="350" y="296">forwards everything else</text>
+
+    <rect class="box" x="600" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="620" y="222">Broker C</text>
+    <text class="sub" x="620" y="242">leads</text>
+    <rect class="chip" x="620" y="250" width="100" height="22" rx="4"/>
+    <text class="mono" x="670" y="265" text-anchor="middle">sessions · 0</text>
+    <text class="sub" x="620" y="296">forwards everything else</text>
+  </g>
+
+  <!-- peer traffic -->
+  <path class="peer" d="M 300 255 L 330 255" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <path class="peer" d="M 570 255 L 600 255" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <text class="edgelb" x="450" y="340" text-anchor="middle">peer QUIC · forward what it does not own, replicate what it leads</text>
+
+  <!-- ============ control plane ============ -->
+  <path class="flow" d="M 450 358 L 450 424" marker-end="url(#ah)" marker-start="url(#ah)"/>
+  <text class="edgelb" x="462" y="396">watch assignments · report status</text>
+
+  <line class="rule" x1="40" y1="440" x2="860" y2="440"/>
+  <text class="band" x="40" y="460">CONTROL PLANE</text>
+
+  <rect class="cp" x="190" y="474" width="520" height="88" rx="8"/>
+  <text class="title" x="214" y="500">Metadata &amp; placement</text>
+  <text class="sub" x="214" y="521">REST · Postgres or in-memory · not on the data path</text>
+  <text class="sub" x="214" y="539">owns tenants, namespaces, streams, caches, nodes, shard assignments</text>
+  <text class="sub" x="214" y="555">places every shard by rendezvous hashing</text>
+
+  <text class="edgelb" x="730" y="504">no Raft, no election:</text>
+  <text class="edgelb" x="730" y="521">placement is a pure</text>
+  <text class="edgelb" x="730" y="538">function of the snapshot</text>
+
+  <!-- ============ one log, many semantics ============ -->
+  <line class="rule" x1="40" y1="588" x2="860" y2="588"/>
+  <text class="band" x="40" y="608">INSIDE ONE SHARD</text>
+
+  <g>
+    <rect class="rec" x="228" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="266" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="304" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="342" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="380" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="418" y="620" width="34" height="22" rx="3"/>
+    <text class="sub" x="212" y="636" text-anchor="end">append-only log</text>
+    <path class="flow" d="M 458 631 L 476 631" marker-end="url(#ah)"/>
+  </g>
+  <text class="lbl" x="492" y="628">stream</text>
+  <text class="sub" x="548" y="628">read forward by offset</text>
+  <text class="lbl" x="492" y="646">cache</text>
+  <text class="sub" x="548" y="646">read through a key → offset index, rebuilt from the log</text>
+</svg>

--- a/docs-site/src/content/docs/architecture/system-design.md
+++ b/docs-site/src/content/docs/architecture/system-design.md
@@ -12,7 +12,7 @@ Internally, Felix is built around a single append-only log abstraction. Differen
 
 - **Streams (Pub/Sub):** Fanout cursors per subscription
 - **Queues:** Shared consumer-group cursors with acknowledgements
-- **Cache:** key → latest value with TTL, written to the same log as records and read back through an index rebuilt from it. Compaction reclaims superseded and expired entries. Cache operations are not yet routed across brokers — see `docs/cache-on-log.md`
+- **Cache:** key → latest value with TTL, written to the same log as records and read back through an index rebuilt from it. Compaction reclaims superseded and expired entries. Cache keys are sharded and routed to their owner like a stream's are, so a value written through any broker is readable through every other — see `docs/cache-on-log.md`
 
 This drastically reduces operational complexity and consistency bugs compared to running Kafka, Redis, and a queueing system side-by-side.
 
@@ -29,123 +29,30 @@ Felix prioritizes predictable low latency over maximum batch throughput:
 
 Felix assumes Kubernetes for process lifecycle, identity (ServiceAccounts), networking and service discovery, and failure detection. Felix does **not** attempt to reimplement scheduling or node membership logic that Kubernetes already provides.
 
-## System Architecture (Current MVP)
+## System Architecture
 
-The current implementation is a single-node broker for development and testing:
+![Clients connect to any broker over QUIC. Brokers are peers that forward requests for shards they do not own and replicate the ones they lead. A control plane backed by Postgres places shards by rendezvous hashing, and brokers watch its assignment feed. Inside a shard, one append-only log is read as a stream by offset and as a cache through a key index.](/felix/diagrams/architecture.svg)
 
-```mermaid
-flowchart TB
-    subgraph Clients["Client Applications"]
-        P1["Publisher 1"]
-        P2["Publisher 2"]
-        S1["Subscriber 1"]
-        S2["Subscriber 2"]
-        C1["Cache Client"]
-    end
+Three things carry most of the design.
 
-    subgraph Broker["Felix Broker (Single Node)"]
-        direction TB
-        Transport["QUIC Transport Layer<br/>felix-transport"]
-        Wire["Wire Protocol Handler<br/>felix-wire framing"]
-        Router["Stream Router<br/>Control vs Event vs Cache"]
-        
-        subgraph DataPlane["Data Plane"]
-            PubSub["Pub/Sub Engine<br/>felix-broker"]
-            Cache["Cache Engine<br/>TTL + eviction"]
-            Storage["Ephemeral Storage<br/>In-memory"]
-        end
-        
-        Metrics["Metrics Server<br/>:8080"]
-        
-        Transport --> Wire
-        Wire --> Router
-        Router --> PubSub
-        Router --> Cache
-        PubSub --> Storage
-        Cache --> Storage
-    end
+**Any broker accepts any request.** A client connects to whichever broker it can reach and asks it for the topology. If that broker does not lead the shard the request belongs to, it forwards the request to the broker that does and relays the answer — the client is never asked to find the right one first, and never talks to more than one broker for a single request.
 
-    P1 & P2 --> Transport
-    Transport --> S1 & S2
-    C1 <--> Transport
-    
-    PubSub -.-> Metrics
-    Cache -.-> Metrics
-```
+**Ownership comes from the control plane, and only from there.** Every shard of every stream and cache has exactly one leader, chosen by rendezvous hashing over the live nodes. Brokers watch the assignment feed — a snapshot, then a change stream — and never negotiate ownership among themselves.
 
-**Key Components:**
+**No consensus protocol runs between brokers.** Placement is a pure function of a metadata snapshot, so two control-plane instances reading the same catalog reach the same answer without having to agree on one. Durability across a leader change comes from log shipping and leader leases: per-shard Raft was considered and rejected, for reasons set out in [`docs/replication-design.md`](https://github.com/gabloe/felix/blob/main/docs/replication-design.md).
 
-- **Transport Layer:** Accepts QUIC connections, manages stream lifecycle
-- **Wire Protocol:** Frames messages, validates envelopes, routes by type
-- **Pub/Sub Engine:** Enqueues publishes, manages subscriptions, fans out events
-- **Cache Engine:** Handles put/get operations with TTL and lazy expiration
-- **Storage:** In-memory ring buffers and hash maps (ephemeral)
-- **Metrics Server:** Prometheus-compatible endpoint for monitoring
+That rejection is specific to *replicating records*. Making the control plane's own metadata highly available is a separate problem, and Raft remains the intended answer there — it is not implemented yet, and until it is, control-plane availability rests on Postgres.
 
-## Planned Multi-Node Architecture
+The control plane is not on the data path. A publish, a subscribe, or a cache operation never calls it; brokers read it in the background and serve from what they already hold.
 
-The intended multi-node design adds explicit control-plane coordination and data-plane scalability:
+### Control plane
 
-```mermaid
-flowchart TB
-    subgraph Clients["Clients"]
-        C1["Producers"]
-        C2["Consumers"]
-        C3["Cache Clients"]
-    end
-    
-    LB["Load Balancer<br/>(L4 for QUIC)"]
-    
-    Clients --> LB
-    
-    subgraph ControlPlane["Control Plane (RAFT)"]
-        direction LR
-        CONTROLPLANE1["controlplane-0"]
-        CONTROLPLANE2["controlplane-1"]
-        CONTROLPLANE3["controlplane-2"]
-        
-        CONTROLPLANE1 <--> CONTROLPLANE2
-        CONTROLPLANE2 <--> CONTROLPLANE3
-        CONTROLPLANE1 <--> CONTROLPLANE3
-        
-        Meta["Metadata Store<br/>• Topics/Streams<br/>• Tenants/Namespaces<br/>• Shard Placement<br/>• ACLs/Quotas"]
-    end
-    
-    subgraph DataPlane["Data Plane (Brokers)"]
-        direction LR
-        B1["Broker A<br/>Shards 0-99"]
-        B2["Broker B<br/>Shards 100-199"]
-        B3["Broker C<br/>Shards 200-299"]
-    end
-    
-    subgraph Storage["Storage Layer"]
-        direction LR
-        Ephemeral["Ephemeral<br/>(in-memory)"]
-        Durable["Durable Log<br/>(persistent volumes)"]
-        Snapshots["Snapshots<br/>(object storage)"]
-    end
-    
-    LB --> DataPlane
-    ControlPlane --> Meta
-    DataPlane <--> ControlPlane
-    DataPlane --> Storage
-```
+Serves metadata over REST, backed by Postgres or an in-memory store. It owns tenants, namespaces, streams, caches, the node catalog, and shard assignments, and it runs placement on a timer. Brokers seed from it at startup and gate readiness on that seeding, so a broker does not accept traffic for streams it does not yet know about.
 
-### Control Plane Responsibilities
+### Data plane
 
-- **Metadata Management:** Topics, tenants, namespaces, ACLs
-- **Shard Placement:** Assign shards to broker nodes
-- **Health Monitoring:** Track broker liveness and readiness
-- **Configuration:** Cluster-wide retention, limits, feature flags
-- **Rebalancing:** Migrate shards on node failures or scaling events
+Brokers serve clients over QUIC and reach each other over a separate QUIC endpoint with its own protocol. Each one leads some shards, replicates the ones it leads to followers, forwards what it does not lead, and refuses what it cannot route — a request served locally by a broker that does not own it is exactly the divergence the ownership check exists to prevent.
 
-### Data Plane Responsibilities
-
-- **Client Connections:** Accept and route QUIC streams
-- **Data Operations:** Publish, subscribe, cache operations
-- **Shard Ownership:** Host assigned shards (leaders and followers)
-- **Replication:** (Future) Replicate log entries to followers
-- **Backpressure:** Enforce flow control and isolation
 
 ## Data Flow Patterns
 
@@ -218,25 +125,33 @@ sequenceDiagram
 - Request IDs for request/response matching
 - Sub-millisecond latency at moderate concurrency
 
-### Cross-Broker Routing (Planned)
+### Cross-Broker Routing
 
-When a client connects to a broker that doesn't own the target shard:
+When a client reaches a broker that does not lead the target shard:
 
 ```mermaid
 sequenceDiagram
     participant C as Client
     participant B1 as Broker (ingress)
-    participant CONTROLPLANE as Control Plane
     participant B2 as Broker (shard owner)
-    
-    C->>B1: Publish(topic, batch)
-    B1->>CONTROLPLANE: Lookup shard placement(topic)
-    CONTROLPLANE-->>B1: owner = B2
-    B1->>B2: Forward publish (internal QUIC)
-    B2->>B2: Commit to log
-    B2-->>B1: ACK
-    B1-->>C: ACK
+
+    C->>B1: Publish(stream, key, batch)
+    B1->>B1: hash the key, resolve the owner locally
+    B1->>B2: ForwardPublish(shard, generation, payloads)
+    B2->>B2: check ownership at that generation, then commit
+    B2-->>B1: ForwardPublishOk(offsets)
+    B1-->>C: Ack
 ```
+
+**The control plane is not in this picture, and that is the point.** Resolving an
+owner is an atomic load of a routing snapshot the broker already holds — no lock,
+no network call — because this is the hottest question the broker is asked. The
+snapshot is refreshed in the background from the assignment feed.
+
+The `generation` the ingress broker resolved against travels with the request.
+The owner compares it against its own and answers a mismatch explicitly in either
+direction, so a stale view is a typed answer rather than a write to a shard
+somebody has already been given.
 
 ## Storage Architecture
 
@@ -282,7 +197,7 @@ See [Durable Storage](/felix/architecture/durable-storage/).
 
 ## Consistency Model
 
-### Single-Node (MVP)
+### Single node
 
 - **Delivery:** At-most-once (best-effort)
 - **Ordering:** Per-stream ordering preserved per subscriber. For a durable
@@ -291,20 +206,27 @@ See [Durable Storage](/felix/architecture/durable-storage/).
 - **Durability:** Per stream. Ephemeral by default; `durable: true` persists
   every publish before acknowledging it.
 
-### Multi-Node (Planned)
+### Clustered
 
-**Tunable per stream:**
+Consistency is declared per stream:
 
-- **Leader-only acknowledgements:** Lowest latency, leader commits before replicating
-- **Quorum acknowledgements:** Higher durability, waits for majority replica confirmation
-- **Asynchronous replication:** Background replication after ACK
-- **Synchronous replication:** Blocks on replication before ACK
+- **`Leader`:** the leader acknowledges once the record is durable locally. Lowest
+  latency, and the default.
+- **`Quorum`:** the leader waits until a majority of the shard's replicas — itself
+  included — hold the record. A record acknowledged this way survives the loss of
+  its leader.
+
+A leader serves only while it holds a lease on the shards it leads, so a broker
+that has been superseded stops acknowledging rather than discovering the fact
+later. On failover, only a replica that actually holds the log is promoted: a
+shard whose leader is gone and whose replicas are behind is left unavailable
+rather than reopened empty, because a silently empty shard *is* the data loss.
 
 **Delivery guarantees:**
 
-- **At-least-once:** With durable storage and replay on failure
-- **At-most-once:** Best-effort with no retries
-- **Exactly-once:** (Future roadmap) via idempotent producers and transactions
+- **At-least-once:** with durable storage and replay on failure
+- **At-most-once:** best-effort with no retries
+- **Exactly-once:** not implemented
 
 ## Multi-Region Architecture (Planned)
 
@@ -366,11 +288,14 @@ regulatory or compliance purposes until it ships.
 
 - **Sharding:** Partition streams across brokers
 - **Connection pooling:** Reuse connections across shards
-- **Control plane:** RAFT quorum for metadata (3-5 nodes)
-- **Data plane:** Many broker nodes for capacity
+- **Control plane:** stateless REST over Postgres; scale by adding instances,
+  since placement is a pure function of the catalog and needs no agreement
+  between them
+- **Data plane:** many broker nodes for capacity
 
-Multi-node is not implemented, so no cluster-level throughput figure is
-claimed here.
+No cluster-level throughput figure is claimed here: the published benchmarks are
+single-node, and a multi-node number measured on one machine would say more
+about the loopback than about Felix.
 
 ## Next Steps
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,108 +175,76 @@ Felix is opinionated by design.
 
 ---
 
-## Planned Multinode Architecture
+## Cluster Architecture
 
-The current MVP is single-node. The intended multinode design adds explicit control-plane
-coordination, shard placement, and a QUIC data plane that scales horizontally.
+![Clients connect to any broker over QUIC. Brokers are peers that forward requests for shards they do not own and replicate the ones they lead. A control plane backed by Postgres places shards by rendezvous hashing, and brokers watch its assignment feed. Inside a shard, one append-only log is read as a stream by offset and as a cache through a key index.](assets/architecture.svg)
 
-```mermaid
-flowchart TB
-  %% ---------- Clients ----------
-  subgraph Clients["Clients"]
-    C1["Producers<br/>(felix-client)"]
-    C2["Consumers<br/>(felix-client)"]
-    C3["Cache clients<br/>(felix-client)"]
-  end
+Three properties carry most of the design.
 
-  %% ---------- Kubernetes / Edge ----------
-  subgraph K8s["Kubernetes Cluster"]
-    Ingress["Ingress / LB<br/>(L4 for QUIC)"]
-    DNS["Service discovery<br/>(K8s Service / DNS)"]
-  end
+**Any broker accepts any request.** A client connects to whichever broker it can
+reach and asks it for the topology. If that broker does not lead the shard the
+request belongs to, it forwards the request to the one that does and relays the
+answer. The client never has to find the right broker first, and never talks to
+two of them for a single request.
 
-  C1 --> Ingress
-  C2 --> Ingress
-  C3 --> Ingress
+**Ownership comes from the control plane and nowhere else.** Every shard of every
+stream and cache has exactly one leader, chosen by rendezvous hashing over the
+live nodes. Brokers watch the assignment feed — a snapshot, then a change stream
+— and never negotiate ownership among themselves.
 
-  %% ---------- Data Plane ----------
-  subgraph DP["Data Plane (Broker Nodes)"]
-    direction LR
-    B1["Broker Pod A<br/>QUIC data-plane"]
-    B2["Broker Pod B<br/>QUIC data-plane"]
-    B3["Broker Pod C<br/>QUIC data-plane"]
+**No consensus protocol runs between brokers.** Placement is a pure function of a
+metadata snapshot, so two control-plane instances reading the same catalog reach
+the same answer without having to agree on one. Durability across a leader change
+comes from log shipping and leader leases instead; `replication-design.md` argues
+that choice in full, including why per-shard Raft was rejected.
 
-    subgraph Shards["Partitioning / Locality"]
-      R1["Shard/Range 0..n"]
-      R2["Shard/Range n..m"]
-    end
+That rejection is about replicating *records*. Making the control plane's own
+metadata highly available is a separate problem, and Raft is still the intended
+answer there — unimplemented, so control-plane availability currently rests on
+Postgres.
 
-    B1 --- Shards
-    B2 --- Shards
-    B3 --- Shards
-  end
-
-  Ingress --> DP
-  DNS --- DP
-
-  %% ---------- Control Plane ----------
-  subgraph CONTROLPLANE["Control Plane"]
-    direction LR
-    CONTROLPLANE1["controlplane-0"]
-    CONTROLPLANE2["controlplane-1"]
-    CONTROLPLANE3["controlplane-2"]
-
-    subgraph Raft["RAFT quorum"]
-      direction LR
-      CONTROLPLANE1 <--> CONTROLPLANE2
-      CONTROLPLANE2 <--> CONTROLPLANE3
-      CONTROLPLANE1 <--> CONTROLPLANE3
-    end
-
-    Meta["Metadata store<br/>(topics, tenants, ACLs,<br/>shards, placements)"]
-    Raft --> Meta
-  end
-
-  %% ---------- Storage ----------
-  subgraph Storage["Storage (evolves over time)"]
-    direction LR
-    CacheStore["Cache store<br/>(in-memory + TTL)"]
-    LogStore["Durable log<br/>(segments + sparse indexes)"]
-    Snapshots["Retention / tiering (future)"]
-    LogStore --> Snapshots
-  end
-
-  %% ---------- Wiring ----------
-  DP <--> CONTROLPLANE
-  DP --> CacheStore
-  DP --> LogStore
-
-```
+The control plane is not on the data path. Resolving an owner is an atomic load
+of a routing snapshot the broker already holds — no lock and no network call,
+because it is the hottest question a broker is asked. The snapshot is refreshed
+in the background.
 
 ## Cross-Broker Delivery
 
-If publishes can enter any broker and forward to the shard owner, the flow looks like:
+A publish entering a broker that does not lead the shard:
 
 ```mermaid
 sequenceDiagram
   participant Client as Producer
   participant B0 as Broker (ingress)
-  participant CONTROLPLANE as Control Plane (RAFT)
   participant Bp as Broker (owner)
   participant S as Subscribers
 
-  Client->>B0: Publish(topic, batch)
-  B0->>CONTROLPLANE: Lookup placement(topic/shard)
-  CONTROLPLANE-->>B0: owner = Bp
-  B0->>Bp: Forward publish (internal QUIC)
+  Client->>B0: Publish(stream, key, batch)
+  B0->>B0: hash the key, resolve the owner locally
+  B0->>Bp: ForwardPublish(shard, generation, payloads)
+  Bp->>Bp: check ownership at that generation, commit
   Bp->>S: Fanout (batched events on uni streams)
+  Bp-->>B0: ForwardPublishOk(offsets)
+  B0-->>Client: Ack
 ```
+
+The control plane does not appear here, and that is the design. Resolving the
+owner is an atomic load of a snapshot the broker already holds.
+
+The `generation` travels with the request. The owner compares it against its own
+and answers a mismatch explicitly in either direction, so a stale routing view
+produces a typed answer rather than a write to a shard that has been reassigned.
+
+A broker asked for a shard it does not own answers `NotLeader` — it never
+forwards onward on the requester's behalf, because a chain of relays would have
+unbounded latency and a failure mode nobody can reason about.
 
 ## Status
 
-This document reflects the **intended architecture**. Implementation will proceed incrementally,
-starting with a single-node broker and expanding toward clustering, durability, and sovereignty
-features over time.
+Clustering, replication, and cross-broker routing are implemented; see the status
+table in `docs-site/src/content/docs/getting-started/what-felix-is-for.md`, which
+is kept current per capability. Multi-region and the sovereignty features below
+are design intent, not code.
 
 ---
 

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 660" width="900" height="660" role="img" aria-label="Clients connect to any broker over QUIC. Brokers are peers that forward requests for shards they do not own and replicate the ones they lead. A control plane backed by Postgres places shards by rendezvous hashing, and brokers watch its assignment feed. Inside a shard, one append-only log is read as a stream by offset and as a cache through a key index.">
+
+  <style>
+    .band   { fill: var(--ink-dim); font: 600 11px ui-sans-serif, system-ui, sans-serif; letter-spacing: .09em; }
+    .title  { fill: var(--ink); font: 600 15px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .lbl    { fill: var(--ink); font: 500 13px ui-sans-serif, system-ui, -apple-system, sans-serif; }
+    .sub    { fill: var(--ink-dim); font: 400 11.5px ui-sans-serif, system-ui, sans-serif; }
+    .mono   { fill: var(--ink); font: 500 11px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .edgelb { fill: var(--ink-dim); font: 500 11.5px ui-sans-serif, system-ui, sans-serif; }
+
+    .box    { stroke: var(--edge); stroke-width: 1.25; fill: var(--c-step); }
+    .cp     { stroke: var(--accent); stroke-width: 1.5;  fill: var(--c-dev); }
+    .chip   { stroke: var(--edge-dim); stroke-width: 1; fill: var(--c-wait); }
+    .rec    { stroke: var(--edge); stroke-width: 1; fill: var(--c-step); }
+    .flow   { stroke: var(--edge); stroke-width: 1.75; fill: none; }
+    .peer   { stroke: var(--edge); stroke-width: 1.75; fill: none; stroke-dasharray: 6 4; }
+    .rule   { stroke: var(--edge-dim); stroke-width: 1; }
+
+    :root {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5;
+    }
+    @media (prefers-color-scheme: dark) { :root {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; } }
+    :root[data-theme="dark"] {
+      --ink:#dfe8f3; --ink-dim:#9aabbf; --edge:#6d94cc; --edge-dim:#46536a;
+      --accent:#d99a6c; --c-step:#24344b; --c-dev:#40301c; --c-wait:#262c36; }
+    :root[data-theme="light"] {
+      --ink:#1a2b40; --ink-dim:#5b6b7f; --edge:#4a6fa5; --edge-dim:#aab6c6;
+      --accent:#b0653a; --c-step:#e8f0fe; --c-dev:#fbe9d6; --c-wait:#eef1f5; }
+  </style>
+
+  <defs>
+    <marker id="ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--edge)"/>
+    </marker>
+    <marker id="ah-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--accent)"/>
+    </marker>
+  </defs>
+
+  <!-- ============ clients ============ -->
+  <text class="band" x="40" y="30">CLIENTS</text>
+  <g>
+    <rect class="box" x="220" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="290" y="66" text-anchor="middle">Producer</text>
+
+    <rect class="box" x="380" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="450" y="66" text-anchor="middle">Consumer</text>
+
+    <rect class="box" x="540" y="42" width="140" height="38" rx="6"/>
+    <text class="lbl" x="610" y="66" text-anchor="middle">Cache client</text>
+  </g>
+  <text class="sub" x="450" y="99" text-anchor="middle">one library · connects to any broker · asks it for the topology</text>
+
+  <path class="flow" d="M 450 108 L 450 146" marker-end="url(#ah)"/>
+  <text class="edgelb" x="462" y="132">QUIC</text>
+
+  <!-- ============ brokers ============ -->
+  <line class="rule" x1="40" y1="160" x2="860" y2="160"/>
+  <text class="band" x="40" y="180">BROKERS · peers, with no coordinator among them</text>
+
+  <g>
+    <rect class="box" x="60" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="80" y="222">Broker A</text>
+    <text class="sub" x="80" y="242">leads</text>
+    <rect class="chip" x="80" y="250" width="96" height="22" rx="4"/>
+    <text class="mono" x="128" y="265" text-anchor="middle">orders · 0</text>
+    <rect class="chip" x="184" y="250" width="100" height="22" rx="4"/>
+    <text class="mono" x="234" y="265" text-anchor="middle">sessions · 1</text>
+    <text class="sub" x="80" y="296">forwards everything else</text>
+
+    <rect class="box" x="330" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="350" y="222">Broker B</text>
+    <text class="sub" x="350" y="242">leads</text>
+    <rect class="chip" x="350" y="250" width="96" height="22" rx="4"/>
+    <text class="mono" x="398" y="265" text-anchor="middle">orders · 1</text>
+    <text class="sub" x="350" y="296">forwards everything else</text>
+
+    <rect class="box" x="600" y="196" width="240" height="118" rx="8"/>
+    <text class="title" x="620" y="222">Broker C</text>
+    <text class="sub" x="620" y="242">leads</text>
+    <rect class="chip" x="620" y="250" width="100" height="22" rx="4"/>
+    <text class="mono" x="670" y="265" text-anchor="middle">sessions · 0</text>
+    <text class="sub" x="620" y="296">forwards everything else</text>
+  </g>
+
+  <!-- peer traffic -->
+  <path class="peer" d="M 300 255 L 330 255" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <path class="peer" d="M 570 255 L 600 255" marker-start="url(#ah)" marker-end="url(#ah)"/>
+  <text class="edgelb" x="450" y="340" text-anchor="middle">peer QUIC · forward what it does not own, replicate what it leads</text>
+
+  <!-- ============ control plane ============ -->
+  <path class="flow" d="M 450 358 L 450 424" marker-end="url(#ah)" marker-start="url(#ah)"/>
+  <text class="edgelb" x="462" y="396">watch assignments · report status</text>
+
+  <line class="rule" x1="40" y1="440" x2="860" y2="440"/>
+  <text class="band" x="40" y="460">CONTROL PLANE</text>
+
+  <rect class="cp" x="190" y="474" width="520" height="88" rx="8"/>
+  <text class="title" x="214" y="500">Metadata &amp; placement</text>
+  <text class="sub" x="214" y="521">REST · Postgres or in-memory · not on the data path</text>
+  <text class="sub" x="214" y="539">owns tenants, namespaces, streams, caches, nodes, shard assignments</text>
+  <text class="sub" x="214" y="555">places every shard by rendezvous hashing</text>
+
+  <text class="edgelb" x="730" y="504">no Raft, no election:</text>
+  <text class="edgelb" x="730" y="521">placement is a pure</text>
+  <text class="edgelb" x="730" y="538">function of the snapshot</text>
+
+  <!-- ============ one log, many semantics ============ -->
+  <line class="rule" x1="40" y1="588" x2="860" y2="588"/>
+  <text class="band" x="40" y="608">INSIDE ONE SHARD</text>
+
+  <g>
+    <rect class="rec" x="228" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="266" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="304" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="342" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="380" y="620" width="34" height="22" rx="3"/>
+    <rect class="rec" x="418" y="620" width="34" height="22" rx="3"/>
+    <text class="sub" x="212" y="636" text-anchor="end">append-only log</text>
+    <path class="flow" d="M 458 631 L 476 631" marker-end="url(#ah)"/>
+  </g>
+  <text class="lbl" x="492" y="628">stream</text>
+  <text class="sub" x="548" y="628">read forward by offset</text>
+  <text class="lbl" x="492" y="646">cache</text>
+  <text class="sub" x="548" y="646">read through a key → offset index, rebuilt from the log</text>
+</svg>

--- a/scripts/check-diagram-copies.mjs
+++ b/scripts/check-diagram-copies.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Hand-authored SVGs are committed twice: once under `docs/assets/` so GitHub
+// renders them in the repo docs, and once under `docs-site/public/diagrams/` so
+// the site serves them. Nothing generates one from the other, so editing one and
+// forgetting the other leaves two diagrams claiming to be the same picture.
+//
+// Only diagrams that genuinely exist in both places are paired. Most do not:
+// the storage-format figures are referenced from `docs/` alone, and the perf
+// charts are generated. A one-sided diagram is a deliberate choice, not drift,
+// so this checks the one thing that is always wrong -- two copies of the same
+// name that no longer agree.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = dirname(dirname(fileURLToPath(import.meta.url)));
+const SITE = join(REPO, 'docs-site/public/diagrams');
+const DOCS = join(REPO, 'docs/assets');
+
+/** Every `.svg` under `dir`, keyed by basename. */
+function svgs(dir) {
+  const found = new Map();
+  const walk = (path) => {
+    for (const entry of readdirSync(path)) {
+      const full = join(path, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith('.svg')) found.set(entry, full);
+    }
+  };
+  try {
+    walk(dir);
+  } catch {
+    // A missing directory is not a drift failure; there is simply nothing to pair.
+  }
+  return found;
+}
+
+const site = svgs(SITE);
+const docs = svgs(DOCS);
+const failures = [];
+let paired = 0;
+
+for (const [name, sitePath] of site) {
+  const docsPath = docs.get(name);
+  if (!docsPath) continue;
+  paired += 1;
+  if (readFileSync(sitePath, 'utf8') !== readFileSync(docsPath, 'utf8')) {
+    failures.push(
+      `${name}: docs/assets and docs-site/public/diagrams have drifted apart`,
+    );
+  }
+}
+
+for (const f of failures) console.error(`\x1b[31mFAIL\x1b[0m ${f}`);
+console.log(`${paired} duplicated diagram(s) checked, ${failures.length} out of sync`);
+process.exit(failures.length === 0 ? 0 : 1);


### PR DESCRIPTION
The architecture pages were drawn before the cluster existed and never caught up. The mermaid diagrams made Felix look considerably more complicated than it is — and three of their claims were **wrong**, not merely stale.

## What was wrong

| Claim | Reality |
|---|---|
| Control plane drawn as a **RAFT quorum** | Per-shard Raft was considered and rejected. It is REST over Postgres. |
| **"Cross-Broker Routing (Planned)"**, **"Multi-Node (Planned)"** | Both shipped. |
| Forwarding sequence showed the ingress broker **calling the control plane to look up placement** | It does not, and the design goes out of its way not to. |

That last one is the one that matters. Resolving an owner is an **atomic load of a routing snapshot the broker already holds** — no lock, no network call — because it is the hottest question a broker is asked. The diagram told a reader the hot path takes a control-plane round trip on every publish. Anyone reasoning about Felix's latency from that picture would have been reasoning about a different system.

## The replacement

A hand-authored SVG in the same style as `group-commit.svg`: CSS variables, light and dark and `data-theme`, no animation — the subject is structural, not temporal.

It says the three things that actually carry the design:

- **Any broker accepts any request**, and forwards what it does not own
- **Ownership comes from the control plane and nowhere else** — brokers never negotiate it among themselves
- **No consensus protocol runs between brokers** — placement is a pure function of a metadata snapshot

And it shows the thesis the project is built on: inside one shard, one append-only log read as a stream by offset and as a cache through a key index.

The nested subgraphs are gone — Kubernetes ingress and DNS boxes, a "Partitioning / Locality" subgraph wired to all three brokers. None of it was load-bearing and all of it added apparent complexity.

## The Raft claim, stated precisely

Rejecting Raft is specific to **replicating records**. Making the control plane's own metadata highly available is a separate problem, and Raft is still the intended answer there — unimplemented, so that availability currently rests on Postgres.

Both pages now say this explicitly, because a flat "no Raft" contradicts the roadmap row in the status table and would have been the next wrong claim.

## A guard for the duplication

Hand-authored SVGs are committed twice — `docs/assets/` so GitHub renders them, `docs-site/public/diagrams/` so the site serves them — and nothing kept them in step. This change doubles the number of pairs, so it adds `scripts/check-diagram-copies.mjs`, wired into the docs build.

It compares only copies that exist in **both** places. One-sided diagrams are ignored deliberately: the storage-format figures are referenced from `docs/` alone and the perf charts are generated, so a single copy is a choice rather than drift. My first version flagged all 22 of those as failures, which is how I learned the convention was narrower than I assumed.

## Verification

- `node scripts/check-mermaid.mjs` — 90 diagrams, 0 invalid
- `node scripts/check-diagram-copies.mjs` — 2 pairs, 0 out of sync, and it fails when a copy is edited
- `npm run build` in `docs-site` — 45 pages, clean
- The SVG was rendered and read at full size rather than trusted from coordinates; two collisions were found and fixed that way

## Note

Independent of #302, but the two touch adjacent claims — this one leaves the cache row alone.